### PR TITLE
Manual: Translate manual/zh/game.html to Chinese

### DIFF
--- a/manual/en/game.html
+++ b/manual/en/game.html
@@ -1401,7 +1401,7 @@ and change that later.</p>
 <p>When I first started this I used just one radius for all animals
 but of course that was no good as the pug is much smaller than the horse.
 So I added the difference sizes but I wanted to be able to visualize
-things. To do that I made a <code class="notranslate" translate="no">StatusDisplayHelper</code> component.</p>
+things. To do that I made a <code class="notranslate" translate="no">StateDisplayHelper</code> component.</p>
 <p>I uses a <a href="/docs/#api/en/helpers/PolarGridHelper"><code class="notranslate" translate="no">PolarGridHelper</code></a> to draw a circle around each character
 and it uses html elements to let each character show some status using
 the techniques covered in <a href="align-html-elements-to-3d.html">the article on aligning html elements to 3D</a>.</p>
@@ -1673,7 +1673,7 @@ coroutines while other coroutines are running. It also handles nested coroutines
 <p>To make a coroutine you make a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">JavaScript generator function</a>.
 A generator function is preceded by the keyword <code class="notranslate" translate="no">function*</code> (the asterisk is important!)</p>
 <p>Generator functions can <code class="notranslate" translate="no">yield</code>. For example</p>
