### PR TITLE
UniformsGroup: Fix incorrect index in Vector4 dirty check

### DIFF
--- a/src/renderers/common/UniformsGroup.js
+++ b/src/renderers/common/UniformsGroup.js
@@ -369,7 +369,7 @@ class UniformsGroup extends UniformBuffer {
 		const offset = uniform.offset;
 		const type = uniform.getType();
 
-		if ( a[ offset + 0 ] !== v.x || a[ offset + 1 ] !== v.y || a[ offset + 2 ] !== v.z || a[ offset + 4 ] !== v.w ) {
+		if ( a[ offset + 0 ] !== v.x || a[ offset + 1 ] !== v.y || a[ offset + 2 ] !== v.z || a[ offset + 3 ] !== v.w ) {
 
 			const b = this._getBufferForType( type );
 


### PR DESCRIPTION
### Summary

Fixes an incorrect index used in the dirty check of `UniformsGroup.updateVector4`.

---

### Problem

The current implementation compares the `w` component using an incorrect offset:

```js
a[ offset + 4 ] !== v.w
```

However, the corresponding write uses:

```js
a[ offset + 3 ] = v.w
```

This mismatch causes the dirty check to read from the wrong position.

---

### Impact

When only the `w` component changes:

- The dirty check may incorrectly pass  
- The value is not updated  
- Results in stale data being used during rendering  

---

### Fix

Correct the index used in the comparison:

```js
a[ offset + 3 ] !== v.w
```

---

### Notes

- Minimal fix (1 character change)  
- No impact on bundle size  
- Fixes a silent rendering issue  