### PR TITLE
WebGPURenderer: Premultiply in sRGB color space

### DIFF
--- a/src/nodes/display/ColorSpaceNode.js
+++ b/src/nodes/display/ColorSpaceNode.js
@@ -1,10 +1,11 @@
 import TempNode from '../core/TempNode.js';
-import { addMethodChaining, mat3, nodeObject, vec4 } from '../tsl/TSLCore.js';
+import { addMethodChaining, mat3, nodeObject, vec3, vec4 } from '../tsl/TSLCore.js';
 
 import { SRGBTransfer } from '../../constants.js';
 import { ColorManagement } from '../../math/ColorManagement.js';
 import { sRGBTransferEOTF, sRGBTransferOETF } from './ColorSpaceFunctions.js';
 import { Matrix3 } from '../../math/Matrix3.js';
+import { clamp } from '../math/MathNode.js';
 
 const WORKING_COLOR_SPACE = 'WorkingColorSpace';
 const OUTPUT_COLOR_SPACE = 'OutputColorSpace';
@@ -114,7 +115,19 @@ class ColorSpaceNode extends TempNode {
 
 		if ( ColorManagement.getTransfer( target ) === SRGBTransfer ) {
 
+			// premultiply in sRGB color space for the HTML compositor #33104
+
+			// un-premultiply in linear space
+			outputNode = vec4( outputNode.a.greaterThan( 0.0 ).select( outputNode.rgb.div( outputNode.a ), vec3( 0.0 ) ), outputNode.a );
+
+			// clamp RGB to [ 0,1 ]
+			outputNode = vec4( clamp( outputNode.rgb, 0.0, 1.0 ), outputNode.a );
+
+			// encode to sRGB
 			outputNode = vec4( sRGBTransferOETF( outputNode.rgb ), outputNode.a );
+
+			// premultiply in sRGB color space
+			outputNode = vec4( outputNode.rgb.mul( outputNode.a ), outputNode.a );
 
 		}
 


### PR DESCRIPTION
Fixes #33104

The browser compositor performs a Porter-Duff source-over blend operation of the renderer output with the HTML canvas, blending in sRGB color space. And in fact, the compositor expects color values to be _premultiplied in sRGB space_.

`WebGPURenderer`, on the other hand, generates premultiplied RGB values in _linear-sRGB color space_, and then converts the result to sRGB color space.

`WebGPURenderer`'s workflow is proper, but it is not compatible with what the compositor expects, and the mismatch produces visible artifacts as described in #33104.

This is a proposal for discussion, only.

/ping @gkjohnson 
/ping @donmccurdy 