### PR TITLE
CatmullRomCurve3: Geometry corruption on 2-point curves.

### DIFF
--- a/src/extras/curves/CatmullRomCurve3.js
+++ b/src/extras/curves/CatmullRomCurve3.js
@@ -78,6 +78,7 @@ function CubicPoly() {
 //
 
 const tmp = /*@__PURE__*/ new Vector3();
+const tmp2 = /*@__PURE__*/ new Vector3();
 const px = /*@__PURE__*/ new CubicPoly();
 const py = /*@__PURE__*/ new CubicPoly();
 const pz = /*@__PURE__*/ new CubicPoly();
@@ -202,8 +203,8 @@ class CatmullRomCurve3 extends Curve {
 		} else {
 
 			// extrapolate first point
-			tmp.subVectors( points[ 0 ], points[ 1 ] ).add( points[ 0 ] );
-			p0 = tmp;
+			tmp2.subVectors( points[ 0 ], points[ 1 ] ).add( points[ 0 ] );
+			p0 = tmp2;
 
 		}
 

--- a/test/unit/src/extras/curves/CatmullRomCurve3.tests.js
+++ b/test/unit/src/extras/curves/CatmullRomCurve3.tests.js
@@ -387,6 +387,26 @@ export default QUnit.module( 'Extras', () => {
 				assert.deepEqual( points, expectedPoints, 'Correct points calculated' );
 
 			} );
+			
+			QUnit.test( 'two points', ( assert ) => {
+
+				const curve = new CatmullRomCurve3( [
+					new Vector3( 0, 0, 0 ),
+					new Vector3( 10, 0, 0 )
+				], false, 'catmullrom' );
+
+				const expectedPoints = [
+					new Vector3( 0, 0, 0 ),
+					new Vector3( 5, 0, 0 ),
+					new Vector3( 10, 0, 0 )
+				];
+
+				const points = curve.getPoints( 2 );
+
+				assert.strictEqual( points.length, expectedPoints.length, 'Correct number of points' );
+				assert.deepEqual( points, expectedPoints, 'Correct points calculated' );
+
+			} );
 
 		} );
 


### PR DESCRIPTION
**Description**

Hello again! Following up on the `Line3` and `Plane` edge cases I submitted earlier, I kept digging into the math and geometry utilities and found a subtle reference-sharing bug in `CatmullRomCurve3.getPoint()`. It currently generates incorrect geometry for open curves with exactly 2 points.

**The Problem:**
To avoid GC overhead, the module uses a shared `tmp` Vector3. However, if you pass an open curve with exactly 2 points, the logic is forced to extrapolate both the first point (`p0`) and the last point (`p3`) in the same cycle. 

1. `p0` is calculated using `tmp`, and assigned via `p0 = tmp`.
2. Just below that, `p3` is calculated using the *same* `tmp` variable. 

Because `p0` is holding a reference to `tmp`, recalculating `p3` silently mutates `p0`. By the time the actual Catmull-Rom interpolation runs at the bottom of the function, `p0 === p3`, completely collapsing the spline math.

**The Fix:**
I introduced a second module-level temporary vector (`tmp2`) and assigned it to the `p0` extrapolation branch. This ensures `p0` and `p3` retain their distinct, correct coordinates without triggering any new memory allocations inside the `getPoint()` call.

**Examples:**

```javascript
const curve = new THREE.CatmullRomCurve3([
  new THREE.Vector3(0, 0, 0),
  new THREE.Vector3(10, 0, 0)
], false, 'catmullrom');

// Getting the midpoint of a 2-point CatmullRom curve
const point = curve.getPoint(0.5);

// Before Fix: 
// p0 and p3 both resolve to (20, 0, 0).
// point returns an incorrect interpolation.

// After Fix:
// p0 correctly resolves to (-10, 0, 0).
// p3 correctly resolves to (20, 0, 0).
// point correctly returns (5, 0, 0).
```

