### PR TITLE
 Fix `PropertyBinding` crash when `morphTargetDictionary` is undefined

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -677,7 +677,7 @@ class PropertyBinding {
 
 				}
 
-				if ( targetObject.morphTargetDictionary[ propertyIndex ] !== undefined ) {
+				if ( targetObject.morphTargetDictionary !== undefined && targetObject.morphTargetDictionary[ propertyIndex ] !== undefined ) {
 
 					propertyIndex = targetObject.morphTargetDictionary[ propertyIndex ];
 

--- a/test/unit/src/animation/PropertyBinding.tests.js
+++ b/test/unit/src/animation/PropertyBinding.tests.js
@@ -327,6 +327,32 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
+		QUnit.test( 'bind - gracefully handles undefined morphTargetDictionary', ( assert ) => {
+
+		// Scenario: A user adds morphAttributes to a geometry *after* the Mesh is constructed,
+		// but hasn't called updateMorphTargets() yet. In this lifecycle gap, 
+		// mesh.morphTargetDictionary remains undefined.
+		const geometry = new BoxGeometry();
+		geometry.morphAttributes.position = [ geometry.getAttribute( 'position' ).clone() ];
+		
+		const mesh = new Mesh( geometry, new MeshBasicMaterial() );
+
+		// Force the dictionary to undefined to guarantee we simulate this exact state.
+		mesh.morphTargetDictionary = undefined;
+
+		// Attempting to bind to a named morph target (like 'smile') in this state 
+		// should fail gracefully instead of throwing a fatal TypeError.
+		const binding = new PropertyBinding( mesh, '.morphTargetInfluences[smile]' );
+		
+		try {
+			binding.bind();
+			assert.ok( true, 'bind() safely aborted without throwing a TypeError.' );
+		} catch ( error ) {
+			assert.ok( false, `bind() threw an unexpected error: ${error.message}` );
+		}
+
+	} );
+
 	} );
 
 } );


### PR DESCRIPTION
**Description:**

Hello again! Still poking around the edges of the codebase. I ran into a lifecycle edge case in `PropertyBinding.bind()` that throws a fatal error, and wanted to get a safety guard in place for it.

**The Problem:**
If a user adds `morphAttributes` to a geometry *after* a Mesh is constructed, but hasn't yet called `updateMorphTargets()`, the `mesh.morphTargetDictionary` remains `undefined` (its default state). 

If an animation mixer tries to bind to a named morph target during this gap (e.g., trying to resolve `.morphTargetInfluences[smile]`), `PropertyBinding` attempts to read the name key directly from the undefined dictionary, resulting in a hard crash: `TypeError: Cannot read properties of undefined`.

**The Fix:**
I added a simple safety check to fail gracefully if the dictionary is missing. Instead of throwing a fatal error, it aborts the binding cleanly. 

**Testing:**
I also added a QUnit test to `test/unit/src/animation/PropertyBinding.tests.js` that recreates this exact mesh lifecycle gap to ensure it safely bypasses the throw.