### PR TITLE
RenderTarget: Preserve multiview in copy()

### DIFF
--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -369,6 +369,7 @@ class RenderTarget extends EventDispatcher {
 		if ( source.depthTexture !== null ) this.depthTexture = source.depthTexture.clone();
 
 		this.samples = source.samples;
+		this.multiview = source.multiview;
 
 		return this;
 


### PR DESCRIPTION
Fixed #33284 

**Description**

The `RenderTarget.copy()` method does not copy the `multiview` property from the source instance.

The constructor initializes `multiview` using `options.multiview`, but it was missing in the `copy()` method. This leads to inconsistent behavior when cloning render targets configured with multiview enabled.

This PR fixes the issue by copying the `multiview` property:

```js
this.multiview = source.multiview;
```

This ensures that cloned render targets retain the same configuration as the source.
