### PR TITLE
EXRLoader: Put known headers into "skipped" section.

### DIFF
--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -2357,8 +2357,9 @@ class EXRLoader extends DataTextureLoader {
 
 				return parseTimecode( dataView, offset );
 
-			} else if ( type === 'preview' ) {
+			} else if ( type === 'preview' || type === 'deepImageState' || type === 'idmanifest' ) {
 
+				// Known metadata-only types: silently skip, they carry no pixel data.
 				offset.value += size;
 				return 'skipped';
 


### PR DESCRIPTION
Related issue: #28055

**Description**

The PR extends `EXRLoader` by putting the headers `deepImageState` and `idmanifest` into the "skipped" section. These hold only metadata and should not be reported as unknown EXR headers. Similar to `preview`, they are not included into pixel processing.