### PR TITLE
WebGPURenderer: Implement `WEBGL_multi_draw` fallback.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -991,14 +991,28 @@ class WebGLBackend extends Backend {
 	 * @param {number} firstVertex - The first vertex to render.
 	 * @param {number} vertexCount - The vertex count.
 	 * @param {number} instanceCount - The intance count.
+	 * @param {WebGLProgram} programGPU - The raw WebGL shader program.
 	 */
-	_draw( object, renderer, firstVertex, vertexCount, instanceCount ) {
+	_draw( object, renderer, firstVertex, vertexCount, instanceCount, programGPU ) {
 
 		if ( object.isBatchedMesh ) {
 
 			if ( this.hasFeature( 'WEBGL_multi_draw' ) === false ) {
 
-				warnOnce( 'WebGLBackend: WEBGL_multi_draw not supported.' );
+				const { gl } = this;
+
+				const drawIdLocation = gl.getUniformLocation( programGPU, 'nodeUniformDrawId' );
+
+				const starts = object._multiDrawStarts;
+				const counts = object._multiDrawCounts;
+				const drawCount = object._multiDrawCount;
+
+				for ( let i = 0; i < drawCount; i ++ ) {
+
+					gl.uniform1ui( drawIdLocation, i );
+					renderer.render( starts[ i ], counts[ i ] );
+
+				}
 
 			} else {
 
@@ -1267,7 +1281,7 @@ class WebGLBackend extends Backend {
 
 					state.bindBufferBase( gl.UNIFORM_BUFFER, cameraIndexBufferIndex, cameraData.indexesGPU[ i ] );
 
-					this._draw( object, renderer, firstVertex, vertexCount, instanceCount );
+					this._draw( object, renderer, firstVertex, vertexCount, instanceCount, programGPU );
 
 				}
 
@@ -1278,7 +1292,7 @@ class WebGLBackend extends Backend {
 
 		} else {
 
-			this._draw( object, renderer, firstVertex, vertexCount, instanceCount );
+			this._draw( object, renderer, firstVertex, vertexCount, instanceCount, programGPU );
 
 		}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -1223,17 +1223,9 @@ ${ flowData.code }
 			const ext = this.renderer.backend.extensions;
 			const isBatchedMesh = this.object.isBatchedMesh;
 
-			if ( isBatchedMesh ) {
+			if ( isBatchedMesh && ext.has( 'WEBGL_multi_draw' ) ) {
 
-				if ( ext.has( 'WEBGL_multi_draw' ) ) {
-
-					this.enableExtension( 'GL_ANGLE_multi_draw', 'require', shaderStage );
-
-				} else {
-
-					snippets.push( 'uniform uint nodeUniformDrawId;' );
-
-				}
+				this.enableExtension( 'GL_ANGLE_multi_draw', 'require', shaderStage );
 
 			}
 
@@ -1565,6 +1557,20 @@ void main() {
 			stageData.codes = this.getCodes( shaderStage );
 			stageData.transforms = this.getTransforms( shaderStage );
 			stageData.flow = flow;
+
+			// fallbacks
+
+			if ( shaderStage === 'vertex' ) {
+
+				const ext = this.renderer.backend.extensions;
+
+				if ( this.object.isBatchedMesh && ext.has( 'WEBGL_multi_draw' ) === false ) {
+
+					stageData.uniforms += '\nuniform uint nodeUniformDrawId;\n';
+
+				}
+
+			}
 
 		}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -1145,9 +1145,11 @@ ${ flowData.code }
 
 			return 'uint( gl_DrawID )';
 
-		}
+		} else {
 
-		return null;
+			return 'nodeUniformDrawId'; // fallback to uniform
+
+		}
 
 	}
 
@@ -1221,9 +1223,17 @@ ${ flowData.code }
 			const ext = this.renderer.backend.extensions;
 			const isBatchedMesh = this.object.isBatchedMesh;
 
-			if ( isBatchedMesh && ext.has( 'WEBGL_multi_draw' ) ) {
+			if ( isBatchedMesh ) {
 
-				this.enableExtension( 'GL_ANGLE_multi_draw', 'require', shaderStage );
+				if ( ext.has( 'WEBGL_multi_draw' ) ) {
+
+					this.enableExtension( 'GL_ANGLE_multi_draw', 'require', shaderStage );
+
+				} else {
+
+					snippets.push( 'uniform uint nodeUniformDrawId;' );
+
+				}
 
 			}
 


### PR DESCRIPTION
Fixed #31070.

**Description**

The PR makes sure `BatchedMesh` can be used with WebGPURenderer and its WebG 2 backend even if `WEBGL_multi_draw` isn't supported like in Firefox.

I was able to implement this fallback without any changes to `BatchNode`. The idea is to fallback to a uniform if `WEBGL_multi_draw` isn't supported and update it directly right before performing the drawing command. That matches the existing approach in `WebGLRenderer`.
