### PR TITLE
fix(Vector4): clamp quaternion w before acos to prevent NaN

### DIFF
--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -650,7 +650,7 @@ class Vector4 {
 		this.x = ( m32 - m23 ) / s;
 		this.y = ( m13 - m31 ) / s;
 		this.z = ( m21 - m12 ) / s;
-		this.w = Math.acos( ( m11 + m22 + m33 - 1 ) / 2 );
+		this.w = Math.acos( clamp( ( m11 + m22 + m33 - 1 ) / 2, - 1, 1 ) );
 
 		return this;
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -497,7 +497,7 @@ class Vector4 {
 
 		// q is assumed to be normalized
 
-		this.w = 2 * Math.acos( q.w );
+		this.w = 2 * Math.acos( clamp( q.w, - 1, 1 ) );
 
 		const s = Math.sqrt( 1 - q.w * q.w );
 


### PR DESCRIPTION
## Summary

Clamps the quaternion `w` component to the valid range [-1, 1] before passing it to `Math.acos` in `Vector4.setAxisAngleFromQuaternion`.

## Problem

Due to floating-point precision errors, a normalized quaternion may occasionally produce a `w` value slightly outside the valid range for `acos` (e.g., 1.0000000000000002).

In such cases:
```js
Math.acos(q.w)
