### PR TITLE
Inspector: Replace deprecated `substr()` with `slice()`.

### DIFF
--- a/examples/jsm/inspector/ui/List.js
+++ b/examples/jsm/inspector/ui/List.js
@@ -8,7 +8,7 @@ export class List {
 		this.domElement = document.createElement( 'div' );
 		this.domElement.className = 'list-container';
 		this.domElement.style.padding = '10px';
-		this.id = `list-${Math.random().toString( 36 ).substr( 2, 9 )}`;
+		this.id = `list-${Math.random().toString( 36 ).slice( 2, 11 )}`;
 		this.domElement.dataset.listId = this.id;
 
 		this.gridStyleElement = document.createElement( 'style' );


### PR DESCRIPTION
## Summary

Replaces deprecated `String.prototype.substr` with `String.prototype.slice` in `examples/jsm/inspector/ui/List.js`.

## Details

`substr(start, length)` is a legacy API and is no longer recommended for modern JavaScript usage. The equivalent behavior can be achieved using `slice(start, end)`.

In this case:
- `substr(2, 9)` → `slice(2, 11)`

This change preserves the exact same functionality while avoiding deprecated APIs.

## Impact

No functional changes. This is a safe, one-line update that improves consistency with modern JavaScript standards.
