### PR TITLE
Texture: Fix typo in JSDoc.

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -415,7 +415,7 @@ class Texture extends EventDispatcher {
 	}
 
 	/**
-	 * Updates the texture transformation matrix from the from the properties {@link Texture#offset},
+	 * Updates the texture transformation matrix from the properties {@link Texture#offset},
 	 * {@link Texture#repeat}, {@link Texture#rotation}, and {@link Texture#center}.
 	 */
 	updateMatrix() {


### PR DESCRIPTION
Fixes a JSDoc typo in `Texture.js`.