### PR TITLE
NodeUtils: Replace `instanceof Array` with `Array.isArray()`.

### DIFF
--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -18,7 +18,7 @@ function cyrb53( value, seed = 0 ) {
 
 	let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
 
-	if ( value instanceof Array ) {
+	if ( Array.isArray( value ) ) {
 
 		for ( let i = 0, val; i < value.length; i ++ ) {
 


### PR DESCRIPTION
## Summary

Replaces `instanceof Array` with `Array.isArray` for more robust array checking.

## Impact

`Array.isArray` is the recommended approach and works correctly across different execution contexts. No functional change intended.