### PR TITLE
WebGLRenderer: Set depth mask when clearing depth.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -998,6 +998,7 @@ class WebGLRenderer {
 			if ( depth ) {
 
 				bits |= _gl.DEPTH_BUFFER_BIT;
+				this.state.buffers.depth.setMask( true );
 
 			}
 


### PR DESCRIPTION
**Description**

Set depth mask when clearing depth, in case the state has been changed during previous render calls.

**Some background:** We have forked three.js and are rendering through `renderBufferDirect`. We ran into an issue where trying to clear depth failed after rendering translucent geometry, due the depth mask being changed in a previous render call.

In practice this may not be an issue for most users using three.js out of the box, since renderScene calls `state.buffers.depth.setMask( true );` , but it's consistent with the pattern already used for stencil on [line 1007-1008 below](https://github.com/mrdoob/three.js/blob/d31df14f23f383ded1c92fd643eb149c74ee10a8/src/renderers/WebGLRenderer.js#L1007):

```js
if ( stencil ) {

   bits |= _gl.STENCIL_BUFFER_BIT;
   this.state.buffers.stencil.setMask( 0xffffffff );

}
```
