### PR TITLE
refactor(FileLoader): add explicit radix to parseInt

### DIFF
--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -170,7 +170,7 @@ class Tokenizer {
 
 	skip( ...params ) {
 
-		let remainingCode = this.source.substr( this.position );
+		let remainingCode = this.source.slice( this.position );
 		let i = params.length;
 
 		while ( i -- ) {
@@ -182,7 +182,7 @@ class Tokenizer {
 
 				this.position += skipLength;
 
-				remainingCode = this.source.substr( this.position );
+				remainingCode = this.source.slice( this.position );
 
 				// re-skip, new remainingCode is generated
 				// maybe exist previous regexp non detected

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -167,7 +167,7 @@ class FileLoader extends Loader {
 					// Nginx needs X-File-Size check
 					// https://serverfault.com/questions/482875/why-does-nginx-remove-content-length-header-for-chunked-content
 					const contentLength = response.headers.get( 'X-File-Size' ) || response.headers.get( 'Content-Length' );
-					const total = contentLength ? parseInt( contentLength ) : 0;
+					const total = contentLength ? parseInt( contentLength, 10 ) : 0;
 					const lengthComputable = total !== 0;
 					let loaded = 0;
 


### PR DESCRIPTION
## Summary

Adds an explicit radix (10) to `parseInt` when parsing the `Content-Length` header.

## Impact

Ensures consistent decimal parsing and avoids ambiguity. No functional change.