### PR TITLE
WebGPURenderer: Use `depth32float` instead of `depth24plus` when using `reversedDepthBuffer`

### DIFF
--- a/examples/webgpu_reversed_depth_buffer.html
+++ b/examples/webgpu_reversed_depth_buffer.html
@@ -185,7 +185,14 @@
 				logarithmicRenderPipeline.outputNode = pass( scene, camera );
 
 				reverseRenderPipeline = new THREE.RenderPipeline( reverseRenderer );
-				reverseRenderPipeline.outputNode = pass( scene, reversedCamera );
+				const reverseScenePass = pass( scene, reversedCamera );
+				const reverseDepthTexture = reverseScenePass.getTexture( 'depth' );
+				reverseDepthTexture.type = THREE.FloatType;
+				reverseDepthTexture.format = THREE.DepthFormat;
+				reverseDepthTexture.minFilter = THREE.NearestFilter;
+				reverseDepthTexture.magFilter = THREE.NearestFilter;
+				reverseRenderPipeline.outputNode = reverseScenePass;
+
 
 				await Promise.all( [ normalRenderer.init(), logarithmicRenderer.init(), reverseRenderer.init() ] );
 

--- a/examples/webgpu_reversed_depth_buffer.html
+++ b/examples/webgpu_reversed_depth_buffer.html
@@ -193,7 +193,6 @@
 				reverseDepthTexture.magFilter = THREE.NearestFilter;
 				reverseRenderPipeline.outputNode = reverseScenePass;
 
-
 				await Promise.all( [ normalRenderer.init(), logarithmicRenderer.init(), reverseRenderer.init() ] );
 
 				window.addEventListener( 'resize', onWindowResize );

--- a/examples/webgpu_reversed_depth_buffer.html
+++ b/examples/webgpu_reversed_depth_buffer.html
@@ -185,13 +185,7 @@
 				logarithmicRenderPipeline.outputNode = pass( scene, camera );
 
 				reverseRenderPipeline = new THREE.RenderPipeline( reverseRenderer );
-				const reverseScenePass = pass( scene, reversedCamera );
-				const reverseDepthTexture = reverseScenePass.getTexture( 'depth' );
-				reverseDepthTexture.type = THREE.FloatType;
-				reverseDepthTexture.format = THREE.DepthFormat;
-				reverseDepthTexture.minFilter = THREE.NearestFilter;
-				reverseDepthTexture.magFilter = THREE.NearestFilter;
-				reverseRenderPipeline.outputNode = reverseScenePass;
+				reverseRenderPipeline.outputNode = pass( scene, reversedCamera );
 
 				await Promise.all( [ normalRenderer.init(), logarithmicRenderer.init(), reverseRenderer.init() ] );
 

--- a/examples/webgpu_reversed_depth_buffer.html
+++ b/examples/webgpu_reversed_depth_buffer.html
@@ -185,9 +185,7 @@
 				logarithmicRenderPipeline.outputNode = pass( scene, camera );
 
 				reverseRenderPipeline = new THREE.RenderPipeline( reverseRenderer );
-				const reverseScenePass = pass( scene, reversedCamera );
-				reverseScenePass.renderTarget.depthTexture.type = THREE.FloatType;
-				reverseRenderPipeline.outputNode = reverseScenePass;
+				reverseRenderPipeline.outputNode = pass( scene, reversedCamera );
 
 				await Promise.all( [ normalRenderer.init(), logarithmicRenderer.init(), reverseRenderer.init() ] );
 

--- a/examples/webgpu_reversed_depth_buffer.html
+++ b/examples/webgpu_reversed_depth_buffer.html
@@ -186,11 +186,7 @@
 
 				reverseRenderPipeline = new THREE.RenderPipeline( reverseRenderer );
 				const reverseScenePass = pass( scene, reversedCamera );
