### PR TITLE
WebGLRenderer: Improve reverse depth buffer logging.

### DIFF
--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -95,6 +95,12 @@ function WebGLCapabilities( gl, extensions, parameters, utils ) {
 	const logarithmicDepthBuffer = parameters.logarithmicDepthBuffer === true;
 	const reversedDepthBuffer = parameters.reversedDepthBuffer === true && extensions.has( 'EXT_clip_control' );
 
+	if ( parameters.reversedDepthBuffer === true && reversedDepthBuffer === false ) {
+
+		warn( 'WebGLRenderer: Unable to use reversed depth buffer due to missing EXT_clip_control extension. Fallback to default depth buffer.' );
+
+	}
+
 	const maxTextures = gl.getParameter( gl.MAX_TEXTURE_IMAGE_UNITS );
 	const maxVertexTextures = gl.getParameter( gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS );
 	const maxTextureSize = gl.getParameter( gl.MAX_TEXTURE_SIZE );


### PR DESCRIPTION
Related issue: #33166

**Description**

The PR adds a warning to `WebGLRenderer` that informs the user if reverse depth buffer can't be used because `EXT_clip_control` support is missing.

In this way, `WebGLRenderer` provides the same feedback like `WebGPURenderer`.