### PR TITLE
TransformControls: Allow visibility control of plane gizmos.

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -252,6 +252,33 @@ class TransformControls extends Controls {
 		defineProperty( 'showZ', true );
 
 		/**
+		 * Whether the xy-plane helper should be visible or not.
+		 *
+		 * @name TransformControls#showXY
+		 * @type {boolean}
+		 * @default true
+		 */
+		defineProperty( 'showXY', true );
+
+		/**
+		 * Whether the yz-plane helper should be visible or not.
+		 *
+		 * @name TransformControls#showYZ
+		 * @type {boolean}
+		 * @default true
+		 */
+		defineProperty( 'showYZ', true );
+
+		/**
+		 * Whether the xz-axis helper should be visible or not.
+		 *
+		 * @name TransformControls#showXZ
+		 * @type {boolean}
+		 * @default true
+		 */
+		defineProperty( 'showXZ', true );
+
+		/**
 		 * The minimum allowed X position during translation.
 		 *
 		 * @name TransformControls#minX
@@ -1783,6 +1810,11 @@ class TransformControlsGizmo extends Object3D {
 			handle.visible = handle.visible && ( handle.name.indexOf( 'Y' ) === - 1 || this.showY );
 			handle.visible = handle.visible && ( handle.name.indexOf( 'Z' ) === - 1 || this.showZ );
 			handle.visible = handle.visible && ( handle.name.indexOf( 'E' ) === - 1 || ( this.showX && this.showY && this.showZ ) );
+
+			// Hide disabled plane helpers
+			handle.visible = handle.visible && ( handle.name.indexOf( 'XY' ) === - 1 || this.showXY );
+			handle.visible = handle.visible && ( handle.name.indexOf( 'YZ' ) === - 1 || this.showYZ );
+			handle.visible = handle.visible && ( handle.name.indexOf( 'XZ' ) === - 1 || this.showXZ );
 
 			// highlight selected axis
 


### PR DESCRIPTION
Fixed #27627.

**Description**

The PR makes sure the visibility of the plane gizmos of `TransformControls` are configurable. These are the red, green and blue quads that allow to transform the attached 3D object along a plane.

The additional `showXY`, `showYZ` and `showXZ` flags make the controls a bit more flexible and implement a feature request that has come up more than once.
