### PR TITLE
MathNode: Fix `transformDirection()`.

### DIFF
--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -1,5 +1,5 @@
 import { attribute } from '../core/AttributeNode.js';
-import { cameraViewMatrix } from './Camera.js';
+import { cameraViewMatrix, cameraWorldMatrix } from './Camera.js';
 import { modelNormalMatrix, modelWorldMatrix } from './ModelNode.js';
 import { mat3, vec3, Fn } from '../tsl/TSLBase.js';
 import { positionView } from './Position.js';
@@ -74,7 +74,7 @@ export const normalViewGeometry = /*@__PURE__*/ ( Fn( ( builder ) => {
  */
 export const normalWorldGeometry = /*@__PURE__*/ ( Fn( ( builder ) => {
 
-	let normal = normalViewGeometry.transformDirection( cameraViewMatrix );
+	let normal = normalViewGeometry.transformDirection( cameraWorldMatrix );
 
 	if ( builder.isFlatShading() !== true ) {
 
@@ -124,7 +124,7 @@ export const normalView = /*@__PURE__*/ ( Fn( ( builder ) => {
  * @tsl
  * @type {Node<vec3>}
  */
-export const normalWorld = /*@__PURE__*/ normalView.transformDirection( cameraViewMatrix ).toVar( 'normalWorld' );
+export const normalWorld = /*@__PURE__*/ normalView.transformDirection( cameraWorldMatrix ).toVar( 'normalWorld' );
 
 /**
  * TSL object that represents the clearcoat vertex normal of the current rendered object in view space.

--- a/src/nodes/accessors/ReflectVector.js
+++ b/src/nodes/accessors/ReflectVector.js
@@ -1,4 +1,4 @@
-import { cameraViewMatrix } from './Camera.js';
+import { cameraWorldMatrix } from './Camera.js';
 import { normalView } from './Normal.js';
 import { positionViewDirection } from './Position.js';
 import { materialRefractionRatio } from './MaterialProperties.js';
@@ -25,7 +25,7 @@ export const refractView = /*@__PURE__*/ positionViewDirection.negate().refract(
  * @tsl
  * @type {Node<vec3>}
  */
-export const reflectVector = /*@__PURE__*/ reflectView.transformDirection( cameraViewMatrix ).toVar( 'reflectVector' );
+export const reflectVector = /*@__PURE__*/ reflectView.transformDirection( cameraWorldMatrix ).toVar( 'reflectVector' );
 
 /**
  * Used for sampling cube maps when using cube refraction mapping.
@@ -33,4 +33,4 @@ export const reflectVector = /*@__PURE__*/ reflectView.transformDirection( camer
  * @tsl
  * @type {Node<vec3>}
  */
-export const refractVector = /*@__PURE__*/ refractView.transformDirection( cameraViewMatrix ).toVar( 'reflectVector' );
+export const refractVector = /*@__PURE__*/ refractView.transformDirection( cameraWorldMatrix ).toVar( 'reflectVector' );

--- a/src/nodes/accessors/Tangent.js
+++ b/src/nodes/accessors/Tangent.js
@@ -1,5 +1,5 @@
 import { attribute } from '../core/AttributeNode.js';
-import { cameraViewMatrix } from './Camera.js';
+import { cameraWorldMatrix } from './Camera.js';
 import { modelViewMatrix } from './ModelNode.js';
 import { Fn, vec4 } from '../tsl/TSLBase.js';
 import { tangentViewFrame } from './TangentUtils.js';
@@ -57,4 +57,4 @@ export const tangentView = /*@__PURE__*/ ( Fn( ( builder ) => {
  * @tsl
  * @type {Node<vec3>}
  */
-export const tangentWorld = /*@__PURE__*/ tangentView.transformDirection( cameraViewMatrix ).toVarying( 'v_tangentWorld' ).normalize().toVar( 'tangentWorld' );
+export const tangentWorld = /*@__PURE__*/ tangentView.transformDirection( cameraWorldMatrix ).toVarying( 'v_tangentWorld' ).normalize().toVar( 'tangentWorld' );

--- a/src/nodes/lighting/EnvironmentNode.js
+++ b/src/nodes/lighting/EnvironmentNode.js
@@ -1,7 +1,7 @@
 import LightingNode from './LightingNode.js';
 import { isolate } from '../core/IsolateNode.js';
 import { roughness, clearcoatRoughness } from '../core/PropertyNode.js';
-import { cameraViewMatrix } from '../accessors/Camera.js';
+import { cameraWorldMatrix } from '../accessors/Camera.js';
 import { normalView, clearcoatNormalView, normalWorld } from '../accessors/Normal.js';
 import { positionViewDirection } from '../accessors/Position.js';
 import { float, pow4 } from '../tsl/TSLBase.js';
@@ -144,7 +144,7 @@ const createRadianceContext = ( roughnessNode, normalViewNode ) => {
 				// Mixing the reflection with the normal is more accurate and keeps rough objects from gathering light from behind their tangent plane.
 				reflectVec = pow4( roughnessNode ).mix( reflectVec, normalViewNode ).normalize();
 
-				reflectVec = reflectVec.transformDirection( cameraViewMatrix );
+				reflectVec = reflectVec.transformDirection( cameraWorldMatrix );
 
 			}
 

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -184,22 +184,21 @@ class MathNode extends TempNode {
 			// dir can be either a direction vector or a normal vector
 			// upper-left 3x3 of matrix is assumed to be orthogonal
 
-			let tA = aNode;
-			let tB = bNode;
+			let matrixNode, dirNode;
 
-			if ( builder.isMatrix( tA.getNodeType( builder ) ) ) {
+			if ( builder.isMatrix( aNode.getNodeType( builder ) ) ) {
 
-				tB = vec4( vec3( tB ), 0.0 );
+				matrixNode = aNode;
+				dirNode = vec4( vec3( bNode ), 0.0 );
 
 			} else {
 
-				tA = vec4( vec3( tA ), 0.0 );
+				matrixNode = bNode;
+				dirNode = vec4( vec3( aNode ), 0.0 );
 
 			}
 
-			const mulNode = mul( tA, tB ).xyz;
-
-			outputNode = normalize( mulNode );
+			outputNode = normalize( mul( matrixNode, dirNode ).xyz );
 
 		}
 


### PR DESCRIPTION
Fixed #33309.

**Description**

The PR makes sure the TSL function `transformDirection()` produces a consistent result no matter how the function is used. Meaning `matrix.transformDirection( dirVector )` or `dirVector.transformDirection( matrix )`.

To avoid breakage, it was necessary to update some TSL code that used `transformDirection()` unintentionally incorrect. Modules like `Normal.js` have to transform a view space vector into world space and used this style:

``` 
cameraViewMatrix * viewVec   (= "apply world→view transform to a vec that's already in view space")
```
Which is of course wrong. It should use camera's world matrix instead. The previous code did only work because the bug in `transformDirection()` accidentally produced the inverse of the view matrix for free. Now we are doing it correctly.