### PR TITLE
refactor(FileLoader): add explicit radix to parseInt

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -167,7 +167,7 @@ class FileLoader extends Loader {
 					// Nginx needs X-File-Size check
 					// https://serverfault.com/questions/482875/why-does-nginx-remove-content-length-header-for-chunked-content
 					const contentLength = response.headers.get( 'X-File-Size' ) || response.headers.get( 'Content-Length' );
-					const total = contentLength ? parseInt( contentLength ) : 0;
+					const total = contentLength ? parseInt( contentLength, 10 ) : 0;
 					const lengthComputable = total !== 0;
 					let loaded = 0;
 


### PR DESCRIPTION
## Summary

Adds an explicit radix (10) to `parseInt` when parsing the `X-File-Size` or `Content-Length` header.

## Impact

Ensures consistent decimal parsing and avoids ambiguity. No functional change.