### PR TITLE
WebGPURenderer: Ensure render targets have consistent default depth values.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1465,6 +1465,28 @@ class Renderer {
 
 		}
 
+		// make sure a new render target has correct default depth values
+
+		if ( renderTarget !== null && renderTarget.depthBuffer === true ) {
+
+			const renderTargetData = this._textures.get( renderTarget );
+
+			if ( renderTargetData.depthInitialized !== true ) {
+
+				// we need a single manual clear if auto clear depth is disabled
+
+				if ( this.autoClear === false || ( this.autoClear === true && this.autoClearDepth === false ) ) {
+
+					this.clearDepth();
+
+				}
+
+				renderTargetData.depthInitialized = true;
+
+			}
+
+		}
+
 		//
 
 		const renderContext = this._renderContexts.get( renderTarget, this._mrt, this._callDepth );
@@ -2217,6 +2239,8 @@ class Renderer {
 			renderContext.activeCubeFace = this.getActiveCubeFace();
 			renderContext.activeMipmapLevel = this.getActiveMipmapLevel();
 
+			if ( renderTarget.depthBuffer === true ) renderTargetData.depthInitialized = true;
+
 		}
 
 		this.backend.clear( color, depth, stencil, renderContext );
@@ -2480,7 +2504,7 @@ class Renderer {
 	/**
 	 * Sets the output render target for the renderer.
 	 *
-	 * @param {Object} renderTarget - The render target to set as the output target.
+	 * @param {?RenderTarget} renderTarget - The render target to set as the output target.
 	 */
 	setOutputRenderTarget( renderTarget ) {
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2220,7 +2220,7 @@ class Renderer {
 
 			const renderTargetData = this._textures.get( renderTarget );
 
-			renderContext = this._renderContexts.get( renderTarget );
+			renderContext = this._renderContexts.get( renderTarget, null, - 1 ); // using - 1 for the call depth to get a render context for the clear operation
 			renderContext.textures = renderTargetData.textures;
 			renderContext.depthTexture = renderTargetData.depthTexture;
 			renderContext.width = renderTargetData.width;


### PR DESCRIPTION
Related issue: -

**Description**

This issue has driven me nuts^^. I've encountered a strange rendering issue in a complex render setup and couldn't find the root cause. It took a while to isolate this issue but the following test case demonstrates a bug in `WebGPURenderer`:

https://jsfiddle.net/2mdwzyge/

As you can see nothing is rendered but when switching to the WebGL 2 backend the result is as expected (a rotating cube producing trails). 

When `autoClear` is set to `false`, the default values in a depth texture actually _vary_ between WebGPU and WebGL (0 vs 1). This can produce hard to track bugs/inconsistent behavior so we should make sure `WebGPURenderer` setups depth textures with consistent default depth values. 

The PR is doing this by checking for uninitialized render targets and clears the depth once if `autoClear` or `autoClearDepth` is disabled. When the auto clear flags are not changed, the render target will be guaranteed in a valid state because of the automatic clear.