### PR TITLE
Fix WebGPU 'Destroyed texture used in a submit' on render target resize

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -353,8 +353,6 @@ class WebGPUTextureUtils {
 		const backend = this.backend;
 		const textureData = backend.get( texture );
 
-		if ( textureData.texture !== undefined && isDefaultTexture === false ) textureData.texture.destroy();
-
 		if ( textureData.msaaTexture !== undefined ) textureData.msaaTexture.destroy();
 
 		backend.delete( texture );


### PR DESCRIPTION
fixes this issue: https://github.com/mrdoob/three.js/issues/30766

edit: deferring the destroy didnt work either (caused some visual artifacts before renderer would automatically "recover" by itself)

removing the synchronous destroy altogether and letting gpu handle it seems to work better.