### PR TITLE
Line2NodeMaterial: Fix clone() losing worldUnits, dashed, and linewidth

### DIFF
--- a/src/materials/nodes/Line2NodeMaterial.js
+++ b/src/materials/nodes/Line2NodeMaterial.js
@@ -537,6 +537,33 @@ class Line2NodeMaterial extends NodeMaterial {
 
 	}
 
+	/**
+	 * Copies the properties of the given material to this instance.
+	 *
+	 * @param {Line2NodeMaterial} source - The material to copy.
+	 * @return {Line2NodeMaterial} A reference to this material.
+	 */
+	copy( source ) {
+
+		super.copy( source );
+
+		this.vertexColors = source.vertexColors;
+		this.dashOffset = source.dashOffset;
+
+		this.lineColorNode = source.lineColorNode;
+		this.offsetNode = source.offsetNode;
+		this.dashScaleNode = source.dashScaleNode;
+		this.dashSizeNode = source.dashSizeNode;
+		this.gapSizeNode = source.gapSizeNode;
+
+		this._useDash = source._useDash;
+		this._useAlphaToCoverage = source._useAlphaToCoverage;
+		this._useWorldUnits = source._useWorldUnits;
+
+		return this;
+
+	}
+
 }
 
 export default Line2NodeMaterial;


### PR DESCRIPTION
**Problem**
When calling `clone()` on a `Line2NodeMaterial`, the backing fields `_useWorldUnits`, `_useDash`, and `_useAlphaToCoverage` are not copied to the new instance. This causes the cloned material to lose its configuration.

**Solution**
Override the `copy()` method to properly copy all Line2NodeMaterial-specific properties, including the backing fields that were missing.

**Changes**
- Added `copy()` method that copies:
  - Backing fields: `_useWorldUnits`, `_useDash`, `_useAlphaToCoverage`
  - Other properties: `vertexColors`, `dashOffset`, `lineColorNode`, `offsetNode`, `dashScaleNode`, `dashSizeNode`, `gapSizeNode`

Fixes #33235