### PR TITLE
WGSLNodeBuilder: Fix `textureDimensions()` cache scope

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -436,7 +436,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 */
 	generateTextureDimension( texture, textureProperty, levelSnippet ) {
 
-		const textureData = this.getDataFromNode( texture, this.shaderStage, this.globalCache );
+		const textureData = this.getDataFromNode( texture, this.shaderStage, this.cache );
 
 		if ( textureData.dimensionsSnippet === undefined ) textureData.dimensionsSnippet = {};
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/33295

**Description**

I fixed the cache scope by making the example from the issue work. I still need to review the generated code; it seems the optimizer is not acting correctly.

