### PR TITLE
Fix the output pass cache for multi-canvas rendering

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -463,6 +463,14 @@ class Renderer {
 		 */
 		this._frameBufferTargets = new Map();
 
+		/**
+		 * Intermediate color texture last used for the output pass.
+		 *
+		 * @private
+		 * @type {?Texture}
+		 */
+		this._lastOutputFramebufferTexture = null;
+
 		const alphaClear = this.alpha === true ? 0 : 1;
 
 		/**

--- a/src/renderers/common/nodes/NodeManager.js
+++ b/src/renderers/common/nodes/NodeManager.js
@@ -863,6 +863,8 @@ class NodeManager extends DataMap {
 	 */
 	hasOutputChange( outputTarget ) {
 
+		if ( this.renderer._lastOutputFramebufferTexture !== outputTarget ) return true;
+
 		const cacheKey = _outputNodeMap.get( outputTarget );
 
 		return cacheKey !== this.getOutputCacheKey();
@@ -886,6 +888,7 @@ class NodeManager extends DataMap {
 			texture( outputTarget, screenUV ).renderOutput( renderer.toneMapping, renderer.currentColorSpace );
 
 		_outputNodeMap.set( outputTarget, cacheKey );
+		renderer._lastOutputFramebufferTexture = outputTarget;
 
 		return output;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/32689

**Description**

#32690 introduced regression that caused [webgpu_multiple_canvas](https://rawcdn.githack.com/mrdoob/three.js/dev/examples/webgpu_multiple_canvas.html) to render same output to all canvases where each canvas should have unique output buffer.

the problem is that this line returns false negative because it only represents output config from `getOutputCacheKey()`: tone mapping, color space, XR state It does not encode which texture is currently bound
```javascript
return cacheKey !== this.getOutputCacheKey();
```

This fix, however feels more like a band-aid rather than something that addresses the real issue. The caching mechanism relies on a cacheKey that does not correctly check for the identity of the target being cached.

I'm submitting this as draft and looking for better solution.