-<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* countOTo9() {
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* count0To9() {
   for (let i = 0; i &lt; 10; ++i) {
     console.log(i);
     yield;

--- a/manual/fr/game.html
+++ b/manual/fr/game.html
@@ -1196,7 +1196,7 @@ et modifierai cela plus tard.</p>
 <p>Lorsque j'ai commencé cela, j'ai utilisé un seul rayon pour tous les animaux,
 mais bien sûr, ce n'était pas bon, car le carlin est beaucoup plus petit que le cheval.
 J'ai donc ajouté les différentes tailles, mais je voulais pouvoir visualiser
-les choses. Pour ce faire, j'ai créé un composant <code class="notranslate" translate="no">StatusDisplayHelper</code>.</p>
+les choses. Pour ce faire, j'ai créé un composant <code class="notranslate" translate="no">StateDisplayHelper</code>.</p>
 <p>J'utilise un <a href="/docs/#api/en/helpers/PolarGridHelper"><code class="notranslate" translate="no">PolarGridHelper</code></a> pour dessiner un cercle autour de chaque personnage,
 et il utilise des éléments html pour permettre à chaque personnage d'afficher un certain statut en utilisant
 les techniques couvertes dans <a href="align-html-elements-to-3d.html">l'article sur l'alignement des éléments html en 3D</a>.</p>
@@ -1498,7 +1498,7 @@ des coroutines pendant que d'autres coroutines s'exécutent. Il gère également
 <p>Pour créer une coroutine, vous créez une <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">fonction génératrice JavaScript</a>.
 Une fonction génératrice est précédée du mot-clé <code class="notranslate" translate="no">function*</code> (l'astérisque est important !)</p>
 <p>Les fonctions génératrices peuvent <code class="notranslate" translate="no">yield</code> (céder). Par exemple</p>
-<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* countOTo9() {
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* count0To9() {
   for (let i = 0; i &lt; 10; ++i) {
     console.log(i);
     yield;

--- a/manual/ko/game.html
+++ b/manual/ko/game.html
@@ -1206,7 +1206,7 @@ class Animal extends Component {
 +    globals.playerRadius = model.size / 2;
 </pre>
 <p>이제 와 생각해보니 플레이어가 아니라 기차의 머리를 바라보게 하는 편이 더 나았겠네요. 이건 나중에 돌아와 고치도록 하겠습니다.</p>
-<p>예제를 처음 만들었을 때는 동물들이 모두 같은 크기의 경계 원(radius)을 썼지만, 이렇게 하고 보니 말과 퍼그(강아지)의 크기가 같은 게 말이 안 된다는 생각이 들었습니다. 그래서 각 모델의 크기에 따라 경계 원을 따로 지정했죠. 그리고 상태를 보여주면 좋겠다는 생각이 들어 상태를 보여 줄 <code class="notranslate" translate="no">StatusDisplayHelper</code> 컴포넌트를 추가했습니다.</p>
+<p>예제를 처음 만들었을 때는 동물들이 모두 같은 크기의 경계 원(radius)을 썼지만, 이렇게 하고 보니 말과 퍼그(강아지)의 크기가 같은 게 말이 안 된다는 생각이 들었습니다. 그래서 각 모델의 크기에 따라 경계 원을 따로 지정했죠. 그리고 상태를 보여주면 좋겠다는 생각이 들어 상태를 보여 줄 <code class="notranslate" translate="no">StateDisplayHelper</code> 컴포넌트를 추가했습니다.</p>
 <p>또한 <a href="/docs/#api/ko/helpers/PolarGridHelper"><code class="notranslate" translate="no">PolarGridHelper</code></a>를 써 각 캐릭터의 경계 원이 보이도록 했고, <a href="align-html-elements-to-3d.html">HTML 요소를 3D로 정렬하기</a>에서 썼던 방법으로 각 캐릭터의 상태를 HTML로 보여주도록 했습니다.</p>
 <p>먼저 각 요소를 담을 HTML을 추가합니다.</p>
 <pre class="prettyprint showlinemods notranslate lang-html" translate="no">&lt;body&gt;
@@ -1438,7 +1438,7 @@ class CoroutineRunner {
 <p>위 클래스는 다른 코루틴이 실행되는 동안 요소를 안전하게 제거/추가하도록 <code class="notranslate" translate="no">SafeArray</code>와 비슷한 구조로 만들었습니다. 또한 이 클래스는 중첩된 코루틴도 처리합니다.</p>
 <p>코루틴을 만들려면 자바스크립트의 <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Statements/function*">제너레이터 함수</a>를 만들어야 합니다. 제너레이터 함수는 <code class="notranslate" translate="no">function*</code>이라는 키워드로 생성하죠(별표를 붙여야 합니다!).</p>
 <p>제너레이터 함수는 <code class="notranslate" translate="no">yield</code> 키워드로 실행 순서를 <strong>양보(yield)</strong>할 수 있습니다.</p>
-<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* countOTo9() {
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* count0To9() {
   for (let i = 0; i &lt; 10; ++i) {
     console.log(i);
     yield;

--- a/manual/zh/game.html
+++ b/manual/zh/game.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="zh"><head>
+<!DOCTYPE html><html lang="en"><head>
     <meta charset="utf-8">
     <title>Making a Game</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -18,7 +18,6 @@
   }
 }
 </script>
-    <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>
     <div class="container">
@@ -27,9 +26,1899 @@
       </div>
       <div class="lesson">
         <div class="lesson-main">
-          <p>抱歉，还没有中文翻译哦。 <a href="https://github.com/mrdoob/three.js">欢迎加入翻译</a>! 😄</p>
-<p><a href="/manual/en/game.html">英文原文链接</a>.</p>
+          <p>Many people want to write games using three.js. This article
+will hopefully give you some ideas on how to start.</p>
+<p>At least at the time I'm writing this article it's probably going to be the
+longest article on this site. It's possible the code here is massively over
+engineered but as I wrote each new feature I'd run into a problem that needed a
+solution I'm used to from other games I've written. In other words each new
+solution seemed important so I'll try to show why. Of course the smaller your
+game the less you might need some of the solutions shown here but this is a
+pretty small game and yet with the complexities of 3D characters many things
+take more organization than they might with 2D characters.</p>
+<p>As an example if you're making PacMan in 2D, when PacMan turns a corner
+that happens instantly at 90 degrees. There is no in-between step. But
+in a 3D game often we need the character to rotate over several frames.
+That simple change can add a bunch of complexity and require different
+solutions.</p>
+<p>The majority of the code here will not really be three.js and
+that's important to note, <strong>three.js is not a game engine</strong>.
+Three.js is a 3D library. It provides a <a href="scenegraph.html">scene graph</a>
+and features for displaying 3D objects added to that scene graph
+but it does not provide all the other things needed to make a game.
+No collisions, no physics, no input systems, no path finding, etc, etc...
+So, we'll have to provide those things ourselves.</p>
+<p>I ended up writing quite a bit of code to make this simple <em>unfinished</em>
+game like thing and again, it's certainly possible I over engineered and there
+are simpler solutions but I feel like I actually didn't write
+enough code and hopefully I can explain what I think is missing.</p>
+<p>Many of the ideas here are heavily influenced by <a href="https://unity.com">Unity</a>.
+If you're not familiar with Unity that probably does not matter.
+I only bring it up as 10s of 1000s of games have shipped using
+these ideas.</p>
+<p>Let's start with the three.js parts. We need to load models for our game.</p>
+<p>At <a href="https://opengameart.org">opengameart.org</a> I found this <a href="https://opengameart.org/content/lowpoly-animated-knight">animated knight
+model</a> by <a href="https://opengameart.org/users/quaternius">quaternius</a></p>
+<div class="threejs_center"><img src="../resources/images/knight.jpg" style="width: 375px;"></div>
 
+<p><a href="https://opengameart.org/users/quaternius">quaternius</a> also made <a href="https://opengameart.org/content/lowpoly-animated-farm-animal-pack">these animated animals</a>.</p>
+<div class="threejs_center"><img src="../resources/images/animals.jpg" style="width: 606px;"></div>
+
+<p>These seem like good models to start with so the first thing we need to
+do is load them.</p>
+<p>We covered <a href="load-gltf.html">loading glTF files before</a>.
+The difference this time is we need to load multiple models and
+we can't start the game until all the models are loaded.</p>
+<p>Fortunately three.js provides the <a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> just for this purpose.
+We create a <a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> and pass it to the other loaders. The
+<a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> provides both <a href="/docs/#api/en/loaders/managers/LoadingManager#onProgress"><code class="notranslate" translate="no">onProgress</code></a> and
+<a href="/docs/#api/en/loaders/managers/LoadingManager#onLoad"><code class="notranslate" translate="no">onLoad</code></a> properties we can attach callbacks to.
+The <a href="/docs/#api/en/loaders/managers/LoadingManager#onLoad"><code class="notranslate" translate="no">onLoad</code></a> callback will be called when
+all files have been loaded. The <a href="/docs/#api/en/loaders/managers/LoadingManager#onProgress"><code class="notranslate" translate="no">onProgress</code></a> callback
+as called after each individual file arrives to give as a chance to show
+loading progress.</p>
+<p>Starting with the code from <a href="load-gltf.html">loading a glTF file</a> I removed all
+the code related to framing the scene and added this code to load all models.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">const manager = new THREE.LoadingManager();
+manager.onLoad = init;
+const models = {
+  pig:    { url: 'resources/models/animals/Pig.gltf' },
+  cow:    { url: 'resources/models/animals/Cow.gltf' },
+  llama:  { url: 'resources/models/animals/Llama.gltf' },
+  pug:    { url: 'resources/models/animals/Pug.gltf' },
+  sheep:  { url: 'resources/models/animals/Sheep.gltf' },
+  zebra:  { url: 'resources/models/animals/Zebra.gltf' },
+  horse:  { url: 'resources/models/animals/Horse.gltf' },
+  knight: { url: 'resources/models/knight/KnightCharacter.gltf' },
+};
+{
+  const gltfLoader = new GLTFLoader(manager);
+  for (const model of Object.values(models)) {
+    gltfLoader.load(model.url, (gltf) =&gt; {
+      model.gltf = gltf;
+    });
+  }
+}
+
+function init() {
+  // TBD
+}
+</pre>
+<p>This code will load all the models above and the <a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> will call
+<code class="notranslate" translate="no">init</code> when done. We'll use the <code class="notranslate" translate="no">models</code> object later to let us access the
+loaded models so the <a href="/docs/#examples/loaders/GLTFLoader"><code class="notranslate" translate="no">GLTFLoader</code></a> callback for each individual model attaches
+the loaded data to that model's info.</p>
+<p>All the models with all their animation are currently about 6.6meg. That's a
+pretty big download. Assuming your server supports compression (the server this
+site runs on does) it's able to compress them to around 1.4meg. That's
+definitely better than 6.6meg bit it's still not a tiny amount of data. It would
+probably be good if we added a progress bar so the user has some idea how much
+longer they have to wait.</p>
+<p>So, let's add an <a href="/docs/#api/en/loaders/managers/LoadingManager#onProgress"><code class="notranslate" translate="no">onProgress</code></a> callback. It will be
+called with 3 arguments, the <code class="notranslate" translate="no">url</code> of the last loaded object and then the number
+of items loaded so far as well as the total number of items.</p>
+<p>Let's setup some HTML for a loading bar</p>
+<pre class="prettyprint showlinemods notranslate lang-html" translate="no">&lt;body&gt;
+  &lt;canvas id="c"&gt;&lt;/canvas&gt;
++  &lt;div id="loading"&gt;
++    &lt;div&gt;
++      &lt;div&gt;...loading...&lt;/div&gt;
++      &lt;div class="progress"&gt;&lt;div id="progressbar"&gt;&lt;/div&gt;&lt;/div&gt;
++    &lt;/div&gt;
++  &lt;/div&gt;
+&lt;/body&gt;
+</pre>
+<p>We'll look up the <code class="notranslate" translate="no">#progressbar</code> div and we can set the width from 0% to 100%
+to show our progress. All we need to do is set that in our callback.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">const manager = new THREE.LoadingManager();
+manager.onLoad = init;
+
++const progressbarElem = document.querySelector('#progressbar');
++manager.onProgress = (url, itemsLoaded, itemsTotal) =&gt; {
++  progressbarElem.style.width = `${itemsLoaded / itemsTotal * 100 | 0}%`;
++};
+</pre>
+<p>We already setup <code class="notranslate" translate="no">init</code> to be called when all the models are loaded so
+we can turn off the progress bar by hiding the <code class="notranslate" translate="no">#loading</code> element.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
++  // hide the loading bar
++  const loadingElem = document.querySelector('#loading');
++  loadingElem.style.display = 'none';
+}
+</pre>
+<p>Here's a bunch of CSS for styling the bar. The CSS makes the <code class="notranslate" translate="no">#loading</code> <code class="notranslate" translate="no">&lt;div&gt;</code>
+the full size of the page and centers its children. The CSS makes a <code class="notranslate" translate="no">.progress</code>
+area to contain the progress bar. The CSS also gives the progress bar
+a CSS animation of diagonal stripes.</p>
+<pre class="prettyprint showlinemods notranslate lang-css" translate="no">#loading {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: xx-large;
+  font-family: sans-serif;
+}
+#loading&gt;div&gt;div {
+  padding: 2px;
+}
+.progress {
+  width: 50vw;
+  border: 1px solid black;
+}
+#progressbar {
+  width: 0;
+  transition: width ease-out .5s;
+  height: 1em;
+  background-color: #888;
+  background-image: linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, .5) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, .5) 50%,
+    rgba(255, 255, 255, .5) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 50px 50px;
+  animation: progressanim 2s linear infinite;
+}
+
+@keyframes progressanim {
+  0% {
+    background-position: 50px 50px;
+  }
+  100% {
+    background-position: 0 0;
+  }
+}
+</pre>
+<p>Now that we have a progress bar let's deal with the models. These models
+have animations and we want to be able to access those animations.
+Animations are stored in an array by default be we'd like to be able to
+easily access them by name so let's setup an <code class="notranslate" translate="no">animations</code> property for
+each model to do that. Note of course this means animations must have unique names.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">+function prepModelsAndAnimations() {
++  Object.values(models).forEach(model =&gt; {
++    const animsByName = {};
++    model.gltf.animations.forEach((clip) =&gt; {
++      animsByName[clip.name] = clip;
++    });
++    model.animations = animsByName;
++  });
++}
+
+function init() {
+  // hide the loading bar
+  const loadingElem = document.querySelector('#loading');
+  loadingElem.style.display = 'none';
+
++  prepModelsAndAnimations();
+}
+</pre>
+<p>Let's display the animated models.</p>
+<p>Unlike the <a href="load-gltf.html">previous example of loading a glTF file</a>
+This time we probably want to be able to display more than one instance
+of each model. To do this, instead of adding
+the loaded gltf scene directly like we did in <a href="load-gltf.html">the article on loading a glTF</a>,
+we instead want to clone the scene and in particular we want to clone
+it for skinned animated characters. Fortunately there's a utility function,
+<code class="notranslate" translate="no">SkeletonUtils.clone</code> we can use to do this. So, first we need to include
+the utils.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
+import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
+import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
++import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
+</pre>
+<p>Then we can clone the models we just loaded</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
+  // hide the loading bar
+  const loadingElem = document.querySelector('#loading');
+  loadingElem.style.display = 'none';
+
+  prepModelsAndAnimations();
+
++  Object.values(models).forEach((model, ndx) =&gt; {
++    const clonedScene = SkeletonUtils.clone(model.gltf.scene);
++    const root = new THREE.Object3D();
++    root.add(clonedScene);
++    scene.add(root);
++    root.position.x = (ndx - 3) * 3;
++  });
+}
+</pre>
+<p>Above, for each model, we clone the <code class="notranslate" translate="no">gltf.scene</code> we loaded and we parent that
+to a new <a href="/docs/#api/en/core/Object3D"><code class="notranslate" translate="no">Object3D</code></a>. We need to parent it to another object because when
+we play animations the animation will apply animated positions to the nodes
+in the loaded scene which means we won't have control over those positions.</p>
+<p>To play the animations each model we clone needs an <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a>.
+An <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a> contains 1 or more <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a>s. An
+<a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> references an <a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a>. <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a>s
+have all kinds of settings for playing then chaining to another
+action or cross fading between actions. Let's just get the first
+<a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a> and create an action for it. The default is for
+an action to play its clip in a loop forever.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">+const mixers = [];
+
+function init() {
+  // hide the loading bar
+  const loadingElem = document.querySelector('#loading');
+  loadingElem.style.display = 'none';
+
+  prepModelsAndAnimations();
+
+  Object.values(models).forEach((model, ndx) =&gt; {
+    const clonedScene = SkeletonUtils.clone(model.gltf.scene);
+    const root = new THREE.Object3D();
+    root.add(clonedScene);
+    scene.add(root);
+    root.position.x = (ndx - 3) * 3;
+
++    const mixer = new THREE.AnimationMixer(clonedScene);
++    const firstClip = Object.values(model.animations)[0];
++    const action = mixer.clipAction(firstClip);
++    action.play();
++    mixers.push(mixer);
+  });
+}
+</pre>
+<p>We called <a href="/docs/#api/en/animation/AnimationAction#play"><code class="notranslate" translate="no">play</code></a> to start the action and stored
+off all the <code class="notranslate" translate="no">AnimationMixers</code> in an array called <code class="notranslate" translate="no">mixers</code>. Finally
+we need to update each <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a> in our render loop by computing
+the time since the last frame and passing that to <a href="/docs/#api/en/animation/AnimationMixer.update"><code class="notranslate" translate="no">AnimationMixer.update</code></a>.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">+let then = 0;
+function render(now) {
++  now *= 0.001;  // convert to seconds
++  const deltaTime = now - then;
++  then = now;
+
+  if (resizeRendererToDisplaySize(renderer)) {
+    const canvas = renderer.domElement;
+    camera.aspect = canvas.clientWidth / canvas.clientHeight;
+    camera.updateProjectionMatrix();
+  }
+
++  for (const mixer of mixers) {
++    mixer.update(deltaTime);
++  }
+
+  renderer.render(scene, camera);
+
+  requestAnimationFrame(render);
+}
+</pre>
+<p>And with that we should get each model loaded and playing its first animation.</p>
+<p></p><div translate="no" class="threejs_example_container notranslate">
+  <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-load-models.html"></iframe></div>
+  <a class="threejs_center" href="/manual/examples/game-load-models.html" target="_blank">click here to open in a separate window</a>
+</div>
+
+<p></p>
+<p>Let's make it so we can check all of the animations.
+We'll add all of the clips as actions and then enable just one at
+a time.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">-const mixers = [];
++const mixerInfos = [];
+
+function init() {
+  // hide the loading bar
+  const loadingElem = document.querySelector('#loading');
+  loadingElem.style.display = 'none';
+
+  prepModelsAndAnimations();
+
+  Object.values(models).forEach((model, ndx) =&gt; {
+    const clonedScene = SkeletonUtils.clone(model.gltf.scene);
+    const root = new THREE.Object3D();
+    root.add(clonedScene);
+    scene.add(root);
+    root.position.x = (ndx - 3) * 3;
+
+    const mixer = new THREE.AnimationMixer(clonedScene);
+-    const firstClip = Object.values(model.animations)[0];
+-    const action = mixer.clipAction(firstClip);
+-    action.play();
+-    mixers.push(mixer);
++    const actions = Object.values(model.animations).map((clip) =&gt; {
++      return mixer.clipAction(clip);
++    });
++    const mixerInfo = {
++      mixer,
++      actions,
++      actionNdx: -1,
++    };
++    mixerInfos.push(mixerInfo);
++    playNextAction(mixerInfo);
+  });
+}
+
++function playNextAction(mixerInfo) {
++  const {actions, actionNdx} = mixerInfo;
++  const nextActionNdx = (actionNdx + 1) % actions.length;
++  mixerInfo.actionNdx = nextActionNdx;
++  actions.forEach((action, ndx) =&gt; {
++    const enabled = ndx === nextActionNdx;
++    action.enabled = enabled;
++    if (enabled) {
++      action.play();
++    }
++  });
++}
+</pre>
+<p>The code above makes an array of <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a>s,
+one for each <a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a>. It makes an array of objects, <code class="notranslate" translate="no">mixerInfos</code>,
+with references to the <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a> and all the <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a>s
+for each model. It then calls <code class="notranslate" translate="no">playNextAction</code> which sets <code class="notranslate" translate="no">enabled</code> on
+all but one action for that mixer.</p>
+<p>We need to update the render loop for the new array</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">-for (const mixer of mixers) {
++for (const {mixer} of mixerInfos) {
+  mixer.update(deltaTime);
+}
+</pre>
+<p>Let's make it so pressing a key 1 to 8 will play the next animation
+for each model</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">window.addEventListener('keydown', (e) =&gt; {
+  const mixerInfo = mixerInfos[e.keyCode - 49];
+  if (!mixerInfo) {
+    return;
+  }
+  playNextAction(mixerInfo);
+});
+</pre>
+<p>Now you should be able to click on the example and then press keys 1 through 8
+to cycle each of the models through their available animations.</p>
+<p></p><div translate="no" class="threejs_example_container notranslate">
+  <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-check-animations.html"></iframe></div>
+  <a class="threejs_center" href="/manual/examples/game-check-animations.html" target="_blank">click here to open in a separate window</a>
+</div>
+
+<p></p>
+<p>So that is arguably the sum-total of the three.js portion of this
+article. We covered loading multiple files, cloning skinned models,
+and playing animations on them. In a real game you'd have to do a
+ton more manipulation of <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> objects.</p>
+<p>Let's start making a game infrastructure</p>
+<p>A common pattern for making a modern game is to use an
+<a href="https://www.google.com/search?q=entity+component+system">Entity Component System</a>.
+In an Entity Component System an object in a game is called an <em>entity</em> that consists
+of a bunch of <em>components</em>. You build up entities by deciding which components to
+attach to them. So, let's make an Entity Component System.</p>
+<p>We'll call our entities <code class="notranslate" translate="no">GameObject</code>. It's effectively just a collection
+of components and a three.js <a href="/docs/#api/en/core/Object3D"><code class="notranslate" translate="no">Object3D</code></a>.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function removeArrayElement(array, element) {
+  const ndx = array.indexOf(element);
+  if (ndx &gt;= 0) {
+    array.splice(ndx, 1);
+  }
+}
+
+class GameObject {
+  constructor(parent, name) {
+    this.name = name;
+    this.components = [];
+    this.transform = new THREE.Object3D();
+    parent.add(this.transform);
+  }
+  addComponent(ComponentType, ...args) {
+    const component = new ComponentType(this, ...args);
+    this.components.push(component);
+    return component;
+  }
+  removeComponent(component) {
+    removeArrayElement(this.components, component);
+  }
+  getComponent(ComponentType) {
+    return this.components.find(c =&gt; c instanceof ComponentType);
+  }
+  update() {
+    for (const component of this.components) {
+      component.update();
+    }
+  }
+}
+</pre>
+<p>Calling <code class="notranslate" translate="no">GameObject.update</code> calls <code class="notranslate" translate="no">update</code> on all the components.</p>
+<p>I included a name only to help in debugging so if I look at a <code class="notranslate" translate="no">GameObject</code>
+in the debugger I can see a name to help identify it.</p>
+<p>Some things that might seem a little strange:</p>
+<p><code class="notranslate" translate="no">GameObject.addComponent</code> is used to create components. Whether or not
+this a good idea or a bad idea I'm not sure. My thinking was it makes
+no sense for a component to exist outside of a gameobject so I thought
+it might be good if creating a component automatically added that component
+to the gameobject and passed the gameobject to the component's constructor.
+In other words to add a component you do this</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">const gameObject = new GameObject(scene, 'foo');
+gameObject.addComponent(TypeOfComponent);
+</pre>
+<p>If I didn't do it this way you'd instead do something like this</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">const gameObject = new GameObject(scene, 'foo');
+const component = new TypeOfComponent(gameObject);
+gameObject.addComponent(component);
+</pre>
+<p>Is it better that the first way is shorter and more automated or is it worse
+because it looks out of the ordinary? I don't know.</p>
+<p><code class="notranslate" translate="no">GameObject.getComponent</code> looks up components by type. That has
+the implication that you can not have 2 components of the same
+type on a single game object or at least if you do you can only
+look up the first one without adding some other API.</p>
+<p>It's common for one component to look up another and when looking them up they
+have to match by type otherwise you might get the wrong one. We could instead
+give each component a name and you could look them up by name. That would be
+more flexible in that you could have more than one component of the same type but it
+would also be more tedious. Again, I'm not sure which is better.</p>
+<p>On to the components themselves. Here is their base class.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// Base for all components
+class Component {
+  constructor(gameObject) {
+    this.gameObject = gameObject;
+  }
+  update() {
+  }
+}
+</pre>
+<p>Do components need a base class? JavaScript is not like most strictly
+typed languages so effectively we could have no base class and just
+leave it up to each component to do whatever it wants in its constructor
+knowing that the first argument is always the component's gameobject.
+If it doesn't care about gameobject it wouldn't store it. I kind of feel like this
+common base is good though. It means if you have a reference to a
+component you know you can find its parent gameobject always and from its
+parent you can easily look up other components as well as look at its
+transform.</p>
+<p>To manage the gameobjects we probably need some kind of gameobject manager. You
+might think we could just keep an array of gameobjects but in a real game the
+components of a gameobject might add and remove other gameobjects at runtime.
+For example a gun gameobject might add a bullet gameobject every time the gun
+fires. A monster gameobject might remove itself if it has been killed. We then
+would have an issue that we might have code like this</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">for (const gameObject of globalArrayOfGameObjects) {
+  gameObject.update();
+}
+</pre>
+<p>The loop above would fail or do un-expected things if
+gameobjects are added or removed from <code class="notranslate" translate="no">globalArrayOfGameObjects</code>
+in the middle of the loop in some component's <code class="notranslate" translate="no">update</code> function.</p>
+<p>To try to prevent that problem we need something a little safer.
+Here's one attempt.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class SafeArray {
+  constructor() {
+    this.array = [];
+    this.addQueue = [];
+    this.removeQueue = new Set();
+  }
+  get isEmpty() {
+    return this.addQueue.length + this.array.length &gt; 0;
+  }
+  add(element) {
+    this.addQueue.push(element);
+  }
+  remove(element) {
+    this.removeQueue.add(element);
+  }
+  forEach(fn) {
+    this._addQueued();
+    this._removeQueued();
+    for (const element of this.array) {
+      if (this.removeQueue.has(element)) {
+        continue;
+      }
+      fn(element);
+    }
+    this._removeQueued();
+  }
+  _addQueued() {
+    if (this.addQueue.length) {
+      this.array.splice(this.array.length, 0, ...this.addQueue);
+      this.addQueue = [];
+    }
+  }
+  _removeQueued() {
+    if (this.removeQueue.size) {
+      this.array = this.array.filter(element =&gt; !this.removeQueue.has(element));
+      this.removeQueue.clear();
+    }
+  }
+}
+</pre>
+<p>The class above lets you add or remove elements from the <code class="notranslate" translate="no">SafeArray</code>
+but won't mess with the array itself while it's being iterated over. Instead
+new elements get added to <code class="notranslate" translate="no">addQueue</code> and removed elements to the <code class="notranslate" translate="no">removeQueue</code>
+and then added or removed outside of the loop.</p>
+<p>Using that here is our class to manage gameobjects.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class GameObjectManager {
+  constructor() {
+    this.gameObjects = new SafeArray();
+  }
+  createGameObject(parent, name) {
+    const gameObject = new GameObject(parent, name);
+    this.gameObjects.add(gameObject);
+    return gameObject;
+  }
+  removeGameObject(gameObject) {
+    this.gameObjects.remove(gameObject);
+  }
+  update() {
+    this.gameObjects.forEach(gameObject =&gt; gameObject.update());
+  }
+}
+</pre>
+<p>With all that now let's make our first component. This component
+will just manage a skinned three.js object like the ones we just created.
+To keep it simple it will just have one method, <code class="notranslate" translate="no">setAnimation</code> that
+takes the name of the animation to play and plays it.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class SkinInstance extends Component {
+  constructor(gameObject, model) {
+    super(gameObject);
+    this.model = model;
+    this.animRoot = SkeletonUtils.clone(this.model.gltf.scene);
+    this.mixer = new THREE.AnimationMixer(this.animRoot);
+    gameObject.transform.add(this.animRoot);
+    this.actions = {};
+  }
+  setAnimation(animName) {
+    const clip = this.model.animations[animName];
+    // turn off all current actions
+    for (const action of Object.values(this.actions)) {
+      action.enabled = false;
+    }
+    // get or create existing action for clip
+    const action = this.mixer.clipAction(clip);
+    action.enabled = true;
+    action.reset();
+    action.play();
+    this.actions[animName] = action;
+  }
+  update() {
+    this.mixer.update(globals.deltaTime);
+  }
+}
+</pre>
+<p>You can see it's basically the code we had before that clones the scene we loaded,
+then sets up an <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a>. <code class="notranslate" translate="no">setAnimation</code> adds a <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> for a
+particular <a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a> if one does not already exist and disables all
+existing actions.</p>
+<p>The code references <code class="notranslate" translate="no">globals.deltaTime</code>. Let's make a globals object</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">const globals = {
+  time: 0,
+  deltaTime: 0,
+};
+</pre>
+<p>And update it in the render loop</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">let then = 0;
+function render(now) {
+  // convert to seconds
+  globals.time = now * 0.001;
+  // make sure delta time isn't too big.
+  globals.deltaTime = Math.min(globals.time - then, 1 / 20);
+  then = globals.time;
+</pre>
+<p>The check above for making sure <code class="notranslate" translate="no">deltaTime</code> is not more than 1/20th
+of a second is because otherwise we'd get a huge value for <code class="notranslate" translate="no">deltaTime</code>
+if we hide the tab. We might hide it for seconds or minutes and then
+when our tab was brought to the front <code class="notranslate" translate="no">deltaTime</code> would be huge
+and might teleport characters across our game world if we had code like</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">position += velocity * deltaTime;
+</pre>
+<p>By limiting the maximum <code class="notranslate" translate="no">deltaTime</code> that issue is prevented.</p>
+<p>Now let's make a component for the player.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Player extends Component {
+  constructor(gameObject) {
+    super(gameObject);
+    const model = models.knight;
+    this.skinInstance = gameObject.addComponent(SkinInstance, model);
+    this.skinInstance.setAnimation('Run');
+  }
+}
+</pre>
+<p>The player calls <code class="notranslate" translate="no">setAnimation</code> with <code class="notranslate" translate="no">'Run'</code>. To know which animations
+are available I modified our previous example to print out the names of
+the animations</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function prepModelsAndAnimations() {
+  Object.values(models).forEach(model =&gt; {
++    console.log('-------&gt;:', model.url);
+    const animsByName = {};
+    model.gltf.animations.forEach((clip) =&gt; {
+      animsByName[clip.name] = clip;
++      console.log('  ', clip.name);
+    });
+    model.animations = animsByName;
+  });
+}
+</pre>
+<p>And running it got this list in <a href="https://developers.google.com/web/tools/chrome-devtools/console/javascript">the JavaScript console</a>.</p>
+<pre class="prettyprint showlinemods notranslate notranslate" translate="no"> -------&gt;:  resources/models/animals/Pig.gltf
+    Idle
+    Death
+    WalkSlow
+    Jump
+    Walk
+ -------&gt;:  resources/models/animals/Cow.gltf
+    Walk
+    Jump
+    WalkSlow
+    Death
+    Idle
+ -------&gt;:  resources/models/animals/Llama.gltf
+    Jump
+    Idle
+    Walk
+    Death
+    WalkSlow
+ -------&gt;:  resources/models/animals/Pug.gltf
+    Jump
+    Walk
+    Idle
+    WalkSlow
+    Death
+ -------&gt;:  resources/models/animals/Sheep.gltf
+    WalkSlow
+    Death
+    Jump
+    Walk
+    Idle
+ -------&gt;:  resources/models/animals/Zebra.gltf
+    Jump
+    Walk
+    Death
+    WalkSlow
+    Idle
+ -------&gt;:  resources/models/animals/Horse.gltf
+    Jump
+    WalkSlow
+    Death
+    Walk
+    Idle
+ -------&gt;:  resources/models/knight/KnightCharacter.gltf
+    Run_swordRight
+    Run
+    Idle_swordLeft
+    Roll_sword
+    Idle
+    Run_swordAttack
+</pre><p>Fortunately the names of the animations for all the animals match
+which will come in handy later. For now we only care the that the
+player has an animation called <code class="notranslate" translate="no">Run</code>.</p>
+<p>Let's use these components. Here's the updated init function.
+All it does is create a <code class="notranslate" translate="no">GameObject</code> and add a <code class="notranslate" translate="no">Player</code> component to it.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">const globals = {
+  time: 0,
+  deltaTime: 0,
+};
++const gameObjectManager = new GameObjectManager();
+
+function init() {
+  // hide the loading bar
+  const loadingElem = document.querySelector('#loading');
+  loadingElem.style.display = 'none';
+
+  prepModelsAndAnimations();
+
++  {
++    const gameObject = gameObjectManager.createGameObject(scene, 'player');
++    gameObject.addComponent(Player);
++  }
+}
+</pre>
+<p>And we need to call <code class="notranslate" translate="no">gameObjectManager.update</code> in our render loop</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">let then = 0;
+function render(now) {
+  // convert to seconds
+  globals.time = now * 0.001;
+  // make sure delta time isn't too big.
+  globals.deltaTime = Math.min(globals.time - then, 1 / 20);
+  then = globals.time;
+
+  if (resizeRendererToDisplaySize(renderer)) {
+    const canvas = renderer.domElement;
+    camera.aspect = canvas.clientWidth / canvas.clientHeight;
+    camera.updateProjectionMatrix();
+  }
+
+-  for (const {mixer} of mixerInfos) {
+-    mixer.update(deltaTime);
+-  }
++  gameObjectManager.update();
+
+  renderer.render(scene, camera);
+
+  requestAnimationFrame(render);
+}
+</pre>
+<p>and if we run that we get a single player.</p>
+<p></p><div translate="no" class="threejs_example_container notranslate">
+  <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-just-player.html"></iframe></div>
+  <a class="threejs_center" href="/manual/examples/game-just-player.html" target="_blank">click here to open in a separate window</a>
+</div>
+
+<p></p>
+<p>That was a lot of code just for an entity component system but
+it's infrastructure that most games need.</p>
+<p>Let's add an input system. Rather than read keys directly we'll
+make a class that other parts of the code can check <code class="notranslate" translate="no">left</code> or <code class="notranslate" translate="no">right</code>.
+That way we can assign multiple ways to input <code class="notranslate" translate="no">left</code> or <code class="notranslate" translate="no">right</code> etc..
+We'll start with just keys</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// Keeps the state of keys/buttons
+//
+// You can check
+//
+//   inputManager.keys.left.down
+//
+// to see if the left key is currently held down
+// and you can check
+//
+//   inputManager.keys.left.justPressed
+//
+// To see if the left key was pressed this frame
+//
+// Keys are 'left', 'right', 'a', 'b', 'up', 'down'
+class InputManager {
+  constructor() {
+    this.keys = {};
+    const keyMap = new Map();
+
+    const setKey = (keyName, pressed) =&gt; {
+      const keyState = this.keys[keyName];
+      keyState.justPressed = pressed &amp;&amp; !keyState.down;
+      keyState.down = pressed;
+    };
+
+    const addKey = (keyCode, name) =&gt; {
+      this.keys[name] = { down: false, justPressed: false };
+      keyMap.set(keyCode, name);
+    };
+
+    const setKeyFromKeyCode = (keyCode, pressed) =&gt; {
+      const keyName = keyMap.get(keyCode);
+      if (!keyName) {
+        return;
+      }
+      setKey(keyName, pressed);
+    };
+
+    addKey(37, 'left');
+    addKey(39, 'right');
+    addKey(38, 'up');
+    addKey(40, 'down');
+    addKey(90, 'a');
+    addKey(88, 'b');
+
+    window.addEventListener('keydown', (e) =&gt; {
+      setKeyFromKeyCode(e.keyCode, true);
+    });
+    window.addEventListener('keyup', (e) =&gt; {
+      setKeyFromKeyCode(e.keyCode, false);
+    });
+  }
+  update() {
+    for (const keyState of Object.values(this.keys)) {
+      if (keyState.justPressed) {
+        keyState.justPressed = false;
+      }
+    }
+  }
+}
+</pre>
+<p>The code above tracks whether keys are up or down and you can check
+if a key is currently pressed by checking for example
+<code class="notranslate" translate="no">inputManager.keys.left.down</code>. It also has a <code class="notranslate" translate="no">justPressed</code> property
+for each key so that you can check the user just pressed the key.
+For example a jump key you don't want to know if the button is being
+held down, you want to know did the user press it now.</p>
+<p>Let's create an instance of <code class="notranslate" translate="no">InputManager</code></p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">const globals = {
+  time: 0,
+  deltaTime: 0,
+};
+const gameObjectManager = new GameObjectManager();
++const inputManager = new InputManager();
+</pre>
+<p>and update it in our render loop</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function render(now) {
+
+  ...
+
+  gameObjectManager.update();
++  inputManager.update();
+
+  ...
+}
+</pre>
+<p>It needs to be called after <code class="notranslate" translate="no">gameObjectManager.update</code> otherwise
+<code class="notranslate" translate="no">justPressed</code> would never be true inside a component's <code class="notranslate" translate="no">update</code> function.</p>
+<p>Let's use it in the <code class="notranslate" translate="no">Player</code> component</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">+const kForward = new THREE.Vector3(0, 0, 1);
+const globals = {
+  time: 0,
+  deltaTime: 0,
++  moveSpeed: 16,
+};
+
+class Player extends Component {
+  constructor(gameObject) {
+    super(gameObject);
+    const model = models.knight;
+    this.skinInstance = gameObject.addComponent(SkinInstance, model);
+    this.skinInstance.setAnimation('Run');
++    this.turnSpeed = globals.moveSpeed / 4;
+  }
++  update() {
++    const {deltaTime, moveSpeed} = globals;
++    const {transform} = this.gameObject;
++    const delta = (inputManager.keys.left.down  ?  1 : 0) +
++                  (inputManager.keys.right.down ? -1 : 0);
++    transform.rotation.y += this.turnSpeed * delta * deltaTime;
++    transform.translateOnAxis(kForward, moveSpeed * deltaTime);
++  }
+}
+</pre>
+<p>The code above uses <a href="/docs/#api/en/core/Object3D.transformOnAxis"><code class="notranslate" translate="no">Object3D.transformOnAxis</code></a> to move the player
+forward. <a href="/docs/#api/en/core/Object3D.transformOnAxis"><code class="notranslate" translate="no">Object3D.transformOnAxis</code></a> works in local space so it only
+works if the object in question is at the root of the scene, not if it's
+parented to something else <a class="footnote" href="#parented" id="parented-backref">1</a></p>
+<p>We also added a global <code class="notranslate" translate="no">moveSpeed</code> and based a <code class="notranslate" translate="no">turnSpeed</code> on the move speed.
+The turn speed is based on the move speed to try to make sure a character
+can turn sharply enough to meet its target. If <code class="notranslate" translate="no">turnSpeed</code> so too small
+a character will turn around and around circling its target but never
+hitting it. I didn't bother to do the math to calculate the required
+turn speed for a given move speed. I just guessed.</p>
+<p>The code so far would work but if the player runs off the screen there's no
+way to find out where they are. Let's make it so if they are offscreen
+for more than a certain time they get teleported back to the origin.
+We can do that by using the three.js <a href="/docs/#api/en/math/Frustum"><code class="notranslate" translate="no">Frustum</code></a> class to check if a point
+is inside the camera's view frustum.</p>
+<p>We need to build a frustum from the camera. We could do this in the Player
+component but other objects might want to use this too so let's add another
+gameobject with a component to manage a frustum.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class CameraInfo extends Component {
+  constructor(gameObject) {
+    super(gameObject);
+    this.projScreenMatrix = new THREE.Matrix4();
+    this.frustum = new THREE.Frustum();
+  }
+  update() {
+    const {camera} = globals;
+    this.projScreenMatrix.multiplyMatrices(
+        camera.projectionMatrix,
+        camera.matrixWorldInverse);
+    this.frustum.setFromProjectionMatrix(this.projScreenMatrix);
+  }
+}
+</pre>
+<p>Then let's setup another gameobject at init time.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
+  // hide the loading bar
+  const loadingElem = document.querySelector('#loading');
+  loadingElem.style.display = 'none';
+
+  prepModelsAndAnimations();
+
++  {
++    const gameObject = gameObjectManager.createGameObject(camera, 'camera');
++    globals.cameraInfo = gameObject.addComponent(CameraInfo);
++  }
+
+  {
+    const gameObject = gameObjectManager.createGameObject(scene, 'player');
+    gameObject.addComponent(Player);
+  }
+}
+</pre>
+<p>and now we can use it in the <code class="notranslate" translate="no">Player</code> component.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Player extends Component {
+  constructor(gameObject) {
+    super(gameObject);
+    const model = models.knight;
+    this.skinInstance = gameObject.addComponent(SkinInstance, model);
+    this.skinInstance.setAnimation('Run');
+    this.turnSpeed = globals.moveSpeed / 4;
++    this.offscreenTimer = 0;
++    this.maxTimeOffScreen = 3;
+  }
+  update() {
+-    const {deltaTime, moveSpeed} = globals;
++    const {deltaTime, moveSpeed, cameraInfo} = globals;
+    const {transform} = this.gameObject;
+    const delta = (inputManager.keys.left.down  ?  1 : 0) +
+                  (inputManager.keys.right.down ? -1 : 0);
+    transform.rotation.y += this.turnSpeed * delta * deltaTime;
+    transform.translateOnAxis(kForward, moveSpeed * deltaTime);
+
++    const {frustum} = cameraInfo;
++    if (frustum.containsPoint(transform.position)) {
++      this.offscreenTimer = 0;
++    } else {
++      this.offscreenTimer += deltaTime;
++      if (this.offscreenTimer &gt;= this.maxTimeOffScreen) {
++        transform.position.set(0, 0, 0);
++      }
++    }
+  }
+}
+</pre>
+<p>One more thing before we try it out, let's add touchscreen support
+for mobile. First let's add some HTML to touch</p>
+<pre class="prettyprint showlinemods notranslate lang-html" translate="no">&lt;body&gt;
+  &lt;canvas id="c"&gt;&lt;/canvas&gt;
++  &lt;div id="ui"&gt;
++    &lt;div id="left"&gt;&lt;img src="../resources/images/left.svg"&gt;&lt;/div&gt;
++    &lt;div style="flex: 0 0 40px;"&gt;&lt;/div&gt;
++    &lt;div id="right"&gt;&lt;img src="../resources/images/right.svg"&gt;&lt;/div&gt;
++  &lt;/div&gt;
+  &lt;div id="loading"&gt;
+    &lt;div&gt;
+      &lt;div&gt;...loading...&lt;/div&gt;
+      &lt;div class="progress"&gt;&lt;div id="progressbar"&gt;&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/body&gt;
+</pre>
+<p>and some CSS to style it</p>
+<pre class="prettyprint showlinemods notranslate lang-css" translate="no">#ui {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-items: center;
+  align-content: stretch;
+}
+#ui&gt;div {
+  display: flex;
+  align-items: flex-end;
+  flex: 1 1 auto;
+}
+.bright {
+  filter: brightness(2);
+}
+#left {
+  justify-content: flex-end;
+}
+#right {
+  justify-content: flex-start;
+}
+#ui img {
+  padding: 10px;
+  width: 80px;
+  height: 80px;
+  display: block;
+}
+</pre>
+<p>The idea here is there is one div, <code class="notranslate" translate="no">#ui</code>, that
+covers the entire page. Inside will be 2 divs, <code class="notranslate" translate="no">#left</code> and <code class="notranslate" translate="no">#right</code>
+both of which are almost half the page wide and the entire screen tall.
+In between there is a 40px separator. If the user slides their finger
+over the left or right side then we need up update <code class="notranslate" translate="no">keys.left</code> and <code class="notranslate" translate="no">keys.right</code>
+in the <code class="notranslate" translate="no">InputManager</code>. This makes the entire screen sensitive to being touched
+which seemed better than just small arrows.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class InputManager {
+  constructor() {
+    this.keys = {};
+    const keyMap = new Map();
+
+    const setKey = (keyName, pressed) =&gt; {
+      const keyState = this.keys[keyName];
+      keyState.justPressed = pressed &amp;&amp; !keyState.down;
+      keyState.down = pressed;
+    };
+
+    const addKey = (keyCode, name) =&gt; {
+      this.keys[name] = { down: false, justPressed: false };
+      keyMap.set(keyCode, name);
+    };
+
+    const setKeyFromKeyCode = (keyCode, pressed) =&gt; {
+      const keyName = keyMap.get(keyCode);
+      if (!keyName) {
+        return;
+      }
+      setKey(keyName, pressed);
+    };
+
+    addKey(37, 'left');
+    addKey(39, 'right');
+    addKey(38, 'up');
+    addKey(40, 'down');
+    addKey(90, 'a');
+    addKey(88, 'b');
+
+    window.addEventListener('keydown', (e) =&gt; {
+      setKeyFromKeyCode(e.keyCode, true);
+    });
+    window.addEventListener('keyup', (e) =&gt; {
+      setKeyFromKeyCode(e.keyCode, false);
+    });
+
++    const sides = [
++      { elem: document.querySelector('#left'),  key: 'left'  },
++      { elem: document.querySelector('#right'), key: 'right' },
++    ];
++
++    const clearKeys = () =&gt; {
++      for (const {key} of sides) {
++          setKey(key, false);
++      }
++    };
++
++    const handleMouseMove = (e) =&gt; {
++      e.preventDefault();
++      // this is needed because we call preventDefault();
++      // we also gave the canvas a tabindex so it can
++      // become the focus
++      canvas.focus();
++      window.addEventListener('pointermove', handleMouseMove);
++      window.addEventListener('pointerup', handleMouseUp);
++
++      for (const {elem, key} of sides) {
++        let pressed = false;
++        const rect = elem.getBoundingClientRect();
++        const x = e.clientX;
++        const y = e.clientY;
++        const inRect = x &gt;= rect.left &amp;&amp; x &lt; rect.right &amp;&amp;
++                       y &gt;= rect.top &amp;&amp; y &lt; rect.bottom;
++        if (inRect) {
++          pressed = true;
++        }
++        setKey(key, pressed);
++      }
++    };
++
++    function handleMouseUp() {
++      clearKeys();
++      window.removeEventListener('pointermove', handleMouseMove, {passive: false});
++      window.removeEventListener('pointerup', handleMouseUp);
++    }
++
++    const uiElem = document.querySelector('#ui');
++    uiElem.addEventListener('pointerdown', handleMouseMove, {passive: false});
++
++    uiElem.addEventListener('touchstart', (e) =&gt; {
++      // prevent scrolling
++      e.preventDefault();
++    }, {passive: false});
+  }
+  update() {
+    for (const keyState of Object.values(this.keys)) {
+      if (keyState.justPressed) {
+        keyState.justPressed = false;
+      }
+    }
+  }
+}
+</pre>
+<p>And now we should be able to control the character with the left and right
+cursor keys or with our fingers on a touchscreen</p>
+<p></p><div translate="no" class="threejs_example_container notranslate">
+  <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-player-input.html"></iframe></div>
+  <a class="threejs_center" href="/manual/examples/game-player-input.html" target="_blank">click here to open in a separate window</a>
+</div>
+
+<p></p>
+<p>Ideally we'd do something else if the player went off the screen like move
+the camera or maybe offscreen = death but this article is already going to be
+too long so for now teleporting to the middle was the simplest thing.</p>
+<p>Lets add some animals. We can start it off similar to the <code class="notranslate" translate="no">Player</code> by making
+an <code class="notranslate" translate="no">Animal</code> component.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Animal extends Component {
+  constructor(gameObject, model) {
+    super(gameObject);
+    const skinInstance = gameObject.addComponent(SkinInstance, model);
+    skinInstance.mixer.timeScale = globals.moveSpeed / 4;
+    skinInstance.setAnimation('Idle');
+  }
+}
+</pre>
+<p>The code above sets the <a href="/docs/#api/en/animation/AnimationMixer.timeScale"><code class="notranslate" translate="no">AnimationMixer.timeScale</code></a> to set the playback
+speed of the animations relative to the move speed. This way if we
+adjust the move speed the animation will speed up or slow down as well.</p>
+<p>To start we could setup one of each type of animal</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
+  // hide the loading bar
+  const loadingElem = document.querySelector('#loading');
+  loadingElem.style.display = 'none';
+
+  prepModelsAndAnimations();
+  {
+    const gameObject = gameObjectManager.createGameObject(camera, 'camera');
+    globals.cameraInfo = gameObject.addComponent(CameraInfo);
+  }
+
+  {
+    const gameObject = gameObjectManager.createGameObject(scene, 'player');
+    globals.player = gameObject.addComponent(Player);
+    globals.congaLine = [gameObject];
+  }
+
++  const animalModelNames = [
++    'pig',
++    'cow',
++    'llama',
++    'pug',
++    'sheep',
++    'zebra',
++    'horse',
++  ];
++  animalModelNames.forEach((name, ndx) =&gt; {
++    const gameObject = gameObjectManager.createGameObject(scene, name);
++    gameObject.addComponent(Animal, models[name]);
++    gameObject.transform.position.x = (ndx + 1) * 5;
++  });
+}
+</pre>
+<p>And that would get us animals standing on the screen but we want them to do
+something.</p>
+<p>Let's make them follow the player in a conga line but only if the player gets near enough.
+To do this we need several states.</p>
+<ul>
+<li><p>Idle:</p>
+<p>Animal is waiting for player to get close</p>
+</li>
+<li><p>Wait for End of Line:</p>
+<p>Animal was tagged by player but now needs to wait for the animal
+at the end of the line to come by so they can join the end of the line.</p>
+</li>
+<li><p>Go to Last:</p>
+<p>Animal needs to walk to where the animal they are following was, at the same time recording
+a history of where the animal they are following is currently.</p>
+</li>
+<li><p>Follow</p>
+<p>Animal needs to keep recording a history of where the animal they are following is while
+moving to where the animal they are following was before.</p>
+</li>
+</ul>
+<p>There are many ways to handle different states like this. A common one is to use
+a <a href="https://www.google.com/search?q=finite+state+machine">Finite State Machine</a> and
+to build some class to help us manage the state.</p>
+<p>So, let's do that.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class FiniteStateMachine {
+  constructor(states, initialState) {
+    this.states = states;
+    this.transition(initialState);
+  }
+  get state() {
+    return this.currentState;
+  }
+  transition(state) {
+    const oldState = this.states[this.currentState];
+    if (oldState &amp;&amp; oldState.exit) {
+      oldState.exit.call(this);
+    }
+    this.currentState = state;
+    const newState = this.states[state];
+    if (newState.enter) {
+      newState.enter.call(this);
+    }
+  }
+  update() {
+    const state = this.states[this.currentState];
+    if (state.update) {
+      state.update.call(this);
+    }
+  }
+}
+</pre>
+<p>Here's a simple class. We pass it an object with a bunch of states.
+Each state as 3 optional functions, <code class="notranslate" translate="no">enter</code>, <code class="notranslate" translate="no">update</code>, and <code class="notranslate" translate="no">exit</code>.
+To switch states we call <code class="notranslate" translate="no">FiniteStateMachine.transition</code> and pass it
+the name of the new state. If the current state has an <code class="notranslate" translate="no">exit</code> function
+it's called. Then if the new state has an <code class="notranslate" translate="no">enter</code> function it's called.
+Finally each frame <code class="notranslate" translate="no">FiniteStateMachine.update</code> calls the <code class="notranslate" translate="no">update</code> function
+of the current state.</p>
+<p>Let's use it to manage the states of the animals.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// Returns true of obj1 and obj2 are close
+function isClose(obj1, obj1Radius, obj2, obj2Radius) {
+  const minDist = obj1Radius + obj2Radius;
+  const dist = obj1.position.distanceTo(obj2.position);
+  return dist &lt; minDist;
+}
+
+// keeps v between -min and +min
+function minMagnitude(v, min) {
+  return Math.abs(v) &gt; min
+      ? min * Math.sign(v)
+      : v;
+}
+
+const aimTowardAndGetDistance = function() {
+  const delta = new THREE.Vector3();
+
+  return function aimTowardAndGetDistance(source, targetPos, maxTurn) {
+    delta.subVectors(targetPos, source.position);
+    // compute the direction we want to be facing
+    const targetRot = Math.atan2(delta.x, delta.z) + Math.PI * 1.5;
+    // rotate in the shortest direction
+    const deltaRot = (targetRot - source.rotation.y + Math.PI * 1.5) % (Math.PI * 2) - Math.PI;
+    // make sure we don't turn faster than maxTurn
+    const deltaRotation = minMagnitude(deltaRot, maxTurn);
+    // keep rotation between 0 and Math.PI * 2
+    source.rotation.y = THREE.MathUtils.euclideanModulo(
+        source.rotation.y + deltaRotation, Math.PI * 2);
+    // return the distance to the target
+    return delta.length();
+  };
+}();
+
+class Animal extends Component {
+  constructor(gameObject, model) {
+    super(gameObject);
++    const hitRadius = model.size / 2;
+    const skinInstance = gameObject.addComponent(SkinInstance, model);
+    skinInstance.mixer.timeScale = globals.moveSpeed / 4;
++    const transform = gameObject.transform;
++    const playerTransform = globals.player.gameObject.transform;
++    const maxTurnSpeed = Math.PI * (globals.moveSpeed / 4);
++    const targetHistory = [];
++    let targetNdx = 0;
++
++    function addHistory() {
++      const targetGO = globals.congaLine[targetNdx];
++      const newTargetPos = new THREE.Vector3();
++      newTargetPos.copy(targetGO.transform.position);
++      targetHistory.push(newTargetPos);
++    }
++
++    this.fsm = new FiniteStateMachine({
++      idle: {
++        enter: () =&gt; {
++          skinInstance.setAnimation('Idle');
++        },
++        update: () =&gt; {
++          // check if player is near
++          if (isClose(transform, hitRadius, playerTransform, globals.playerRadius)) {
++            this.fsm.transition('waitForEnd');
++          }
++        },
++      },
++      waitForEnd: {
++        enter: () =&gt; {
++          skinInstance.setAnimation('Jump');
++        },
++        update: () =&gt; {
++          // get the gameObject at the end of the conga line
++          const lastGO = globals.congaLine[globals.congaLine.length - 1];
++          const deltaTurnSpeed = maxTurnSpeed * globals.deltaTime;
++          const targetPos = lastGO.transform.position;
++          aimTowardAndGetDistance(transform, targetPos, deltaTurnSpeed);
++          // check if last thing in conga line is near
++          if (isClose(transform, hitRadius, lastGO.transform, globals.playerRadius)) {
++            this.fsm.transition('goToLast');
++          }
++        },
++      },
++      goToLast: {
++        enter: () =&gt; {
++          // remember who we're following
++          targetNdx = globals.congaLine.length - 1;
++          // add ourselves to the conga line
++          globals.congaLine.push(gameObject);
++          skinInstance.setAnimation('Walk');
++        },
++        update: () =&gt; {
++          addHistory();
++          // walk to the oldest point in the history
++          const targetPos = targetHistory[0];
++          const maxVelocity = globals.moveSpeed * globals.deltaTime;
++          const deltaTurnSpeed = maxTurnSpeed * globals.deltaTime;
++          const distance = aimTowardAndGetDistance(transform, targetPos, deltaTurnSpeed);
++          const velocity = distance;
++          transform.translateOnAxis(kForward, Math.min(velocity, maxVelocity));
++          if (distance &lt;= maxVelocity) {
++            this.fsm.transition('follow');
++          }
++        },
++      },
++      follow: {
++        update: () =&gt; {
++          addHistory();
++          // remove the oldest history and just put ourselves there.
++          const targetPos = targetHistory.shift();
++          transform.position.copy(targetPos);
++          const deltaTurnSpeed = maxTurnSpeed * globals.deltaTime;
++          aimTowardAndGetDistance(transform, targetHistory[0], deltaTurnSpeed);
++        },
++      },
++    }, 'idle');
++  }
++  update() {
++    this.fsm.update();
++  }
+}
+</pre>
+<p>That was big chunk of code but it does what was described above.
+Hopefully of you walk through each state it will be clear.</p>
+<p>A few things we need to add. We need the player to add itself
+to the globals so the animals can find it and we need to start the
+conga line with the player's <code class="notranslate" translate="no">GameObject</code>.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
+
+  ...
+
+  {
+    const gameObject = gameObjectManager.createGameObject(scene, 'player');
++    globals.player = gameObject.addComponent(Player);
++    globals.congaLine = [gameObject];
+  }
+
+}
+</pre>
+<p>We also need to compute a size for each model</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function prepModelsAndAnimations() {
++  const box = new THREE.Box3();
++  const size = new THREE.Vector3();
+  Object.values(models).forEach(model =&gt; {
++    box.setFromObject(model.gltf.scene);
++    box.getSize(size);
++    model.size = size.length();
+    const animsByName = {};
+    model.gltf.animations.forEach((clip) =&gt; {
+      animsByName[clip.name] = clip;
+      // Should really fix this in .blend file
+      if (clip.name === 'Walk') {
+        clip.duration /= 2;
+      }
+    });
+    model.animations = animsByName;
+  });
+}
+</pre>
+<p>And we need the player to record their size</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Player extends Component {
+  constructor(gameObject) {
+    super(gameObject);
+    const model = models.knight;
++    globals.playerRadius = model.size / 2;
+</pre>
+<p>Thinking about it now it would probably have been smarter
+for the animals to just target the head of the conga line
+instead of the player specifically. Maybe I'll come back
+and change that later.</p>
+<p>When I first started this I used just one radius for all animals
+but of course that was no good as the pug is much smaller than the horse.
+So I added the difference sizes but I wanted to be able to visualize
+things. To do that I made a <code class="notranslate" translate="no">StatusDisplayHelper</code> component.</p>
+<p>I uses a <a href="/docs/#api/en/helpers/PolarGridHelper"><code class="notranslate" translate="no">PolarGridHelper</code></a> to draw a circle around each character
+and it uses html elements to let each character show some status using
+the techniques covered in <a href="align-html-elements-to-3d.html">the article on aligning html elements to 3D</a>.</p>
+<p>First we need to add some HTML to host these elements</p>
+<pre class="prettyprint showlinemods notranslate lang-html" translate="no">&lt;body&gt;
+  &lt;canvas id="c"&gt;&lt;/canvas&gt;
+  &lt;div id="ui"&gt;
+    &lt;div id="left"&gt;&lt;img src="../resources/images/left.svg"&gt;&lt;/div&gt;
+    &lt;div style="flex: 0 0 40px;"&gt;&lt;/div&gt;
+    &lt;div id="right"&gt;&lt;img src="../resources/images/right.svg"&gt;&lt;/div&gt;
+  &lt;/div&gt;
+  &lt;div id="loading"&gt;
+    &lt;div&gt;
+      &lt;div&gt;...loading...&lt;/div&gt;
+      &lt;div class="progress"&gt;&lt;div id="progressbar"&gt;&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
++  &lt;div id="labels"&gt;&lt;/div&gt;
+&lt;/body&gt;
+</pre>
+<p>And add some CSS for them</p>
+<pre class="prettyprint showlinemods notranslate lang-css" translate="no">#labels {
+  position: absolute;  /* let us position ourself inside the container */
+  left: 0;             /* make our position the top left of the container */
+  top: 0;
+  color: white;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  pointer-events: none;
+}
+#labels&gt;div {
+  position: absolute;  /* let us position them inside the container */
+  left: 0;             /* make their default position the top left of the container */
+  top: 0;
+  font-size: large;
+  font-family: monospace;
+  user-select: none;   /* don't let the text get selected */
+  text-shadow:         /* create a black outline */
+    -1px -1px 0 #000,
+     0   -1px 0 #000,
+     1px -1px 0 #000,
+     1px  0   0 #000,
+     1px  1px 0 #000,
+     0    1px 0 #000,
+    -1px  1px 0 #000,
+    -1px  0   0 #000;
+}
+</pre>
+<p>Then here's the component</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">const labelContainerElem = document.querySelector('#labels');
+
+class StateDisplayHelper extends Component {
+  constructor(gameObject, size) {
+    super(gameObject);
+    this.elem = document.createElement('div');
+    labelContainerElem.appendChild(this.elem);
+    this.pos = new THREE.Vector3();
+
+    this.helper = new THREE.PolarGridHelper(size / 2, 1, 1, 16);
+    gameObject.transform.add(this.helper);
+  }
+  setState(s) {
+    this.elem.textContent = s;
+  }
+  setColor(cssColor) {
+    this.elem.style.color = cssColor;
+    this.helper.material.color.set(cssColor);
+  }
+  update() {
+    const {pos} = this;
+    const {transform} = this.gameObject;
+    const {canvas} = globals;
+    pos.copy(transform.position);
+
+    // get the normalized screen coordinate of that position
+    // x and y will be in the -1 to +1 range with x = -1 being
+    // on the left and y = -1 being on the bottom
+    pos.project(globals.camera);
+
+    // convert the normalized position to CSS coordinates
+    const x = (pos.x *  .5 + .5) * canvas.clientWidth;
+    const y = (pos.y * -.5 + .5) * canvas.clientHeight;
+
+    // move the elem to that position
+    this.elem.style.transform = `translate(-50%, -50%) translate(${x}px,${y}px)`;
+  }
+}
+</pre>
+<p>And we can then add them to the animals like this</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Animal extends Component {
+  constructor(gameObject, model) {
+    super(gameObject);
++    this.helper = gameObject.addComponent(StateDisplayHelper, model.size);
+
+     ...
+
+  }
+  update() {
+    this.fsm.update();
++    const dir = THREE.MathUtils.radToDeg(this.gameObject.transform.rotation.y);
++    this.helper.setState(`${this.fsm.state}:${dir.toFixed(0)}`);
+  }
+}
+</pre>
+<p>While we're at it lets make it so we can turn them on/off using lil-gui like
+we've used else where</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
+import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
+import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
+import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
++import {GUI} from 'three/addons/libs/lil-gui.module.min.js';
+</pre>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">+const gui = new GUI();
++gui.add(globals, 'debug').onChange(showHideDebugInfo);
++showHideDebugInfo();
+
+const labelContainerElem = document.querySelector('#labels');
++function showHideDebugInfo() {
++  labelContainerElem.style.display = globals.debug ? '' : 'none';
++}
++showHideDebugInfo();
+
+class StateDisplayHelper extends Component {
+
+  ...
+
+  update() {
++    this.helper.visible = globals.debug;
++    if (!globals.debug) {
++      return;
++    }
+
+    ...
+  }
+}
+</pre>
+<p>And with that we get the kind of start of a game</p>
+<p></p><div translate="no" class="threejs_example_container notranslate">
+  <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-conga-line.html"></iframe></div>
+  <a class="threejs_center" href="/manual/examples/game-conga-line.html" target="_blank">click here to open in a separate window</a>
+</div>
+
+<p></p>
+<p>Originally I set out to make a <a href="https://www.google.com/search?q=snake+game">snake game</a>
+where as you add animals to your line it gets harder because you need to avoid
+crashing into them. I'd also have put some obstacles in the scene and maybe a fence or some
+barrier around the perimeter.</p>
+<p>Unfortunately the animals are long and thin. From above here's the zebra.</p>
+<div class="threejs_center"><img src="../resources/images/zebra.png" style="width: 113px;"></div>
+
+<p>The code so far is using circle collisions which means if we had obstacles like a fence
+then this would be considered a collision</p>
+<div class="threejs_center"><img src="../resources/images/zebra-collisions.svg" style="width: 400px;"></div>
+
+<p>That's no good. Even animal to animal we'd have the same issue</p>
+<p>I thought about writing a 2D rectangle to rectangle collision system but I
+quickly realized it could really be a lot of code. Checking that 2 arbitrarily
+oriented boxes overlap is not too much code and for our game with just a few
+objects it might work but looking into it after a few objects you quickly start
+needing to optimize the collision checking. First you might go through all
+objects that can possibly collide with each other and check their bounding
+spheres or bounding circles or their axially aligned bounding boxes. Once you
+know which objects <em>might</em> be colliding then you need to do more work to check if
+they are <em>actually</em> colliding. Often even checking the bounding spheres is too
+much work and you need some kind of better spacial structure for the objects so
+you can more quickly only check objects possibly near each other.</p>
+<p>Then, once you write the code to check if 2 objects collide you generally want
+to make a collision system rather than manually asking "do I collide with these
+objects". A collision system emits events or calls callbacks in relation to
+things colliding. The advantage is it can check all the collisions at once so no
+objects get checked more than once where as if you manually call some "am I
+colliding" function often objects will be checked more than once wasting time.</p>
+<p>Making that collision system would probably not be more than 100-300 lines of
+code for just checking arbitrarily oriented rectangles but it's still a ton more
+code so it seemed best to leave it out.</p>
+<p>Another solution would have been to try to find other characters that are
+mostly circular from the top. Other humanoid characters for example instead
+of animals in which case the circle checking might work animal to animal.
+It would not work animal to fence, well we'd have to add circle to rectangle
+checking. I thought about making the fence a fence of bushes or poles, something
+circular but then I'd need probably 120 to 200 of them to surround the play area
+which would run into the optimization issues mentioned above.</p>
+<p>These are reasons many games use an existing solution. Often these solutions
+are part of a physics library. The physical library needs to know if objects
+collide with each other so on top of providing physics they can also be used
+to detect collision.</p>
+<p>If you're looking for a solution some of the three.js examples use
+<a href="https://github.com/kripken/ammo.js/">ammo.js</a> so that might be one.</p>
+<p>One other solution might have been to place the obstacles on a grid
+and try to make it so each animal and the player just need to look at
+the grid. While that would be performant I felt that's best left as an exercise
+for the reader 😜</p>
+<p>One more thing, many game systems have something called <a href="https://www.google.com/search?q=coroutines"><em>coroutines</em></a>.
+Coroutines are routines that can pause while running and continue later.</p>
+<p>Let's make the main character emit musical notes like they are leading
+the line by singing. There are many ways we could implement this but for now
+let's do it using coroutines.</p>
+<p>First, here's a class to manage coroutines</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* waitSeconds(duration) {
+  while (duration &gt; 0) {
+    duration -= globals.deltaTime;
+    yield;
+  }
+}
+
+class CoroutineRunner {
+  constructor() {
+    this.generatorStacks = [];
+    this.addQueue = [];
+    this.removeQueue = new Set();
+  }
+  isBusy() {
+    return this.addQueue.length + this.generatorStacks.length &gt; 0;
+  }
+  add(generator, delay = 0) {
+    const genStack = [generator];
+    if (delay) {
+      genStack.push(waitSeconds(delay));
+    }
+    this.addQueue.push(genStack);
+  }
+  remove(generator) {
+    this.removeQueue.add(generator);
+  }
+  update() {
+    this._addQueued();
+    this._removeQueued();
+    for (const genStack of this.generatorStacks) {
+      const main = genStack[0];
+      // Handle if one coroutine removes another
+      if (this.removeQueue.has(main)) {
+        continue;
+      }
+      while (genStack.length) {
+        const topGen = genStack[genStack.length - 1];
+        const {value, done} = topGen.next();
+        if (done) {
+          if (genStack.length === 1) {
+            this.removeQueue.add(topGen);
+            break;
+          }
+          genStack.pop();
+        } else if (value) {
+          genStack.push(value);
+        } else {
+          break;
+        }
+      }
+    }
+    this._removeQueued();
+  }
+  _addQueued() {
+    if (this.addQueue.length) {
+      this.generatorStacks.splice(this.generatorStacks.length, 0, ...this.addQueue);
+      this.addQueue = [];
+    }
+  }
+  _removeQueued() {
+    if (this.removeQueue.size) {
+      this.generatorStacks = this.generatorStacks.filter(genStack =&gt; !this.removeQueue.has(genStack[0]));
+      this.removeQueue.clear();
+    }
+  }
+}
+</pre>
+<p>It does things similar to <code class="notranslate" translate="no">SafeArray</code> to make sure that it's safe to add or remove
+coroutines while other coroutines are running. It also handles nested coroutines.</p>
+<p>To make a coroutine you make a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">JavaScript generator function</a>.
+A generator function is preceded by the keyword <code class="notranslate" translate="no">function*</code> (the asterisk is important!)</p>
+<p>Generator functions can <code class="notranslate" translate="no">yield</code>. For example</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* countOTo9() {
+  for (let i = 0; i &lt; 10; ++i) {
+    console.log(i);
+    yield;
+  }
+}
+</pre>
+<p>If we added this function to the <code class="notranslate" translate="no">CoroutineRunner</code> above it would print
+out each number, 0 to 9, once per frame or rather once per time we called <code class="notranslate" translate="no">runner.update</code>.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">const runner = new CoroutineRunner();
+runner.add(count0To9);
+while(runner.isBusy()) {
+  runner.update();
+}
+</pre>
+<p>Coroutines are removed automatically when they are finished.
+To remove a coroutine early, before it reaches the end you need to keep
+a reference to its generator like this</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">const gen = count0To9();
+runner.add(gen);
+
+// sometime later
+
+runner.remove(gen);
+</pre>
+<p>In any case, in the player let's use a coroutine to emit a note every half second to 1 second</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Player extends Component {
+  constructor(gameObject) {
+
+    ...
+
++    this.runner = new CoroutineRunner();
++
++    function* emitNotes() {
++      for (;;) {
++        yield waitSeconds(rand(0.5, 1));
++        const noteGO = gameObjectManager.createGameObject(scene, 'note');
++        noteGO.transform.position.copy(gameObject.transform.position);
++        noteGO.transform.position.y += 5;
++        noteGO.addComponent(Note);
++      }
++    }
++
++    this.runner.add(emitNotes());
+  }
+  update() {
++    this.runner.update();
+
+  ...
+
+  }
+}
+
+function rand(min, max) {
+  if (max === undefined) {
+    max = min;
+    min = 0;
+  }
+  return Math.random() * (max - min) + min;
+}
+</pre>
+<p>You can see we make a <code class="notranslate" translate="no">CoroutineRunner</code> and we add an <code class="notranslate" translate="no">emitNotes</code> coroutine.
+That function will run forever, waiting 0.5 to 1 seconds and then creating a game object
+with a <code class="notranslate" translate="no">Note</code> component.</p>
+<p>For the <code class="notranslate" translate="no">Note</code> component first lets make a texture with a note on it and
+instead of loading a note image let's make one using a canvas like we covered in <a href="canvas-textures.html">the article on canvas textures</a>.</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function makeTextTexture(str) {
+  const ctx = document.createElement('canvas').getContext('2d');
+  ctx.canvas.width = 64;
+  ctx.canvas.height = 64;
+  ctx.font = '60px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = '#FFF';
+  ctx.fillText(str, ctx.canvas.width / 2, ctx.canvas.height / 2);
+  return new THREE.CanvasTexture(ctx.canvas);
+}
+const noteTexture = makeTextTexture('♪');
+</pre>
+<p>The texture we create above is white each means when we use it
+we can set the material's color and get a note of any color.</p>
+<p>Now that we have a noteTexture here's the <code class="notranslate" translate="no">Note</code> component.
+It uses <a href="/docs/#api/en/materials/SpriteMaterial"><code class="notranslate" translate="no">SpriteMaterial</code></a> and a <a href="/docs/#api/en/objects/Sprite"><code class="notranslate" translate="no">Sprite</code></a> like we covered in
+<a href="billboards.html">the article on billboards</a> </p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Note extends Component {
+  constructor(gameObject) {
+    super(gameObject);
+    const {transform} = gameObject;
+    const noteMaterial = new THREE.SpriteMaterial({
+      color: new THREE.Color().setHSL(rand(1), 1, 0.5),
+      map: noteTexture,
+      side: THREE.DoubleSide,
+      transparent: true,
+    });
+    const note = new THREE.Sprite(noteMaterial);
+    note.scale.setScalar(3);
+    transform.add(note);
+    this.runner = new CoroutineRunner();
+    const direction = new THREE.Vector3(rand(-0.2, 0.2), 1, rand(-0.2, 0.2));
+
+    function* moveAndRemove() {
+      for (let i = 0; i &lt; 60; ++i) {
+        transform.translateOnAxis(direction, globals.deltaTime * 10);
+        noteMaterial.opacity = 1 - (i / 60);
+        yield;
+      }
+      transform.parent.remove(transform);
+      gameObjectManager.removeGameObject(gameObject);
+    }
+
+    this.runner.add(moveAndRemove());
+  }
+  update() {
+    this.runner.update();
+  }
+}
+</pre>
+<p>All it does is setup a <a href="/docs/#api/en/objects/Sprite"><code class="notranslate" translate="no">Sprite</code></a>, then pick a random velocity and move
+the transform at that velocity for 60 frames while fading out the note
+by setting the material's <a href="/docs/#api/en/materials/Material#opacity"><code class="notranslate" translate="no">opacity</code></a>.
+After the loop it the removes the transform
+from the scene and the note itself from active gameobjects.</p>
+<p>One last thing, let's add a few more animals</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
+
+   ...
+
+  const animalModelNames = [
+    'pig',
+    'cow',
+    'llama',
+    'pug',
+    'sheep',
+    'zebra',
+    'horse',
+  ];
++  const base = new THREE.Object3D();
++  const offset = new THREE.Object3D();
++  base.add(offset);
++
++  // position animals in a spiral.
++  const numAnimals = 28;
++  const arc = 10;
++  const b = 10 / (2 * Math.PI);
++  let r = 10;
++  let phi = r / b;
++  for (let i = 0; i &lt; numAnimals; ++i) {
++    const name = animalModelNames[rand(animalModelNames.length) | 0];
+    const gameObject = gameObjectManager.createGameObject(scene, name);
+    gameObject.addComponent(Animal, models[name]);
++    base.rotation.y = phi;
++    offset.position.x = r;
++    offset.updateWorldMatrix(true, false);
++    offset.getWorldPosition(gameObject.transform.position);
++    phi += arc / r;
++    r = b * phi;
+  }
+</pre>
+<p></p><div translate="no" class="threejs_example_container notranslate">
+  <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-conga-line-w-notes.html"></iframe></div>
+  <a class="threejs_center" href="/manual/examples/game-conga-line-w-notes.html" target="_blank">click here to open in a separate window</a>
+</div>
+
+<p></p>
+<p>You might be asking, why not use <code class="notranslate" translate="no">setTimeout</code>? The problem with <code class="notranslate" translate="no">setTimeout</code>
+is it's not related to the game clock. For example above we made the maximum
+amount of time allowed to elapse between frames to be 1/20th of a second.
+Our coroutine system will respect that limit but <code class="notranslate" translate="no">setTimeout</code> would not.</p>
+<p>Of course we could have made a simple timer ourselves</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Player ... {
+  update() {
+    this.noteTimer -= globals.deltaTime;
+    if (this.noteTimer &lt;= 0) {
+      // reset timer
+      this.noteTimer = rand(0.5, 1);
+      // create a gameobject with a note component
+    }
+  }
+</pre>
+<p>And for this particular case that might have been better but as you add
+more and things you'll get more and more variables added to your classes
+where as with coroutines you can often just <em>fire and forget</em>.</p>
+<p>Given our animal's simple states we could also have implemented them
+with a coroutine in the form of</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// pseudo code!
+function* animalCoroutine() {
+   setAnimation('Idle');
+   while(playerIsTooFar()) {
+     yield;
+   }
+   const target = endOfLine;
+   setAnimation('Jump');
+   while(targetIsTooFar()) {
+     aimAt(target);
+     yield;
+   }
+   setAnimation('Walk')
+   while(notAtOldestPositionOfTarget()) {
+     addHistory();
+     aimAt(target);
+     yield;
+   }
+   for(;;) {
+     addHistory();
+     const pos = history.unshift();
+     transform.position.copy(pos);
+     aimAt(history[0]);
+     yield;
+   }
+}
+</pre>
+<p>This would have worked but of course as soon as our states were not so linear
+we'd have had to switch to a <code class="notranslate" translate="no">FiniteStateMachine</code>.</p>
+<p>It also wasn't clear to me if coroutines should run independently of their
+components. We could have made a global <code class="notranslate" translate="no">CoroutineRunner</code> and put all
+coroutines on it. That would make cleaning them up harder. As it is now
+if the gameobject is removed all of its components are removed and
+therefore the coroutine runners created are no longer called and it will
+all get garbage collected. If we had global runner then it would be
+the responsibility of each component to remove any coroutines it added
+or else some other mechanism of registering coroutines with a particular
+component or gameobject would be needed so that removing one removes the
+others.</p>
+<p>There are lots more issues a
+normal game engine would deal with. As it is there is no order to how
+gameobjects or their components are run. They are just run in the order added.
+Many game systems add a priority so the order can be set or changed.</p>
+<p>Another issue we ran into is the <code class="notranslate" translate="no">Note</code> removing its gameobject's transform from the scene.
+That seems like something that should happen in <code class="notranslate" translate="no">GameObject</code> since it was <code class="notranslate" translate="no">GameObject</code>
+that added the transform in the first place. Maybe <code class="notranslate" translate="no">GameObject</code> should have
+a <code class="notranslate" translate="no">dispose</code> method that is called by <code class="notranslate" translate="no">GameObjectManager.removeGameObject</code>?</p>
+<p>Yet another is how we're manually calling <code class="notranslate" translate="no">gameObjectManager.update</code> and <code class="notranslate" translate="no">inputManager.update</code>.
+Maybe there should be a <code class="notranslate" translate="no">SystemManager</code> which these global services can add themselves
+and each service will have its <code class="notranslate" translate="no">update</code> function called. In this way if we added a new
+service like <code class="notranslate" translate="no">CollisionManager</code> we could just add it to the system manager and not
+have to edit the render loop.</p>
+<p>I'll leave those kinds of issues up to you.
+I hope this article has given you some ideas for your own game engine.</p>
+<p>Maybe I should promote a game jam. If you click the <em>jsfiddle</em> or <em>codepen</em> buttons
+above the last example they'll open in those sites ready to edit. Add some features,
+Change the game to a pug leading a bunch of knights. Use the knight's rolling animation
+as a bowling ball and make an animal bowling game. Make an animal relay race.
+If you make a cool game post a link in the comments below.</p>
+<div class="footnotes">
+[<a id="parented">1</a>]: technically it would still work if none of the parents have any translation, rotation, or scale <a href="#parented-backref">§</a>.
+</div>
         </div>
       </div>
     </div>

--- a/manual/zh/game.html
+++ b/manual/zh/game.html
@@ -1204,7 +1204,7 @@ class Animal extends Component {
 +    globals.playerRadius = model.size / 2;
 </pre>
 <p>现在想想，让动物瞄准康加舞队列的头部而不是特定的玩家可能会更聪明。也许我以后会回来改。</p>
-<p>刚开始时我对所有动物只用一个半径，但这当然不好，因为哈巴狗比马小得多。所以我添加了不同的大小，但我想要能够可视化这些东西。为此我创建了一个 <code class="notranslate" translate="no">StatusDisplayHelper</code> 组件。</p>
+<p>刚开始时我对所有动物只用一个半径，但这当然不好，因为哈巴狗比马小得多。所以我添加了不同的大小，但我想要能够可视化这些东西。为此我创建了一个 <code class="notranslate" translate="no">StateDisplayHelper</code> 组件。</p>
 <p>它使用 <a href="/docs/#api/en/helpers/PolarGridHelper"><code class="notranslate" translate="no">PolarGridHelper</code></a> 在每个角色周围画一个圆圈，并使用 HTML 元素让每个角色显示一些状态，使用的是<a href="align-html-elements-to-3d.html">将 HTML 元素对齐到 3D 的文章</a>中介绍的技术。</p>
 <p>首先我们需要添加一些 HTML 来承载这些元素</p>
 <pre class="prettyprint showlinemods notranslate lang-html" translate="no">&lt;body&gt;
@@ -1434,7 +1434,7 @@ class CoroutineRunner {
 <p>它和 <code class="notranslate" translate="no">SafeArray</code> 做了类似的事情，确保在其他协程运行时添加或移除协程是安全的。它还处理嵌套协程。</p>
 <p>要创建协程，你需要创建一个 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">JavaScript 生成器函数</a>。生成器函数前面有关键字 <code class="notranslate" translate="no">function*</code>（星号很重要！）</p>
 <p>生成器函数可以 <code class="notranslate" translate="no">yield</code>。例如</p>
-<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* countOTo9() {
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* count0To9() {
   for (let i = 0; i &lt; 10; ++i) {
     console.log(i);
     yield;

--- a/manual/zh/game.html
+++ b/manual/zh/game.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html><html lang="zh"><head>
     <meta charset="utf-8">
-    <title>Making a Game</title>
+    <title>制作一个游戏</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – Making a Game">
+    <meta name="twitter:title" content="Three.js – 制作一个游戏">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="../../files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="../../files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -22,63 +22,27 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>Making a Game</h1>
+        <h1>制作一个游戏</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">
-          <p>Many people want to write games using three.js. This article
-will hopefully give you some ideas on how to start.</p>
-<p>At least at the time I'm writing this article it's probably going to be the
-longest article on this site. It's possible the code here is massively over
-engineered but as I wrote each new feature I'd run into a problem that needed a
-solution I'm used to from other games I've written. In other words each new
-solution seemed important so I'll try to show why. Of course the smaller your
-game the less you might need some of the solutions shown here but this is a
-pretty small game and yet with the complexities of 3D characters many things
-take more organization than they might with 2D characters.</p>
-<p>As an example if you're making PacMan in 2D, when PacMan turns a corner
-that happens instantly at 90 degrees. There is no in-between step. But
-in a 3D game often we need the character to rotate over several frames.
-That simple change can add a bunch of complexity and require different
-solutions.</p>
-<p>The majority of the code here will not really be three.js and
-that's important to note, <strong>three.js is not a game engine</strong>.
-Three.js is a 3D library. It provides a <a href="scenegraph.html">scene graph</a>
-and features for displaying 3D objects added to that scene graph
-but it does not provide all the other things needed to make a game.
-No collisions, no physics, no input systems, no path finding, etc, etc...
-So, we'll have to provide those things ourselves.</p>
-<p>I ended up writing quite a bit of code to make this simple <em>unfinished</em>
-game like thing and again, it's certainly possible I over engineered and there
-are simpler solutions but I feel like I actually didn't write
-enough code and hopefully I can explain what I think is missing.</p>
-<p>Many of the ideas here are heavily influenced by <a href="https://unity.com">Unity</a>.
-If you're not familiar with Unity that probably does not matter.
-I only bring it up as 10s of 1000s of games have shipped using
-these ideas.</p>
-<p>Let's start with the three.js parts. We need to load models for our game.</p>
-<p>At <a href="https://opengameart.org">opengameart.org</a> I found this <a href="https://opengameart.org/content/lowpoly-animated-knight">animated knight
-model</a> by <a href="https://opengameart.org/users/quaternius">quaternius</a></p>
+          <p>很多人想用 three.js 来写游戏。这篇文章希望能给你一些如何开始的思路。</p>
+<p>至少在我写这篇文章的时候，它可能会成为本站最长的文章。这里的代码可能过度设计了，但在我编写每个新功能时，都会遇到需要解决的问题，而这些解决方案都来自我以前写过的其他游戏。换句话说，每个新的解决方案看起来都很重要，所以我会尽量解释为什么需要它们。当然，你的游戏越小，就越不需要这里展示的某些解决方案，但这本身是一个相当小的游戏，然而由于 3D 角色的复杂性，许多事情比 2D 角色需要更多的组织。</p>
+<p>举个例子，如果你在制作 2D 版的吃豆人，吃豆人转弯时会瞬间完成 90 度旋转，没有中间过程。但在 3D 游戏中，我们通常需要角色在多帧之间旋转。这个简单的变化就会增加很多复杂性，并需要不同的解决方案。</p>
+<p>这里的大部分代码实际上并不是 three.js 的代码，这一点很重要，<strong>three.js 不是一个游戏引擎</strong>。Three.js 是一个 3D 库。它提供了一个<a href="scenegraph.html">场景图</a>以及在场景图中显示 3D 对象的功能，但它不提供制作游戏所需的所有其他东西。没有碰撞检测，没有物理引擎，没有输入系统，没有寻路等等...所以，我们必须自己提供这些功能。</p>
+<p>我最终写了相当多的代码来制作这个简单的<em>未完成的</em>游戏原型，而且我觉得可能过度设计了，应该有更简单的解决方案，但我觉得我实际上还没有写够代码，希望我能解释我认为还缺少什么。</p>
+<p>这里的许多想法深受 <a href="https://unity.com">Unity</a> 的影响。如果你不熟悉 Unity，那可能并不重要。我提到它只是因为有数以万计的游戏是使用这些理念发布的。</p>
+<p>让我们从 three.js 部分开始。我们需要为游戏加载模型。</p>
+<p>在 <a href="https://opengameart.org">opengameart.org</a> 上我找到了这个由 <a href="https://opengameart.org/users/quaternius">quaternius</a> 制作的<a href="https://opengameart.org/content/lowpoly-animated-knight">动画骑士模型</a></p>
 <div class="threejs_center"><img src="../resources/images/knight.jpg" style="width: 375px;"></div>
 
-<p><a href="https://opengameart.org/users/quaternius">quaternius</a> also made <a href="https://opengameart.org/content/lowpoly-animated-farm-animal-pack">these animated animals</a>.</p>
+<p><a href="https://opengameart.org/users/quaternius">quaternius</a> 还制作了<a href="https://opengameart.org/content/lowpoly-animated-farm-animal-pack">这些动画动物</a>。</p>
 <div class="threejs_center"><img src="../resources/images/animals.jpg" style="width: 606px;"></div>
 
-<p>These seem like good models to start with so the first thing we need to
-do is load them.</p>
-<p>We covered <a href="load-gltf.html">loading glTF files before</a>.
-The difference this time is we need to load multiple models and
-we can't start the game until all the models are loaded.</p>
-<p>Fortunately three.js provides the <a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> just for this purpose.
-We create a <a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> and pass it to the other loaders. The
-<a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> provides both <a href="/docs/#api/en/loaders/managers/LoadingManager#onProgress"><code class="notranslate" translate="no">onProgress</code></a> and
-<a href="/docs/#api/en/loaders/managers/LoadingManager#onLoad"><code class="notranslate" translate="no">onLoad</code></a> properties we can attach callbacks to.
-The <a href="/docs/#api/en/loaders/managers/LoadingManager#onLoad"><code class="notranslate" translate="no">onLoad</code></a> callback will be called when
-all files have been loaded. The <a href="/docs/#api/en/loaders/managers/LoadingManager#onProgress"><code class="notranslate" translate="no">onProgress</code></a> callback
-as called after each individual file arrives to give as a chance to show
-loading progress.</p>
-<p>Starting with the code from <a href="load-gltf.html">loading a glTF file</a> I removed all
-the code related to framing the scene and added this code to load all models.</p>
+<p>这些看起来是很好的起步模型，所以我们首先需要加载它们。</p>
+<p>我们之前讲过<a href="load-gltf.html">加载 glTF 文件</a>。这次的不同之处在于我们需要加载多个模型，而且在所有模型加载完成之前不能开始游戏。</p>
+<p>幸运的是 three.js 提供了 <a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> 来满足这个需求。我们创建一个 <a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> 并将它传递给其他加载器。<a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> 提供了 <a href="/docs/#api/en/loaders/managers/LoadingManager#onProgress"><code class="notranslate" translate="no">onProgress</code></a> 和 <a href="/docs/#api/en/loaders/managers/LoadingManager#onLoad"><code class="notranslate" translate="no">onLoad</code></a> 属性供我们附加回调函数。当所有文件加载完成时会调用 <a href="/docs/#api/en/loaders/managers/LoadingManager#onLoad"><code class="notranslate" translate="no">onLoad</code></a> 回调。每个单独的文件加载完成后会调用 <a href="/docs/#api/en/loaders/managers/LoadingManager#onProgress"><code class="notranslate" translate="no">onProgress</code></a> 回调，让我们有机会显示加载进度。</p>
+<p>从<a href="load-gltf.html">加载 glTF 文件</a>的代码开始，我移除了所有与场景取景相关的代码，并添加了以下代码来加载所有模型。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const manager = new THREE.LoadingManager();
 manager.onLoad = init;
 const models = {
@@ -101,23 +65,13 @@ const models = {
 }
 
 function init() {
-  // TBD
+  // 待实现
 }
 </pre>
-<p>This code will load all the models above and the <a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> will call
-<code class="notranslate" translate="no">init</code> when done. We'll use the <code class="notranslate" translate="no">models</code> object later to let us access the
-loaded models so the <a href="/docs/#examples/loaders/GLTFLoader"><code class="notranslate" translate="no">GLTFLoader</code></a> callback for each individual model attaches
-the loaded data to that model's info.</p>
-<p>All the models with all their animation are currently about 6.6meg. That's a
-pretty big download. Assuming your server supports compression (the server this
-site runs on does) it's able to compress them to around 1.4meg. That's
-definitely better than 6.6meg bit it's still not a tiny amount of data. It would
-probably be good if we added a progress bar so the user has some idea how much
-longer they have to wait.</p>
-<p>So, let's add an <a href="/docs/#api/en/loaders/managers/LoadingManager#onProgress"><code class="notranslate" translate="no">onProgress</code></a> callback. It will be
-called with 3 arguments, the <code class="notranslate" translate="no">url</code> of the last loaded object and then the number
-of items loaded so far as well as the total number of items.</p>
-<p>Let's setup some HTML for a loading bar</p>
+<p>这段代码会加载上面所有的模型，<a href="/docs/#api/en/loaders/managers/LoadingManager"><code class="notranslate" translate="no">LoadingManager</code></a> 会在完成后调用 <code class="notranslate" translate="no">init</code>。我们稍后会使用 <code class="notranslate" translate="no">models</code> 对象来访问已加载的模型，所以每个模型的 <a href="/docs/#examples/loaders/GLTFLoader"><code class="notranslate" translate="no">GLTFLoader</code></a> 回调会将加载的数据附加到该模型的信息上。</p>
+<p>所有模型及其动画目前大约 6.6MB。这是一个相当大的下载量。假设你的服务器支持压缩（本站的服务器就支持），可以将它们压缩到大约 1.4MB。这肯定比 6.6MB 好，但仍然不是很小的数据量。如果我们添加一个进度条，让用户知道还需要等待多长时间，那就好了。</p>
+<p>所以，让我们添加一个 <a href="/docs/#api/en/loaders/managers/LoadingManager#onProgress"><code class="notranslate" translate="no">onProgress</code></a> 回调。调用时会传入 3 个参数：最后加载的对象的 <code class="notranslate" translate="no">url</code>，到目前为止已加载的项目数量，以及项目总数。</p>
+<p>让我们设置一些 HTML 来做加载条</p>
 <pre class="prettyprint showlinemods notranslate lang-html" translate="no">&lt;body&gt;
   &lt;canvas id="c"&gt;&lt;/canvas&gt;
 +  &lt;div id="loading"&gt;
@@ -128,8 +82,7 @@ of items loaded so far as well as the total number of items.</p>
 +  &lt;/div&gt;
 &lt;/body&gt;
 </pre>
-<p>We'll look up the <code class="notranslate" translate="no">#progressbar</code> div and we can set the width from 0% to 100%
-to show our progress. All we need to do is set that in our callback.</p>
+<p>我们会查找 <code class="notranslate" translate="no">#progressbar</code> div，并将其宽度从 0% 设置到 100% 来显示进度。我们只需要在回调中设置它即可。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const manager = new THREE.LoadingManager();
 manager.onLoad = init;
 
@@ -138,18 +91,14 @@ manager.onLoad = init;
 +  progressbarElem.style.width = `${itemsLoaded / itemsTotal * 100 | 0}%`;
 +};
 </pre>
-<p>We already setup <code class="notranslate" translate="no">init</code> to be called when all the models are loaded so
-we can turn off the progress bar by hiding the <code class="notranslate" translate="no">#loading</code> element.</p>
+<p>我们已经设置了 <code class="notranslate" translate="no">init</code> 在所有模型加载完成时被调用，所以我们可以通过隐藏 <code class="notranslate" translate="no">#loading</code> 元素来关闭进度条。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
-+  // hide the loading bar
++  // 隐藏加载条
 +  const loadingElem = document.querySelector('#loading');
 +  loadingElem.style.display = 'none';
 }
 </pre>
-<p>Here's a bunch of CSS for styling the bar. The CSS makes the <code class="notranslate" translate="no">#loading</code> <code class="notranslate" translate="no">&lt;div&gt;</code>
-the full size of the page and centers its children. The CSS makes a <code class="notranslate" translate="no">.progress</code>
-area to contain the progress bar. The CSS also gives the progress bar
-a CSS animation of diagonal stripes.</p>
+<p>这是一堆用于样式化进度条的 CSS。CSS 使 <code class="notranslate" translate="no">#loading</code> <code class="notranslate" translate="no">&lt;div&gt;</code> 占满整个页面并居中其子元素。CSS 创建了一个 <code class="notranslate" translate="no">.progress</code> 区域来包含进度条。CSS 还为进度条添加了对角条纹的 CSS 动画。</p>
 <pre class="prettyprint showlinemods notranslate lang-css" translate="no">#loading {
   position: absolute;
   left: 0;
@@ -198,11 +147,7 @@ a CSS animation of diagonal stripes.</p>
   }
 }
 </pre>
-<p>Now that we have a progress bar let's deal with the models. These models
-have animations and we want to be able to access those animations.
-Animations are stored in an array by default be we'd like to be able to
-easily access them by name so let's setup an <code class="notranslate" translate="no">animations</code> property for
-each model to do that. Note of course this means animations must have unique names.</p>
+<p>现在我们有了进度条，让我们来处理模型。这些模型有动画，我们希望能够访问这些动画。动画默认存储在数组中，但我们希望能够通过名称轻松访问它们，所以让我们为每个模型设置一个 <code class="notranslate" translate="no">animations</code> 属性来实现这一点。当然，这意味着动画必须有唯一的名称。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">+function prepModelsAndAnimations() {
 +  Object.values(models).forEach(model =&gt; {
 +    const animsByName = {};
@@ -214,30 +159,23 @@ each model to do that. Note of course this means animations must have unique nam
 +}
 
 function init() {
-  // hide the loading bar
+  // 隐藏加载条
   const loadingElem = document.querySelector('#loading');
   loadingElem.style.display = 'none';
 
 +  prepModelsAndAnimations();
 }
 </pre>
-<p>Let's display the animated models.</p>
-<p>Unlike the <a href="load-gltf.html">previous example of loading a glTF file</a>
-This time we probably want to be able to display more than one instance
-of each model. To do this, instead of adding
-the loaded gltf scene directly like we did in <a href="load-gltf.html">the article on loading a glTF</a>,
-we instead want to clone the scene and in particular we want to clone
-it for skinned animated characters. Fortunately there's a utility function,
-<code class="notranslate" translate="no">SkeletonUtils.clone</code> we can use to do this. So, first we need to include
-the utils.</p>
+<p>让我们显示带动画的模型。</p>
+<p>与<a href="load-gltf.html">之前加载 glTF 文件的例子</a>不同，这次我们可能想要显示每个模型的多个实例。为此，我们不是像在<a href="load-gltf.html">加载 glTF 文章</a>中那样直接添加加载的 gltf 场景，而是要克隆场景，特别是为蒙皮动画角色克隆场景。幸运的是有一个工具函数 <code class="notranslate" translate="no">SkeletonUtils.clone</code> 可以用来做这件事。所以，首先我们需要引入这个工具。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
 import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
 import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
 +import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
 </pre>
-<p>Then we can clone the models we just loaded</p>
+<p>然后我们可以克隆刚刚加载的模型</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
-  // hide the loading bar
+  // 隐藏加载条
   const loadingElem = document.querySelector('#loading');
   loadingElem.style.display = 'none';
 
@@ -252,21 +190,12 @@ import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
 +  });
 }
 </pre>
-<p>Above, for each model, we clone the <code class="notranslate" translate="no">gltf.scene</code> we loaded and we parent that
-to a new <a href="/docs/#api/en/core/Object3D"><code class="notranslate" translate="no">Object3D</code></a>. We need to parent it to another object because when
-we play animations the animation will apply animated positions to the nodes
-in the loaded scene which means we won't have control over those positions.</p>
-<p>To play the animations each model we clone needs an <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a>.
-An <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a> contains 1 or more <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a>s. An
-<a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> references an <a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a>. <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a>s
-have all kinds of settings for playing then chaining to another
-action or cross fading between actions. Let's just get the first
-<a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a> and create an action for it. The default is for
-an action to play its clip in a loop forever.</p>
+<p>上面的代码中，对于每个模型，我们克隆了加载的 <code class="notranslate" translate="no">gltf.scene</code> 并将其挂载到一个新的 <a href="/docs/#api/en/core/Object3D"><code class="notranslate" translate="no">Object3D</code></a> 上。我们需要将它挂载到另一个对象上，因为播放动画时，动画会将动画位置应用到加载场景中的节点上，这意味着我们将无法控制这些位置。</p>
+<p>要播放动画，每个克隆的模型都需要一个 <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a>。一个 <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a> 包含一个或多个 <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a>。<a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> 引用一个 <a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a>。<a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> 有各种播放设置，可以链接到另一个动作或在动作之间交叉淡入淡出。让我们先获取第一个 <a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a> 并为它创建一个动作。默认情况下，动作会永远循环播放其片段。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">+const mixers = [];
 
 function init() {
-  // hide the loading bar
+  // 隐藏加载条
   const loadingElem = document.querySelector('#loading');
   loadingElem.style.display = 'none';
 
@@ -287,13 +216,10 @@ function init() {
   });
 }
 </pre>
