### PR TITLE
CSMShadowNode: Fix error when disposed multiple times

### DIFF
--- a/examples/jsm/csm/CSMShadowNode.js
+++ b/examples/jsm/csm/CSMShadowNode.js
@@ -574,8 +574,12 @@ class CSMShadowNode extends ShadowBaseNode {
 			const light = this.lights[ i ];
 			const parent = light.parent;
 
-			parent.remove( light.target );
-			parent.remove( light );
+			if ( parent !== null ) {
+
+				parent.remove( light.target );
+				parent.remove( light );
+
+			}
 
 		}
 


### PR DESCRIPTION
This PR fixes `CSMShadowNode` throwing errors when disposed multiple times.

Disposing an instance multiple times may be invalid in itself, but it's better to be robust.

This happens when a `CSMShadowNode` is attached to a light's shadow, and the light and the CSM node are disposed independently.

```ts
const light = new DirectionalLight()
const csm = new CSMShadowNode()
light.shadow.shadowNode = csm

renderer.render() // Render a frame so that the CSM node is setup

light.dispose()
csm.dispose() // Error
```