### PR TITLE
Inspector: Add export functionality to Inspector Timeline tab and enhance call detail logging

### DIFF
--- a/examples/jsm/inspector/tabs/Timeline.js
+++ b/examples/jsm/inspector/tabs/Timeline.js
@@ -736,11 +736,17 @@ class Timeline extends Tab {
 
 		for ( const key in detail ) {
 
-			if ( detail[ key ] !== undefined ) parts.push( detail[ key ] );
+			if ( detail[ key ] !== undefined ) {
+
+				parts.push( `<span style="opacity: 0.5">${key}:</span> <span style="color: var(--text-secondary); opacity: 0.8">${detail[ key ]}</span>` );
+
+			}
 
 		}
 
-		return parts.length > 0 ? '[ ' + parts.join( ', ' ) + ' ]' : '';
+		if ( parts.length === 0 ) return '';
+
+		return `<span style="font-size: 11px; margin-left: 8px; color: var(--text-secondary); opacity: 0.8;">{ ${parts.join( '<span style="opacity: 0.5">, </span>' )} }</span>`;
 
 	}
 
@@ -934,7 +940,7 @@ class Timeline extends Tab {
 
 					// Title
 					const title = document.createElement( 'span' );
-					title.textContent = call.method + ( call.detailStr ? ' ' + call.detailStr : '' ) + ( call.count > 1 ? ` ( ${call.count} )` : '' );
+					title.innerHTML = call.method + ( call.detailStr ? call.detailStr : '' ) + ( call.count > 1 ? ` <span style="opacity: 0.5">( ${call.count} )</span>` : '' );
 					block.appendChild( title );
 
 					block.addEventListener( 'click', ( e ) => {
@@ -960,14 +966,14 @@ class Timeline extends Tab {
 
 				} else if ( call.method.startsWith( 'finish' ) ) {
 
-					block.textContent = call.method + ( call.detailStr ? ' ' + call.detailStr : '' ) + ( call.count > 1 ? ` ( ${call.count} )` : '' );
+					block.innerHTML = call.method + ( call.detailStr ? call.detailStr : '' ) + ( call.count > 1 ? ` <span style="opacity: 0.5">( ${call.count} )</span>` : '' );
 
 					currentIndent = Math.max( 0, currentIndent - 1 );
 					elementStack.pop();
 
 				} else {
 
-					block.textContent = call.method + ( call.detailStr ? ' ' + call.detailStr : '' ) + ( call.count > 1 ? ` ( ${call.count} )` : '' );
+					block.innerHTML = call.method + ( call.detailStr ? call.detailStr : '' ) + ( call.count > 1 ? ` <span style="opacity: 0.5">( ${call.count} )</span>` : '' );
 
 				}
 

--- a/examples/jsm/inspector/tabs/Timeline.js
+++ b/examples/jsm/inspector/tabs/Timeline.js
@@ -102,11 +102,22 @@ class Timeline extends Tab {
 
 		} );
 
+		this.exportButton = document.createElement( 'button' );
+		this.exportButton.className = 'console-copy-button';
+		this.exportButton.title = 'Export';
+		this.exportButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>';
+		this.exportButton.style.padding = '0 10px';
+		this.exportButton.style.lineHeight = '24px';
+		this.exportButton.style.display = 'flex';
+		this.exportButton.style.alignItems = 'center';
+		this.exportButton.addEventListener( 'click', () => this.exportData() );
+
 		const buttonsGroup = document.createElement( 'div' );
 		buttonsGroup.className = 'console-buttons-group';
 		buttonsGroup.appendChild( this.viewModeButton );
 		buttonsGroup.appendChild( this.recordButton );
 		buttonsGroup.appendChild( this.recordRefreshButton );
+		buttonsGroup.appendChild( this.exportButton );
 		buttonsGroup.appendChild( clearButton );
 
 		header.style.display = 'flex';
@@ -597,8 +608,12 @@ class Timeline extends Tab {
 
 					}
 
-					// Only record method name as requested, skipping detail arguments
-					this.currentFrame.calls.push( { method: methodLabel } );
+					const call = { method: methodLabel };
+					const detail = this.getCallDetail( prop, args );
+
+					if ( detail ) call.detail = detail;
+
+					this.currentFrame.calls.push( call );
 
 					return originalFunc.apply( backend, args );
 
@@ -644,6 +659,88 @@ class Timeline extends Tab {
 		this.graph.lines[ 'fps' ].points = [];
 		this.graph.resetLimit();
 		this.graph.update();
+
+	}
+
+	exportData() {
+
+		if ( this.frames.length === 0 ) return;
+
+		const data = JSON.stringify( this.frames, null, '\t' );
+		const blob = new Blob( [ data ], { type: 'application/json' } );
+		const url = URL.createObjectURL( blob );
+		const a = document.createElement( 'a' );
+		a.href = url;
+		a.download = 'threejs-timeline.json';
+		a.click();
+		URL.revokeObjectURL( url );
+
+	}
+
+	getCallDetail( method, args ) {
+
+		switch ( method ) {
+
+			case 'draw': {
+
+				const renderObject = args[ 0 ];
+				if ( ! renderObject ) return null;
+
+				const detail = {};
+				if ( renderObject.object ) detail.object = renderObject.object.name || renderObject.object.type;
+				if ( renderObject.material ) detail.material = renderObject.material.name || renderObject.material.type;
+				if ( renderObject.geometry ) detail.geometry = renderObject.geometry.name || undefined;
+				return detail;
+
+			}
+
+			case 'updateBinding': {
+
+				const binding = args[ 0 ];
+				return binding?.name ? { binding: binding.name } : null;
+
+			}
+
+			case 'createProgram': {
+
+				const program = args[ 0 ];
+				if ( ! program ) return null;
+				return { stage: program.stage, name: program.name || undefined };
+
+			}
+
+			case 'createBindings': {
+
+				const bindGroup = args[ 0 ];
+				return bindGroup?.name ? { group: bindGroup.name } : null;
+
+			}
+
+			case 'createTexture':
+			case 'destroyTexture': {
+
+				const texture = args[ 0 ];
+				return texture?.name ? { texture: texture.name } : null;
+
+			}
+
+		}
+
+		return null;
+
+	}
+
+	formatDetail( detail ) {
+
+		const parts = [];
+
+		for ( const key in detail ) {
+
+			if ( detail[ key ] !== undefined ) parts.push( detail[ key ] );
+
+		}
+
+		return parts.length > 0 ? '[ ' + parts.join( ', ' ) + ' ]' : '';
 
 	}
 
@@ -768,14 +865,15 @@ class Timeline extends Tab {
 
 				const call = frame.calls[ i ];
 				const isStructural = call.method.startsWith( 'begin' ) || call.method.startsWith( 'finish' );
+				const detailStr = call.detail ? this.formatDetail( call.detail ) : '';
 
-				if ( currentGroup && currentGroup.method === call.method && ! isStructural ) {
+				if ( currentGroup && currentGroup.method === call.method && currentGroup.detailStr === detailStr && ! isStructural ) {
 
 					currentGroup.count ++;
 
 				} else {
 
-					currentGroup = { method: call.method, count: 1 };
+					currentGroup = { method: call.method, count: 1, detailStr };
 					groupedCalls.push( currentGroup );
 
 				}
@@ -836,7 +934,7 @@ class Timeline extends Tab {
 
 					// Title
 					const title = document.createElement( 'span' );
-					title.textContent = call.method + ( call.count > 1 ? ` ( ${call.count} )` : '' );
+					title.textContent = call.method + ( call.detailStr ? ' ' + call.detailStr : '' ) + ( call.count > 1 ? ` ( ${call.count} )` : '' );
 					block.appendChild( title );
 
 					block.addEventListener( 'click', ( e ) => {
@@ -862,14 +960,14 @@ class Timeline extends Tab {
 
 				} else if ( call.method.startsWith( 'finish' ) ) {
 
-					block.textContent = call.method + ( call.count > 1 ? ` ( ${call.count} )` : '' );
+					block.textContent = call.method + ( call.detailStr ? ' ' + call.detailStr : '' ) + ( call.count > 1 ? ` ( ${call.count} )` : '' );
 
 					currentIndent = Math.max( 0, currentIndent - 1 );
 					elementStack.pop();
 
 				} else {
 
-					block.textContent = call.method + ( call.count > 1 ? ` ( ${call.count} )` : '' );
+					block.textContent = call.method + ( call.detailStr ? ' ' + call.detailStr : '' ) + ( call.count > 1 ? ` ( ${call.count} )` : '' );
 
 				}
 

--- a/examples/jsm/inspector/tabs/Timeline.js
+++ b/examples/jsm/inspector/tabs/Timeline.js
@@ -701,6 +701,9 @@ class Timeline extends Tab {
 
 				if ( renderObject.material ) detail.material = renderObject.material.name || renderObject.material.type;
 				if ( renderObject.geometry ) detail.geometry = renderObject.geometry.name || undefined;
+
+				if ( renderObject.camera ) detail.camera = renderObject.camera.name || renderObject.camera.type;
+
 				return detail;
 
 			}

--- a/examples/jsm/inspector/tabs/Timeline.js
+++ b/examples/jsm/inspector/tabs/Timeline.js
@@ -609,9 +609,9 @@ class Timeline extends Tab {
 					}
 
 					const call = { method: methodLabel };
-					const detail = this.getCallDetail( prop, args );
+					const details = this.getCallDetail( prop, args );
 
-					if ( detail ) call.detail = detail;
+					if ( details ) call.details = details;
 
 					this.currentFrame.calls.push( call );
 
@@ -686,25 +686,25 @@ class Timeline extends Tab {
 				const renderObject = args[ 0 ];
 				if ( ! renderObject ) return null;
 
-				const detail = {};
+				const details = {};
 				if ( renderObject.object ) {
 
-					detail.object = renderObject.object.name || renderObject.object.type;
+					details.object = renderObject.object.name || renderObject.object.type;
 
 					if ( renderObject.object.count > 1 ) {
 
-						detail.instances = renderObject.object.count;
+						details.instance = renderObject.object.count;
 
 					}
 
 				}
 
-				if ( renderObject.material ) detail.material = renderObject.material.name || renderObject.material.type;
-				if ( renderObject.geometry ) detail.geometry = renderObject.geometry.name || undefined;
+				if ( renderObject.material ) details.material = renderObject.material.name || renderObject.material.type;
+				if ( renderObject.geometry ) details.geometry = renderObject.geometry.name || undefined;
 
-				if ( renderObject.camera ) detail.camera = renderObject.camera.name || renderObject.camera.type;
+				if ( renderObject.camera ) details.camera = renderObject.camera.name || renderObject.camera.type;
 
-				return detail;
+				return details;
 
 			}
 
@@ -744,15 +744,15 @@ class Timeline extends Tab {
 
 	}
 
-	formatDetail( detail ) {
+	formatDetails( details ) {
 
 		const parts = [];
 
-		for ( const key in detail ) {
+		for ( const key in details ) {
 
-			if ( detail[ key ] !== undefined ) {
+			if ( details[ key ] !== undefined ) {
 
-				parts.push( `<span style="opacity: 0.5">${key}:</span> <span style="color: var(--text-secondary); opacity: 0.8">${detail[ key ]}</span>` );
+				parts.push( `<span style="opacity: 0.5">${key}:</span> <span style="color: var(--text-secondary); opacity: 0.8">${details[ key ]}</span>` );
 
 			}
 
@@ -885,15 +885,15 @@ class Timeline extends Tab {
 
 				const call = frame.calls[ i ];
 				const isStructural = call.method.startsWith( 'begin' ) || call.method.startsWith( 'finish' );
-				const detailStr = call.detail ? this.formatDetail( call.detail ) : '';
+				const formatedDetails = call.details ? this.formatDetails( call.details ) : '';
 
-				if ( currentGroup && currentGroup.method === call.method && currentGroup.detailStr === detailStr && ! isStructural ) {
+				if ( currentGroup && currentGroup.method === call.method && currentGroup.formatedDetails === formatedDetails && ! isStructural ) {
 
 					currentGroup.count ++;
 
 				} else {
 
-					currentGroup = { method: call.method, count: 1, detailStr };
+					currentGroup = { method: call.method, count: 1, formatedDetails };
 					groupedCalls.push( currentGroup );
 
 				}
@@ -954,7 +954,7 @@ class Timeline extends Tab {
 
 					// Title
 					const title = document.createElement( 'span' );
-					title.innerHTML = call.method + ( call.detailStr ? call.detailStr : '' ) + ( call.count > 1 ? ` <span style="opacity: 0.5">( ${call.count} )</span>` : '' );
+					title.innerHTML = call.method + ( call.formatedDetails ? call.formatedDetails : '' ) + ( call.count > 1 ? ` <span style="opacity: 0.5">( ${call.count} )</span>` : '' );
 					block.appendChild( title );
 
 					block.addEventListener( 'click', ( e ) => {
@@ -980,14 +980,14 @@ class Timeline extends Tab {
 
 				} else if ( call.method.startsWith( 'finish' ) ) {
 
-					block.innerHTML = call.method + ( call.detailStr ? call.detailStr : '' ) + ( call.count > 1 ? ` <span style="opacity: 0.5">( ${call.count} )</span>` : '' );
+					block.innerHTML = call.method + ( call.formatedDetails ? call.formatedDetails : '' ) + ( call.count > 1 ? ` <span style="opacity: 0.5">( ${call.count} )</span>` : '' );
 
 					currentIndent = Math.max( 0, currentIndent - 1 );
 					elementStack.pop();
 
 				} else {
 
-					block.innerHTML = call.method + ( call.detailStr ? call.detailStr : '' ) + ( call.count > 1 ? ` <span style="opacity: 0.5">( ${call.count} )</span>` : '' );
+					block.innerHTML = call.method + ( call.formatedDetails ? call.formatedDetails : '' ) + ( call.count > 1 ? ` <span style="opacity: 0.5">( ${call.count} )</span>` : '' );
 
 				}
 

--- a/examples/jsm/inspector/tabs/Timeline.js
+++ b/examples/jsm/inspector/tabs/Timeline.js
@@ -687,7 +687,18 @@ class Timeline extends Tab {
 				if ( ! renderObject ) return null;
 
 				const detail = {};
-				if ( renderObject.object ) detail.object = renderObject.object.name || renderObject.object.type;
+				if ( renderObject.object ) {
+
+					detail.object = renderObject.object.name || renderObject.object.type;
+
+					if ( renderObject.object.count > 1 ) {
+
+						detail.instances = renderObject.object.count;
+
+					}
+
+				}
+
 				if ( renderObject.material ) detail.material = renderObject.material.name || renderObject.material.type;
 				if ( renderObject.geometry ) detail.geometry = renderObject.geometry.name || undefined;
 				return detail;

--- a/examples/jsm/inspector/tabs/Timeline.js
+++ b/examples/jsm/inspector/tabs/Timeline.js
@@ -752,7 +752,7 @@ class Timeline extends Tab {
 
 			if ( details[ key ] !== undefined ) {
 
-				parts.push( `<span style="opacity: 0.5">${key}:</span> <span style="color: var(--text-secondary); opacity: 0.8">${details[ key ]}</span>` );
+				parts.push( `<span style="opacity: 0.5">${key}:</span> <span style="color: var(--text-secondary); opacity: 1">${details[ key ]}</span>` );
 
 			}
 
@@ -760,7 +760,7 @@ class Timeline extends Tab {
 
 		if ( parts.length === 0 ) return '';
 
-		return `<span style="font-size: 11px; margin-left: 8px; color: var(--text-secondary); opacity: 0.8;">{ ${parts.join( '<span style="opacity: 0.5">, </span>' )} }</span>`;
+		return `<span style="font-size: 11px; margin-left: 8px; color: var(--text-secondary); opacity: 1;">{ ${parts.join( '<span style="opacity: 0.5">, </span>' )} }</span>`;
 
 	}
 


### PR DESCRIPTION
# Improve Timeline in the inspector

- Add an export button to the Timeline tab that downloads recorded frames as threejs-timeline.json

- Enrich recorded backend calls with contextual details (object name, material, geometry, binding name, program stage, texture name)

- Display call details in the hierarchy view so individual operations are identifiable (e.g. draw [ Mesh, MeshStandardMaterial ] instead of just draw)

Before in webgpu_animation_retargeting
<img width="632" height="379" alt="Screenshot 2026-03-16 at 23 57 36" src="https://github.com/user-attachments/assets/c31469ac-f3d7-44d6-9406-9297918774ca" />

After ( + new button top right )
<img width="1359" height="478" alt="Screenshot 2026-03-17 at 00 06 16" src="https://github.com/user-attachments/assets/444005df-7abc-4955-8d7f-d2cbd503109f" />

