### PR TITLE
ExtrudeGeometry: Fix iteration over mutating array in mergeOverlappingPoints

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -189,6 +189,8 @@ class ExtrudeGeometry extends BufferGeometry {
 					const thresholdSqScaled = THRESHOLD_SQ * scalingFactorSqrt * scalingFactorSqrt;
 					if ( distSq <= thresholdSqScaled ) {
 
+						if ( points.length <= 1 ) break;
+
 						points.splice( currentIndex, 1 );
 						i --;
 						continue;


### PR DESCRIPTION
### Summary

Prevents potential array collapse in `ExtrudeGeometry.mergeOverlappingPoints` when removing overlapping points during iteration.

---

### Problem

The current implementation removes points from the `points` array using `splice()` while iterating over it. Since the array length changes dynamically, certain edge cases can lead to unintended behavior.

In particular, when:
- the input contains overlapping points, or  
- the contour size is very small  

the repeated removal of elements can reduce the array to length ≤ 1 while the loop is still running.

---

### Impact

This can result in:

- The `points` array becoming empty or invalid  
- Downstream logic receiving incomplete contour data  
- Runtime errors during geometry construction  

---

### Fix

Add a guard to stop iteration when the array becomes too small:

```js
if ( points.length <= 1 ) break;
```

---

### Notes

- This is a minimal safety check that prevents invalid states during mutation  
- Does not affect normal behavior for valid input  
- Ensures robustness when handling edge-case or degenerate geometries  