### PR TITLE
DataTextureLoader: Move `return` in catch block to correct position.

### DIFF
--- a/src/loaders/DataTextureLoader.js
+++ b/src/loaders/DataTextureLoader.js
@@ -67,9 +67,10 @@ class DataTextureLoader extends Loader {
 				} else {
 
 					error( e );
-					return;
 
 				}
+
+				return;
 
 			}
 

--- a/test/unit/src/loaders/DataTextureLoader.tests.js
+++ b/test/unit/src/loaders/DataTextureLoader.tests.js
@@ -1,5 +1,5 @@
 import { DataTextureLoader } from '../../../../src/loaders/DataTextureLoader.js';
-
+import { FileLoader } from '../../../../src/loaders/FileLoader.js';
 import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
@@ -22,6 +22,32 @@ export default QUnit.module( 'Loaders', () => {
 
 			const object = new DataTextureLoader();
 			assert.ok( object, 'Can instantiate a DataTextureLoader.' );
+
+		} );
+
+		// BUG: Missing return in error handling causes TypeError
+		QUnit.test( 'parse error handling (missing return bug)', ( assert ) => {
+
+			const loader = new DataTextureLoader();
+			// Mock parse to throw an error intentionally
+			loader.parse = function () {
+				throw new Error( 'Mock Parse Error' );
+			};
+
+			const originalLoad = FileLoader.prototype.load;
+			FileLoader.prototype.load = function ( url, onLoad ) {
+				onLoad( new ArrayBuffer( 0 ) );
+			};
+
+			let callbackFired = false;
+			loader.load( 'dummy.dds', function () {}, undefined, function ( err ) {
+				callbackFired = err.message === 'Mock Parse Error';
+			} );
+
+			// If the bug is present, the test will crash with a TypeError before reaching this assertion
+			assert.ok( callbackFired, 'onError is properly called before the crash' );
+
+			FileLoader.prototype.load = originalLoad;
 
 		} );
 

--- a/test/unit/src/loaders/DataTextureLoader.tests.js
+++ b/test/unit/src/loaders/DataTextureLoader.tests.js
@@ -1,5 +1,5 @@
 import { DataTextureLoader } from '../../../../src/loaders/DataTextureLoader.js';
-import { FileLoader } from '../../../../src/loaders/FileLoader.js';
+
 import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
@@ -22,32 +22,6 @@ export default QUnit.module( 'Loaders', () => {
 
 			const object = new DataTextureLoader();
 			assert.ok( object, 'Can instantiate a DataTextureLoader.' );
-
-		} );
-
-		// BUG: Missing return in error handling causes TypeError
-		QUnit.test( 'parse error handling (missing return bug)', ( assert ) => {
-
-			const loader = new DataTextureLoader();
-			// Mock parse to throw an error intentionally
-			loader.parse = function () {
-				throw new Error( 'Mock Parse Error' );
-			};
-
-			const originalLoad = FileLoader.prototype.load;
-			FileLoader.prototype.load = function ( url, onLoad ) {
-				onLoad( new ArrayBuffer( 0 ) );
-			};
-
-			let callbackFired = false;
-			loader.load( 'dummy.dds', function () {}, undefined, function ( err ) {
-				callbackFired = err.message === 'Mock Parse Error';
-			} );
-
-			// If the bug is present, the test will crash with a TypeError before reaching this assertion
-			assert.ok( callbackFired, 'onError is properly called before the crash' );
-
-			FileLoader.prototype.load = originalLoad;
 
 		} );
 


### PR DESCRIPTION
**Description**
This PR fixes a missing `return` statement in the `DataTextureLoader.js` error handling block. 

Previously, if a parsing error occurred and an `onError` callback was provided, the callback was invoked but execution continued, eventually throwing a `TypeError` when evaluating `texData.image`. This moves the `return;` statement to ensure execution halts appropriately.