### PR TITLE
FBXLoader: Add coordinate system correction for Z-up.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -1012,6 +1012,24 @@ class FBXTreeParser {
 
 		sceneGraph.animations = animations;
 
+		// Apply coordinate system correction. FBX files can use different
+		// up-axis conventions (Y-up or Z-up). Three.js uses Y-up, so rotate
+		// the scene when the file uses Z-up (UpAxis === 2).
+
+		if ( 'GlobalSettings' in fbxTree && 'UpAxis' in fbxTree.GlobalSettings ) {
+
+			const upAxis = fbxTree.GlobalSettings.UpAxis.value;
+
+			if ( upAxis === 2 ) {
+
+				console.warn( 'THREE.FBXLoader: You are loading an asset with a Z-UP coordinate system. The loader just rotates the asset to transform it into Y-UP. The vertex data are not converted.' );
+
+				sceneGraph.rotation.set( - Math.PI / 2, 0, 0 );
+
+			}
+
+		}
+
 	}
 
 	// parse nodes in FBXTree.Objects.Model


### PR DESCRIPTION
Fixed #28193.

**Description**

The PR makes sure `FBXLoader` extracts the asset's up axis convention and handles the +Z-up case by rotating the scene similar to `ColladaLoader`. `FBXLoader` informs the users with a warning about this operation in the same way `ColladaLoader` does.
