### PR TITLE
Add forceMonoscopic option for WebXR

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -112,6 +112,15 @@ class WebXRManager extends EventDispatcher {
 		this.isPresenting = false;
 
 		/**
+		 * When `true`, both eyes use the left eye's view position. Useful for content
+		 * that must be viewed from a single viewpoint (e.g. 360° panoramas, Matterport-style).
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.forceMonoscopic = false;
+
+		/**
 		 * Returns a group representing the `target ray` space of the XR controller.
 		 * Use this space for visualizing 3D objects that support the user in pointing
 		 * tasks like UI interaction.
@@ -982,6 +991,13 @@ class WebXRManager extends EventDispatcher {
 
 					camera.matrix.fromArray( view.transform.matrix );
 					camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
+					if ( scope.forceMonoscopic && i === 1 && cameras[ 0 ] !== undefined ) {
+
+						camera.position.copy( cameras[ 0 ].position );
+						camera.matrix.compose( camera.position, camera.quaternion, camera.scale );
+
+					}
+
 					camera.projectionMatrix.fromArray( view.projectionMatrix );
 					camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
 					camera.viewport.set( viewport.x, viewport.y, viewport.width, viewport.height );

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -500,7 +500,7 @@ class WebXRManager extends EventDispatcher {
 							glProjLayer.forceMonoPresentation = true;
 
 						} catch ( e ) {}
-			
+
 					}
 
 					session.updateRenderState( { layers: [ glProjLayer ] } );
@@ -1007,9 +1007,9 @@ class WebXRManager extends EventDispatcher {
 					camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
 
 					// Monoscopic fallback: override right eye position when native API not available
-					if ( scope.forceMonoscopic && i === 1 && cameras[0] !== undefined ) {
+					if ( scope.forceMonoscopic && i === 1 && cameras[ 0 ] !== undefined ) {
 
-						camera.position.copy( cameras[0].position );
+						camera.position.copy( cameras[ 0 ].position );
 						camera.matrix.compose( camera.position, camera.quaternion, camera.scale );
 
 					}

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -114,6 +114,8 @@ class WebXRManager extends EventDispatcher {
 		/**
 		 * When `true`, both eyes use the left eye's view position. Useful for content
 		 * that must be viewed from a single viewpoint (e.g. 360° panoramas, Matterport-style).
+		 * Uses native `forceMonoPresentation` when available, otherwise a position-override fallback.
+		 * Maintainers: please review the implementation when the WebXR Layers API evolves.
 		 *
 		 * @type {boolean}
 		 * @default false
@@ -488,6 +490,18 @@ class WebXRManager extends EventDispatcher {
 					glBinding = this.getBinding();
 
 					glProjLayer = glBinding.createProjectionLayer( projectionlayerInit );
+
+					// Monoscopic: fallback to native XR API if available.
+					// This will be ignored if the device/browser already supports native mono presentation
+					if ( scope.forceMonoscopic && 'forceMonoPresentation' in glProjLayer ) {
+
+						try {
+
+							glProjLayer.forceMonoPresentation = true;
+
+						} catch ( e ) {}
+			
+					}
 
 					session.updateRenderState( { layers: [ glProjLayer ] } );
 
@@ -991,9 +1005,11 @@ class WebXRManager extends EventDispatcher {
 
 					camera.matrix.fromArray( view.transform.matrix );
 					camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
-					if ( scope.forceMonoscopic && i === 1 && cameras[ 0 ] !== undefined ) {
 
-						camera.position.copy( cameras[ 0 ].position );
+					// Monoscopic fallback: override right eye position when native API not available
+					if ( scope.forceMonoscopic && i === 1 && cameras[0] !== undefined ) {
+
+						camera.position.copy( cameras[0].position );
 						camera.matrix.compose( camera.position, camera.quaternion, camera.scale );
 
 					}

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -51,6 +51,7 @@ class WebXRManager extends EventDispatcher {
 		let glBinding = null;
 		let glProjLayer = null;
 		let glBaseLayer = null;
+		let supportsMonoscopic = false;
 		let xrFrame = null;
 
 		const supportsGlBinding = typeof XRWebGLBinding !== 'undefined';
@@ -438,6 +439,8 @@ class WebXRManager extends EventDispatcher {
 
 				if ( ! supportsLayers ) {
 
+					supportsMonoscopic = false;
+
 					const layerInit = {
 						antialias: attributes.antialias,
 						alpha: true,
@@ -491,15 +494,12 @@ class WebXRManager extends EventDispatcher {
 
 					glProjLayer = glBinding.createProjectionLayer( projectionlayerInit );
 
+					supportsMonoscopic = 'forceMonoPresentation' in glProjLayer;
 					// Monoscopic: fallback to native XR API if available.
 					// This will be ignored if the device/browser already supports native mono presentation
-					if ( scope.forceMonoscopic && 'forceMonoPresentation' in glProjLayer ) {
+					if ( scope.forceMonoscopic && supportsMonoscopic ) {
 
-						try {
-
-							glProjLayer.forceMonoPresentation = true;
-
-						} catch ( e ) {}
+						glProjLayer.forceMonoPresentation = true;
 
 					}
 
@@ -1007,7 +1007,7 @@ class WebXRManager extends EventDispatcher {
 					camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
 
 					// Monoscopic fallback: override right eye position when native API not available
-					if ( scope.forceMonoscopic && i === 1 && cameras[ 0 ] !== undefined ) {
+					if ( scope.forceMonoscopic && ! supportsMonoscopic && i === 1 && cameras[ 0 ] !== undefined ) {
 
 						camera.position.copy( cameras[ 0 ].position );
 						camera.matrix.compose( camera.position, camera.quaternion, camera.scale );


### PR DESCRIPTION
Related issue: #33177 

**Description**

Adds optional `forceMonoscopic` flag to WebXRManager for single-viewpoint content. When enabled, both eyes use the left eye's view position, fixing projection misalignment on the right eye for content authored from a single viewpoint.
- `renderer.xr.forceMonoscopic = true` enables monoscopic mode
- Default remains stereo (backward compatible)