### PR TITLE
WebGPURenderer: Support unfilterable float32 StorageTextures

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -708,7 +708,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 	isUnfilterable( texture ) {
 
 		return this.getComponentTypeFromTexture( texture ) !== 'float' ||
-			( ! this.isAvailable( 'float32Filterable' ) && texture.isDataTexture === true && texture.type === FloatType ) ||
+			( ! this.isAvailable( 'float32Filterable' ) && texture.type === FloatType ) ||
 			( this.isSampleCompare( texture ) === false && texture.minFilter === NearestFilter && texture.magFilter === NearestFilter ) ||
 			this.renderer.backend.utils.getTextureSampleData( texture ).primarySamples > 1;
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -520,7 +520,7 @@ class WebGPUBindingUtils {
 
 					}
 
-				} else if ( binding.texture.isDataTexture || binding.texture.isDataArrayTexture || binding.texture.isData3DTexture ) {
+				} else if ( binding.texture.isDataTexture || binding.texture.isDataArrayTexture || binding.texture.isData3DTexture || binding.texture.isStorageTexture ) {
 
 					const type = binding.texture.type;
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/33147

**Description**

This PR allows the use of `FloatType` `StorageTextures` devices that do not support the `float32-filterable`.

Previously, the fallback to set the sampleType to `unfilterable` (when filtering was not supported) strictly checked if the texture was a `DataTexture` or its variants.