### PR TITLE
FBXLoader: Guard against orphaned animation curve nodes.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -2750,13 +2750,15 @@ class AnimationParser {
 
 							if ( layerCurveNodes[ i ] === undefined ) {
 
-								const childConnection = connections.get( child.ID );
-								const modelRelationship = childConnection ? childConnection.parents.filter( function ( parent ) {
+								const filteredParents = connections.get( child.ID ).parents.filter( function ( parent ) {
 
 									return parent.relationship !== undefined;
 
-								} )[ 0 ] : undefined;
-								const modelID = modelRelationship ? modelRelationship.ID : undefined;
+								} );
+
+								if ( filteredParents.length === 0 ) return;
+
+								const modelID = filteredParents[ 0 ].ID;
 
 								if ( modelID !== undefined ) {
 
@@ -2816,15 +2818,15 @@ class AnimationParser {
 
 							if ( layerCurveNodes[ i ] === undefined ) {
 
-								const childConnection = connections.get( child.ID );
-								const deformerRelationship = childConnection ? childConnection.parents.filter( function ( parent ) {
+								const filteredParents = connections.get( child.ID ).parents.filter( function ( parent ) {
 
 									return parent.relationship !== undefined;
 
-								} )[ 0 ] : undefined;
-								const deformerID = deformerRelationship ? deformerRelationship.ID : undefined;
+								} );
 
-								if ( deformerID === undefined ) return;
+								if ( filteredParents.length === 0 ) return;
+
+								const deformerID = filteredParents[ 0 ].ID;
 
 								const morpherID = connections.get( deformerID ).parents[ 0 ].ID;
 								const geoID = connections.get( morpherID ).parents[ 0 ].ID;

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -2750,11 +2750,13 @@ class AnimationParser {
 
 							if ( layerCurveNodes[ i ] === undefined ) {
 
-								const modelID = connections.get( child.ID ).parents.filter( function ( parent ) {
+								const childConnection = connections.get( child.ID );
+								const modelRelationship = childConnection ? childConnection.parents.filter( function ( parent ) {
 
 									return parent.relationship !== undefined;
 
-								} )[ 0 ].ID;
+								} )[ 0 ] : undefined;
+								const modelID = modelRelationship ? modelRelationship.ID : undefined;
 
 								if ( modelID !== undefined ) {
 
@@ -2814,11 +2816,15 @@ class AnimationParser {
 
 							if ( layerCurveNodes[ i ] === undefined ) {
 
-								const deformerID = connections.get( child.ID ).parents.filter( function ( parent ) {
+								const childConnection = connections.get( child.ID );
+								const deformerRelationship = childConnection ? childConnection.parents.filter( function ( parent ) {
 
 									return parent.relationship !== undefined;
 
-								} )[ 0 ].ID;
+								} )[ 0 ] : undefined;
+								const deformerID = deformerRelationship ? deformerRelationship.ID : undefined;
+
+								if ( deformerID === undefined ) return;
 
 								const morpherID = connections.get( deformerID ).parents[ 0 ].ID;
 								const geoID = connections.get( morpherID ).parents[ 0 ].ID;


### PR DESCRIPTION
Fixed #33326

**Description**

This patch guards the parent lookup and skips curve nodes that do not resolve to a valid target model/deformer so the rest of the valid scene and animation data can still load.