-<p>We called <a href="/docs/#api/en/animation/AnimationAction#play"><code class="notranslate" translate="no">play</code></a> to start the action and stored
-off all the <code class="notranslate" translate="no">AnimationMixers</code> in an array called <code class="notranslate" translate="no">mixers</code>. Finally
-we need to update each <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a> in our render loop by computing
-the time since the last frame and passing that to <a href="/docs/#api/en/animation/AnimationMixer.update"><code class="notranslate" translate="no">AnimationMixer.update</code></a>.</p>
+<p>我们调用了 <a href="/docs/#api/en/animation/AnimationAction#play"><code class="notranslate" translate="no">play</code></a> 来启动动作，并将所有 <code class="notranslate" translate="no">AnimationMixer</code> 存储在一个名为 <code class="notranslate" translate="no">mixers</code> 的数组中。最后我们需要在渲染循环中更新每个 <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a>，计算自上一帧以来经过的时间并将其传递给 <a href="/docs/#api/en/animation/AnimationMixer.update"><code class="notranslate" translate="no">AnimationMixer.update</code></a>。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">+let then = 0;
 function render(now) {
-+  now *= 0.001;  // convert to seconds
++  now *= 0.001;  // 转换为秒
 +  const deltaTime = now - then;
 +  then = now;
 
@@ -312,21 +238,19 @@ function render(now) {
   requestAnimationFrame(render);
 }
 </pre>
-<p>And with that we should get each model loaded and playing its first animation.</p>
+<p>这样我们应该能加载每个模型并播放其第一个动画了。</p>
 <p></p><div translate="no" class="threejs_example_container notranslate">
   <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-load-models.html"></iframe></div>
-  <a class="threejs_center" href="/manual/examples/game-load-models.html" target="_blank">click here to open in a separate window</a>
+  <a class="threejs_center" href="/manual/examples/game-load-models.html" target="_blank">点击此处在新标签页中打开</a>
 </div>
 
 <p></p>
-<p>Let's make it so we can check all of the animations.
-We'll add all of the clips as actions and then enable just one at
-a time.</p>
+<p>让我们能够检查所有动画。我们将所有片段作为动作添加，然后一次只启用一个。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">-const mixers = [];
 +const mixerInfos = [];
 
 function init() {
-  // hide the loading bar
+  // 隐藏加载条
   const loadingElem = document.querySelector('#loading');
   loadingElem.style.display = 'none';
 
@@ -370,19 +294,14 @@ function init() {
 +  });
 +}
 </pre>
