### PR TITLE
Fix Dashed LineSegments2 rendering horizontally (Issue #33051)

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -96,7 +96,6 @@ ShaderLib[ 'line' ] = {
 			#ifdef USE_DASH
 
 				vLineDistance = ( position.y < 0.5 ) ? dashScale * instanceDistanceStart : dashScale * instanceDistanceEnd;
-				vUv = uv;
 
 			#endif
 
@@ -110,6 +109,12 @@ ShaderLib[ 'line' ] = {
 
 				worldStart = start.xyz;
 				worldEnd = end.xyz;
+
+				#ifdef USE_DASH
+
+					vUv = uv;
+
+				#endif
 
 			#else
 


### PR DESCRIPTION
Fixes #33051

**Description**

This PR resolves a bug where [LineSegments2](cci:2://file:///Users/yashrajchouhan/Desktop/three.js/examples/jsm/lines/LineSegments2.js:250:0-423:1) using [LineMaterial](cci:2://file:///Users/yashrajchouhan/Desktop/three.js/examples/jsm/lines/LineMaterial.js:421:0-705:1) with `dashed: true` would render dashed lines horizontally regardless of their actual diagonal path and vertex positions.

The root cause was a redundant assignment to the varying `vUv` inside the `#ifdef USE_DASH` block of [LineMaterial](cci:2://file:///Users/yashrajchouhan/Desktop/three.js/examples/jsm/lines/LineMaterial.js:421:0-705:1)'s vertex shader. Because `vUv = uv;` was evaluated a second time later in the script (inside the `#ifndef WORLD_UNITS` block), it triggered an optimization/register-allocation bug on some GLSL translation layers (such as Chrome's ANGLE compiler on Linux). This compiler confusion corrupted the evaluation of `instanceStart.y` and `instanceEnd.y`, forcing the line's bounding quads to render uniformly horizontally.

**Changes**
* Removed the redundant `vUv = uv;` assignment from inside the early `#ifdef USE_DASH` block.
* Relocated the conditional `vUv` assignment securely inside the `#ifdef WORLD_UNITS` block to exactly mirror the conditional logic of its `varying` declaration, guaranteeing it is assigned exactly once per valid execution path.

This reliably fixes the horizontal striping artifact and restores accurate diagonal rendering to all dashed lines and multi-segments.

