### PR TITLE
Docs: Fix typos in TessellateModifier and LineMaterial

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -647,7 +647,7 @@ class LineMaterial extends ShaderMaterial {
 
 	/**
 	 * The size of the viewport, in screen pixels. This must be kept updated to make
-	 * screen-space rendering accurate.The `LineSegments2.onBeforeRender` callback
+	 * screen-space rendering accurate. The `LineSegments2.onBeforeRender` callback
 	 * performs the update for visible objects.
 	 *
 	 * @type {Vector2}

--- a/examples/jsm/modifiers/TessellateModifier.js
+++ b/examples/jsm/modifiers/TessellateModifier.js
@@ -46,7 +46,7 @@ class TessellateModifier {
 	}
 
 	/**
-	 * Returns a new, modified version of the given geometry by applying a tesselation.
+	 * Returns a new, modified version of the given geometry by applying a tessellation.
 	 * Please note that the resulting geometry is always non-indexed.
 	 *
 	 * @param {BufferGeometry} geometry - The geometry to modify.


### PR DESCRIPTION
 Docs: Fix typos in TessellateModifier and LineMaterial

This PR corrects a few minor typographical and formatting issues in the documentation and comments:

- Fixed misspelling of **"tessellation"** (previously "tesselation") in [TessellateModifier.js](cci:7://file:///Users/yashrajchouhan/Desktop/three.js/examples/jsm/modifiers/TessellateModifier.js:0:0-0:0) and its corresponding documentation files ([TessellateModifier.html](cci:7://file:///Users/yashrajchouhan/Desktop/three.js/docs/pages/TessellateModifier.html:0:0-0:0) and [TessellateModifier.html.md](cci:7://file:///Users/yashrajchouhan/Desktop/three.js/docs/pages/TessellateModifier.html.md:0:0-0:0)).
- Added a missing space after a period in a JSDoc comment within [LineMaterial.js](cci:7://file:///Users/yashrajchouhan/Desktop/three.js/examples/jsm/lines/LineMaterial.js:0:0-0:0).

These are non-functional changes aimed at improving the clarity and professional quality of the codebase and documentation.

