### PR TITLE
GLSLDecoder: Replace deprecated `substr()` with `slice()`.

### DIFF
--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -170,7 +170,7 @@ class Tokenizer {
 
 	skip( ...params ) {
 
-		let remainingCode = this.source.substr( this.position );
+		let remainingCode = this.source.slice( this.position );
 		let i = params.length;
 
 		while ( i -- ) {
@@ -182,7 +182,7 @@ class Tokenizer {
 
 				this.position += skipLength;
 
-				remainingCode = this.source.substr( this.position );
+				remainingCode = this.source.slice( this.position );
 
 				// re-skip, new remainingCode is generated
 				// maybe exist previous regexp non detected


### PR DESCRIPTION
## Summary

Replaces usage of deprecated `String.prototype.substr()` with `String.prototype.slice()` in `GLSLDecoder.js`.

`substr()` is considered a legacy feature and is no longer recommended. `slice()` provides equivalent functionality and is part of modern JavaScript standards.

## Changes

- Replaced two occurrences of `substr()` with `slice()` in:
  - `examples/jsm/transpiler/GLSLDecoder.js`

## Impact

This is a minimal, low-risk change that does not affect existing behavior and improves code quality by avoiding deprecated APIs.