-				const reverseDepthTexture = reverseScenePass.getTexture( 'depth' );
-				reverseDepthTexture.type = THREE.FloatType;
-				reverseDepthTexture.format = THREE.DepthFormat;
-				reverseDepthTexture.minFilter = THREE.NearestFilter;
-				reverseDepthTexture.magFilter = THREE.NearestFilter;
+				reverseScenePass.renderTarget.depthTexture.type = THREE.FloatType;
 				reverseRenderPipeline.outputNode = reverseScenePass;
 
 				await Promise.all( [ normalRenderer.init(), logarithmicRenderer.init(), reverseRenderer.init() ] );

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -5,7 +5,7 @@ import { context } from '../tsl/TSLBase.js';
 import { uniform } from '../core/UniformNode.js';
 import { viewZToOrthographicDepth, perspectiveDepthToViewZ } from './ViewportDepthNode.js';
 
-import { HalfFloatType/*, FloatType*/ } from '../../constants.js';
+import { HalfFloatType, FloatType } from '../../constants.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Vector4 } from '../../math/Vector4.js';
 import { DepthTexture } from '../../textures/DepthTexture.js';
@@ -756,6 +756,12 @@ class PassNode extends TempNode {
 		this.renderTarget.samples = this.options.samples === undefined ? renderer.samples : this.options.samples;
 
 		this.renderTarget.texture.type = renderer.getOutputBufferType();
+
+		if ( renderer.reversedDepthBuffer === true && this.renderTarget.depthTexture !== null && this.renderTarget.stencilBuffer !== true ) {
+
+			this.renderTarget.depthTexture.type = FloatType;
+
+		}
 
 		return this.scope === PassNode.COLOR ? this.getTextureNode() : this.getLinearDepthNode();
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -757,7 +757,7 @@ class PassNode extends TempNode {
 
 		this.renderTarget.texture.type = renderer.getOutputBufferType();
 
-		if ( renderer.reversedDepthBuffer === true && this.renderTarget.depthTexture !== null && this.renderTarget.stencilBuffer !== true ) {
+		if ( renderer.reversedDepthBuffer === true ) {
 
 			this.renderTarget.depthTexture.type = FloatType;
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -463,7 +463,7 @@ class WebGPUTextureUtils {
 		if ( stencil ) {
 
 			format = DepthStencilFormat;
-			type = UnsignedInt248Type;
+			type = backend.renderer.reversedDepthBuffer === true ? FloatType : UnsignedInt248Type;
 
 		} else if ( depth ) {
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -468,7 +468,7 @@ class WebGPUTextureUtils {
 		} else if ( depth ) {
 
 			format = DepthFormat;
-			type = UnsignedIntType;
+			type = backend.renderer.reversedDepthBuffer === true ? FloatType : UnsignedIntType;
 
 		}
 

--- a/src/renderers/webgpu/utils/WebGPUUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUUtils.js
@@ -42,7 +42,15 @@ class WebGPUUtils {
 
 			} else if ( renderContext.stencil ) {
 
-				format = GPUTextureFormat.Depth24PlusStencil8;
+				if ( this.backend.renderer.reversedDepthBuffer === true ) {
+
+					format = GPUTextureFormat.Depth32FloatStencil8;
+
+				} else {
+
+					format = GPUTextureFormat.Depth24PlusStencil8;
+
+				}
 
 			} else {
 

--- a/src/renderers/webgpu/utils/WebGPUUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUUtils.js
@@ -46,7 +46,15 @@ class WebGPUUtils {
 
 			} else {
 
-				format = GPUTextureFormat.Depth24Plus;
+				if ( this.backend.renderer.reversedDepthBuffer === true ) {
+
+					format = GPUTextureFormat.Depth32Float;
+
+				} else {
+
+					format = GPUTextureFormat.Depth24Plus;
+
+				}
 
 			}
 


### PR DESCRIPTION
Fixed #33166 

**Description**

This PR makes WebGPU use `depth32float` when `reversedDepthBuffer` is enabled.

Right now, `PassNode` creates a `DepthTexture` for its internal `RenderTarget`, but it leaves the depth texture on the default type. The WebGPU format mapping already supports `DepthFormat + FloatType -> Depth32Float`, but the default non-stencil canvas path and the pipeline format query still use `Depth24Plus`.

This fixes the Firefox `webgpu_reversed_depth_buffer` z-fighting issue: the example itself already notes that "for best results, a floating-point depth buffer should be used," and explicitly using float depth removes the remaining z-fighting seen in Firefox for the reverse-Z column.