### PR TITLE
Renderers: Make animation modules more robust.

### DIFF
--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -95,7 +95,7 @@ class Animation {
 	 */
 	stop() {
 
-		this._context.cancelAnimationFrame( this._requestId );
+		if ( this._context !== null ) this._context.cancelAnimationFrame( this._requestId );
 
 		this._requestId = null;
 

--- a/src/renderers/webgl/WebGLAnimation.js
+++ b/src/renderers/webgl/WebGLAnimation.js
@@ -19,6 +19,7 @@ function WebGLAnimation() {
 
 			if ( isAnimating === true ) return;
 			if ( animationLoop === null ) return;
+			if ( context === null ) return;
 
 			requestId = context.requestAnimationFrame( onAnimationFrame );
 
@@ -28,7 +29,7 @@ function WebGLAnimation() {
 
 		stop: function () {
 
-			context.cancelAnimationFrame( requestId );
+			if ( context !== null ) context.cancelAnimationFrame( requestId );
 
 			isAnimating = false;
 


### PR DESCRIPTION
Fixed #33157.

**Description**

Makes sure the animation modules of `WebGPURenderer` and `WebGLRenderer` handle a `null` context more gracefully.
