### PR TITLE
WebGLRenderer: Fix active texture setting in `copyTextureToTexture()`.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3238,9 +3238,10 @@ class WebGLRenderer {
 
 				textures.setTexture2D( dstTexture, 0 );
 				glTarget = _gl.TEXTURE_2D;
-				state.activeTexture( _gl.TEXTURE0 );
 
 			}
+
+			state.activeTexture( _gl.TEXTURE0 ); // see #33153
 
 			_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, dstTexture.flipY );
 			_gl.pixelStorei( _gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, dstTexture.premultiplyAlpha );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3238,6 +3238,7 @@ class WebGLRenderer {
 
 				textures.setTexture2D( dstTexture, 0 );
 				glTarget = _gl.TEXTURE_2D;
+				state.activeTexture( _gl.TEXTURE0 );
 
 			}
 


### PR DESCRIPTION
Fixed #25618.

**Description**

In some cases, calling `gl.copyTextureToTexture` can target a different texture than the one actually passed as parameter. This happens if:
- the target texture is already in slot 0
- the active slot is not slot 0

In this case, when `copyTextureToTexture` calls `textures.setTexture2D`, `state.bindTexture` is called but because this texture was already in slot 0, `state.bindTexture` is a noop. It means that the active slot is not changed and if it's not 0, then the target of `copyTextureToTexture` is invalid.

The fix in this PR solves the problem for `copyTextureToTexture` specifically but maybe we should fix `state.bindTexture` instead. The current behavior of `state.bindTexture` can create problems because it only set the active slot if the texture was not already bound to this slot. 

Here's what it currently does:
```js
if ( boundTexture.type !== webglType || boundTexture.texture !== webglTexture ) {

	if ( currentTextureSlot !== webglSlot ) {

		gl.activeTexture( webglSlot );
		currentTextureSlot = webglSlot;

	}

	gl.bindTexture( webglType, webglTexture || emptyTextures[ webglType ] );

	boundTexture.type = webglType;
	boundTexture.texture = webglTexture;

}
```

But instead we could do:

```js
if ( currentTextureSlot !== webglSlot ) {

	gl.activeTexture( webglSlot );
	currentTextureSlot = webglSlot;

}

if ( boundTexture.type !== webglType || boundTexture.texture !== webglTexture ) {

	gl.bindTexture( webglType, webglTexture || emptyTextures[ webglType ] );

	boundTexture.type = webglType;
	boundTexture.texture = webglTexture;

}

```

I'm not sure if this will cause some other side-effect. Let me know what you think!