### PR TITLE
GodraysNode: Simplify shadow coord computation.

### DIFF
--- a/examples/jsm/tsl/display/GodraysNode.js
+++ b/examples/jsm/tsl/display/GodraysNode.js
@@ -1,4 +1,4 @@
-import { Frustum, Matrix4, RenderTarget, Vector2, RendererUtils, QuadMesh, TempNode, NodeMaterial, NodeUpdateType, Vector3, Plane, WebGPUCoordinateSystem } from 'three/webgpu';
+import { Frustum, Matrix4, RenderTarget, Vector2, RendererUtils, QuadMesh, TempNode, NodeMaterial, NodeUpdateType, Vector3, Plane } from 'three/webgpu';
 import { cubeTexture, clamp, viewZToPerspectiveDepth, logarithmicDepthToViewZ, float, Loop, max, Fn, passTexture, uv, dot, uniformArray, If, getViewPosition, uniform, vec4, add, interleavedGradientNoise, screenCoordinate, round, mul, uint, mix, exp, vec3, distance, pow, reference, lightPosition, vec2, bool, texture, perspectiveDepthToViewZ, lightShadowMatrix } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
@@ -351,8 +351,6 @@ class GodraysNode extends TempNode {
 	 */
 	setup( builder ) {
 
-		const { renderer } = builder;
-
 		const uvNode = uv();
 		const lightPos = lightPosition( this._light );
 
@@ -389,15 +387,8 @@ class GodraysNode extends TempNode {
 
 			const shadowPosition = lightShadowMatrix( this._light ).mul( worldPos );
 			const shadowCoord = shadowPosition.xyz.div( shadowPosition.w );
-			let coordZ = shadowCoord.z;
 
-			if ( renderer.coordinateSystem === WebGPUCoordinateSystem ) {
-
-				coordZ = coordZ.mul( 2 ).sub( 1 ); // WebGPU: Conversion [ 0, 1 ] to [ - 1, 1 ]
-
-			}
-
-			return vec3( shadowCoord.x, shadowCoord.y.oneMinus(), coordZ );
+			return vec3( shadowCoord.x, shadowCoord.y.oneMinus(), shadowCoord.z );
 
 		};
 


### PR DESCRIPTION
Related issue: #32967

**Description**

Because of the fixes in #32967, the shadow coord computation in `GodraysNode` can be simplified.
