### PR TITLE
DataTextureLoader: Fix log regression.

### DIFF
--- a/src/loaders/DataTextureLoader.js
+++ b/src/loaders/DataTextureLoader.js
@@ -2,6 +2,7 @@ import { LinearFilter, LinearMipmapLinearFilter, ClampToEdgeWrapping } from '../
 import { FileLoader } from './FileLoader.js';
 import { DataTexture } from '../textures/DataTexture.js';
 import { Loader } from './Loader.js';
+import { error } from '../utils.js';
 
 /**
  * Abstract base class for loading binary texture formats RGBE, EXR or TGA.
@@ -57,15 +58,15 @@ class DataTextureLoader extends Loader {
 
 				texData = scope.parse( buffer );
 
-			} catch ( error ) {
+			} catch ( e ) {
 
 				if ( onError !== undefined ) {
 
-					onError( error );
+					onError( e );
 
 				} else {
 
-					error( error );
+					error( e );
 					return;
 
 				}


### PR DESCRIPTION
Related issue: #31790

**Description**

The PR fixes a small regression that has been introduced via #31790 in `DataTextureLoader`. When the new log utils were introduces, it was missed to import `error()` from `utils.js`, probably because the error object in the `catch` block has the same name.

Without this fix, you get a runtime error when the loading process of a data texture fails.
