### PR TITLE
WebGPURenderer: Refactor getArrayBufferAsync to return MappedStorageBufferData

### DIFF
--- a/docs/pages/Renderer.html.md
+++ b/docs/pages/Renderer.html.md
@@ -445,7 +445,7 @@ Returns the current animation loop callback.
 
 **Returns:** The current animation loop callback.
 
-### .getArrayBufferAsync( attribute : StorageBufferAttribute ) : Promise.<ArrayBuffer> (async)
+### .getArrayBufferAsync( attribute : StorageBufferAttribute ) : Promise.<MappedStorageBufferData> (async)
 
 Can be used to transfer buffer data from a storage buffer attribute from the GPU to the CPU in context of compute shaders.
 

--- a/docs/pages/Renderer.html.md
+++ b/docs/pages/Renderer.html.md
@@ -445,7 +445,7 @@ Returns the current animation loop callback.
 
 **Returns:** The current animation loop callback.
 
-### .getArrayBufferAsync( attribute : StorageBufferAttribute ) : Promise.<MappedStorageBufferData> (async)
+### .getArrayBufferAsync( attribute : StorageBufferAttribute ) : Promise.<ArrayBuffer> (async)
 
 Can be used to transfer buffer data from a storage buffer attribute from the GPU to the CPU in context of compute shaders.
 

--- a/examples/webgpu_compute_audio.html
+++ b/examples/webgpu_compute_audio.html
@@ -58,7 +58,7 @@
 
 				renderer.compute( computeNode );
 
-				const wave = new Float32Array( await renderer.getArrayBufferAsync( waveArray.value ) );
+				const mappedData = await renderer.getArrayBufferAsync( waveArray.value );\n\t\t\t\tconst wave = new Float32Array( mappedData.array.slice( 0 ) );\n\t\t\t\tmappedData.destroy();
 
 				// play result
 
@@ -111,7 +111,7 @@
 				const originalWave = instancedArray( waveBuffer ).toReadOnly();
 
 				// The Pixel Buffer Object (PBO) is required to get the GPU computed data to the CPU in the WebGL2 fallback.
-				// As used in `renderer.getArrayBufferAsync( waveArray.value )`.
+				// As used in `renderer.getArrayBufferAsync( waveArray.value ).array`.
 
 				originalWave.setPBO( true );
 				waveArray.setPBO( true );

--- a/examples/webgpu_compute_audio.html
+++ b/examples/webgpu_compute_audio.html
@@ -58,7 +58,9 @@
 
 				renderer.compute( computeNode );
 
-				const mappedData = await renderer.getArrayBufferAsync( waveArray.value );\n\t\t\t\tconst wave = new Float32Array( mappedData.array.slice( 0 ) );\n\t\t\t\tmappedData.destroy();
+				const mappedData = await renderer.getArrayBufferAsync( waveArray.value );
+				const wave = new Float32Array( mappedData.array.slice( 0 ) );
+				mappedData.destroy();
 
 				// play result
 

--- a/examples/webgpu_compute_reduce.html
+++ b/examples/webgpu_compute_reduce.html
@@ -963,7 +963,9 @@
 				functionObj[ logFunctionName ] = async() => {
 
 					const selectedBuffer = buffers[ unifiedEffectController.loggedBuffer ];
-					const mappedData = await renderer.getArrayBufferAsync( selectedBuffer.value );\n\t\t\t\t\tconsole.log( new Uint32Array( mappedData.array.slice( 0 ) ) );\n\t\t\t\t\tmappedData.destroy();
+					const mappedData = await renderer.getArrayBufferAsync( selectedBuffer.value );
+					console.log( new Uint32Array( mappedData.array.slice( 0 ) ) );
+					mappedData.destroy();
 
 				};
 

--- a/examples/webgpu_compute_reduce.html
+++ b/examples/webgpu_compute_reduce.html
@@ -963,7 +963,7 @@
 				functionObj[ logFunctionName ] = async() => {
 
 					const selectedBuffer = buffers[ unifiedEffectController.loggedBuffer ];
-					console.log( new Uint32Array( await renderer.getArrayBufferAsync( selectedBuffer.value ) ) );
+					const mappedData = await renderer.getArrayBufferAsync( selectedBuffer.value );\n\t\t\t\t\tconsole.log( new Uint32Array( mappedData.array.slice( 0 ) ) );\n\t\t\t\t\tmappedData.destroy();
 
 				};
 
