### PR TITLE
Rename `AudioContext` to `AudioContextProvider`

### DIFF
--- a/src/Three.Core.js
+++ b/src/Three.Core.js
@@ -71,7 +71,7 @@ export { ArrayCamera } from './cameras/ArrayCamera.js';
 export { Camera } from './cameras/Camera.js';
 export { AudioListener } from './audio/AudioListener.js';
 export { PositionalAudio } from './audio/PositionalAudio.js';
-export { AudioContext } from './audio/AudioContext.js';
+export { AudioContextProvider } from './audio/AudioContextProvider.js';
 export { AudioAnalyser } from './audio/AudioAnalyser.js';
 export { Audio } from './audio/Audio.js';
 export { VectorKeyframeTrack } from './animation/tracks/VectorKeyframeTrack.js';

--- a/src/audio/AudioContextProvider.js
+++ b/src/audio/AudioContextProvider.js
@@ -5,7 +5,7 @@ let _context;
  *
  * @hideconstructor
  */
-class AudioContext {
+class AudioContextProvider {
 
 	/**
 	 * Returns the global native audio context.
@@ -37,4 +37,4 @@ class AudioContext {
 
 }
 
-export { AudioContext };
+export { AudioContextProvider };

--- a/src/audio/AudioListener.js
+++ b/src/audio/AudioListener.js
@@ -2,7 +2,7 @@ import { Vector3 } from '../math/Vector3.js';
 import { Quaternion } from '../math/Quaternion.js';
 import { Timer } from '../core/Timer.js';
 import { Object3D } from '../core/Object3D.js';
-import { AudioContext } from './AudioContext.js';
+import { AudioContextProvider } from './AudioContextProvider.js';
 
 const _position = /*@__PURE__*/ new Vector3();
 const _quaternion = /*@__PURE__*/ new Quaternion();
@@ -38,7 +38,7 @@ class AudioListener extends Object3D {
 		 * @type {AudioContext}
 		 * @readonly
 		 */
-		this.context = AudioContext.getContext();
+		this.context = AudioContextProvider.getContext();
 
 		/**
 		 * The gain node used for volume control.

--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -1,4 +1,4 @@
-import { AudioContext } from '../audio/AudioContext.js';
+import { AudioContextProvider } from '../audio/AudioContextProvider.js';
 import { FileLoader } from './FileLoader.js';
 import { Loader } from './Loader.js';
 import { error } from '../utils.js';
@@ -59,7 +59,7 @@ class AudioLoader extends Loader {
 				// detaches the buffer when complete, preventing reuse.
 				const bufferCopy = buffer.slice( 0 );
 
-				const context = AudioContext.getContext();
+				const context = AudioContextProvider.getContext();
 				context.decodeAudioData( bufferCopy, function ( audioBuffer ) {
 
 					onLoad( audioBuffer );

--- a/test/unit/src/audio/AudioContextProvider.tests.js
+++ b/test/unit/src/audio/AudioContextProvider.tests.js
@@ -1,8 +1,8 @@
-import { AudioContext } from '../../../../src/audio/AudioContext.js';
+import { AudioContextProvider } from '../../../../src/audio/AudioContextProvider.js';
 
 export default QUnit.module( 'Audios', () => {
 
-	QUnit.module( 'AudioContext', ( hooks ) => {
+	QUnit.module( 'AudioContextProvider', ( hooks ) => {
 
 		function mockWindowAudioContext() {
 
@@ -43,21 +43,21 @@ export default QUnit.module( 'Audios', () => {
 		// STATIC
 		QUnit.test( 'getContext', ( assert ) => {
 
-			const context = AudioContext.getContext();
+			const context = AudioContextProvider.getContext();
 			assert.strictEqual(
 				context instanceof Object, true,
-				'AudioContext.getContext creates a context.'
+				'AudioContextProvider.getContext creates a context.'
 			);
 
 		} );
 
 		QUnit.test( 'setContext', ( assert ) => {
 
-			AudioContext.setContext( new window.AudioContext() );
-			const context = AudioContext.getContext();
+			AudioContextProvider.setContext( new window.AudioContext() );
+			const context = AudioContextProvider.getContext();
 			assert.strictEqual(
 				context instanceof Object, true,
-				'AudioContext.setContext updates the context.'
+				'AudioContextProvider.setContext updates the context.'
 			);
 
 		} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -28,7 +28,7 @@ import './src/animation/tracks/VectorKeyframeTrack.tests.js';
 //src/audio
 import './src/audio/Audio.tests.js';
 import './src/audio/AudioAnalyser.tests.js';
-import './src/audio/AudioContext.tests.js';
+import './src/audio/AudioContextProvider.tests.js';
 import './src/audio/AudioListener.tests.js';
 import './src/audio/PositionalAudio.tests.js';
 


### PR DESCRIPTION
Related issue: #33206 

**Description**

Rename `AudioContext` to `AudioContextProvider` so JSDoc references the correct types in info hover tooltips. There is already an existing `window.AudioContext` type that trips IDEs up.