### PR TITLE
Docs: Fix module links in search.

### DIFF
--- a/utils/docs/template/publish.js
+++ b/utils/docs/template/publish.js
@@ -191,7 +191,7 @@ function buildSearchListForData() {
 
 					const category = categoryMap[ className ];
 					const entry = {
-						title: item.longname,
+						title: item.longname.replace( 'module:', 'module-' ),
 						kind: item.kind
 					};
 
@@ -228,7 +228,7 @@ function buildSearchListForData() {
 					}
 
 					const entry = {
-						title: item.longname,
+						title: item.longname.replace( 'module:', 'module-' ),
 						kind: item.kind
 					};
 


### PR DESCRIPTION
Fixed #33254.

**Description**

The PR  fixes the module links in the doc search by replacing any `module:` titles in the list via `module-`.