-<p>The code above makes an array of <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a>s,
-one for each <a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a>. It makes an array of objects, <code class="notranslate" translate="no">mixerInfos</code>,
-with references to the <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a> and all the <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a>s
-for each model. It then calls <code class="notranslate" translate="no">playNextAction</code> which sets <code class="notranslate" translate="no">enabled</code> on
-all but one action for that mixer.</p>
-<p>We need to update the render loop for the new array</p>
+<p>上面的代码为每个 <a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a> 创建了一个 <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> 数组。它创建了一个 <code class="notranslate" translate="no">mixerInfos</code> 对象数组，其中包含对每个模型的 <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a> 和所有 <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> 的引用。然后它调用 <code class="notranslate" translate="no">playNextAction</code>，将除了一个动作之外的所有动作的 <code class="notranslate" translate="no">enabled</code> 设为 false。</p>
+<p>我们需要为新数组更新渲染循环</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">-for (const mixer of mixers) {
 +for (const {mixer} of mixerInfos) {
   mixer.update(deltaTime);
 }
 </pre>
-<p>Let's make it so pressing a key 1 to 8 will play the next animation
-for each model</p>
+<p>让我们实现按键 1 到 8 来播放每个模型的下一个动画</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">window.addEventListener('keydown', (e) =&gt; {
   const mixerInfo = mixerInfos[e.keyCode - 49];
   if (!mixerInfo) {
@@ -391,26 +310,17 @@ for each model</p>
   playNextAction(mixerInfo);
 });
 </pre>
