### PR TITLE
Loaders, Editor: Improve handling of assets with unicode characters.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -45,6 +45,14 @@ function Loader( editor ) {
 				while ( normalized.startsWith( '../' ) ) normalized = normalized.slice( 3 );
 				while ( normalized.startsWith( '/' ) ) normalized = normalized.slice( 1 );
 
+				try {
+
+					normalized = decodeURIComponent( normalized );
+
+				} catch ( e ) { /* malformed URI — keep as-is */ }
+
+				normalized = normalized.normalize( 'NFC' );
+
 				return normalized;
 
 			};
@@ -982,10 +990,22 @@ function Loader( editor ) {
 
 		const zip = unzipSync( new Uint8Array( contents ) );
 
+		// Build a lookup map with NFC-normalized keys to handle
+		// unicode normalization differences (e.g. NFD vs NFC)
+
+		const zipLookup = {};
+
+		for ( const path in zip ) {
+
+			zipLookup[ path.normalize( 'NFC' ) ] = zip[ path ];
+
+		}
+
 		const manager = new THREE.LoadingManager();
 		manager.setURLModifier( function ( url ) {
 
-			const file = zip[ url ];
+			const normalized = decodeURIComponent( url ).normalize( 'NFC' );
+			const file = zipLookup[ normalized ];
 
 			if ( file ) {
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -156,6 +156,11 @@ class LoadingManager {
 		 */
 		this.resolveURL = function ( url ) {
 
+			// Normalize to NFC so that Unicode URIs (e.g. from glTF)
+			// are percent-encoded correctly per RFC 3987.
+
+			url = url.normalize( 'NFC' );
+
 			if ( urlModifier ) {
 
 				return urlModifier( url );


### PR DESCRIPTION
Fixed #29963.

**Description**

The PR improves the loading of glTF assets with URL-encoded UTF8 characters in the editor via drag'n'drop or via "Import". Both the zipped glTF assets as well as the unzipped versions from #29963 can be imported now as expected. Besides, to fix network requests outside of the editor, `LoadingManager` was also updated.

To further explain: There are different Normalization Forms in Unicode. Only when the normalization is handled consistently, the loading process works as expected. The PR makes sure the editor (zipped and drag'n'drop) as well as plain network requests use a NFC normalization.