@@ -1306,7 +1306,7 @@
 
 						}
 
-						// DEBUG: const reductionResult = new Uint32Array( await renderer.getArrayBufferAsync( currentBuffer ) )[0];
+						// DEBUG: const mappedData = await renderer.getArrayBufferAsync( currentBuffer.value ); const reductionResult = new Uint32Array( mappedData.array )[ 0 ]; mappedData.destroy();
 
 						let passInfoString = '';
 

--- a/src/Three.WebGPU.js
+++ b/src/Three.WebGPU.js
@@ -20,6 +20,7 @@ export { default as StorageArrayTexture } from './renderers/common/StorageArrayT
 export { default as StorageBufferAttribute } from './renderers/common/StorageBufferAttribute.js';
 export { default as StorageInstancedBufferAttribute } from './renderers/common/StorageInstancedBufferAttribute.js';
 export { default as IndirectStorageBufferAttribute } from './renderers/common/IndirectStorageBufferAttribute.js';
+export { default as MappedStorageBufferData } from './renderers/common/MappedStorageBufferData.js';
 export { default as IESSpotLight } from './lights/webgpu/IESSpotLight.js';
 export { default as ProjectorLight } from './lights/webgpu/ProjectorLight.js';
 export { default as NodeLoader } from './loaders/nodes/NodeLoader.js';

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -60,8 +60,8 @@ class Backend {
 
 		/**
 		 * A reference to the timestamp query pool.
-   		 *
-   		 * @type {{render: ?TimestampQueryPool, compute: ?TimestampQueryPool}}
+				 *
+				 * @type {{render: ?TimestampQueryPool, compute: ?TimestampQueryPool}}
 		 */
 		this.timestampQueryPool = {
 			[ TimestampQuery.RENDER ]: null,
@@ -100,7 +100,7 @@ class Backend {
 	 * @type {number}
 	 * @readonly
 	 */
-	get coordinateSystem() {}
+	get coordinateSystem() { }
 
 	// render context
 
@@ -112,7 +112,7 @@ class Backend {
 	 * @abstract
 	 * @param {RenderContext} renderContext - The render context.
 	 */
-	beginRender( /*renderContext*/ ) {}
+	beginRender( /*renderContext*/ ) { }
 
 	/**
 	 * This method is executed at the end of a render call and
@@ -122,7 +122,7 @@ class Backend {
 	 * @abstract
 	 * @param {RenderContext} renderContext - The render context.
 	 */
-	finishRender( /*renderContext*/ ) {}
+	finishRender( /*renderContext*/ ) { }
 
 	/**
 	 * This method is executed at the beginning of a compute call and
@@ -132,7 +132,7 @@ class Backend {
 	 * @abstract
 	 * @param {Node|Array<Node>} computeGroup - The compute node(s).
 	 */
-	beginCompute( /*computeGroup*/ ) {}
+	beginCompute( /*computeGroup*/ ) { }
 
 	/**
 	 * This method is executed at the end of a compute call and
@@ -142,7 +142,7 @@ class Backend {
 	 * @abstract
 	 * @param {Node|Array<Node>} computeGroup - The compute node(s).
 	 */
-	finishCompute( /*computeGroup*/ ) {}
+	finishCompute( /*computeGroup*/ ) { }
 
 	// render object
 
@@ -338,7 +338,7 @@ class Backend {
 	 * @param {number} faceIndex - The face index.
 	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
 	 */
-	async copyTextureToBuffer( /*texture, x, y, width, height, faceIndex*/ ) {}
+	async copyTextureToBuffer( /*texture, x, y, width, height, faceIndex*/ ) { }
 
 	/**
 	 * Copies data of the given source texture to the given destination texture.
@@ -351,7 +351,7 @@ class Backend {
 	 * @param {number} [srcLevel=0] - The source mip level to copy from.
 	 * @param {number} [dstLevel=0] - The destination mip level to copy to.
 	 */
-	copyTextureToTexture( /*srcTexture, dstTexture, srcRegion = null, dstPosition = null, srcLevel = 0, dstLevel = 0*/ ) {}
+	copyTextureToTexture( /*srcTexture, dstTexture, srcRegion = null, dstPosition = null, srcLevel = 0, dstLevel = 0*/ ) { }
 
 	/**
 	* Copies the current bound framebuffer to the given texture.
@@ -361,7 +361,7 @@ class Backend {
 	* @param {RenderContext} renderContext - The render context.
 	* @param {Vector4} rectangle - A four dimensional vector defining the origin and dimension of the copy.
 	*/
-	copyFramebufferToTexture( /*texture, renderContext, rectangle*/ ) {}
+	copyFramebufferToTexture( /*texture, renderContext, rectangle*/ ) { }
 
 	// attributes
 
@@ -429,7 +429,7 @@ class Backend {
 	 * @abstract
 	 * @param {RenderContext} renderContext - The render context.
 	 */
-	updateViewport( /*renderContext*/ ) {}
+	updateViewport( /*renderContext*/ ) { }
 
 	// utils
 
@@ -540,7 +540,7 @@ class Backend {
 	 * @param {Object3D} object - The 3D object to test.
 	 * @return {boolean} Whether the 3D object is fully occluded or not.
 	 */
-	isOccluded( /*renderContext, object*/ ) {}
+	isOccluded( /*renderContext, object*/ ) { }
 
 	/**
 	 * Resolves the time stamp for the given render context and type.
@@ -581,9 +581,9 @@ class Backend {
 	 *
 	 * @async
 	 * @param {StorageBufferAttribute} attribute - The storage buffer attribute.
-	 * @return {Promise<ArrayBuffer>} A promise that resolves with the buffer data when the data are ready.
+	 * @return {Promise<MappedStorageBufferData>} A promise that resolves with the mapped buffer data when the data are ready.
 	 */
-	async getArrayBufferAsync( /* attribute */ ) {}
+	async getArrayBufferAsync( /* attribute */ ) { }
 
 	/**
 	 * Checks if the given feature is supported by the backend.
@@ -602,7 +602,7 @@ class Backend {
 	 * @param {string} name - The feature's name.
 	 * @return {boolean} Whether the feature is supported or not.
 	 */
-	hasFeature( /*name*/ ) {}
+	hasFeature( /*name*/ ) { }
 
 	/**
 	 * Returns the drawing buffer size.
@@ -689,7 +689,7 @@ class Backend {
 	 * @abstract
 	 * @param {RenderContext} renderContext - The render context.
 	 */
-	initRenderTarget( /*renderContext*/ ) {}
+	initRenderTarget( /*renderContext*/ ) { }
 
 	/**
 	 * Sets a dictionary for the given object into the

--- a/src/renderers/common/MappedStorageBufferData.js
+++ b/src/renderers/common/MappedStorageBufferData.js
@@ -1,0 +1,24 @@
+class MappedStorageBufferData {
+
+	constructor( array, readBufferGPU = null ) {
+
+		this.array = array;
+		this.readBufferGPU = readBufferGPU;
+
+	}
+
+	destroy() {
+
+		if ( this.readBufferGPU !== null ) {
+
+			this.readBufferGPU.unmap();
+			this.readBufferGPU.destroy();
+			this.readBufferGPU = null;
+
+		}
+
+	}
+
+}
+
+export default MappedStorageBufferData;

--- a/src/renderers/common/MappedStorageBufferData.js
+++ b/src/renderers/common/MappedStorageBufferData.js
@@ -1,21 +1,51 @@
+
+/**
+ * This class represents a mapped storage buffer data.
+ * It is used for efficient readback of data from the GPU.
+ */
 class MappedStorageBufferData {
 
-	constructor( array, readBufferGPU = null ) {
+	/**
+	 * Constructs a new MappedStorageBufferData.
+	 *
+	 * @param {ArrayBuffer} array - The mapped data.
+	 * @param {GPUBuffer} [readBufferGPU=null] - The GPU buffer the data is mapped from.
+	 */
+	constructor(array, readBufferGPU = null) {
 
+		/**
+		 * The mapped data as an ArrayBuffer.
+		 *
+		 * @type {ArrayBuffer}
+		 */
 		this.array = array;
+
+		/**
+		 * The GPU buffer the data is mapped from.
+		 *
+		 * @private
+		 * @type {?GPUBuffer}
+		 * @default null
+		 */
 		this.readBufferGPU = readBufferGPU;
 
 	}
 
+	/**
+	 * Releases the mapped data. After calling this method, the `array` property
+	 * will be null and the data is no longer accessible.
+	 */
 	destroy() {
 
-		if ( this.readBufferGPU !== null ) {
+		if (this.readBufferGPU !== null) {
 
 			this.readBufferGPU.unmap();
 			this.readBufferGPU.destroy();
 			this.readBufferGPU = null;
 
 		}
+
+		this.array = null;
 
 	}
 

--- a/src/renderers/common/MappedStorageBufferData.js
+++ b/src/renderers/common/MappedStorageBufferData.js
@@ -11,7 +11,7 @@ class MappedStorageBufferData {
 	 * @param {ArrayBuffer} array - The mapped data.
 	 * @param {GPUBuffer} [readBufferGPU=null] - The GPU buffer the data is mapped from.
 	 */
-	constructor(array, readBufferGPU = null) {
+	constructor( array, readBufferGPU = null ) {
 
 		/**
 		 * The mapped data as an ArrayBuffer.
@@ -37,7 +37,7 @@ class MappedStorageBufferData {
 	 */
 	destroy() {
 
-		if (this.readBufferGPU !== null) {
+		if ( this.readBufferGPU !== null ) {
 
 			this.readBufferGPU.unmap();
 			this.readBufferGPU.destroy();

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1858,7 +1858,7 @@ class Renderer {
 	 *
 	 * @async
 	 * @param {StorageBufferAttribute} attribute - The storage buffer attribute.
-	 * @return {Promise<ArrayBuffer>} A promise that resolves with the buffer data when the data are ready.
+	 * @return {Promise<MappedStorageBufferData>} A promise that resolves with the mapped buffer data when the data are ready.
 	 */
 	async getArrayBufferAsync( attribute ) {
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -227,7 +227,7 @@ class WebGLBackend extends Backend {
 
 		const glContext = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgl2', contextAttributes );
 
-	 	function onContextLost( event ) {
+		function onContextLost( event ) {
 
 			event.preventDefault();
 
@@ -313,7 +313,7 @@ class WebGLBackend extends Backend {
 	 *
 	 * @async
 	 * @param {StorageBufferAttribute} attribute - The storage buffer attribute.
-	 * @return {Promise<ArrayBuffer>} A promise that resolves with the buffer data when the data are ready.
+	 * @return {Promise<MappedStorageBufferData>} A promise that resolves with the mapped buffer data when the data are ready.
 	 */
 	async getArrayBufferAsync( attribute ) {
 

--- a/src/renderers/webgl-fallback/utils/WebGLAttributeUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLAttributeUtils.js
@@ -1,4 +1,5 @@
 import { IntType } from '../../../constants.js';
+import MappedStorageBufferData from '../../common/MappedStorageBufferData.js';
 
 let _id = 0;
 
@@ -30,7 +31,7 @@ class DualAttributeData {
 
 	get id() {
 
-		return `${ this.baseId }|${ this.activeBufferIndex }`;
+		return `${this.baseId}|${this.activeBufferIndex}`;
 
 	}
 
@@ -258,7 +259,7 @@ class WebGLAttributeUtils {
 	 *
 	 * @async
 	 * @param {StorageBufferAttribute} attribute - The storage buffer attribute.
-	 * @return {Promise<ArrayBuffer>} A promise that resolves with the buffer data when the data are ready.
+	 * @return {Promise<MappedStorageBufferData>} A promise that resolves with the mapped buffer data when the data are ready.
 	 */
 	async getArrayBufferAsync( attribute ) {
 
@@ -294,7 +295,7 @@ class WebGLAttributeUtils {
 		gl.bindBuffer( gl.COPY_READ_BUFFER, null );
 		gl.bindBuffer( gl.COPY_WRITE_BUFFER, null );
 
-		return dstBuffer.buffer;
+		return new MappedStorageBufferData( dstBuffer.buffer );
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -287,7 +287,7 @@ class WebGPUBackend extends Backend {
 			}
 
 			// OffscreenCanvas does not have setAttribute, see #22811
-			if ( 'setAttribute' in canvasTarget.domElement ) canvasTarget.domElement.setAttribute( 'data-engine', `three.js r${ REVISION } webgpu` );
+			if ( 'setAttribute' in canvasTarget.domElement ) canvasTarget.domElement.setAttribute( 'data-engine', `three.js r${REVISION} webgpu` );
 
 			const alphaMode = parameters.alpha ? 'premultiplied' : 'opaque';
 
@@ -329,7 +329,7 @@ class WebGPUBackend extends Backend {
 	 *
 	 * @async
 	 * @param {StorageBufferAttribute} attribute - The storage buffer attribute.
-	 * @return {Promise<ArrayBuffer>} A promise that resolves with the buffer data when the data are ready.
+	 * @return {Promise<MappedStorageBufferData>} A promise that resolves with the mapped buffer data when the data are ready.
 	 */
 	async getArrayBufferAsync( attribute ) {
 
@@ -474,7 +474,7 @@ class WebGPUBackend extends Backend {
 				const textureData = this.get( textures[ i ] );
 
 				const viewDescriptor = {
-					label: `colorAttachment_${ i }`,
+					label: `colorAttachment_${i}`,
 					baseMipLevel: renderContext.activeMipmapLevel,
 					mipLevelCount: 1,
 					baseArrayLayer: renderContext.activeCubeFace,
@@ -646,7 +646,7 @@ class WebGPUBackend extends Backend {
 
 			//
 
-			occlusionQuerySet = device.createQuerySet( { type: 'occlusion', count: occlusionQueryCount, label: `occlusionQuerySet_${ renderContext.id }` } );
+			occlusionQuerySet = device.createQuerySet( { type: 'occlusion', count: occlusionQueryCount, label: `occlusionQuerySet_${renderContext.id}` } );
 
 			renderContextData.occlusionQuerySet = occlusionQuerySet;
 			renderContextData.occlusionQueryIndex = 0;
@@ -726,7 +726,7 @@ class WebGPUBackend extends Backend {
 
 			}
 
-		  	colorAttachment.storeOp = GPUStoreOp.Store;
+			colorAttachment.storeOp = GPUStoreOp.Store;
 
 		}
 
@@ -745,13 +745,13 @@ class WebGPUBackend extends Backend {
 
 			}
 
-		  depthStencilAttachment.depthStoreOp = GPUStoreOp.Store;
+			depthStencilAttachment.depthStoreOp = GPUStoreOp.Store;
 
 		}
 
 		if ( renderContext.stencil ) {
 
-		  if ( renderContext.clearStencil ) {
+			if ( renderContext.clearStencil ) {
 
 				depthStencilAttachment.stencilClearValue = renderContext.clearStencilValue;
 				depthStencilAttachment.stencilLoadOp = GPULoadOp.Clear;
@@ -762,7 +762,7 @@ class WebGPUBackend extends Backend {
 
 			}
 
-		  depthStencilAttachment.stencilStoreOp = GPUStoreOp.Store;
+			depthStencilAttachment.stencilStoreOp = GPUStoreOp.Store;
 
 		}
 
@@ -1000,16 +1000,16 @@ class WebGPUBackend extends Backend {
 
 		if ( this._isRenderCameraDepthArray( renderContext ) === true ) {
 
-		  const bundles = [];
+			const bundles = [];
 
-		  for ( let i = 0; i < renderContextData.bundleEncoders.length; i ++ ) {
+			for ( let i = 0; i < renderContextData.bundleEncoders.length; i ++ ) {
 
 				const bundleEncoder = renderContextData.bundleEncoders[ i ];
 				bundles.push( bundleEncoder.finish() );
 
 			}
 
-		  for ( let i = 0; i < renderContextData.layerDescriptors.length; i ++ ) {
+			for ( let i = 0; i < renderContextData.layerDescriptors.length; i ++ ) {
 
 				if ( i < bundles.length ) {
 
@@ -1040,7 +1040,7 @@ class WebGPUBackend extends Backend {
 
 		} else if ( renderContextData.currentPass ) {
 
-		  renderContextData.currentPass.end();
+			renderContextData.currentPass.end();
 
 		}
 
@@ -2086,7 +2086,7 @@ class WebGPUBackend extends Backend {
 		const programGPU = this.get( program );
 
 		programGPU.module = {
-			module: this.device.createShaderModule( { code: program.code, label: program.stage + ( program.name !== '' ? `_${ program.name }` : '' ) } ),
+			module: this.device.createShaderModule( { code: program.code, label: program.stage + ( program.name !== '' ? `_${program.name}` : '' ) } ),
 			entryPoint: 'main'
 		};
 

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -1,4 +1,5 @@
 import { GPUInputStepMode } from './WebGPUConstants.js';
+import MappedStorageBufferData from '../../common/MappedStorageBufferData.js';
 
 import { Float16BufferAttribute } from '../../../core/BufferAttribute.js';
 import { isTypedArray, error } from '../../../utils.js';
@@ -319,7 +320,7 @@ class WebGPUAttributeUtils {
 	 *
 	 * @async
 	 * @param {StorageBufferAttribute} attribute - The storage buffer attribute.
-	 * @return {Promise<ArrayBuffer>} A promise that resolves with the buffer data when the data are ready.
+	 * @return {Promise<MappedStorageBufferData>} A promise that resolves with the mapped buffer data when the data are ready.
 	 */
 	async getArrayBufferAsync( attribute ) {
 
@@ -331,13 +332,13 @@ class WebGPUAttributeUtils {
 		const size = bufferGPU.size;
 
 		const readBufferGPU = device.createBuffer( {
-			label: `${ attribute.name }_readback`,
+			label: `${attribute.name}_readback`,
 			size,
 			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
 		} );
 
 		const cmdEncoder = device.createCommandEncoder( {
-			label: `readback_encoder_${ attribute.name }`
+			label: `readback_encoder_${attribute.name}`
 		} );
 
 		cmdEncoder.copyBufferToBuffer(
@@ -355,11 +356,7 @@ class WebGPUAttributeUtils {
 
 		const arrayBuffer = readBufferGPU.getMappedRange();
 
-		const dstBuffer = new attribute.array.constructor( arrayBuffer.slice( 0 ) );
-
-		readBufferGPU.unmap();
-
-		return dstBuffer.buffer;
+		return new MappedStorageBufferData( arrayBuffer, readBufferGPU );
 
 	}
 


### PR DESCRIPTION
Fixes #33281

**Description**

This PR resolves the severe Garbage Collection (GC) pressure and GPU buffer memory leaks associated with frequent usage of `.getArrayBufferAsync()` by providing the user manual control over data mapping extraction. 

Previously, [getArrayBufferAsync](cci:1://file:///Users/gouravnss/three.js/src/renderers/webgl-fallback/WebGLBackend.js:309:1-321:2) automatically created and returned a newly detached JavaScript [ArrayBuffer](cci:1://file:///Users/gouravnss/three.js/src/renderers/webgl-fallback/WebGLBackend.js:309:1-321:2) copy on each call without destroying the underlying GPU buffer (`readBufferGPU`). 

Following @gkjohnson's suggestion, [getArrayBufferAsync()](cci:1://file:///Users/gouravnss/three.js/src/renderers/webgl-fallback/WebGLBackend.js:309:1-321:2) now resolves with a [MappedStorageBufferData](cci:2://file:///Users/gouravnss/three.js/src/renderers/common/MappedStorageBufferData.js:0:0-21:1) instance instead. This allows the user to access the data without incurring automatic mapping copies and explicitly release it back.

**Key Changes:**
- **Common**: Added [MappedStorageBufferData](cci:2://file:///Users/gouravnss/three.js/src/renderers/common/MappedStorageBufferData.js:0:0-21:1) wrapper class supporting an `array` property and `.destroy()` cleanup method.
- **WebGPUBackend**: Updated [getArrayBufferAsync](cci:1://file:///Users/gouravnss/three.js/src/renderers/webgl-fallback/WebGLBackend.js:309:1-321:2) payload to return [MappedStorageBufferData](cci:2://file:///Users/gouravnss/three.js/src/renderers/common/MappedStorageBufferData.js:0:0-21:1). Safely destroys the dynamically allocated readback GPU compute buffers when `.destroy()` is called.
- **WebGLBackend**: Parity update to return the [MappedStorageBufferData](cci:2://file:///Users/gouravnss/three.js/src/renderers/common/MappedStorageBufferData.js:0:0-21:1) wrapper to ensure fallback API consistency.  
- **Examples / Docs**: Updated JSDoc signatures and modified `webgpu_compute_audio` and `webgpu_compute_reduce` workflows to destructure `.array` and trigger `.destroy()`.

**Example Usage:**
```javascript
const mappedData = await renderer.getArrayBufferAsync( storageAttribute );
myBuffer.set( new Uint32Array( mappedData.array ) );

// User explicitly frees the backend buffer
mappedData.destroy(); 