### PR TITLE
Add forceMonoscopic option for WebXR

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -112,6 +112,15 @@ class WebXRManager extends EventDispatcher {
 		this.isPresenting = false;
 
 		/**
+		 * When `true`, both eyes use the left eye's view position. Useful for content
+		 * that must be viewed from a single viewpoint (e.g. 360° panoramas, Matterport-style).
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.forceMonoscopic = false;
+
+		/**
 		 * Returns a group representing the `target ray` space of the XR controller.
 		 * Use this space for visualizing 3D objects that support the user in pointing
 		 * tasks like UI interaction.
@@ -982,6 +991,13 @@ class WebXRManager extends EventDispatcher {
 
 					camera.matrix.fromArray( view.transform.matrix );
 					camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
+					if ( scope.forceMonoscopic && i === 1 && cameras[ 0 ] !== undefined ) {
+
+						camera.position.copy( cameras[ 0 ].position );
+						camera.matrix.compose( camera.position, camera.quaternion, camera.scale );
+
+					}
+
 					camera.projectionMatrix.fromArray( view.projectionMatrix );
 					camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
 					camera.viewport.set( viewport.x, viewport.y, viewport.width, viewport.height );


### PR DESCRIPTION
Related issue: #33177 

**Description**

Adds optional `forceMonoscopic` flag to WebXRManager for single-viewpoint content. When enabled, both eyes use the left eye's view position, fixing projection misalignment on the right eye for content authored from a single viewpoint.
- `renderer.xr.forceMonoscopic = true` enables monoscopic mode
- Default remains stereo (backward compatible)