-<p>Now you should be able to click on the example and then press keys 1 through 8
-to cycle each of the models through their available animations.</p>
+<p>现在你应该能点击示例，然后按 1 到 8 键来循环切换每个模型的可用动画。</p>
 <p></p><div translate="no" class="threejs_example_container notranslate">
   <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-check-animations.html"></iframe></div>
-  <a class="threejs_center" href="/manual/examples/game-check-animations.html" target="_blank">click here to open in a separate window</a>
+  <a class="threejs_center" href="/manual/examples/game-check-animations.html" target="_blank">点击此处在新标签页中打开</a>
 </div>
 
 <p></p>
-<p>So that is arguably the sum-total of the three.js portion of this
-article. We covered loading multiple files, cloning skinned models,
-and playing animations on them. In a real game you'd have to do a
-ton more manipulation of <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> objects.</p>
-<p>Let's start making a game infrastructure</p>
-<p>A common pattern for making a modern game is to use an
-<a href="https://www.google.com/search?q=entity+component+system">Entity Component System</a>.
-In an Entity Component System an object in a game is called an <em>entity</em> that consists
-of a bunch of <em>components</em>. You build up entities by deciding which components to
-attach to them. So, let's make an Entity Component System.</p>
-<p>We'll call our entities <code class="notranslate" translate="no">GameObject</code>. It's effectively just a collection
-of components and a three.js <a href="/docs/#api/en/core/Object3D"><code class="notranslate" translate="no">Object3D</code></a>.</p>
+<p>这基本上就是本文 three.js 部分的全部内容了。我们讲解了加载多个文件、克隆蒙皮模型以及在它们上播放动画。在真正的游戏中，你需要对 <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> 对象做更多的操作。</p>
+<p>让我们开始构建游戏基础架构</p>
+<p>制作现代游戏的一个常见模式是使用<a href="https://www.google.com/search?q=entity+component+system">实体组件系统</a>（Entity Component System）。在实体组件系统中，游戏中的对象被称为<em>实体</em>（entity），由一组<em>组件</em>（component）组成。你通过决定将哪些组件附加到实体上来构建实体。那么，让我们来构建一个实体组件系统。</p>
+<p>我们将实体称为 <code class="notranslate" translate="no">GameObject</code>。它实际上只是组件的集合和一个 three.js <a href="/docs/#api/en/core/Object3D"><code class="notranslate" translate="no">Object3D</code></a>。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function removeArrayElement(array, element) {
   const ndx = array.indexOf(element);
   if (ndx &gt;= 0) {
@@ -443,37 +353,23 @@ class GameObject {
   }
 }
 </pre>
-<p>Calling <code class="notranslate" translate="no">GameObject.update</code> calls <code class="notranslate" translate="no">update</code> on all the components.</p>
-<p>I included a name only to help in debugging so if I look at a <code class="notranslate" translate="no">GameObject</code>
-in the debugger I can see a name to help identify it.</p>
-<p>Some things that might seem a little strange:</p>
-<p><code class="notranslate" translate="no">GameObject.addComponent</code> is used to create components. Whether or not
-this a good idea or a bad idea I'm not sure. My thinking was it makes
-no sense for a component to exist outside of a gameobject so I thought
-it might be good if creating a component automatically added that component
-to the gameobject and passed the gameobject to the component's constructor.
-In other words to add a component you do this</p>
+<p>调用 <code class="notranslate" translate="no">GameObject.update</code> 会调用所有组件的 <code class="notranslate" translate="no">update</code>。</p>
+<p>我添加 name 只是为了帮助调试，这样在调试器中查看 <code class="notranslate" translate="no">GameObject</code> 时可以看到一个名称来帮助识别。</p>
+<p>有些东西可能看起来有点奇怪：</p>
+<p><code class="notranslate" translate="no">GameObject.addComponent</code> 用于创建组件。我不确定这是好主意还是坏主意。我的想法是，组件存在于游戏对象之外没有意义，所以我认为如果创建组件时自动将该组件添加到游戏对象并将游戏对象传递给组件的构造函数会比较好。换句话说，添加组件时你这样做</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const gameObject = new GameObject(scene, 'foo');
 gameObject.addComponent(TypeOfComponent);
 </pre>
-<p>If I didn't do it this way you'd instead do something like this</p>
+<p>如果我不这样做，你就需要这样写</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const gameObject = new GameObject(scene, 'foo');
 const component = new TypeOfComponent(gameObject);
 gameObject.addComponent(component);
 </pre>
-<p>Is it better that the first way is shorter and more automated or is it worse
-because it looks out of the ordinary? I don't know.</p>
-<p><code class="notranslate" translate="no">GameObject.getComponent</code> looks up components by type. That has
-the implication that you can not have 2 components of the same
-type on a single game object or at least if you do you can only
-look up the first one without adding some other API.</p>
-<p>It's common for one component to look up another and when looking them up they
-have to match by type otherwise you might get the wrong one. We could instead
-give each component a name and you could look them up by name. That would be
-more flexible in that you could have more than one component of the same type but it
-would also be more tedious. Again, I'm not sure which is better.</p>
-<p>On to the components themselves. Here is their base class.</p>
-<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// Base for all components
+<p>第一种方式更短更自动化，这是更好还是更差，因为它看起来不太常规？我不知道。</p>
+<p><code class="notranslate" translate="no">GameObject.getComponent</code> 通过类型查找组件。这意味着你不能在一个游戏对象上有两个相同类型的组件，或者至少如果你有的话，在不添加其他 API 的情况下只能查找到第一个。</p>
+<p>一个组件查找另一个组件是很常见的，查找时必须按类型匹配，否则你可能会找到错误的组件。我们也可以给每个组件一个名称，然后按名称查找。这样会更灵活，因为你可以有多个相同类型的组件，但也会更繁琐。同样，我不确定哪种更好。</p>
+<p>现在来看组件本身。这是它们的基类。</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// 所有组件的基类
 class Component {
   constructor(gameObject) {
     this.gameObject = gameObject;
@@ -482,30 +378,14 @@ class Component {
   }
 }
 </pre>
-<p>Do components need a base class? JavaScript is not like most strictly
-typed languages so effectively we could have no base class and just
-leave it up to each component to do whatever it wants in its constructor
-knowing that the first argument is always the component's gameobject.
-If it doesn't care about gameobject it wouldn't store it. I kind of feel like this
-common base is good though. It means if you have a reference to a
-component you know you can find its parent gameobject always and from its
-parent you can easily look up other components as well as look at its
-transform.</p>
-<p>To manage the gameobjects we probably need some kind of gameobject manager. You
-might think we could just keep an array of gameobjects but in a real game the
-components of a gameobject might add and remove other gameobjects at runtime.
-For example a gun gameobject might add a bullet gameobject every time the gun
-fires. A monster gameobject might remove itself if it has been killed. We then
-would have an issue that we might have code like this</p>
+<p>组件需要基类吗？JavaScript 不像大多数严格类型语言，所以实际上我们可以没有基类，让每个组件在其构造函数中做它想做的事，知道第一个参数始终是组件的游戏对象。如果它不关心游戏对象就不存储它。但我还是觉得这个公共基类是好的。它意味着如果你有一个组件的引用，你总是可以找到它的父游戏对象，从父对象你可以轻松查找其他组件以及查看它的变换。</p>
+<p>要管理游戏对象，我们可能需要某种游戏对象管理器。你可能认为我们可以只维护一个游戏对象数组，但在真正的游戏中，游戏对象的组件可能在运行时添加和移除其他游戏对象。例如，一个枪游戏对象可能在每次开火时添加一个子弹游戏对象。一个怪物游戏对象可能在被杀死时移除自己。这样我们就会遇到一个问题，我们可能有这样的代码</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">for (const gameObject of globalArrayOfGameObjects) {
   gameObject.update();
 }
 </pre>
-<p>The loop above would fail or do un-expected things if
-gameobjects are added or removed from <code class="notranslate" translate="no">globalArrayOfGameObjects</code>
-in the middle of the loop in some component's <code class="notranslate" translate="no">update</code> function.</p>
-<p>To try to prevent that problem we need something a little safer.
-Here's one attempt.</p>
+<p>如果在某个组件的 <code class="notranslate" translate="no">update</code> 函数中在循环中途向 <code class="notranslate" translate="no">globalArrayOfGameObjects</code> 添加或移除游戏对象，上面的循环就会失败或产生意外行为。</p>
+<p>为了防止这个问题，我们需要一些更安全的东西。这是一个尝试。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class SafeArray {
   constructor() {
     this.array = [];
@@ -546,11 +426,8 @@ Here's one attempt.</p>
   }
 }
 </pre>
-<p>The class above lets you add or remove elements from the <code class="notranslate" translate="no">SafeArray</code>
-but won't mess with the array itself while it's being iterated over. Instead
-new elements get added to <code class="notranslate" translate="no">addQueue</code> and removed elements to the <code class="notranslate" translate="no">removeQueue</code>
-and then added or removed outside of the loop.</p>
-<p>Using that here is our class to manage gameobjects.</p>
+<p>上面的类允许你向 <code class="notranslate" translate="no">SafeArray</code> 添加或移除元素，但在遍历时不会直接修改数组本身。新元素会被添加到 <code class="notranslate" translate="no">addQueue</code>，要移除的元素添加到 <code class="notranslate" translate="no">removeQueue</code>，然后在循环之外进行实际的添加或移除。</p>
+<p>使用它，这是我们管理游戏对象的类。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class GameObjectManager {
   constructor() {
     this.gameObjects = new SafeArray();
@@ -568,10 +445,7 @@ and then added or removed outside of the loop.</p>
   }
 }
 </pre>
-<p>With all that now let's make our first component. This component
-will just manage a skinned three.js object like the ones we just created.
-To keep it simple it will just have one method, <code class="notranslate" translate="no">setAnimation</code> that
-takes the name of the animation to play and plays it.</p>
+<p>有了这些，现在让我们创建第一个组件。这个组件只负责管理像我们刚才创建的那种蒙皮 three.js 对象。为了简单起见，它只有一个方法 <code class="notranslate" translate="no">setAnimation</code>，接受要播放的动画名称并播放它。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class SkinInstance extends Component {
   constructor(gameObject, model) {
     super(gameObject);
@@ -583,11 +457,11 @@ takes the name of the animation to play and plays it.</p>
   }
   setAnimation(animName) {
     const clip = this.model.animations[animName];
-    // turn off all current actions
+    // 关闭所有当前动作
     for (const action of Object.values(this.actions)) {
       action.enabled = false;
     }
-    // get or create existing action for clip
+    // 获取或创建该片段的动作
     const action = this.mixer.clipAction(clip);
     action.enabled = true;
     action.reset();
@@ -599,34 +473,27 @@ takes the name of the animation to play and plays it.</p>
   }
 }
 </pre>
-<p>You can see it's basically the code we had before that clones the scene we loaded,
-then sets up an <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a>. <code class="notranslate" translate="no">setAnimation</code> adds a <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a> for a
-particular <a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a> if one does not already exist and disables all
-existing actions.</p>
-<p>The code references <code class="notranslate" translate="no">globals.deltaTime</code>. Let's make a globals object</p>
+<p>你可以看到，它基本上就是我们之前的代码，克隆加载的场景，然后设置一个 <a href="/docs/#api/en/animation/AnimationMixer"><code class="notranslate" translate="no">AnimationMixer</code></a>。<code class="notranslate" translate="no">setAnimation</code> 为特定的 <a href="/docs/#api/en/animation/AnimationClip"><code class="notranslate" translate="no">AnimationClip</code></a> 添加一个 <a href="/docs/#api/en/animation/AnimationAction"><code class="notranslate" translate="no">AnimationAction</code></a>（如果还不存在的话），并禁用所有现有的动作。</p>
+<p>代码引用了 <code class="notranslate" translate="no">globals.deltaTime</code>。让我们创建一个 globals 对象</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const globals = {
   time: 0,
   deltaTime: 0,
 };
 </pre>
-<p>And update it in the render loop</p>
+<p>并在渲染循环中更新它</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">let then = 0;
 function render(now) {
-  // convert to seconds
+  // 转换为秒
   globals.time = now * 0.001;
-  // make sure delta time isn't too big.
+  // 确保 deltaTime 不会太大
   globals.deltaTime = Math.min(globals.time - then, 1 / 20);
   then = globals.time;
 </pre>
-<p>The check above for making sure <code class="notranslate" translate="no">deltaTime</code> is not more than 1/20th
-of a second is because otherwise we'd get a huge value for <code class="notranslate" translate="no">deltaTime</code>
-if we hide the tab. We might hide it for seconds or minutes and then
-when our tab was brought to the front <code class="notranslate" translate="no">deltaTime</code> would be huge
-and might teleport characters across our game world if we had code like</p>
+<p>上面确保 <code class="notranslate" translate="no">deltaTime</code> 不超过 1/20 秒的检查是因为，如果我们隐藏标签页，就会得到一个巨大的 <code class="notranslate" translate="no">deltaTime</code> 值。我们可能隐藏标签页几秒或几分钟，然后当标签页被切回前台时 <code class="notranslate" translate="no">deltaTime</code> 会非常大，如果我们有这样的代码，可能会把角色传送到游戏世界的另一端</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">position += velocity * deltaTime;
 </pre>
-<p>By limiting the maximum <code class="notranslate" translate="no">deltaTime</code> that issue is prevented.</p>
-<p>Now let's make a component for the player.</p>
+<p>通过限制 <code class="notranslate" translate="no">deltaTime</code> 的最大值可以防止这个问题。</p>
+<p>现在让我们为玩家创建一个组件。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Player extends Component {
   constructor(gameObject) {
     super(gameObject);
@@ -636,9 +503,7 @@ and might teleport characters across our game world if we had code like</p>
   }
 }
 </pre>
-<p>The player calls <code class="notranslate" translate="no">setAnimation</code> with <code class="notranslate" translate="no">'Run'</code>. To know which animations
-are available I modified our previous example to print out the names of
-the animations</p>
+<p>玩家用 <code class="notranslate" translate="no">'Run'</code> 调用 <code class="notranslate" translate="no">setAnimation</code>。为了知道有哪些可用的动画，我修改了之前的示例来打印动画名称</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function prepModelsAndAnimations() {
   Object.values(models).forEach(model =&gt; {
 +    console.log('-------&gt;:', model.url);
@@ -651,7 +516,7 @@ the animations</p>
   });
 }
 </pre>
-<p>And running it got this list in <a href="https://developers.google.com/web/tools/chrome-devtools/console/javascript">the JavaScript console</a>.</p>
+<p>运行后在 <a href="https://developers.google.com/web/tools/chrome-devtools/console/javascript">JavaScript 控制台</a>中得到了这个列表。</p>
 <pre class="prettyprint showlinemods notranslate notranslate" translate="no"> -------&gt;:  resources/models/animals/Pig.gltf
     Idle
     Death
@@ -701,11 +566,8 @@ the animations</p>
     Roll_sword
     Idle
     Run_swordAttack
-</pre><p>Fortunately the names of the animations for all the animals match
-which will come in handy later. For now we only care the that the
-player has an animation called <code class="notranslate" translate="no">Run</code>.</p>
-<p>Let's use these components. Here's the updated init function.
-All it does is create a <code class="notranslate" translate="no">GameObject</code> and add a <code class="notranslate" translate="no">Player</code> component to it.</p>
+</pre><p>幸运的是，所有动物的动画名称都是一样的，这在之后会很方便。目前我们只关心玩家有一个叫 <code class="notranslate" translate="no">Run</code> 的动画。</p>
+<p>让我们使用这些组件。这是更新后的 init 函数。它所做的就是创建一个 <code class="notranslate" translate="no">GameObject</code> 并添加一个 <code class="notranslate" translate="no">Player</code> 组件。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const globals = {
   time: 0,
   deltaTime: 0,
@@ -713,7 +575,7 @@ All it does is create a <code class="notranslate" translate="no">GameObject</cod
 +const gameObjectManager = new GameObjectManager();
 
 function init() {
-  // hide the loading bar
+  // 隐藏加载条
   const loadingElem = document.querySelector('#loading');
   loadingElem.style.display = 'none';
 
@@ -725,12 +587,12 @@ function init() {
 +  }
 }
 </pre>
-<p>And we need to call <code class="notranslate" translate="no">gameObjectManager.update</code> in our render loop</p>
+<p>我们需要在渲染循环中调用 <code class="notranslate" translate="no">gameObjectManager.update</code></p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">let then = 0;
 function render(now) {
-  // convert to seconds
+  // 转换为秒
   globals.time = now * 0.001;
-  // make sure delta time isn't too big.
+  // 确保 deltaTime 不会太大
   globals.deltaTime = Math.min(globals.time - then, 1 / 20);
   then = globals.time;
 
@@ -750,33 +612,29 @@ function render(now) {
   requestAnimationFrame(render);
 }
 </pre>
-<p>and if we run that we get a single player.</p>
+<p>如果我们运行它，会得到一个单独的玩家。</p>
 <p></p><div translate="no" class="threejs_example_container notranslate">
   <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-just-player.html"></iframe></div>
-  <a class="threejs_center" href="/manual/examples/game-just-player.html" target="_blank">click here to open in a separate window</a>
+  <a class="threejs_center" href="/manual/examples/game-just-player.html" target="_blank">点击此处在新标签页中打开</a>
 </div>
 
 <p></p>
-<p>That was a lot of code just for an entity component system but
-it's infrastructure that most games need.</p>
-<p>Let's add an input system. Rather than read keys directly we'll
-make a class that other parts of the code can check <code class="notranslate" translate="no">left</code> or <code class="notranslate" translate="no">right</code>.
-That way we can assign multiple ways to input <code class="notranslate" translate="no">left</code> or <code class="notranslate" translate="no">right</code> etc..
-We'll start with just keys</p>
-<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// Keeps the state of keys/buttons
+<p>仅仅为了一个实体组件系统就写了这么多代码，但这是大多数游戏需要的基础设施。</p>
+<p>让我们添加一个输入系统。与其直接读取按键，我们将创建一个类，让代码的其他部分可以检查 <code class="notranslate" translate="no">left</code> 或 <code class="notranslate" translate="no">right</code>。这样我们可以分配多种方式来输入 <code class="notranslate" translate="no">left</code> 或 <code class="notranslate" translate="no">right</code> 等。我们先从按键开始</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// 保持按键/按钮的状态
 //
-// You can check
+// 你可以检查
 //
 //   inputManager.keys.left.down
 //
-// to see if the left key is currently held down
-// and you can check
+// 来查看左键是否当前被按住
+// 你也可以检查
 //
 //   inputManager.keys.left.justPressed
 //
-// To see if the left key was pressed this frame
+// 来查看左键是否在这一帧被按下
 //
-// Keys are 'left', 'right', 'a', 'b', 'up', 'down'
+// 按键有 'left', 'right', 'a', 'b', 'up', 'down'
 class InputManager {
   constructor() {
     this.keys = {};
@@ -824,13 +682,8 @@ class InputManager {
   }
 }
 </pre>
-<p>The code above tracks whether keys are up or down and you can check
-if a key is currently pressed by checking for example
-<code class="notranslate" translate="no">inputManager.keys.left.down</code>. It also has a <code class="notranslate" translate="no">justPressed</code> property
-for each key so that you can check the user just pressed the key.
-For example a jump key you don't want to know if the button is being
-held down, you want to know did the user press it now.</p>
-<p>Let's create an instance of <code class="notranslate" translate="no">InputManager</code></p>
+<p>上面的代码跟踪按键是按下还是松开，你可以通过检查例如 <code class="notranslate" translate="no">inputManager.keys.left.down</code> 来判断一个键是否当前被按下。它还为每个键提供了 <code class="notranslate" translate="no">justPressed</code> 属性，这样你可以检查用户是否刚刚按下了该键。例如跳跃键，你不想知道按钮是否被持续按住，你想知道用户是否现在按下了它。</p>
+<p>让我们创建一个 <code class="notranslate" translate="no">InputManager</code> 实例</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const globals = {
   time: 0,
   deltaTime: 0,
@@ -838,7 +691,7 @@ held down, you want to know did the user press it now.</p>
 const gameObjectManager = new GameObjectManager();
 +const inputManager = new InputManager();
 </pre>
-<p>and update it in our render loop</p>
+<p>并在渲染循环中更新它</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function render(now) {
 
   ...
@@ -849,9 +702,8 @@ const gameObjectManager = new GameObjectManager();
   ...
 }
 </pre>
-<p>It needs to be called after <code class="notranslate" translate="no">gameObjectManager.update</code> otherwise
-<code class="notranslate" translate="no">justPressed</code> would never be true inside a component's <code class="notranslate" translate="no">update</code> function.</p>
-<p>Let's use it in the <code class="notranslate" translate="no">Player</code> component</p>
+<p>它需要在 <code class="notranslate" translate="no">gameObjectManager.update</code> 之后调用，否则 <code class="notranslate" translate="no">justPressed</code> 在组件的 <code class="notranslate" translate="no">update</code> 函数中永远不会为 true。</p>
+<p>让我们在 <code class="notranslate" translate="no">Player</code> 组件中使用它</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">+const kForward = new THREE.Vector3(0, 0, 1);
 const globals = {
   time: 0,
@@ -877,24 +729,10 @@ class Player extends Component {
 +  }
 }
 </pre>
-<p>The code above uses <a href="/docs/#api/en/core/Object3D.transformOnAxis"><code class="notranslate" translate="no">Object3D.transformOnAxis</code></a> to move the player
-forward. <a href="/docs/#api/en/core/Object3D.transformOnAxis"><code class="notranslate" translate="no">Object3D.transformOnAxis</code></a> works in local space so it only
-works if the object in question is at the root of the scene, not if it's
-parented to something else <a class="footnote" href="#parented" id="parented-backref">1</a></p>
-<p>We also added a global <code class="notranslate" translate="no">moveSpeed</code> and based a <code class="notranslate" translate="no">turnSpeed</code> on the move speed.
-The turn speed is based on the move speed to try to make sure a character
-can turn sharply enough to meet its target. If <code class="notranslate" translate="no">turnSpeed</code> so too small
-a character will turn around and around circling its target but never
-hitting it. I didn't bother to do the math to calculate the required
-turn speed for a given move speed. I just guessed.</p>
-<p>The code so far would work but if the player runs off the screen there's no
-way to find out where they are. Let's make it so if they are offscreen
-for more than a certain time they get teleported back to the origin.
-We can do that by using the three.js <a href="/docs/#api/en/math/Frustum"><code class="notranslate" translate="no">Frustum</code></a> class to check if a point
-is inside the camera's view frustum.</p>
-<p>We need to build a frustum from the camera. We could do this in the Player
-component but other objects might want to use this too so let's add another
-gameobject with a component to manage a frustum.</p>
+<p>上面的代码使用 <a href="/docs/#api/en/core/Object3D.transformOnAxis"><code class="notranslate" translate="no">Object3D.transformOnAxis</code></a> 来向前移动玩家。<a href="/docs/#api/en/core/Object3D.transformOnAxis"><code class="notranslate" translate="no">Object3D.transformOnAxis</code></a> 在本地空间中工作，所以只有当对象在场景的根级别时才有效，如果它是其他东西的子对象则不行 <a class="footnote" href="#parented" id="parented-backref">1</a></p>
+<p>我们还添加了一个全局 <code class="notranslate" translate="no">moveSpeed</code>，并基于移动速度计算 <code class="notranslate" translate="no">turnSpeed</code>。转向速度基于移动速度，以确保角色能够足够快地转向以到达目标。如果 <code class="notranslate" translate="no">turnSpeed</code> 太小，角色会围绕目标转圈但永远无法到达。我没有费心去计算给定移动速度所需的转向速度，只是猜的。</p>
+<p>到目前为止的代码可以工作，但如果玩家跑出屏幕就无法知道他们在哪里了。让我们实现如果他们离开屏幕超过一定时间就传送回原点。我们可以使用 three.js 的 <a href="/docs/#api/en/math/Frustum"><code class="notranslate" translate="no">Frustum</code></a> 类来检查一个点是否在摄像机的视锥体内。</p>
+<p>我们需要从摄像机构建一个视锥体。我们可以在 Player 组件中做这件事，但其他对象可能也想使用它，所以让我们添加另一个带有管理视锥体组件的游戏对象。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class CameraInfo extends Component {
   constructor(gameObject) {
     super(gameObject);
@@ -910,9 +748,9 @@ gameobject with a component to manage a frustum.</p>
   }
 }
 </pre>
-<p>Then let's setup another gameobject at init time.</p>
+<p>然后让我们在初始化时设置另一个游戏对象。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
-  // hide the loading bar
+  // 隐藏加载条
   const loadingElem = document.querySelector('#loading');
   loadingElem.style.display = 'none';
 
@@ -929,7 +767,7 @@ gameobject with a component to manage a frustum.</p>
   }
 }
 </pre>
-<p>and now we can use it in the <code class="notranslate" translate="no">Player</code> component.</p>
+<p>现在我们可以在 <code class="notranslate" translate="no">Player</code> 组件中使用它了。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Player extends Component {
   constructor(gameObject) {
     super(gameObject);
@@ -961,8 +799,7 @@ gameobject with a component to manage a frustum.</p>
   }
 }
 </pre>
-<p>One more thing before we try it out, let's add touchscreen support
-for mobile. First let's add some HTML to touch</p>
+<p>在试运行之前还有一件事，让我们为移动端添加触摸屏支持。首先添加一些 HTML 用于触摸</p>
 <pre class="prettyprint showlinemods notranslate lang-html" translate="no">&lt;body&gt;
   &lt;canvas id="c"&gt;&lt;/canvas&gt;
 +  &lt;div id="ui"&gt;
@@ -978,7 +815,7 @@ for mobile. First let's add some HTML to touch</p>
   &lt;/div&gt;
 &lt;/body&gt;
 </pre>
-<p>and some CSS to style it</p>
+<p>以及一些 CSS 来样式化它</p>
 <pre class="prettyprint showlinemods notranslate lang-css" translate="no">#ui {
   position: absolute;
   left: 0;
@@ -1010,13 +847,7 @@ for mobile. First let's add some HTML to touch</p>
   display: block;
 }
 </pre>
-<p>The idea here is there is one div, <code class="notranslate" translate="no">#ui</code>, that
-covers the entire page. Inside will be 2 divs, <code class="notranslate" translate="no">#left</code> and <code class="notranslate" translate="no">#right</code>
-both of which are almost half the page wide and the entire screen tall.
-In between there is a 40px separator. If the user slides their finger
-over the left or right side then we need up update <code class="notranslate" translate="no">keys.left</code> and <code class="notranslate" translate="no">keys.right</code>
-in the <code class="notranslate" translate="no">InputManager</code>. This makes the entire screen sensitive to being touched
-which seemed better than just small arrows.</p>
+<p>这里的想法是有一个 <code class="notranslate" translate="no">#ui</code> div 覆盖整个页面。里面有两个 div，<code class="notranslate" translate="no">#left</code> 和 <code class="notranslate" translate="no">#right</code>，它们都几乎是页面宽度的一半，高度为整个屏幕。中间有一个 40px 的分隔。如果用户在左侧或右侧滑动手指，我们需要更新 <code class="notranslate" translate="no">InputManager</code> 中的 <code class="notranslate" translate="no">keys.left</code> 和 <code class="notranslate" translate="no">keys.right</code>。这使整个屏幕都对触摸敏感，这比仅使用小箭头要好。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class InputManager {
   constructor() {
     this.keys = {};
@@ -1068,9 +899,9 @@ which seemed better than just small arrows.</p>
 +
 +    const handleMouseMove = (e) =&gt; {
 +      e.preventDefault();
-+      // this is needed because we call preventDefault();
-+      // we also gave the canvas a tabindex so it can
-+      // become the focus
++      // 这是必要的，因为我们调用了 preventDefault()；
++      // 我们还给 canvas 添加了 tabindex 以便它可以
++      // 获得焦点
 +      canvas.focus();
 +      window.addEventListener('pointermove', handleMouseMove);
 +      window.addEventListener('pointerup', handleMouseUp);
@@ -1099,7 +930,7 @@ which seemed better than just small arrows.</p>
 +    uiElem.addEventListener('pointerdown', handleMouseMove, {passive: false});
 +
 +    uiElem.addEventListener('touchstart', (e) =&gt; {
-+      // prevent scrolling
++      // 阻止滚动
 +      e.preventDefault();
 +    }, {passive: false});
   }
@@ -1112,19 +943,15 @@ which seemed better than just small arrows.</p>
   }
 }
 </pre>
-<p>And now we should be able to control the character with the left and right
-cursor keys or with our fingers on a touchscreen</p>
+<p>现在我们应该能用左右方向键或在触摸屏上用手指来控制角色了</p>
 <p></p><div translate="no" class="threejs_example_container notranslate">
   <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-player-input.html"></iframe></div>
-  <a class="threejs_center" href="/manual/examples/game-player-input.html" target="_blank">click here to open in a separate window</a>
+  <a class="threejs_center" href="/manual/examples/game-player-input.html" target="_blank">点击此处在新标签页中打开</a>
 </div>
 
 <p></p>
-<p>Ideally we'd do something else if the player went off the screen like move
-the camera or maybe offscreen = death but this article is already going to be
-too long so for now teleporting to the middle was the simplest thing.</p>
-<p>Lets add some animals. We can start it off similar to the <code class="notranslate" translate="no">Player</code> by making
-an <code class="notranslate" translate="no">Animal</code> component.</p>
+<p>理想情况下，如果玩家离开屏幕我们会做其他事情，比如移动摄像机或者离开屏幕就死亡，但这篇文章已经够长了，所以目前传送回中心是最简单的方案。</p>
+<p>让我们添加一些动物。我们可以像 <code class="notranslate" translate="no">Player</code> 类似地开始，创建一个 <code class="notranslate" translate="no">Animal</code> 组件。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Animal extends Component {
   constructor(gameObject, model) {
     super(gameObject);
@@ -1134,12 +961,10 @@ an <code class="notranslate" translate="no">Animal</code> component.</p>
   }
 }
 </pre>
-<p>The code above sets the <a href="/docs/#api/en/animation/AnimationMixer.timeScale"><code class="notranslate" translate="no">AnimationMixer.timeScale</code></a> to set the playback
-speed of the animations relative to the move speed. This way if we
-adjust the move speed the animation will speed up or slow down as well.</p>
-<p>To start we could setup one of each type of animal</p>
+<p>上面的代码设置 <a href="/docs/#api/en/animation/AnimationMixer.timeScale"><code class="notranslate" translate="no">AnimationMixer.timeScale</code></a> 来设置动画相对于移动速度的播放速度。这样如果我们调整移动速度，动画也会相应加速或减速。</p>
+<p>首先我们可以设置每种动物各一个</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
-  // hide the loading bar
+  // 隐藏加载条
   const loadingElem = document.querySelector('#loading');
   loadingElem.style.display = 'none';
 
@@ -1171,31 +996,24 @@ adjust the move speed the animation will speed up or slow down as well.</p>
 +  });
 }
 </pre>
