### PR TITLE
Line3: Handle degenerate line in `closestPointToPointParameter()`.

### DIFF
--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -142,6 +142,9 @@ class Line3 {
 		_startEnd.subVectors( this.end, this.start );
 
 		const startEnd2 = _startEnd.dot( _startEnd );
+
+		if ( startEnd2 === 0 ) return 0;
+
 		const startEnd_startP = _startEnd.dot( _startP );
 
 		let t = startEnd_startP / startEnd2;

--- a/test/unit/src/math/Line3.tests.js
+++ b/test/unit/src/math/Line3.tests.js
@@ -161,6 +161,12 @@ export default QUnit.module( 'Maths', () => {
 			a.closestPointToPoint( one3.clone(), true, point );
 			assert.ok( point.distanceTo( one3.clone() ) < 0.0001, 'Passed!' );
 
+			// degenerate line (zero-length)
+			const b = new Line3( one3.clone(), one3.clone() );
+			assert.ok( b.closestPointToPointParameter( zero3.clone(), true ) == 0, 'Passed!' );
+			b.closestPointToPoint( zero3.clone(), true, point );
+			assert.ok( point.distanceTo( one3.clone() ) < 0.0001, 'Passed!' );
+
 		} );
 
 		QUnit.test( 'applyMatrix4', ( assert ) => {


### PR DESCRIPTION
**Description**:

This PR fixes a division-by-zero issue in Line3.closestPointToPointParameter when working with degenerate lines (where the start and end points are the same).

**The Problem:**
If a Line3 has zero length, the computed squared length (startEnd2) becomes 0. This leads to a 0 / 0 operation when calculating t, which results in NaN. That NaN can then propagate into other methods like closestPointToPoint and at(), causing unexpected results in downstream calculations.

**The Solution:**
This change adds a simple guard for the zero-length case. If startEnd2 === 0, the function now returns 0 early instead of performing the division. This avoids producing NaN and keeps the behavior stable for degenerate lines.

**Failing Scenario Fixed**:
```
const line = new THREE.Line3(
  new THREE.Vector3(1, 1, 1),
  new THREE.Vector3(1, 1, 1) // Degenerate line
);

const t = line.closestPointToPointParameter(new THREE.Vector3(5, 5, 5), true);

// Previously: NaN
// Now: 0
```
