### PR TITLE
ShadowNode: Add support for `renderer.highPrecision`

### DIFF
--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -508,15 +508,16 @@ class ShadowNode extends ShadowBaseNode {
 		const shadowIntensity = reference( 'intensity', 'float', shadow ).setGroup( renderGroup );
 		const normalBias = reference( 'normalBias', 'float', shadow ).setGroup( renderGroup );
 
+		const shadowMatrix = lightShadowMatrix( light );
+		const shadowNormalBias = normalWorld.mul( normalBias );
+
 		let shadowPosition;
 
 		if ( ! renderer.highPrecision || builder.material.receivedShadowPositionNode || builder.context.shadowPositionWorld ) {
 
-			shadowPosition = lightShadowMatrix( light ).mul( shadowPositionWorld.add( normalWorld.mul( normalBias ) ) );
+			shadowPosition = shadowMatrix.mul( shadowPositionWorld.add( shadowNormalBias ) );
 
 		} else {
-
-			const shadowMatrix = lightShadowMatrix( light );
 
 			const highpShadowModelMatrix = uniform( 'mat4' ).onObjectUpdate( ( { object }, self ) => {
 
@@ -524,7 +525,7 @@ class ShadowNode extends ShadowBaseNode {
 
 			} );
 
-			shadowPosition = highpShadowModelMatrix.mul( positionLocal ).add( shadowMatrix.mul( vec4( normalWorld.mul( normalBias ), 0 ) ) );
+			shadowPosition = highpShadowModelMatrix.mul( positionLocal ).add( shadowMatrix.mul( vec4( shadowNormalBias, 0 ) ) );
 
 		}
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -1,5 +1,5 @@
 import ShadowBaseNode, { shadowPositionWorld } from './ShadowBaseNode.js';
-import { float, vec2, vec3, int, Fn } from '../tsl/TSLBase.js';
+import { float, vec2, vec3, vec4, int, Fn } from '../tsl/TSLBase.js';
 import { reference } from '../accessors/ReferenceNode.js';
 import { texture, textureLoad } from '../accessors/TextureNode.js';
 import { cubeTexture } from '../accessors/CubeTextureNode.js';
@@ -21,6 +21,8 @@ import { getShadowMaterial, disposeShadowMaterial, BasicShadowFilter, PCFShadowF
 import ChainMap from '../../renderers/common/ChainMap.js';
 import { textureSize } from '../accessors/TextureSizeNode.js';
 import { uv } from '../accessors/UV.js';
+import { positionLocal } from '../accessors/Position.js';
+import { uniform } from '../core/UniformNode.js';
 
 //
 
@@ -506,7 +508,26 @@ class ShadowNode extends ShadowBaseNode {
 		const shadowIntensity = reference( 'intensity', 'float', shadow ).setGroup( renderGroup );
 		const normalBias = reference( 'normalBias', 'float', shadow ).setGroup( renderGroup );
 
-		const shadowPosition = lightShadowMatrix( light ).mul( shadowPositionWorld.add( normalWorld.mul( normalBias ) ) );
+		let shadowPosition;
+
+		if ( ! renderer.highPrecision || builder.material.receivedShadowPositionNode || builder.context.shadowPositionWorld ) {
+
+			shadowPosition = lightShadowMatrix( light ).mul( shadowPositionWorld.add( normalWorld.mul( normalBias ) ) );
+
+		} else {
+
+			const shadowMatrix = lightShadowMatrix( light );
+
+			const highpShadowModelMatrix = uniform( 'mat4' ).onObjectUpdate( ( { object }, self ) => {
+
+				return self.value.multiplyMatrices( shadowMatrix.value, object.matrixWorld );
+
+			} );
+
+			shadowPosition = highpShadowModelMatrix.mul( positionLocal ).add( shadowMatrix.mul( vec4( normalWorld.mul( normalBias ), 0 ) ) );
+
+		}
+
 		const shadowCoord = this.setupShadowCoord( builder, shadowPosition );
 
 		//


### PR DESCRIPTION
Related issue: #30955

**Description**

This PR multiplies the light shadow matrix and object world matrix on the CPU when `renderer.highPrecision` is enabled.

This is the shadow maps equivalent of the issue https://github.com/mrdoob/three.js/issues/30955. Shadow maps become unusable at a large distance from the origin (and relatively at a small scale) in WebGPURenderer, because `ShadowNode` uses world positions multiplied on the GPU. WebGLRenderer has no such issue.

**Alternatives**

We could use a custom shadow node on the user side, but this is not very feasible because `ShadowNode` is not a leaf class here.

Doing world origin rebasing would surely solve this precision issue, but the purpose of `renderer.highPrecision` is to handle such use cases where world origin rebasing is difficult to implement for various reasons, with some performance trade off.

--

Results with a torus knot with a diameter of 1 at 6e6 away from the origin, with `renderer.highPrecision` enabled for all cases.

| | r183 | PR |
|-|-|-|
| Directional Light | <img width="978" height="881" alt="image" src="https://github.com/user-attachments/assets/1138a7df-c213-446f-9ad6-c15678eff465" /> | <img width="978" height="881" alt="image" src="https://github.com/user-attachments/assets/4ba249e6-e354-454e-9067-d188759f9d50" /> |
| Spot Light | <img width="978" height="881" alt="image" src="https://github.com/user-attachments/assets/a1bbc601-cfbc-43d4-900b-38031ca92923" /> | <img width="978" height="881" alt="image" src="https://github.com/user-attachments/assets/4ab3315b-b9ea-42b3-a02f-1860df8c878f" /> |