-<p>And that would get us animals standing on the screen but we want them to do
-something.</p>
-<p>Let's make them follow the player in a conga line but only if the player gets near enough.
-To do this we need several states.</p>
+<p>这样我们会得到站在屏幕上的动物，但我们希望它们做些什么。</p>
+<p>让我们让它们在玩家靠近时跟随玩家排成康加舞队列。为此我们需要几种状态。</p>
 <ul>
-<li><p>Idle:</p>
-<p>Animal is waiting for player to get close</p>
+<li><p>空闲（Idle）：</p>
+<p>动物等待玩家靠近</p>
 </li>
-<li><p>Wait for End of Line:</p>
-<p>Animal was tagged by player but now needs to wait for the animal
-at the end of the line to come by so they can join the end of the line.</p>
+<li><p>等待队尾（Wait for End of Line）：</p>
+<p>动物被玩家标记了，但现在需要等待队列末尾的动物过来，这样它才能加入队尾。</p>
 </li>
-<li><p>Go to Last:</p>
-<p>Animal needs to walk to where the animal they are following was, at the same time recording
-a history of where the animal they are following is currently.</p>
+<li><p>走向队尾（Go to Last）：</p>
+<p>动物需要走到它跟随的动物之前所在的位置，同时记录它跟随的动物当前的位置历史。</p>
 </li>
