### PR TITLE
Update ESLint to ECMA 2022.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,7 @@ export default [
 			jsdoc
 		},
 		languageOptions: {
-			ecmaVersion: 2018,
+			ecmaVersion: 2022,
 			sourceType: 'module',
 			globals: {
 				...globals.browser,
@@ -134,7 +134,7 @@ export default [
 		name: 'editor rules',
 		files: [ 'editor/**/*.js' ],
 		languageOptions: {
-			ecmaVersion: 2020,
+			ecmaVersion: 2022,
 			sourceType: 'module'
 		}
 	}


### PR DESCRIPTION
**Description**

This PR enables ESLint support for `static` and private `#` members.

```javascript
class SomeClass {

  #somePrivateField = 123;

  static someStaticMethod() {

    console.log('hello world');

  }

}
```