### PR TITLE
FirstPersonControls: Update interaction model.

### DIFF
--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -42,7 +42,7 @@ class FirstPersonControls extends Controls {
 		 * @type {number}
 		 * @default 0.005
 		 */
-		this.lookSpeed = 0.005;
+		this.lookSpeed = 0.1;
 
 		/**
 		 * Whether it's possible to vertically look around or not.
@@ -59,14 +59,6 @@ class FirstPersonControls extends Controls {
 		 * @default false
 		 */
 		this.autoForward = false;
-
-		/**
-		 * Whether it's possible to look around or not.
-		 *
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.activeLook = true;
 
 		/**
 		 * Whether or not the camera's height influences the forward movement speed.
@@ -138,16 +130,13 @@ class FirstPersonControls extends Controls {
 
 		this._autoSpeedFactor = 0.0;
 
-		this._pointerX = 0;
-		this._pointerY = 0;
+		this._pointerDeltaX = 0;
+		this._pointerDeltaY = 0;
 
 		this._moveForward = false;
 		this._moveBackward = false;
 		this._moveLeft = false;
 		this._moveRight = false;
-
-		this._viewHalfX = 0;
-		this._viewHalfY = 0;
 
 		this._lat = 0;
 		this._lon = 0;
@@ -166,8 +155,6 @@ class FirstPersonControls extends Controls {
 		if ( domElement !== null ) {
 
 			this.connect( domElement );
-
-			this.handleResize();
 
 		}
 
@@ -204,25 +191,6 @@ class FirstPersonControls extends Controls {
 	dispose() {
 
 		this.disconnect();
-
-	}
-
-	/**
-	 * Must be called if the application window is resized.
-	 */
-	handleResize() {
-
-		if ( this.domElement === document ) {
-
-			this._viewHalfX = window.innerWidth / 2;
-			this._viewHalfY = window.innerHeight / 2;
-
-		} else {
-
-			this._viewHalfX = this.domElement.offsetWidth / 2;
-			this._viewHalfY = this.domElement.offsetHeight / 2;
-
-		}
 
 	}
 
@@ -282,14 +250,6 @@ class FirstPersonControls extends Controls {
 		if ( this._moveUp ) this.object.translateY( actualMoveSpeed );
 		if ( this._moveDown ) this.object.translateY( - actualMoveSpeed );
 
-		let actualLookSpeed = delta * this.lookSpeed;
-
-		if ( ! this.activeLook ) {
-
-			actualLookSpeed = 0;
-
-		}
-
 		let verticalLookRatio = 1;
 
 		if ( this.constrainVertical ) {
@@ -298,8 +258,11 @@ class FirstPersonControls extends Controls {
 
 		}
 
-		this._lon -= this._pointerX * actualLookSpeed;
-		if ( this.lookVertical ) this._lat -= this._pointerY * actualLookSpeed * verticalLookRatio;
+		this._lon -= this._pointerDeltaX * this.lookSpeed;
+		if ( this.lookVertical ) this._lat -= this._pointerDeltaY * this.lookSpeed * verticalLookRatio;
+
+		this._pointerDeltaX = 0;
+		this._pointerDeltaY = 0;
 
 		this._lat = Math.max( - 85, Math.min( 85, this._lat ) );
 
@@ -332,6 +295,15 @@ class FirstPersonControls extends Controls {
 
 	}
 
+	/**
+	 * @deprecated, r184. The controls now handle resize internally.
+	 */
+	handleResize() {
+
+		console.warn( 'THREE.FirstPersonControls: handleResize() has been removed. The controls now handle resize internally.' );
+
+	}
+
 }
 
 function onPointerDown( event ) {
@@ -342,16 +314,7 @@ function onPointerDown( event ) {
 
 	}
 
-	if ( this.activeLook ) {
-
-		switch ( event.button ) {
-
-			case 0: this._moveForward = true; break;
-			case 2: this._moveBackward = true; break;
-
-		}
-
-	}
+	this.domElement.setPointerCapture( event.pointerId );
 
 	this.mouseDragOn = true;
 
@@ -359,16 +322,7 @@ function onPointerDown( event ) {
 
 function onPointerUp( event ) {
 
-	if ( this.activeLook ) {
-
-		switch ( event.button ) {
-
-			case 0: this._moveForward = false; break;
-			case 2: this._moveBackward = false; break;
-
-		}
-
-	}
+	this.domElement.releasePointerCapture( event.pointerId );
 
 	this.mouseDragOn = false;
 
@@ -376,17 +330,10 @@ function onPointerUp( event ) {
 
 function onPointerMove( event ) {
 
-	if ( this.domElement === document ) {
+	if ( this.mouseDragOn === false ) return;
 
-		this._pointerX = event.pageX - this._viewHalfX;
-		this._pointerY = event.pageY - this._viewHalfY;
-
-	} else {
-
-		this._pointerX = event.pageX - this.domElement.offsetLeft - this._viewHalfX;
-		this._pointerY = event.pageY - this.domElement.offsetTop - this._viewHalfY;
-
-	}
+	this._pointerDeltaX += event.movementX;
+	this._pointerDeltaY += event.movementY;
 
 }
 

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -136,6 +136,8 @@ class FirstPersonControls extends Controls {
 		this._pointerDownX = 0;
 		this._pointerDownY = 0;
 
+		this._pointerCount = 0;
+
 		this._moveForward = false;
 		this._moveBackward = false;
 		this._moveLeft = false;
@@ -326,10 +328,21 @@ function onPointerDown( event ) {
 
 	this.domElement.setPointerCapture( event.pointerId );
 
-	switch ( event.button ) {
+	this._pointerCount ++;
 
-		case 0: this._moveForward = true; break;
-		case 2: this._moveBackward = true; break;
+	if ( event.pointerType === 'touch' ) {
+
+		this._moveForward = this._pointerCount === 1;
+		this._moveBackward = this._pointerCount >= 2;
+
+	} else {
+
+		switch ( event.button ) {
+
+			case 0: this._moveForward = true; break;
+			case 2: this._moveBackward = true; break;
+
+		}
 
 	}
 
@@ -347,17 +360,28 @@ function onPointerUp( event ) {
 
 	this.domElement.releasePointerCapture( event.pointerId );
 
-	switch ( event.button ) {
+	this._pointerCount --;
 
-		case 0: this._moveForward = false; break;
-		case 2: this._moveBackward = false; break;
+	if ( event.pointerType === 'touch' ) {
+
+		this._moveForward = this._pointerCount === 1;
+		this._moveBackward = false;
+
+	} else {
+
+		switch ( event.button ) {
+
+			case 0: this._moveForward = false; break;
+			case 2: this._moveBackward = false; break;
+
+		}
 
 	}
 
 	this._pointerX = 0;
 	this._pointerY = 0;
 
-	this.mouseDragOn = false;
+	if ( this._pointerCount === 0 ) this.mouseDragOn = false;
 
 }
 

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -42,7 +42,7 @@ class FirstPersonControls extends Controls {
 		 * @type {number}
 		 * @default 0.005
 		 */
-		this.lookSpeed = 0.1;
+		this.lookSpeed = 0.005;
 
 		/**
 		 * Whether it's possible to vertically look around or not.
@@ -130,8 +130,11 @@ class FirstPersonControls extends Controls {
 
 		this._autoSpeedFactor = 0.0;
 
-		this._pointerDeltaX = 0;
-		this._pointerDeltaY = 0;
+		this._pointerX = 0;
+		this._pointerY = 0;
+
+		this._pointerDownX = 0;
+		this._pointerDownY = 0;
 
 		this._moveForward = false;
 		this._moveBackward = false;
@@ -250,6 +253,8 @@ class FirstPersonControls extends Controls {
 		if ( this._moveUp ) this.object.translateY( actualMoveSpeed );
 		if ( this._moveDown ) this.object.translateY( - actualMoveSpeed );
 
+		const actualLookSpeed = delta * this.lookSpeed;
+
 		let verticalLookRatio = 1;
 
 		if ( this.constrainVertical ) {
@@ -258,11 +263,12 @@ class FirstPersonControls extends Controls {
 
 		}
 
-		this._lon -= this._pointerDeltaX * this.lookSpeed;
-		if ( this.lookVertical ) this._lat -= this._pointerDeltaY * this.lookSpeed * verticalLookRatio;
+		if ( this.mouseDragOn ) {
 
-		this._pointerDeltaX = 0;
-		this._pointerDeltaY = 0;
+			this._lon -= this._pointerX * actualLookSpeed;
+			if ( this.lookVertical ) this._lat -= this._pointerY * actualLookSpeed * verticalLookRatio;
+
+		}
 
 		this._lat = Math.max( - 85, Math.min( 85, this._lat ) );
 
@@ -316,6 +322,19 @@ function onPointerDown( event ) {
 
 	this.domElement.setPointerCapture( event.pointerId );
 
+	switch ( event.button ) {
+
+		case 0: this._moveForward = true; break;
+		case 2: this._moveBackward = true; break;
+
+	}
+
+	this._pointerDownX = event.pageX;
+	this._pointerDownY = event.pageY;
+
+	this._pointerX = 0;
+	this._pointerY = 0;
+
 	this.mouseDragOn = true;
 
 }
@@ -323,6 +342,16 @@ function onPointerDown( event ) {
 function onPointerUp( event ) {
 
 	this.domElement.releasePointerCapture( event.pointerId );
+
+	switch ( event.button ) {
+
+		case 0: this._moveForward = false; break;
+		case 2: this._moveBackward = false; break;
+
+	}
+
+	this._pointerX = 0;
+	this._pointerY = 0;
 
 	this.mouseDragOn = false;
 
@@ -332,8 +361,8 @@ function onPointerMove( event ) {
 
 	if ( this.mouseDragOn === false ) return;
 
-	this._pointerDeltaX += event.movementX;
-	this._pointerDeltaY += event.movementY;
+	this._pointerX = event.pageX - this._pointerDownX;
+	this._pointerY = event.pageY - this._pointerDownY;
 
 }
 

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -177,6 +177,8 @@ class FirstPersonControls extends Controls {
 		this.domElement.addEventListener( 'pointerup', this._onPointerUp );
 		this.domElement.addEventListener( 'contextmenu', this._onContextMenu );
 
+		this.domElement.style.touchAction = 'none'; // disable touch scroll
+
 	}
 
 	disconnect() {
@@ -188,6 +190,8 @@ class FirstPersonControls extends Controls {
 		this.domElement.removeEventListener( 'pointerdown', this._onPointerDown );
 		this.domElement.removeEventListener( 'pointerup', this._onPointerUp );
 		this.domElement.removeEventListener( 'contextmenu', this._onContextMenu );
+
+		this.domElement.style.touchAction = 'auto';
 
 	}
 

--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -239,8 +239,6 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
-
 			}
 
 			function animate() {

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -192,8 +192,6 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
-
 			}
 
 			function generateHeight( width, height ) {

--- a/examples/webgl_geometry_terrain.html
+++ b/examples/webgl_geometry_terrain.html
@@ -109,8 +109,6 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
-
 			}
 
 			function generateHeight( width, height ) {

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -141,8 +141,6 @@
 
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 
-				controls.handleResize();
-
 			}
 
 			function createScene( ) {


### PR DESCRIPTION
**Description**

Changed the interaction model so the camera orientation is controlled by dragging from the press point. The further you drag from where you pressed, the faster the camera rotates — like the original center-based approach but anchored to your press position instead of the screen center. This also adds mobile touch support via pointer events and uses `setPointerCapture` to handle pointer release outside the window. `activeLook` and `handleResize()` are no longer needed — the former has been removed and the latter replaced with a deprecated stub.

http://raw.githack.com/mrdoob/three.js/controls/examples/webaudio_sandbox.html
http://raw.githack.com/mrdoob/three.js/controls/examples/webgl_geometry_minecraft.html
http://raw.githack.com/mrdoob/three.js/controls/examples/webgl_geometry_terrain.html
http://raw.githack.com/mrdoob/three.js/controls/examples/webgl_shadowmap_performance.html