### PR TITLE
HDRLoader: Fix header parse logic.

### DIFF
--- a/examples/jsm/loaders/HDRLoader.js
+++ b/examples/jsm/loaders/HDRLoader.js
@@ -100,7 +100,7 @@ class HDRLoader extends DataTextureLoader {
 
 					s += chunk; len += chunk.length;
 					p += chunkSize;
-					chunk += String.fromCharCode.apply( null, new Uint16Array( buffer.subarray( p, p + chunkSize ) ) );
+					chunk = String.fromCharCode.apply( null, new Uint16Array( buffer.subarray( p, p + chunkSize ) ) );
 
 				}
 

--- a/test/unit/addons/loaders/HDRLoader.tests.js
+++ b/test/unit/addons/loaders/HDRLoader.tests.js
@@ -1,0 +1,49 @@
+import { HDRLoader } from '../../../../examples/jsm/loaders/HDRLoader.js';
+
+export default QUnit.module( 'Addons', () => {
+
+	QUnit.module( 'Loaders', () => {
+
+		QUnit.module( 'HDRLoader', () => {
+
+			QUnit.test( 'Instancing', ( assert ) => {
+
+				const loader = new HDRLoader();
+
+				assert.ok( loader instanceof HDRLoader, 'Can instantiate an HDRLoader.' );
+
+			} );
+
+			QUnit.test( 'parses valid HDR with large header (> chunk size)', ( assert ) => {
+
+				// Regression: fgets uses chunkSize=128. When a line (e.g. pcomb) exceeds
+				// 128 bytes, chunking can skip the FORMAT line, causing "missing format
+				// specifier". This minimal synthetic HDR reproduces the bug.
+				const header = [
+					'#?RADIANCE',
+					'some large header line' + 'x'.repeat( 128 ),
+					'FORMAT=32-bit_rle_rgbe',
+					'-Y 0 +X 0',
+					''
+				].join( '\n' );
+				const encoder = new TextEncoder();
+				const headerBytes = encoder.encode( header );
+
+				const buffer = new Uint8Array( headerBytes.length );
+				buffer.set( headerBytes );
+
+				const loader = new HDRLoader();
+				const result = loader.parse( buffer.buffer );
+
+				assert.ok( result, 'Parse succeeds' );
+				assert.strictEqual( result.width, 0, 'Width' );
+				assert.strictEqual( result.height, 0, 'Height' );
+				assert.ok( result.data, 'Has texture data' );
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -3,4 +3,5 @@
 import './addons/utils/BufferGeometryUtils.tests.js';
 import './addons/math/ColorSpaces.tests.js';
 import './addons/curves/NURBSCurve.tests.js';
+import './addons/loaders/HDRLoader.tests.js';
 import './addons/exporters/USDZExporter.tests.js';


### PR DESCRIPTION
Fixed #33173.

**Description**

The internal fgets function that HDRLoader uses had incorrect logic around chunk accumulation, where it would double count any chunk past the first one. This caused large lines to corrupt the parsing state for all lines proceeding it. This cascaded into HDR headers failing to load.

I fixed this by simply correcting the chunk accumulation logic. There was a "+=" that should have just been an "=" on the "chunk" variable, which is meant to track the head of the scan.

I also added a regression unit test to cover this, which helped me debug this error.