### PR TITLE
WGSLNodeBuilder: Add `allowGlobalVariables`

### DIFF
--- a/src/nodes/gpgpu/BarrierNode.js
+++ b/src/nodes/gpgpu/BarrierNode.js
@@ -25,12 +25,17 @@ class BarrierNode extends Node {
 
 	}
 
+	setup( builder ) {
+
+		builder.allowEarlyReturns = false;
+		builder.allowGlobalVariables = false;
+
+	}
+
 	generate( builder ) {
 
 		const { scope } = this;
 		const { renderer } = builder;
-
-		builder.allowEarlyReturns = false;
 
 		if ( renderer.backend.isWebGLBackend === true ) {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -238,6 +238,14 @@ class WGSLNodeBuilder extends NodeBuilder {
 		 */
 		this.allowEarlyReturns = true;
 
+		/**
+		 * A flag that indicates that global variables are allowed.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.allowGlobalVariables = true;
+
 	}
 
 	/**
@@ -2081,12 +2089,14 @@ ${ flowData.code }
 
 			this.shaderStage = shaderStage;
 
+			const allowGlobal = this.allowGlobalVariables;
+
 			const stageData = shadersData[ shaderStage ];
 			stageData.uniforms = this.getUniforms( shaderStage );
 			stageData.attributes = this.getAttributes( shaderStage );
 			stageData.varyings = this.getVaryings( shaderStage );
 			stageData.structs = this.getStructs( shaderStage );
-			stageData.vars = this.getVars( shaderStage, true );
+			stageData.vars = this.getVars( shaderStage, allowGlobal );
 			stageData.codes = this.getCodes( shaderStage );
 			stageData.directives = this.getDirectives( shaderStage );
 			stageData.scopedArrays = this.getScopedArrays( shaderStage );
@@ -2445,13 +2455,16 @@ ${ shaderData.structs }
 ${ shaderData.uniforms }
 
 // vars
-${ shaderData.vars }
+${ this.allowGlobalVariables ? shaderData.vars : '' }
 
 // codes
 ${ shaderData.codes }
 
 @compute @workgroup_size( ${ workgroupSizeX }, ${ workgroupSizeY }, ${ workgroupSizeZ } )
 fn main( ${ shaderData.attributes } ) {
+
+	// local vars
+	${ this.allowGlobalVariables ? '' : shaderData.vars }
 
 	// system
 	instanceIndex = globalId.x


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33302

**Description**

The PR uses local variables instead of globals when using `workgroupBarrier()` to avoid WGSL compilation errors. The `allow*` points are still somewhat provisional until TSL has a more robust API to handle workgroups and shared memory.
