### PR TITLE
WebGLRenderer: Fix array corruption during UniformsGroup disposal

### DIFF
--- a/src/renderers/webgl/WebGLUniformsGroups.js
+++ b/src/renderers/webgl/WebGLUniformsGroups.js
@@ -375,7 +375,11 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 		uniformsGroup.removeEventListener( 'dispose', onUniformsGroupsDispose );
 
 		const index = allocatedBindingPoints.indexOf( uniformsGroup.__bindingPointIndex );
-		allocatedBindingPoints.splice( index, 1 );
+		if ( index !== - 1 ) {
+
+			allocatedBindingPoints.splice( index, 1 );
+
+		}
 
 		gl.deleteBuffer( buffers[ uniformsGroup.id ] );
 


### PR DESCRIPTION
### Summary

Fixes an issue in `WebGLUniformsGroups` where an invalid index can lead to unintended array mutation during disposal.

---

### Problem

The current implementation removes a binding point index using:

```js
const index = allocatedBindingPoints.indexOf( uniformsGroup.__bindingPointIndex );
allocatedBindingPoints.splice( index, 1 );
```

If the binding point is not found, `indexOf()` returns `-1`.  
Calling `splice(-1, 1)` unintentionally removes the **last element** of the array.

---

### Impact

This can result in:

- Removal of an unrelated active binding point  
- Leaking the intended binding point (not freed correctly)  
- Corruption of internal WebGL uniform binding state  

These issues can lead to subtle rendering bugs and incorrect resource management.

---

### Fix

Add a guard to ensure the index is valid before removing:

```js
if ( index !== -1 ) {
    allocatedBindingPoints.splice( index, 1 );
}
```

---

### Notes

- This change is safe and does not affect normal behavior  
- It only prevents unintended side effects when the index is not found  
- Improves robustness in resource cleanup paths (e.g., repeated or unexpected disposal calls)