-<li><p>Follow</p>
-<p>Animal needs to keep recording a history of where the animal they are following is while
-moving to where the animal they are following was before.</p>
+<li><p>跟随（Follow）</p>
+<p>动物需要持续记录它跟随的动物的位置历史，同时移动到它跟随的动物之前所在的位置。</p>
 </li>
 </ul>
-<p>There are many ways to handle different states like this. A common one is to use
-a <a href="https://www.google.com/search?q=finite+state+machine">Finite State Machine</a> and
-to build some class to help us manage the state.</p>
-<p>So, let's do that.</p>
+<p>处理这样的不同状态有很多方式。一种常见的方式是使用<a href="https://www.google.com/search?q=finite+state+machine">有限状态机</a>（Finite State Machine），并构建一些类来帮助我们管理状态。</p>
+<p>那么，让我们来实现它。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class FiniteStateMachine {
   constructor(states, initialState) {
     this.states = states;
@@ -1223,22 +1041,16 @@ to build some class to help us manage the state.</p>
   }
 }
 </pre>
-<p>Here's a simple class. We pass it an object with a bunch of states.
-Each state as 3 optional functions, <code class="notranslate" translate="no">enter</code>, <code class="notranslate" translate="no">update</code>, and <code class="notranslate" translate="no">exit</code>.
-To switch states we call <code class="notranslate" translate="no">FiniteStateMachine.transition</code> and pass it
-the name of the new state. If the current state has an <code class="notranslate" translate="no">exit</code> function
-it's called. Then if the new state has an <code class="notranslate" translate="no">enter</code> function it's called.
-Finally each frame <code class="notranslate" translate="no">FiniteStateMachine.update</code> calls the <code class="notranslate" translate="no">update</code> function
-of the current state.</p>
-<p>Let's use it to manage the states of the animals.</p>
-<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// Returns true of obj1 and obj2 are close
+<p>这是一个简单的类。我们传给它一个包含一堆状态的对象。每个状态有 3 个可选函数：<code class="notranslate" translate="no">enter</code>、<code class="notranslate" translate="no">update</code> 和 <code class="notranslate" translate="no">exit</code>。要切换状态，我们调用 <code class="notranslate" translate="no">FiniteStateMachine.transition</code> 并传入新状态的名称。如果当前状态有 <code class="notranslate" translate="no">exit</code> 函数就会被调用。然后如果新状态有 <code class="notranslate" translate="no">enter</code> 函数也会被调用。最后每一帧 <code class="notranslate" translate="no">FiniteStateMachine.update</code> 会调用当前状态的 <code class="notranslate" translate="no">update</code> 函数。</p>
+<p>让我们用它来管理动物的状态。</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// 如果 obj1 和 obj2 足够近则返回 true
 function isClose(obj1, obj1Radius, obj2, obj2Radius) {
   const minDist = obj1Radius + obj2Radius;
   const dist = obj1.position.distanceTo(obj2.position);
   return dist &lt; minDist;
 }
 
