### PR TITLE
USDComposer: Fix uv data for multi-material meshes.

### DIFF
--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -1998,10 +1998,17 @@ class USDComposer {
 
 		// Triangulate original data using consistent pattern
 		const { indices: origIndices, pattern: triPattern } = this._triangulateIndicesWithPattern( faceVertexIndices, faceVertexCounts, points, holeMap );
-		const origUvIndices = uvIndices ? this._applyTriangulationPattern( uvIndices, triPattern ) : null;
-		const origUv2Indices = uv2Indices ? this._applyTriangulationPattern( uv2Indices, triPattern ) : null;
-
 		const numFaceVertices = faceVertexCounts.reduce( ( a, b ) => a + b, 0 );
+		const faceVaryingIdentity = ( uvs && ! uvIndices && uvs.length / 2 === numFaceVertices ) ||
+			( uvs2 && ! uv2Indices && uvs2.length / 2 === numFaceVertices )
+			? this._applyTriangulationPattern( Array.from( { length: numFaceVertices }, ( _, i ) => i ), triPattern )
+			: null;
+		const origUvIndices = uvIndices
+			? this._applyTriangulationPattern( uvIndices, triPattern )
+			: ( uvs && uvs.length / 2 === numFaceVertices ? faceVaryingIdentity : null );
+		const origUv2Indices = uv2Indices
+			? this._applyTriangulationPattern( uv2Indices, triPattern )
+			: ( uvs2 && uvs2.length / 2 === numFaceVertices ? faceVaryingIdentity : null );
 		const hasIndexedNormals = normals && normalIndicesRaw && normalIndicesRaw.length > 0;
 		const hasFaceVaryingNormals = normals && normals.length / 3 === numFaceVertices;
 		const origNormalIndices = hasIndexedNormals


### PR DESCRIPTION
Fixed #28693.

**Description**

The PR makes sure `USDComposer` is able support faceVarying UVs for multi-material meshes. The regular `_buildGeometry()` already handled it correctly but not the routine `_buildGeometryWithSubsets()`.

With this change, the test assets from #28693 all load correctly. Before this PR, the textures in the first and second screenshot were missing.

<img width="1021" height="666" alt="image" src="https://github.com/user-attachments/assets/ee8ed959-912e-4a9d-9c4c-060df5d772ac" />

<img width="838" height="426" alt="image" src="https://github.com/user-attachments/assets/e3ed2f02-1529-4b27-8e3c-1f9a977b32db" />

<img width="729" height="319" alt="image" src="https://github.com/user-attachments/assets/9dfab1d5-69e6-49cb-9a2e-19b34b7cadcf" />