### PR TITLE
TSL: Improve `dispose()` of some FX addons.

### DIFF
--- a/examples/jsm/tsl/display/AfterImageNode.js
+++ b/examples/jsm/tsl/display/AfterImageNode.js
@@ -81,6 +81,14 @@ class AfterImageNode extends TempNode {
 		this._textureNodeOld = texture( this._oldRT.texture );
 
 		/**
+		 * The material for the composite pass.
+		 *
+		 * @private
+		 * @type {?NodeMaterial}
+		 */
+		this._materialComposed = null;
+
+		/**
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
@@ -225,6 +233,8 @@ class AfterImageNode extends TempNode {
 
 		this._compRT.dispose();
 		this._oldRT.dispose();
+
+		if ( this._materialComposed !== null ) this._materialComposed.dispose();
 
 	}
 

--- a/examples/jsm/tsl/display/AnamorphicNode.js
+++ b/examples/jsm/tsl/display/AnamorphicNode.js
@@ -99,6 +99,15 @@ class AnamorphicNode extends TempNode {
 		this._textureNode = passTexture( this, this._renderTarget.texture );
 
 		/**
+		 * The material for the anamorphic pass.
+		 *
+		 * @private
+		 * @type {?NodeMaterial}
+		 */
+		this._material = null;
+
+
+		/**
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
@@ -238,6 +247,8 @@ class AnamorphicNode extends TempNode {
 	dispose() {
 
 		this._renderTarget.dispose();
+
+		if ( this._material !== null ) this._material.dispose();
 
 	}
 

--- a/examples/jsm/tsl/display/BilateralBlurNode.js
+++ b/examples/jsm/tsl/display/BilateralBlurNode.js
@@ -113,6 +113,14 @@ class BilateralBlurNode extends TempNode {
 		this._textureNode.uvNode = textureNode.uvNode;
 
 		/**
+		 * The material for the blur pass.
+		 *
+		 * @private
+		 * @type {?NodeMaterial}
+		 */
+		this._material = null;
+
+		/**
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
@@ -317,6 +325,8 @@ class BilateralBlurNode extends TempNode {
 
 		this._horizontalRT.dispose();
 		this._verticalRT.dispose();
+
+		if ( this._material !== null ) this._material.dispose();
 
 	}
 

--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -99,6 +99,14 @@ class GaussianBlurNode extends TempNode {
 		this._textureNode.uvNode = textureNode.uvNode;
 
 		/**
+		 * The material for the blur pass.
+		 *
+		 * @private
+		 * @type {?NodeMaterial}
+		 */
+		this._material = null;
+
+		/**
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
@@ -302,6 +310,8 @@ class GaussianBlurNode extends TempNode {
 
 		this._horizontalRT.dispose();
 		this._verticalRT.dispose();
+
+		if ( this._material !== null ) this._material.dispose();
 
 	}
 


### PR DESCRIPTION
Related issue: #32409, #32452

**Description**

Certain passes did not free their internal materials in `dispose()`which could potentially lead to memory leaks.