### PR TITLE
Manual: Remove reference to Matrix4.setRotationFromQuaternion()

### DIFF
--- a/manual/en/matrix-transformations.html
+++ b/manual/en/matrix-transformations.html
@@ -57,7 +57,7 @@ object.updateMatrix();
               <li>
                 Modify the object's matrix directly. The `Matrix4` class has various methods for modifying the matrix:
 <pre class="prettyprint notranslate lang-js" translate="no">
-object.matrix.setRotationFromQuaternion( quaternion );
+object.matrix.makeRotationFromQuaternion( quaternion );
 object.matrix.setPosition( start_position );
 object.matrixAutoUpdate = false;
 </pre>

--- a/manual/fr/matrix-transformations.html
+++ b/manual/fr/matrix-transformations.html
@@ -56,7 +56,7 @@ object.updateMatrix();
               <li>
                 Modifiez la matrice de l'objet directement. La classe `Matrix4` dispose de différentes méthodes pour modifier la matrice :
 <pre class="prettyprint notranslate lang-js" translate="no">
-object.matrix.setRotationFromQuaternion( quaternion );
+object.matrix.makeRotationFromQuaternion( quaternion );
 object.matrix.setPosition( start_position );
 object.matrixAutoUpdate = false;
 </pre>

--- a/manual/zh/matrix-transformations.html
+++ b/manual/zh/matrix-transformations.html
@@ -60,7 +60,7 @@ object.updateMatrix();
               <li>
                 直接修改对象矩阵。`Matrix4` 提供了多种矩阵修改方法：
 <pre class="prettyprint notranslate lang-js" translate="no">
-object.matrix.setRotationFromQuaternion( quaternion );
+object.matrix.makeRotationFromQuaternion( quaternion );
 object.matrix.setPosition( start_position );
 object.matrixAutoUpdate = false;
 </pre>


### PR DESCRIPTION
**Description**

The Matrix Transformations page in the manual was still making references to `Matrix4.setRotationFromQuaternion()` which has since been removed.
This PR changes these examples to use `Matrix4.makeRotationFromQuaternion()` instead.

Note that `Object3D.setRotationFromQuaternion()` still exists, but this is referring to `Matrix4.setRotationFromQuaternion()` which no longer exists.
