### PR TITLE
GPUComputationRenderer: Call `dispose()` on variable's material.

### DIFF
--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -339,6 +339,8 @@ class GPUComputationRenderer {
 
 				}
 
+				variable.material.dispose();
+
 			}
 
 		};


### PR DESCRIPTION
## Summary

`GPUComputationRenderer.dispose()` disposes render targets and the pass-through shader material (via `quad.dispose()`), but never disposes the `ShaderMaterial` instances created for each computation variable.

These materials are allocated in `createShaderMaterial()` (called from `addVariable()`) and stored on `variable.material`, but `dispose()` never calls `variable.material.dispose()`. The `ShaderMaterial` objects and their associated WebGL programs are never released.

## Fix

One line: `variable.material.dispose()` inside the existing variable loop.

## How I found this

I work on a project that uses `GPUComputationRenderer` for a GPU-computed wave simulation. The app has a router that creates and destroys renderer instances on navigation. After switching between views repeatedly, GPU memory climbed steadily — the undisposed variable `ShaderMaterial` objects were accumulating.

Same fix submitted to three-stdlib: https://github.com/pmndrs/three-stdlib/pull/428