### PR TITLE
Object3D: Correctly copy `pivot`.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1592,7 +1592,7 @@ class Object3D extends EventDispatcher {
 		this.quaternion.copy( source.quaternion );
 		this.scale.copy( source.scale );
 
-		this.pivot = source.pivot ? source.pivot.clone() : null;
+		this.pivot = source.pivot !== null ? source.pivot.clone() : null;
 
 		this.matrix.copy( source.matrix );
 		this.matrixWorld.copy( source.matrixWorld );

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1592,7 +1592,7 @@ class Object3D extends EventDispatcher {
 		this.quaternion.copy( source.quaternion );
 		this.scale.copy( source.scale );
 
-		this.pivot = source.pivot !== null ? source.pivot.clone() : null;
+		this.pivot = ( source.pivot !== null ) ? source.pivot.clone() : null;
 
 		this.matrix.copy( source.matrix );
 		this.matrixWorld.copy( source.matrixWorld );

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1592,11 +1592,7 @@ class Object3D extends EventDispatcher {
 		this.quaternion.copy( source.quaternion );
 		this.scale.copy( source.scale );
 
-		if ( source.pivot !== null ) {
-
-			this.pivot = source.pivot.clone();
-
-		}
+		this.pivot = source.pivot ? source.pivot.clone() : null;
 
 		this.matrix.copy( source.matrix );
 		this.matrixWorld.copy( source.matrixWorld );


### PR DESCRIPTION
**Description**

`Object3D.pivot` does not get set in `Object3D.copy()` if `source.pivot` is `null`. This PR fixes that.