### PR TITLE
Fix/plane intersects line

### DIFF
--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -257,7 +257,7 @@ class Plane {
 		const startSign = this.distanceToPoint( line.start );
 		const endSign = this.distanceToPoint( line.end );
 
-		return ( startSign < 0 && endSign > 0 ) || ( endSign < 0 && startSign > 0 );
+		return ( startSign <= 0 && endSign >= 0 ) || ( endSign <= 0 && startSign >= 0 );
 
 	}
 

--- a/test/unit/src/math/Plane.tests.js
+++ b/test/unit/src/math/Plane.tests.js
@@ -231,6 +231,26 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( 'intersectsLine', ( assert ) => {
+
+			let a = new Plane( new Vector3( 1, 0, 0 ), 0 );
+
+			const l1 = new Line3( new Vector3( - 10, 0, 0 ), new Vector3( 10, 0, 0 ) );
+			assert.ok( a.intersectsLine( l1 ), 'Passed!' );
+
+			const l2 = new Line3( new Vector3( 10, 0, 0 ), new Vector3( 20, 0, 0 ) );
+			assert.ok( ! a.intersectsLine( l2 ), 'Passed!' );
+
+			// coplanar line
+			const l3 = new Line3( new Vector3( 0, - 10, 0 ), new Vector3( 0, 10, 0 ) );
+			assert.ok( a.intersectsLine( l3 ), 'Passed!' );
+
+			// touching line
+			const l4 = new Line3( new Vector3( 0, 0, 0 ), new Vector3( 10, 0, 0 ) );
+			assert.ok( a.intersectsLine( l4 ), 'Passed!' );
+
+		} );
+
 		QUnit.test( 'intersectsBox', ( assert ) => {
 
 			const a = new Box3( zero3.clone(), one3.clone() );


### PR DESCRIPTION
**Title:** Fix `Plane.intersectsLine` failing on coplanar and touching lines

**Description**

Hey everyone! While doing some intersection math recently, I noticed a slight inconsistency in how `Plane.intersectsLine()` behaves compared to `Plane.intersectLine()`. Right now, `intersectsLine` returns `false` if a line is perfectly coplanar, or if it touches the plane exactly at one of its endpoints.

Looking at the source, it's currently doing a strict crossing test:
`return ( startSign < 0 && endSign > 0 ) || ( endSign < 0 && startSign > 0 );`

Because it relies on strict inequalities (`<` and `>`), if either endpoint has a distance of exactly `0` to the plane, the whole check fails. This felt a bit off because `intersectLine()` actually *does* compute and return an intersection point for these exact same scenarios. Semantically, if a line lies on the plane or touches it, it should probably count as an intersection.

**The Fix**
The fix is pretty straightforward. I just updated the strict inequalities to inclusive ones (`<=` and `>=`). I opted to keep the explicit boolean checks rather than doing something like `startSign * endSign <= 0` just to be extra safe against any floating-point underflow quirks. 

**Examples**
Here is a quick look at the two main edge cases this resolves:

```javascript
const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0); // y=0 plane

// Case 1: Line lies completely ON the plane (Coplanar)
const coplanarLine = new THREE.Line3(
  new THREE.Vector3(0, 0, 0),
  new THREE.Vector3(1, 0, 0)
);
plane.intersectsLine(coplanarLine); 
// Before: false
// After: true

// Case 2: Line TOUCHES the plane exactly at one endpoint
const touchingLine = new THREE.Line3(
  new THREE.Vector3(0, 0, 0), // touching
  new THREE.Vector3(0, 1, 0)  // above
);
plane.intersectsLine(touchingLine);
// Before: false
// After: true
```
