### PR TITLE
MeshPhysicalMaterial: Fix Anisotropic regression.

### DIFF
--- a/src/nodes/functions/BSDF/V_GGX_SmithCorrelated_Anisotropic.js
+++ b/src/nodes/functions/BSDF/V_GGX_SmithCorrelated_Anisotropic.js
@@ -8,7 +8,7 @@ const V_GGX_SmithCorrelated_Anisotropic = /*@__PURE__*/ Fn( ( { alphaT, alphaB, 
 
 	const gv = dotNL.mul( vec3( alphaT.mul( dotTV ), alphaB.mul( dotBV ), dotNV ).length() );
 	const gl = dotNV.mul( vec3( alphaT.mul( dotTL ), alphaB.mul( dotBL ), dotNL ).length() );
-	
+
 	return div( 0.5, gv.add( gl ).max( EPSILON ) );
 
 } ).setLayout( {

--- a/src/nodes/functions/BSDF/V_GGX_SmithCorrelated_Anisotropic.js
+++ b/src/nodes/functions/BSDF/V_GGX_SmithCorrelated_Anisotropic.js
@@ -1,4 +1,5 @@
 import { div } from '../../math/OperatorNode.js';
+import { EPSILON } from '../../math/MathNode.js';
 import { Fn, vec3 } from '../../tsl/TSLBase.js';
 
 // https://google.github.io/filament/Filament.md.html#materialsystem/anisotropicmodel/anisotropicspecularbrdf
@@ -7,9 +8,8 @@ const V_GGX_SmithCorrelated_Anisotropic = /*@__PURE__*/ Fn( ( { alphaT, alphaB, 
 
 	const gv = dotNL.mul( vec3( alphaT.mul( dotTV ), alphaB.mul( dotBV ), dotNV ).length() );
 	const gl = dotNV.mul( vec3( alphaT.mul( dotTL ), alphaB.mul( dotBL ), dotNL ).length() );
-	const v = div( 0.5, gv.add( gl ) );
-
-	return v;
+	
+	return div( 0.5, gv.add( gl ).max( EPSILON ) );
 
 } ).setLayout( {
 	name: 'V_GGX_SmithCorrelated_Anisotropic',

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -103,9 +103,7 @@ float D_GGX( const in float alpha, const in float dotNH ) {
 
 		float gv = dotNL * length( vec3( alphaT * dotTV, alphaB * dotBV, dotNV ) );
 		float gl = dotNV * length( vec3( alphaT * dotTL, alphaB * dotBL, dotNL ) );
-		float v = 0.5 / ( gv + gl );
-
-		return v;
+		return 0.5 / max( gv + gl, EPSILON );
 
 	}
 


### PR DESCRIPTION
Fixed #33201.

**Description**

The PR corrects the changes from https://github.com/mrdoob/three.js/pull/32330. Removing the `saturate()` was right but it was missed to introduce the same guard as `V_GGX_SmithCorrelated()` to prevent division through `0`. That produces `NaN` values and the reported black pixels.
