### PR TITLE
PassNode: Fix depthTexture creation when `depthBuffer: false`

### DIFF
--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -251,14 +251,22 @@ class PassNode extends TempNode {
 		 */
 		this._height = 1;
 
-		const depthTexture = new DepthTexture();
-		depthTexture.isRenderTargetTexture = true;
-		//depthTexture.type = FloatType;
-		depthTexture.name = 'depth';
-
 		const renderTarget = new RenderTarget( this._width * this._pixelRatio, this._height * this._pixelRatio, { type: HalfFloatType, ...options, } );
 		renderTarget.texture.name = 'output';
-		renderTarget.depthTexture = depthTexture;
+
+		let depthTexture = null;
+
+		if ( PassNode.DEPTH || options.depthBuffer !== false ) {
+
+			depthTexture = new DepthTexture();
+			depthTexture.isRenderTargetTexture = true;
+			//depthTexture.type = FloatType;
+			depthTexture.name = 'depth';
+
+			renderTarget.depthTexture = depthTexture;
+
+		}
+
 
 		/**
 		 * The pass's render target.
@@ -310,12 +318,17 @@ class PassNode extends TempNode {
 		 * A dictionary holding the internal result textures.
 		 *
 		 * @private
-		 * @type {Object<string, Texture>}
+		 * @type {{ output: Texture, depth?: DepthTexture }}
 		 */
 		this._textures = {
-			output: renderTarget.texture,
-			depth: depthTexture
+			output: renderTarget.texture
 		};
+
+		if ( depthTexture !== null ) {
+
+			this._textures.depth = depthTexture;
+
+		}
 
 		/**
 		 * A dictionary holding the internal texture nodes.
@@ -757,7 +770,7 @@ class PassNode extends TempNode {
 
 		this.renderTarget.texture.type = renderer.getOutputBufferType();
 
-		if ( renderer.reversedDepthBuffer === true ) {
+		if ( renderer.reversedDepthBuffer === true && this.renderTarget.depthTexture !== null ) {
 
 			this.renderTarget.depthTexture.type = FloatType;
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -256,7 +256,7 @@ class PassNode extends TempNode {
 
 		let depthTexture = null;
 
-		if ( PassNode.DEPTH || options.depthBuffer !== false ) {
+		if ( this.scope === PassNode.DEPTH || options.depthBuffer !== false ) {
 
 			depthTexture = new DepthTexture();
 			depthTexture.isRenderTargetTexture = true;

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -71,24 +71,30 @@ class Textures extends DataMap {
 		const mipWidth = size.width >> activeMipmapLevel;
 		const mipHeight = size.height >> activeMipmapLevel;
 
-		let depthTexture = renderTarget.depthTexture || depthTextureMips[ activeMipmapLevel ];
 		const useDepthTexture = renderTarget.depthBuffer === true || renderTarget.stencilBuffer === true;
+		let depthTexture = null;
 
 		let textureNeedsUpdate = false;
 
-		if ( depthTexture === undefined && useDepthTexture ) {
+		if ( useDepthTexture ) {
 
-			depthTexture = new DepthTexture();
+			depthTexture = renderTarget.depthTexture || depthTextureMips[ activeMipmapLevel ];
 
-			depthTexture.format = renderTarget.stencilBuffer ? DepthStencilFormat : DepthFormat;
-			depthTexture.type = renderTarget.stencilBuffer ? UnsignedInt248Type : UnsignedIntType; // FloatType
-			depthTexture.image.width = mipWidth;
-			depthTexture.image.height = mipHeight;
-			depthTexture.image.depth = size.depth;
-			depthTexture.renderTarget = renderTarget;
-			depthTexture.isArrayTexture = renderTarget.multiview === true && size.depth > 1;
+			if ( depthTexture === undefined ) {
 
-			depthTextureMips[ activeMipmapLevel ] = depthTexture;
+				depthTexture = new DepthTexture();
+
+				depthTexture.format = renderTarget.stencilBuffer ? DepthStencilFormat : DepthFormat;
+				depthTexture.type = renderTarget.stencilBuffer ? UnsignedInt248Type : UnsignedIntType; // FloatType
+				depthTexture.image.width = mipWidth;
+				depthTexture.image.height = mipHeight;
+				depthTexture.image.depth = size.depth;
+				depthTexture.renderTarget = renderTarget;
+				depthTexture.isArrayTexture = renderTarget.multiview === true && size.depth > 1;
+
+				depthTextureMips[ activeMipmapLevel ] = depthTexture;
+
+			}
 
 		}
 


### PR DESCRIPTION
With `PassNode` a depth texture was always being created even when explicitly setting `{ depthBuffer: false }`.

Additonally, `Textures.updateRenderTarget()` also handled depth before checking whether it was actually enabled. Because of that, a depth texture could end up being created even with depth disabled.

This pr ensures that when creating a pass such as 
```js
pass(this.scene, this.camera, { depthBuffer: false }))
```
no depth texture is created.