### PR TITLE
TSL: Fix two issues in `StorageTextureNode`

### DIFF
--- a/src/nodes/accessors/StorageTextureNode.js
+++ b/src/nodes/accessors/StorageTextureNode.js
@@ -146,19 +146,14 @@ class StorageTextureNode extends TextureNode {
 	 */
 	generate( builder, output ) {
 
-		let snippet;
-
 		if ( this.storeNode !== null ) {
 
-			snippet = this.generateStore( builder );
-
-		} else {
-
-			snippet = super.generate( builder, output );
+			this.generateStore( builder );
+			return '';
 
 		}
 
-		return snippet;
+		return super.generate( builder, output );
 
 	}
 
@@ -233,7 +228,7 @@ class StorageTextureNode extends TextureNode {
 		const storeSnippet = storeNode.build( builder, 'vec4' );
 		const depthSnippet = depthNode ? depthNode.build( builder, 'int' ) : null;
 
-		const snippet = builder.generateTextureStore( builder, textureProperty, uvSnippet, depthSnippet, storeSnippet );
+		const snippet = builder.generateTextureStore( this.value, textureProperty, uvSnippet, depthSnippet, storeSnippet );
 
 		builder.addLineFlowCode( snippet, this );
 


### PR DESCRIPTION
### Issue 1

In `StorageTextureNode.generateStore()`, this line:

```javascript
const snippet = builder.generateTextureStore( builder, textureProperty, uvSnippet, depthSnippet, storeSnippet );
```

should be changed to this:

```javascript
const snippet = builder.generateTextureStore( this.value, textureProperty, uvSnippet, depthSnippet, storeSnippet );
```

This is because the first argument to `WGSLNodeBuilder.generateTextureStore()` is for the texture, not the builder.

### Issue 2

Because `StorageTextureNode.generateStore()` does not return anything/returns `void`, the method `StorageTextureNode.generate()` should return `''` if `this.storeNode !== null`.

Therefore, this logic:

```javascript
generate( builder, output ) {

	let snippet;

	if ( this.storeNode !== null ) {

		snippet = this.generateStore( builder );

	} else {

		snippet = super.generate( builder, output );

	}

	return snippet;

}
```

should be changed to this:

```javascript
generate( builder, output ) {

	if ( this.storeNode !== null ) {

		this.generateStore( builder );
		return '';

	}

	return super.generate( builder, output );

}
```