-// keeps v between -min and +min
+// 将 v 限制在 -min 和 +min 之间
 function minMagnitude(v, min) {
   return Math.abs(v) &gt; min
       ? min * Math.sign(v)
@@ -1250,16 +1062,16 @@ const aimTowardAndGetDistance = function() {
 
   return function aimTowardAndGetDistance(source, targetPos, maxTurn) {
     delta.subVectors(targetPos, source.position);
-    // compute the direction we want to be facing
+    // 计算我们想要面朝的方向
     const targetRot = Math.atan2(delta.x, delta.z) + Math.PI * 1.5;
-    // rotate in the shortest direction
+    // 沿最短方向旋转
     const deltaRot = (targetRot - source.rotation.y + Math.PI * 1.5) % (Math.PI * 2) - Math.PI;
-    // make sure we don't turn faster than maxTurn
+    // 确保转向速度不超过 maxTurn
     const deltaRotation = minMagnitude(deltaRot, maxTurn);
-    // keep rotation between 0 and Math.PI * 2
+    // 将旋转保持在 0 到 Math.PI * 2 之间
     source.rotation.y = THREE.MathUtils.euclideanModulo(
         source.rotation.y + deltaRotation, Math.PI * 2);
-    // return the distance to the target
+    // 返回到目标的距离
     return delta.length();
   };
 }();
@@ -1289,7 +1101,7 @@ class Animal extends Component {
 +          skinInstance.setAnimation('Idle');
 +        },
 +        update: () =&gt; {
-+          // check if player is near
++          // 检查玩家是否靠近
 +          if (isClose(transform, hitRadius, playerTransform, globals.playerRadius)) {
 +            this.fsm.transition('waitForEnd');
 +          }
@@ -1300,12 +1112,12 @@ class Animal extends Component {
 +          skinInstance.setAnimation('Jump');
 +        },
 +        update: () =&gt; {
-+          // get the gameObject at the end of the conga line
++          // 获取康加舞队列末尾的游戏对象
 +          const lastGO = globals.congaLine[globals.congaLine.length - 1];
 +          const deltaTurnSpeed = maxTurnSpeed * globals.deltaTime;
 +          const targetPos = lastGO.transform.position;
 +          aimTowardAndGetDistance(transform, targetPos, deltaTurnSpeed);
-+          // check if last thing in conga line is near
++          // 检查康加舞队列的最后一个是否靠近
 +          if (isClose(transform, hitRadius, lastGO.transform, globals.playerRadius)) {
 +            this.fsm.transition('goToLast');
 +          }
@@ -1313,15 +1125,15 @@ class Animal extends Component {
 +      },
 +      goToLast: {
 +        enter: () =&gt; {
-+          // remember who we're following
++          // 记住我们跟随的是谁
 +          targetNdx = globals.congaLine.length - 1;
-+          // add ourselves to the conga line
++          // 将自己加入康加舞队列
 +          globals.congaLine.push(gameObject);
 +          skinInstance.setAnimation('Walk');
 +        },
 +        update: () =&gt; {
 +          addHistory();
-+          // walk to the oldest point in the history
++          // 走向历史记录中最旧的点
 +          const targetPos = targetHistory[0];
 +          const maxVelocity = globals.moveSpeed * globals.deltaTime;
 +          const deltaTurnSpeed = maxTurnSpeed * globals.deltaTime;
@@ -1336,7 +1148,7 @@ class Animal extends Component {
 +      follow: {
 +        update: () =&gt; {
 +          addHistory();
-+          // remove the oldest history and just put ourselves there.
++          // 移除最旧的历史记录并将自己放到那个位置
 +          const targetPos = targetHistory.shift();
 +          transform.position.copy(targetPos);
 +          const deltaTurnSpeed = maxTurnSpeed * globals.deltaTime;
@@ -1350,11 +1162,8 @@ class Animal extends Component {
 +  }
 }
 </pre>
-<p>That was big chunk of code but it does what was described above.
-Hopefully of you walk through each state it will be clear.</p>
-<p>A few things we need to add. We need the player to add itself
-to the globals so the animals can find it and we need to start the
-conga line with the player's <code class="notranslate" translate="no">GameObject</code>.</p>
+<p>这是一大段代码，但它实现了上面描述的功能。希望你逐步浏览每个状态时会觉得很清晰。</p>
+<p>我们还需要添加一些东西。我们需要让玩家将自己添加到 globals 中，以便动物可以找到它，并且我们需要用玩家的 <code class="notranslate" translate="no">GameObject</code> 来开始康加舞队列。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
 
   ...
@@ -1367,7 +1176,7 @@ conga line with the player's <code class="notranslate" translate="no">GameObject
 
 }
 </pre>
-<p>We also need to compute a size for each model</p>
+<p>我们还需要计算每个模型的大小</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function prepModelsAndAnimations() {
 +  const box = new THREE.Box3();
 +  const size = new THREE.Vector3();
@@ -1378,7 +1187,7 @@ conga line with the player's <code class="notranslate" translate="no">GameObject
     const animsByName = {};
     model.gltf.animations.forEach((clip) =&gt; {
       animsByName[clip.name] = clip;
-      // Should really fix this in .blend file
+      // 这个应该在 .blend 文件中修复
       if (clip.name === 'Walk') {
         clip.duration /= 2;
       }
@@ -1387,25 +1196,17 @@ conga line with the player's <code class="notranslate" translate="no">GameObject
   });
 }
 </pre>
-<p>And we need the player to record their size</p>
+<p>我们还需要让玩家记录自己的大小</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Player extends Component {
   constructor(gameObject) {
     super(gameObject);
     const model = models.knight;
 +    globals.playerRadius = model.size / 2;
 </pre>
-<p>Thinking about it now it would probably have been smarter
-for the animals to just target the head of the conga line
-instead of the player specifically. Maybe I'll come back
-and change that later.</p>
-<p>When I first started this I used just one radius for all animals
-but of course that was no good as the pug is much smaller than the horse.
-So I added the difference sizes but I wanted to be able to visualize
-things. To do that I made a <code class="notranslate" translate="no">StatusDisplayHelper</code> component.</p>
-<p>I uses a <a href="/docs/#api/en/helpers/PolarGridHelper"><code class="notranslate" translate="no">PolarGridHelper</code></a> to draw a circle around each character
-and it uses html elements to let each character show some status using
-the techniques covered in <a href="align-html-elements-to-3d.html">the article on aligning html elements to 3D</a>.</p>
-<p>First we need to add some HTML to host these elements</p>
+<p>现在想想，让动物瞄准康加舞队列的头部而不是特定的玩家可能会更聪明。也许我以后会回来改。</p>
+<p>刚开始时我对所有动物只用一个半径，但这当然不好，因为哈巴狗比马小得多。所以我添加了不同的大小，但我想要能够可视化这些东西。为此我创建了一个 <code class="notranslate" translate="no">StatusDisplayHelper</code> 组件。</p>
+<p>它使用 <a href="/docs/#api/en/helpers/PolarGridHelper"><code class="notranslate" translate="no">PolarGridHelper</code></a> 在每个角色周围画一个圆圈，并使用 HTML 元素让每个角色显示一些状态，使用的是<a href="align-html-elements-to-3d.html">将 HTML 元素对齐到 3D 的文章</a>中介绍的技术。</p>
+<p>首先我们需要添加一些 HTML 来承载这些元素</p>
 <pre class="prettyprint showlinemods notranslate lang-html" translate="no">&lt;body&gt;
   &lt;canvas id="c"&gt;&lt;/canvas&gt;
   &lt;div id="ui"&gt;
@@ -1422,10 +1223,10 @@ the techniques covered in <a href="align-html-elements-to-3d.html">the article o
 +  &lt;div id="labels"&gt;&lt;/div&gt;
 &lt;/body&gt;
 </pre>
-<p>And add some CSS for them</p>
+<p>并添加一些 CSS</p>
 <pre class="prettyprint showlinemods notranslate lang-css" translate="no">#labels {
-  position: absolute;  /* let us position ourself inside the container */
-  left: 0;             /* make our position the top left of the container */
+  position: absolute;  /* 让我们可以在容器内定位自己 */
+  left: 0;             /* 将位置设为容器的左上角 */
   top: 0;
   color: white;
   width: 100%;
@@ -1434,13 +1235,13 @@ the techniques covered in <a href="align-html-elements-to-3d.html">the article o
   pointer-events: none;
 }
 #labels&gt;div {
-  position: absolute;  /* let us position them inside the container */
-  left: 0;             /* make their default position the top left of the container */
+  position: absolute;  /* 让我们可以在容器内定位它们 */
+  left: 0;             /* 将它们的默认位置设为容器的左上角 */
   top: 0;
   font-size: large;
   font-family: monospace;
-  user-select: none;   /* don't let the text get selected */
-  text-shadow:         /* create a black outline */
+  user-select: none;   /* 禁止文本被选中 */
+  text-shadow:         /* 创建黑色描边 */
     -1px -1px 0 #000,
      0   -1px 0 #000,
      1px -1px 0 #000,
@@ -1451,7 +1252,7 @@ the techniques covered in <a href="align-html-elements-to-3d.html">the article o
     -1px  0   0 #000;
 }
 </pre>
-<p>Then here's the component</p>
+<p>然后这是组件</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const labelContainerElem = document.querySelector('#labels');
 
 class StateDisplayHelper extends Component {
@@ -1477,21 +1278,21 @@ class StateDisplayHelper extends Component {
     const {canvas} = globals;
     pos.copy(transform.position);
 
-    // get the normalized screen coordinate of that position
-    // x and y will be in the -1 to +1 range with x = -1 being
-    // on the left and y = -1 being on the bottom
+    // 获取该位置的归一化屏幕坐标
+    // x 和 y 的范围在 -1 到 +1 之间，x = -1 在左边
+    // y = -1 在底部
     pos.project(globals.camera);
 
-    // convert the normalized position to CSS coordinates
+    // 将归一化位置转换为 CSS 坐标
     const x = (pos.x *  .5 + .5) * canvas.clientWidth;
     const y = (pos.y * -.5 + .5) * canvas.clientHeight;
 
-    // move the elem to that position
+    // 将元素移动到该位置
     this.elem.style.transform = `translate(-50%, -50%) translate(${x}px,${y}px)`;
   }
 }
 </pre>
-<p>And we can then add them to the animals like this</p>
+<p>然后我们可以这样将它们添加到动物上</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Animal extends Component {
   constructor(gameObject, model) {
     super(gameObject);
@@ -1507,8 +1308,7 @@ class StateDisplayHelper extends Component {
   }
 }
 </pre>
-<p>While we're at it lets make it so we can turn them on/off using lil-gui like
-we've used else where</p>
+<p>趁此机会让我们也实现用 lil-gui 来开关它们，就像我们在其他地方使用的那样</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
 import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
 import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
@@ -1539,68 +1339,31 @@ class StateDisplayHelper extends Component {
   }
 }
 </pre>
-<p>And with that we get the kind of start of a game</p>
+<p>这样我们就有了一个游戏的雏形</p>
 <p></p><div translate="no" class="threejs_example_container notranslate">
   <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-conga-line.html"></iframe></div>
-  <a class="threejs_center" href="/manual/examples/game-conga-line.html" target="_blank">click here to open in a separate window</a>
+  <a class="threejs_center" href="/manual/examples/game-conga-line.html" target="_blank">点击此处在新标签页中打开</a>
 </div>
 
 <p></p>
-<p>Originally I set out to make a <a href="https://www.google.com/search?q=snake+game">snake game</a>
-where as you add animals to your line it gets harder because you need to avoid
-crashing into them. I'd also have put some obstacles in the scene and maybe a fence or some
-barrier around the perimeter.</p>
-<p>Unfortunately the animals are long and thin. From above here's the zebra.</p>
+<p>最初我打算做一个<a href="https://www.google.com/search?q=snake+game">贪吃蛇游戏</a>，随着你将动物添加到队列中，游戏会变得更难，因为你需要避免撞到它们。我还会在场景中放置一些障碍物，也许还有围栏或围绕周边的某种屏障。</p>
+<p>不幸的是，这些动物又长又细。从上面看，这是斑马。</p>
 <div class="threejs_center"><img src="../resources/images/zebra.png" style="width: 113px;"></div>
 
-<p>The code so far is using circle collisions which means if we had obstacles like a fence
-then this would be considered a collision</p>
+<p>目前的代码使用圆形碰撞，这意味着如果我们有像围栏这样的障碍物，那么这将被视为碰撞</p>
 <div class="threejs_center"><img src="../resources/images/zebra-collisions.svg" style="width: 400px;"></div>
 
-<p>That's no good. Even animal to animal we'd have the same issue</p>
-<p>I thought about writing a 2D rectangle to rectangle collision system but I
-quickly realized it could really be a lot of code. Checking that 2 arbitrarily
-oriented boxes overlap is not too much code and for our game with just a few
-objects it might work but looking into it after a few objects you quickly start
-needing to optimize the collision checking. First you might go through all
-objects that can possibly collide with each other and check their bounding
-spheres or bounding circles or their axially aligned bounding boxes. Once you
-know which objects <em>might</em> be colliding then you need to do more work to check if
-they are <em>actually</em> colliding. Often even checking the bounding spheres is too
-much work and you need some kind of better spacial structure for the objects so
-you can more quickly only check objects possibly near each other.</p>
-<p>Then, once you write the code to check if 2 objects collide you generally want
-to make a collision system rather than manually asking "do I collide with these
-objects". A collision system emits events or calls callbacks in relation to
-things colliding. The advantage is it can check all the collisions at once so no
-objects get checked more than once where as if you manually call some "am I
-colliding" function often objects will be checked more than once wasting time.</p>
-<p>Making that collision system would probably not be more than 100-300 lines of
-code for just checking arbitrarily oriented rectangles but it's still a ton more
-code so it seemed best to leave it out.</p>
-<p>Another solution would have been to try to find other characters that are
-mostly circular from the top. Other humanoid characters for example instead
-of animals in which case the circle checking might work animal to animal.
-It would not work animal to fence, well we'd have to add circle to rectangle
-checking. I thought about making the fence a fence of bushes or poles, something
-circular but then I'd need probably 120 to 200 of them to surround the play area
-which would run into the optimization issues mentioned above.</p>
-<p>These are reasons many games use an existing solution. Often these solutions
-are part of a physics library. The physical library needs to know if objects
-collide with each other so on top of providing physics they can also be used
-to detect collision.</p>
-<p>If you're looking for a solution some of the three.js examples use
-<a href="https://github.com/kripken/ammo.js/">ammo.js</a> so that might be one.</p>
-<p>One other solution might have been to place the obstacles on a grid
-and try to make it so each animal and the player just need to look at
-the grid. While that would be performant I felt that's best left as an exercise
-for the reader 😜</p>
-<p>One more thing, many game systems have something called <a href="https://www.google.com/search?q=coroutines"><em>coroutines</em></a>.
-Coroutines are routines that can pause while running and continue later.</p>
-<p>Let's make the main character emit musical notes like they are leading
-the line by singing. There are many ways we could implement this but for now
-let's do it using coroutines.</p>
-<p>First, here's a class to manage coroutines</p>
+<p>这不行。即使是动物与动物之间也会有同样的问题。</p>
+<p>我考虑过写一个 2D 矩形对矩形的碰撞系统，但很快意识到这可能需要很多代码。检查两个任意方向的矩形是否重叠本身代码量不大，对于只有少量对象的游戏可能够用，但当对象多了之后你很快就需要优化碰撞检测。首先你可能需要遍历所有可能相互碰撞的对象，检查它们的包围球、包围圆或轴对齐包围盒。一旦你知道哪些对象<em>可能</em>碰撞，你还需要做更多工作来检查它们是否<em>实际</em>碰撞了。通常即使检查包围球也太费劲，你需要某种更好的空间结构来更快地只检查可能彼此靠近的对象。</p>
+<p>然后，一旦你写了检查两个对象是否碰撞的代码，你通常想要做一个碰撞系统，而不是手动询问"我是否与这些对象碰撞"。碰撞系统会发出事件或调用与碰撞相关的回调。优势在于它可以一次检查所有碰撞，这样没有对象会被检查多次，而如果你手动调用某个"我是否碰撞"的函数，对象往往会被多次检查，浪费时间。</p>
+<p>制作这样的碰撞系统可能只需要 100-300 行代码来检查任意方向的矩形，但这仍然是很多额外的代码，所以最好先不做。</p>
+<p>另一个解决方案是尝试找一些从顶部看大致是圆形的其他角色。例如其他人形角色而不是动物，这样圆形检测可能适用于动物之间的碰撞。但对于动物与围栏之间则不行，我们必须添加圆形对矩形的检测。我考虑过把围栏做成灌木丛或柱子，圆形的东西，但那样我可能需要 120 到 200 个来围绕游戏区域，这就会遇到上面提到的优化问题。</p>
+<p>这就是为什么很多游戏使用现有的解决方案。这些解决方案通常是物理库的一部分。物理库需要知道对象是否相互碰撞，所以在提供物理效果的基础上还可以用来检测碰撞。</p>
+<p>如果你在寻找解决方案，一些 three.js 示例使用了 <a href="https://github.com/kripken/ammo.js/">ammo.js</a>，这可能是一个选择。</p>
+<p>另一个解决方案可能是将障碍物放在网格上，让每个动物和玩家只需要查看网格。虽然这样性能会很好，但我觉得这最好留作读者的练习 😜</p>
+<p>还有一件事，很多游戏系统有一种叫做<a href="https://www.google.com/search?q=coroutines"><em>协程</em></a>（coroutines）的东西。协程是可以在运行时暂停并在之后继续的例程。</p>
+<p>让我们让主角发出音符，就像它在通过唱歌带领队伍一样。我们有很多方式可以实现这个，但现在让我们用协程来做。</p>
+<p>首先，这是一个管理协程的类</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* waitSeconds(duration) {
   while (duration &gt; 0) {
     duration -= globals.deltaTime;
@@ -1632,7 +1395,7 @@ class CoroutineRunner {
     this._removeQueued();
     for (const genStack of this.generatorStacks) {
       const main = genStack[0];
-      // Handle if one coroutine removes another
+      // 处理一个协程移除另一个协程的情况
       if (this.removeQueue.has(main)) {
         continue;
       }
@@ -1668,11 +1431,9 @@ class CoroutineRunner {
   }
 }
 </pre>
-<p>It does things similar to <code class="notranslate" translate="no">SafeArray</code> to make sure that it's safe to add or remove
-coroutines while other coroutines are running. It also handles nested coroutines.</p>
-<p>To make a coroutine you make a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">JavaScript generator function</a>.
-A generator function is preceded by the keyword <code class="notranslate" translate="no">function*</code> (the asterisk is important!)</p>
-<p>Generator functions can <code class="notranslate" translate="no">yield</code>. For example</p>
+<p>它和 <code class="notranslate" translate="no">SafeArray</code> 做了类似的事情，确保在其他协程运行时添加或移除协程是安全的。它还处理嵌套协程。</p>
+<p>要创建协程，你需要创建一个 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">JavaScript 生成器函数</a>。生成器函数前面有关键字 <code class="notranslate" translate="no">function*</code>（星号很重要！）</p>
+<p>生成器函数可以 <code class="notranslate" translate="no">yield</code>。例如</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function* countOTo9() {
   for (let i = 0; i &lt; 10; ++i) {
     console.log(i);
@@ -1680,25 +1441,22 @@ A generator function is preceded by the keyword <code class="notranslate" transl
   }
 }
 </pre>
-<p>If we added this function to the <code class="notranslate" translate="no">CoroutineRunner</code> above it would print
-out each number, 0 to 9, once per frame or rather once per time we called <code class="notranslate" translate="no">runner.update</code>.</p>
+<p>如果我们将这个函数添加到上面的 <code class="notranslate" translate="no">CoroutineRunner</code> 中，它会每帧打印一个数字（0 到 9），或者更准确地说是每次调用 <code class="notranslate" translate="no">runner.update</code> 时打印一个。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const runner = new CoroutineRunner();
 runner.add(count0To9);
 while(runner.isBusy()) {
   runner.update();
 }
 </pre>
-<p>Coroutines are removed automatically when they are finished.
-To remove a coroutine early, before it reaches the end you need to keep
-a reference to its generator like this</p>
+<p>协程在完成时会自动被移除。要提前移除一个协程，在它结束之前你需要保持对其生成器的引用，像这样</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const gen = count0To9();
 runner.add(gen);
 
-// sometime later
+// 稍后某个时候
 
 runner.remove(gen);
 </pre>
-<p>In any case, in the player let's use a coroutine to emit a note every half second to 1 second</p>
+<p>无论如何，在玩家中让我们使用协程每隔 0.5 到 1 秒发出一个音符</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Player extends Component {
   constructor(gameObject) {
 
@@ -1734,11 +1492,8 @@ function rand(min, max) {
   return Math.random() * (max - min) + min;
 }
 </pre>
-<p>You can see we make a <code class="notranslate" translate="no">CoroutineRunner</code> and we add an <code class="notranslate" translate="no">emitNotes</code> coroutine.
-That function will run forever, waiting 0.5 to 1 seconds and then creating a game object
-with a <code class="notranslate" translate="no">Note</code> component.</p>
-<p>For the <code class="notranslate" translate="no">Note</code> component first lets make a texture with a note on it and
-instead of loading a note image let's make one using a canvas like we covered in <a href="canvas-textures.html">the article on canvas textures</a>.</p>
+<p>你可以看到我们创建了一个 <code class="notranslate" translate="no">CoroutineRunner</code> 并添加了一个 <code class="notranslate" translate="no">emitNotes</code> 协程。这个函数会永远运行，等待 0.5 到 1 秒然后创建一个带有 <code class="notranslate" translate="no">Note</code> 组件的游戏对象。</p>
+<p>对于 <code class="notranslate" translate="no">Note</code> 组件，首先让我们制作一个带有音符的纹理，我们不加载音符图片，而是像<a href="canvas-textures.html">画布纹理文章</a>中介绍的那样使用画布来制作。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function makeTextTexture(str) {
   const ctx = document.createElement('canvas').getContext('2d');
   ctx.canvas.width = 64;
@@ -1752,11 +1507,8 @@ instead of loading a note image let's make one using a canvas like we covered in
 }
 const noteTexture = makeTextTexture('♪');
 </pre>
-<p>The texture we create above is white each means when we use it
-we can set the material's color and get a note of any color.</p>
-<p>Now that we have a noteTexture here's the <code class="notranslate" translate="no">Note</code> component.
-It uses <a href="/docs/#api/en/materials/SpriteMaterial"><code class="notranslate" translate="no">SpriteMaterial</code></a> and a <a href="/docs/#api/en/objects/Sprite"><code class="notranslate" translate="no">Sprite</code></a> like we covered in
-<a href="billboards.html">the article on billboards</a> </p>
+<p>我们创建的纹理是白色的，这意味着使用时我们可以设置材质的颜色来获得任意颜色的音符。</p>
+<p>现在我们有了 noteTexture，这是 <code class="notranslate" translate="no">Note</code> 组件。它使用了 <a href="/docs/#api/en/materials/SpriteMaterial"><code class="notranslate" translate="no">SpriteMaterial</code></a> 和 <a href="/docs/#api/en/objects/Sprite"><code class="notranslate" translate="no">Sprite</code></a>，就像我们在<a href="billboards.html">广告牌文章</a>中介绍的那样</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Note extends Component {
   constructor(gameObject) {
     super(gameObject);
@@ -1790,12 +1542,8 @@ It uses <a href="/docs/#api/en/materials/SpriteMaterial"><code class="notranslat
   }
 }
 </pre>
-<p>All it does is setup a <a href="/docs/#api/en/objects/Sprite"><code class="notranslate" translate="no">Sprite</code></a>, then pick a random velocity and move
-the transform at that velocity for 60 frames while fading out the note
-by setting the material's <a href="/docs/#api/en/materials/Material#opacity"><code class="notranslate" translate="no">opacity</code></a>.
-After the loop it the removes the transform
-from the scene and the note itself from active gameobjects.</p>
-<p>One last thing, let's add a few more animals</p>
+<p>它所做的就是设置一个 <a href="/docs/#api/en/objects/Sprite"><code class="notranslate" translate="no">Sprite</code></a>，然后选择一个随机速度，以该速度移动变换 60 帧，同时通过设置材质的 <a href="/docs/#api/en/materials/Material#opacity"><code class="notranslate" translate="no">opacity</code></a> 使音符淡出。循环结束后，它将变换从场景中移除，并将音符本身从活动游戏对象中移除。</p>
+<p>最后一件事，让我们添加更多动物</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function init() {
 
    ...
@@ -1813,7 +1561,7 @@ from the scene and the note itself from active gameobjects.</p>
 +  const offset = new THREE.Object3D();
 +  base.add(offset);
 +
-+  // position animals in a spiral.
++  // 将动物排列成螺旋形
 +  const numAnimals = 28;
 +  const arc = 10;
 +  const b = 10 / (2 * Math.PI);
@@ -1833,31 +1581,25 @@ from the scene and the note itself from active gameobjects.</p>
 </pre>
 <p></p><div translate="no" class="threejs_example_container notranslate">
   <div><iframe class="threejs_example notranslate" translate="no" style=" " src="/manual/examples/resources/editor.html?url=/manual/examples/game-conga-line-w-notes.html"></iframe></div>
-  <a class="threejs_center" href="/manual/examples/game-conga-line-w-notes.html" target="_blank">click here to open in a separate window</a>
+  <a class="threejs_center" href="/manual/examples/game-conga-line-w-notes.html" target="_blank">点击此处在新标签页中打开</a>
 </div>
 
 <p></p>
-<p>You might be asking, why not use <code class="notranslate" translate="no">setTimeout</code>? The problem with <code class="notranslate" translate="no">setTimeout</code>
-is it's not related to the game clock. For example above we made the maximum
-amount of time allowed to elapse between frames to be 1/20th of a second.
-Our coroutine system will respect that limit but <code class="notranslate" translate="no">setTimeout</code> would not.</p>
-<p>Of course we could have made a simple timer ourselves</p>
+<p>你可能会问，为什么不用 <code class="notranslate" translate="no">setTimeout</code>？<code class="notranslate" translate="no">setTimeout</code> 的问题是它与游戏时钟无关。例如上面我们将帧之间允许的最大时间设为 1/20 秒。我们的协程系统会遵守这个限制，但 <code class="notranslate" translate="no">setTimeout</code> 不会。</p>
+<p>当然我们可以自己做一个简单的计时器</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">class Player ... {
   update() {
     this.noteTimer -= globals.deltaTime;
     if (this.noteTimer &lt;= 0) {
-      // reset timer
+      // 重置计时器
       this.noteTimer = rand(0.5, 1);
-      // create a gameobject with a note component
+      // 创建一个带有音符组件的游戏对象
     }
   }
 </pre>
-<p>And for this particular case that might have been better but as you add
-more and things you'll get more and more variables added to your classes
-where as with coroutines you can often just <em>fire and forget</em>.</p>
-<p>Given our animal's simple states we could also have implemented them
-with a coroutine in the form of</p>
-<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// pseudo code!
+<p>对于这个特定情况这可能更好，但随着你添加越来越多的东西，你的类中会添加越来越多的变量，而使用协程你通常可以<em>触发后就不用管了</em>。</p>
+<p>鉴于我们动物的简单状态，我们也可以用以下形式的协程来实现它们</p>
+<pre class="prettyprint showlinemods notranslate lang-js" translate="no">// 伪代码！
 function* animalCoroutine() {
    setAnimation('Idle');
    while(playerIsTooFar()) {
@@ -1884,40 +1626,15 @@ function* animalCoroutine() {
    }
 }
 </pre>
-<p>This would have worked but of course as soon as our states were not so linear
-we'd have had to switch to a <code class="notranslate" translate="no">FiniteStateMachine</code>.</p>
-<p>It also wasn't clear to me if coroutines should run independently of their
-components. We could have made a global <code class="notranslate" translate="no">CoroutineRunner</code> and put all
-coroutines on it. That would make cleaning them up harder. As it is now
-if the gameobject is removed all of its components are removed and
-therefore the coroutine runners created are no longer called and it will
-all get garbage collected. If we had global runner then it would be
-the responsibility of each component to remove any coroutines it added
-or else some other mechanism of registering coroutines with a particular
-component or gameobject would be needed so that removing one removes the
-others.</p>
-<p>There are lots more issues a
-normal game engine would deal with. As it is there is no order to how
-gameobjects or their components are run. They are just run in the order added.
-Many game systems add a priority so the order can be set or changed.</p>
-<p>Another issue we ran into is the <code class="notranslate" translate="no">Note</code> removing its gameobject's transform from the scene.
-That seems like something that should happen in <code class="notranslate" translate="no">GameObject</code> since it was <code class="notranslate" translate="no">GameObject</code>
-that added the transform in the first place. Maybe <code class="notranslate" translate="no">GameObject</code> should have
-a <code class="notranslate" translate="no">dispose</code> method that is called by <code class="notranslate" translate="no">GameObjectManager.removeGameObject</code>?</p>
-<p>Yet another is how we're manually calling <code class="notranslate" translate="no">gameObjectManager.update</code> and <code class="notranslate" translate="no">inputManager.update</code>.
-Maybe there should be a <code class="notranslate" translate="no">SystemManager</code> which these global services can add themselves
-and each service will have its <code class="notranslate" translate="no">update</code> function called. In this way if we added a new
-service like <code class="notranslate" translate="no">CollisionManager</code> we could just add it to the system manager and not
-have to edit the render loop.</p>
-<p>I'll leave those kinds of issues up to you.
-I hope this article has given you some ideas for your own game engine.</p>
-<p>Maybe I should promote a game jam. If you click the <em>jsfiddle</em> or <em>codepen</em> buttons
-above the last example they'll open in those sites ready to edit. Add some features,
-Change the game to a pug leading a bunch of knights. Use the knight's rolling animation
-as a bowling ball and make an animal bowling game. Make an animal relay race.
-If you make a cool game post a link in the comments below.</p>
+<p>这样做是可行的，但当然一旦我们的状态不再是线性的，我们就不得不切换到 <code class="notranslate" translate="no">FiniteStateMachine</code>。</p>
+<p>我也不确定协程是否应该独立于它们的组件运行。我们可以创建一个全局的 <code class="notranslate" translate="no">CoroutineRunner</code> 并将所有协程放在上面。但这会使清理变得更难。目前如果游戏对象被移除，它的所有组件都会被移除，因此创建的协程运行器不再被调用，一切都会被垃圾回收。如果我们有一个全局运行器，那么每个组件都有责任移除它添加的任何协程，否则需要某种其他机制将协程注册到特定组件或游戏对象，以便移除一个时也移除其他的。</p>
+<p>一个正常的游戏引擎会处理更多问题。目前游戏对象或其组件的运行没有顺序。它们只是按添加顺序运行。许多游戏系统会添加优先级，以便可以设置或更改顺序。</p>
+<p>我们遇到的另一个问题是 <code class="notranslate" translate="no">Note</code> 从场景中移除其游戏对象的变换。这似乎应该在 <code class="notranslate" translate="no">GameObject</code> 中发生，因为最初是 <code class="notranslate" translate="no">GameObject</code> 添加的变换。也许 <code class="notranslate" translate="no">GameObject</code> 应该有一个 <code class="notranslate" translate="no">dispose</code> 方法，由 <code class="notranslate" translate="no">GameObjectManager.removeGameObject</code> 调用？</p>
+<p>还有一个问题是我们手动调用 <code class="notranslate" translate="no">gameObjectManager.update</code> 和 <code class="notranslate" translate="no">inputManager.update</code>。也许应该有一个 <code class="notranslate" translate="no">SystemManager</code>，这些全局服务可以将自己添加进去，每个服务的 <code class="notranslate" translate="no">update</code> 函数都会被调用。这样如果我们添加了像 <code class="notranslate" translate="no">CollisionManager</code> 这样的新服务，我们只需要将它添加到系统管理器中，而不必编辑渲染循环。</p>
+<p>我会把这些问题留给你。希望这篇文章给了你一些关于制作自己游戏引擎的思路。</p>
+<p>也许我应该搞一个 Game Jam。如果你点击最后一个示例上方的 <em>jsfiddle</em> 或 <em>codepen</em> 按钮，它们会在这些网站上打开，准备好编辑。添加一些功能，把游戏改成一只哈巴狗带领一群骑士。用骑士的翻滚动画做保龄球，制作一个动物保龄球游戏。制作一个动物接力赛。如果你做出了很酷的游戏，请在下面的评论中发布链接。</p>
 <div class="footnotes">
-[<a id="parented">1</a>]: technically it would still work if none of the parents have any translation, rotation, or scale <a href="#parented-backref">§</a>.
+[<a id="parented">1</a>]: 从技术上讲，如果所有父对象都没有任何平移、旋转或缩放，它仍然可以工作 <a href="#parented-backref">§</a>。
 </div>
         </div>
       </div>


### PR DESCRIPTION
**Description**

  This PR replaces the placeholder `manual/zh/game.html` with a full Chinese translation based on `manual/en/game.html`. For easier review, see commit f269574 for a comparison between the original English text and the Chinese translation.

  It also fixes naming inconsistencies in the `game.html` article examples across locales so text and code snippets stay aligned:

  - `StatusDisplayHelper` -> `StateDisplayHelper`
    - Reason: the examples use `StateDisplayHelper`
  - `countOTo9` -> `count0To9`
    - Reason: fix `O` (letter O) vs `0` (zero) typo for clarity.

This is a documentation-only change (no runtime/API behavior changes).
