### PR TITLE
TSL: Make global context available within compute nodes

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -25,7 +25,6 @@ import { modelViewMatrix } from '../../nodes/accessors/ModelNode.js';
 import { vertexColor } from '../../nodes/accessors/VertexColorNode.js';
 import { premultiplyAlpha } from '../../nodes/display/BlendModes.js';
 import { subBuild } from '../../nodes/core/SubBuildNode.js';
-import { error } from '../../utils.js';
 
 /**
  * Base class for all node materials.

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -485,32 +485,6 @@ class NodeMaterial extends Material {
 		const renderer = builder.renderer;
 		const renderTarget = renderer.getRenderTarget();
 
-		// < CONTEXT >
-
-		if ( renderer.contextNode.isContextNode === true ) {
-
-			builder.context = { ...builder.context, ...renderer.contextNode.getFlowContextData() };
-
-		} else {
-
-			error( 'NodeMaterial: "renderer.contextNode" must be an instance of `context()`.' );
-
-		}
-
-		if ( this.contextNode !== null ) {
-
-			if ( this.contextNode.isContextNode === true ) {
-
-				builder.context = { ...builder.context, ...this.contextNode.getFlowContextData() };
-
-			} else {
-
-				error( 'NodeMaterial: "material.contextNode" must be an instance of `context()`.' );
-
-			}
-
-		}
-
 		// < VERTEX STAGE >
 
 		builder.addStack();

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2939,6 +2939,43 @@ class NodeBuilder {
 	}
 
 	/**
+	 * Updates the context of the node builder.
+	 */
+	updateContext() {
+
+		const { renderer, material } = this;
+
+		// < renderer.contextNode >
+
+		if ( renderer.contextNode.isContextNode === true ) {
+
+			this.context = { ...this.context, ...renderer.contextNode.getFlowContextData() };
+
+		} else {
+
+			error( 'NodeBuilder: "renderer.contextNode" must be an instance of `context()`.' );
+
+		}
+
+		// < material.contextNode >
+
+		if ( material && material.contextNode ) {
+
+			if ( material.contextNode.isContextNode === true ) {
+
+				this.context = { ...this.context, ...material.contextNode.getFlowContextData() };
+
+			} else {
+
+				error( 'NodeMaterial: "material.contextNode" must be an instance of `context()`.' );
+
+			}
+
+		}
+
+	}
+
+	/**
 	 * Central build method which controls the build for the given object.
 	 *
 	 * @return {NodeBuilder} A reference to this node builder.
@@ -2946,6 +2983,8 @@ class NodeBuilder {
 	build() {
 
 		const { object, material, renderer } = this;
+
+		this.updateContext();
 
 		if ( material !== null ) {
 
@@ -2964,16 +3003,6 @@ class NodeBuilder {
 		} else {
 
 			this.addFlow( 'compute', object );
-
-			if ( renderer.contextNode.isContextNode === true ) {
-
-				this.context = { ...this.context, ...renderer.contextNode.getFlowContextData() };
-
-			} else {
-
-				error( 'NodeBuilder: "renderer.contextNode" must be an instance of `context()`.' );
-
-			}
 
 		}
 
@@ -3036,6 +3065,8 @@ class NodeBuilder {
 	async buildAsync() {
 
 		const { object, material, renderer } = this;
+
+		this.updateContext();
 
 		if ( material !== null ) {
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2939,11 +2939,11 @@ class NodeBuilder {
 	}
 
 	/**
-	 * Updates the context of the node builder.
+	 * Prebuild the node builder.
 	 */
-	updateContext() {
+	prebuild() {
 
-		const { renderer, material } = this;
+		const { object, renderer, material } = this;
 
 		// < renderer.contextNode >
 
@@ -2967,24 +2967,13 @@ class NodeBuilder {
 
 			} else {
 
-				error( 'NodeMaterial: "material.contextNode" must be an instance of `context()`.' );
+				error( 'NodeBuilder: "material.contextNode" must be an instance of `context()`.' );
 
 			}
 
 		}
 
-	}
-
-	/**
-	 * Central build method which controls the build for the given object.
-	 *
-	 * @return {NodeBuilder} A reference to this node builder.
-	 */
-	build() {
-
-		const { object, material, renderer } = this;
-
-		this.updateContext();
+		// < nodeMaterial >
 
 		if ( material !== null ) {
 
@@ -2992,7 +2981,7 @@ class NodeBuilder {
 
 			if ( nodeMaterial === null ) {
 
-				error( `NodeMaterial: Material "${ material.type }" is not compatible.` );
+				error( `NodeBuilder: Material "${ material.type }" is not compatible.` );
 
 				nodeMaterial = new NodeMaterial();
 
@@ -3005,6 +2994,17 @@ class NodeBuilder {
 			this.addFlow( 'compute', object );
 
 		}
+
+	}
+
+	/**
+	 * Central build method which controls the build for the given object.
+	 *
+	 * @return {NodeBuilder} A reference to this node builder.
+	 */
+	build() {
+
+		this.prebuild();
 
 		// setup() -> stage 1: create possible new nodes and/or return an output reference node
 		// analyze()   -> stage 2: analyze nodes to possible optimization and validation
@@ -3064,29 +3064,7 @@ class NodeBuilder {
 	 */
 	async buildAsync() {
 
-		const { object, material, renderer } = this;
-
-		this.updateContext();
-
-		if ( material !== null ) {
-
-			let nodeMaterial = renderer.library.fromMaterial( material );
-
-			if ( nodeMaterial === null ) {
-
-				error( `NodeMaterial: Material "${ material.type }" is not compatible.` );
-
-				nodeMaterial = new NodeMaterial();
-
-			}
-
-			nodeMaterial.build( this );
-
-		} else {
-
-			this.addFlow( 'compute', object );
-
-		}
+		this.prebuild();
 
 		// setup() -> stage 1: create possible new nodes and/or return an output reference node
 		// analyze()   -> stage 2: analyze nodes to possible optimization and validation

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2965,6 +2965,16 @@ class NodeBuilder {
 
 			this.addFlow( 'compute', object );
 
+			if ( renderer.contextNode.isContextNode === true ) {
+
+				this.context = { ...this.context, ...renderer.contextNode.getFlowContextData() };
+
+			} else {
+
+				error( 'NodeBuilder: "renderer.contextNode" must be an instance of `context()`.' );
+
+			}
+
 		}
 
 		// setup() -> stage 1: create possible new nodes and/or return an output reference node


### PR DESCRIPTION
**Description**

This PR applies the global context in the compute build path.

Although compute shaders can't have the material's cascading behavior, it makes more sense to have the renderer's global context available within compute nodes as well.