### PR TITLE
EXRLoader: Fix channel rule matching.

### DIFF
--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1826,11 +1826,14 @@ class EXRLoader extends DataTextureLoader {
 
 				const cd = channelData[ offset ];
 
+				const dotIndex = cd.name.lastIndexOf( '.' );
+				const suffix = dotIndex >= 0 ? cd.name.substring( dotIndex + 1 ) : cd.name;
+
 				for ( let i = 0; i < channelRules.length; ++ i ) {
 
 					const rule = channelRules[ i ];
 
-					if ( cd.name == rule.name ) {
+					if ( suffix === rule.name && cd.type === rule.type ) {
 
 						cd.compression = rule.compression;
 


### PR DESCRIPTION
Fixed #30775.

**Description**

The PR fixes a bug in context of DWA compressed files. DWA channel rules use suffix-based matching e.g. "R" is not only matched to the color channel name "R" but e.g. "Diffuse.R". Meaning what matters is everything after the dot. `EXRLoader` did not account for that and always compared the full channel name with the rule.

With this fix in place, the test image loads as expected without any console warnings.

<img width="2560" height="1192" alt="Bildschirmfoto 2026-03-19 um 15 22 31" src="https://github.com/user-attachments/assets/3cd70d0a-5c40-468e-a725-a183ecd0eb79" />
