### PR TITLE
BufferAttribute setVector & setColor convenience methods

### DIFF
--- a/examples/jsm/csm/CSMHelper.js
+++ b/examples/jsm/csm/CSMHelper.js
@@ -191,15 +191,15 @@ class CSMHelper extends Group {
 
 		const nearVerts = mainFrustum.vertices.near;
 		const farVerts = mainFrustum.vertices.far;
-		frustumLinePositions.setXYZ( 0, farVerts[ 0 ].x, farVerts[ 0 ].y, farVerts[ 0 ].z );
-		frustumLinePositions.setXYZ( 1, farVerts[ 3 ].x, farVerts[ 3 ].y, farVerts[ 3 ].z );
-		frustumLinePositions.setXYZ( 2, farVerts[ 2 ].x, farVerts[ 2 ].y, farVerts[ 2 ].z );
-		frustumLinePositions.setXYZ( 3, farVerts[ 1 ].x, farVerts[ 1 ].y, farVerts[ 1 ].z );
+		frustumLinePositions.setFromVector3( 0, farVerts[ 0 ] );
+		frustumLinePositions.setFromVector3( 1, farVerts[ 3 ] );
+		frustumLinePositions.setFromVector3( 2, farVerts[ 2 ] );
+		frustumLinePositions.setFromVector3( 3, farVerts[ 1 ] );
 
-		frustumLinePositions.setXYZ( 4, nearVerts[ 0 ].x, nearVerts[ 0 ].y, nearVerts[ 0 ].z );
-		frustumLinePositions.setXYZ( 5, nearVerts[ 3 ].x, nearVerts[ 3 ].y, nearVerts[ 3 ].z );
-		frustumLinePositions.setXYZ( 6, nearVerts[ 2 ].x, nearVerts[ 2 ].y, nearVerts[ 2 ].z );
-		frustumLinePositions.setXYZ( 7, nearVerts[ 1 ].x, nearVerts[ 1 ].y, nearVerts[ 1 ].z );
+		frustumLinePositions.setFromVector3( 4, nearVerts[ 0 ] );
+		frustumLinePositions.setFromVector3( 5, nearVerts[ 3 ] );
+		frustumLinePositions.setFromVector3( 6, nearVerts[ 2 ] );
+		frustumLinePositions.setFromVector3( 7, nearVerts[ 1 ] );
 		frustumLinePositions.needsUpdate = true;
 
 	}

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -884,7 +884,7 @@ class GLTFWriter {
 
 			}
 
-			attribute.setXYZ( i, v.x, v.y, v.z );
+			attribute.setFromVector3( i, v );
 
 		}
 

--- a/examples/jsm/helpers/TextureHelper.js
+++ b/examples/jsm/helpers/TextureHelper.js
@@ -203,11 +203,7 @@ function createCubeGeometry( width, height, depth ) {
 
 		_direction.fromBufferAttribute( position, j ).normalize();
 
-		const u = _direction.x;
-		const v = _direction.y;
-		const w = _direction.z;
-
-		uvw.setXYZ( j, u, v, w );
+		uvw.setFromVector3( j, _direction );
 
 	}
 

--- a/examples/jsm/helpers/TextureHelperGPU.js
+++ b/examples/jsm/helpers/TextureHelperGPU.js
@@ -152,11 +152,7 @@ function createCubeGeometry( width, height, depth ) {
 
 		_direction.fromBufferAttribute( position, j ).normalize();
 
-		const u = _direction.x;
-		const v = _direction.y;
-		const w = _direction.z;
-
-		uvw.setXYZ( j, u, v, w );
+		uvw.setFromVector3( j, _direction );
 
 	}
 

--- a/examples/jsm/helpers/VertexNormalsHelper.js
+++ b/examples/jsm/helpers/VertexNormalsHelper.js
@@ -123,11 +123,11 @@ class VertexNormalsHelper extends LineSegments {
 
 				_v2.applyMatrix3( _normalMatrix ).normalize().multiplyScalar( this.size ).add( _v1 );
 
-				position.setXYZ( idx, _v1.x, _v1.y, _v1.z );
+				position.setFromVector3( idx, _v1 );
 
 				idx = idx + 1;
 
-				position.setXYZ( idx, _v2.x, _v2.y, _v2.z );
+				position.setFromVector3( idx, _v2 );
 
 				idx = idx + 1;
 

--- a/examples/jsm/helpers/VertexTangentsHelper.js
+++ b/examples/jsm/helpers/VertexTangentsHelper.js
@@ -103,11 +103,11 @@ class VertexTangentsHelper extends LineSegments {
 
 			_v2.transformDirection( matrixWorld ).multiplyScalar( this.size ).add( _v1 );
 
-			position.setXYZ( idx, _v1.x, _v1.y, _v1.z );
+			position.setFromVector3( idx, _v1 );
 
 			idx = idx + 1;
 
-			position.setXYZ( idx, _v2.x, _v2.y, _v2.z );
+			position.setFromVector3( idx, _v2 );
 
 			idx = idx + 1;
 

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -322,7 +322,7 @@ class DRACOLoader extends Loader {
 
 			_color.fromBufferAttribute( attribute, i );
 			ColorManagement.colorSpaceToWorking( _color, SRGBColorSpace );
-			attribute.setXYZ( i, _color.r, _color.g, _color.b );
+			attribute.setFromColor( i, _color );
 
 		}
 

--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -3220,7 +3220,7 @@ class VRMLLoader extends Loader {
 
 				ColorManagement.colorSpaceToWorking( color, SRGBColorSpace );
 
-				attribute.setXYZ( i, color.r, color.g, color.b );
+				attribute.setFromColor( i, color );
 
 			}
 
@@ -3327,7 +3327,7 @@ class VRMLLoader extends Loader {
 
 				ColorManagement.colorSpaceToWorking( color, SRGBColorSpace );
 
-				colorAttribute.setXYZ( index, color.r, color.g, color.b );
+				colorAttribute.setFromColor( index, color );
 
 			}
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -1406,7 +1406,7 @@ function toCreasedNormals( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ 
 			}
 
 			tempNorm2.normalize();
-			normAttr.setXYZ( i3 + n, tempNorm2.x, tempNorm2.y, tempNorm2.z );
+			normAttr.setFromVector3( i3 + n, tempNorm2 );
 
 		}
 

--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -200,7 +200,7 @@
 					vertex.y += Math.random() * 2;
 					vertex.z += Math.random() * 20 - 10;
 
-					position.setXYZ( i, vertex.x, vertex.y, vertex.z );
+					position.setFromVector3( i, vertex );
 
 				}
 

--- a/examples/webgl_decals.html
+++ b/examples/webgl_decals.html
@@ -198,8 +198,8 @@
 						mouseHelper.lookAt( n );
 
 						const positions = line.geometry.attributes.position;
-						positions.setXYZ( 0, p.x, p.y, p.z );
-						positions.setXYZ( 1, n.x, n.y, n.z );
+						positions.setFromVector3( 0, p );
+						positions.setFromVector3( 1, n );
 						positions.needsUpdate = true;
 
 						intersection.intersects = true;

--- a/examples/webgl_geometry_colors.html
+++ b/examples/webgl_geometry_colors.html
@@ -120,13 +120,13 @@
 				for ( let i = 0; i < count; i ++ ) {
 
 					color.setHSL( ( positions1.getY( i ) / radius + 1 ) / 2, 1.0, 0.5, THREE.SRGBColorSpace );
-					colors1.setXYZ( i, color.r, color.g, color.b );
+					colors1.setFromColor( i, color );
 
 					color.setHSL( 0, ( positions2.getY( i ) / radius + 1 ) / 2, 0.5, THREE.SRGBColorSpace );
-					colors2.setXYZ( i, color.r, color.g, color.b );
+					colors2.setFromColor( i, color );
 
 					color.setRGB( 1, 0.8 - ( positions3.getY( i ) / radius + 1 ) / 2, 0, THREE.SRGBColorSpace );
-					colors3.setXYZ( i, color.r, color.g, color.b );
+					colors3.setFromColor( i, color );
 
 				}
 

--- a/examples/webgl_geometry_colors_lookuptable.html
+++ b/examples/webgl_geometry_colors_lookuptable.html
@@ -185,7 +185,7 @@
 
 					color.copy( lut.getColor( colorValue ) ).convertSRGBToLinear();
 
-					colors.setXYZ( i, color.r, color.g, color.b );
+					colors.setFromColor( i, color );
 
 				}
 

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -293,7 +293,7 @@
 
 						const t = i / ( ARC_SEGMENTS - 1 );
 						spline.getPoint( t, point );
-						position.setXYZ( i, point.x, point.y, point.z );
+						position.setFromVector3( i, point );
 
 					}
 

--- a/examples/webgl_multiple_views.html
+++ b/examples/webgl_multiple_views.html
@@ -169,13 +169,13 @@
 				for ( let i = 0; i < count; i ++ ) {
 
 					color.setHSL( ( positions1.getY( i ) / radius + 1 ) / 2, 1.0, 0.5, THREE.SRGBColorSpace );
-					colors1.setXYZ( i, color.r, color.g, color.b );
+					colors1.setFromColor( i, color );
 
 					color.setHSL( 0, ( positions2.getY( i ) / radius + 1 ) / 2, 0.5, THREE.SRGBColorSpace );
-					colors2.setXYZ( i, color.r, color.g, color.b );
+					colors2.setFromColor( i, color );
 
 					color.setRGB( 1, 0.8 - ( positions3.getY( i ) / radius + 1 ) / 2, 0, THREE.SRGBColorSpace );
-					colors3.setXYZ( i, color.r, color.g, color.b );
+					colors3.setFromColor( i, color );
 
 				}
 

--- a/examples/webgl_raycaster_bvh.html
+++ b/examples/webgl_raycaster_bvh.html
@@ -234,13 +234,13 @@
 						_matrix.compose( point, _quaternion, _scale );
 						sphereInstance.setMatrixAt( i * 2 + 1, _matrix );
 
-						lineSegments.geometry.attributes.position.setXYZ( lineNum ++, _position.x, _position.y, _position.z );
-						lineSegments.geometry.attributes.position.setXYZ( lineNum ++, point.x, point.y, point.z );
+						lineSegments.geometry.attributes.position.setFromVector3( lineNum ++, _position );
+						lineSegments.geometry.attributes.position.setFromVector3( lineNum ++, point );
 
 					} else {
 
 						sphereInstance.setMatrixAt( i * 2 + 1, _matrix );
-						lineSegments.geometry.attributes.position.setXYZ( lineNum ++, _position.x, _position.y, _position.z );
+						lineSegments.geometry.attributes.position.setFromVector3( lineNum ++, _position );
 						lineSegments.geometry.attributes.position.setXYZ( lineNum ++, 0, 0, 0 );
 
 					}

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -269,7 +269,7 @@ class BufferAttribute extends EventDispatcher {
 				_vector2.fromBufferAttribute( this, i );
 				_vector2.applyMatrix3( m );
 
-				this.setXY( i, _vector2.x, _vector2.y );
+				this.setFromVector2( i, _vector2 );
 
 			}
 
@@ -280,7 +280,7 @@ class BufferAttribute extends EventDispatcher {
 				_vector.fromBufferAttribute( this, i );
 				_vector.applyMatrix3( m );
 
-				this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+				this.setFromVector3( i, _vector );
 
 			}
 
@@ -305,7 +305,7 @@ class BufferAttribute extends EventDispatcher {
 
 			_vector.applyMatrix4( m );
 
-			this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+			this.setFromVector3( i, _vector );
 
 		}
 
@@ -328,7 +328,7 @@ class BufferAttribute extends EventDispatcher {
 
 			_vector.applyNormalMatrix( m );
 
-			this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+			this.setFromVector3( i, _vector );
 
 		}
 
@@ -351,7 +351,7 @@ class BufferAttribute extends EventDispatcher {
 
 			_vector.transformDirection( m );
 
-			this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+			this.setFromVector3( i, _vector );
 
 		}
 
@@ -626,6 +626,58 @@ class BufferAttribute extends EventDispatcher {
 		this.array[ index + 3 ] = w;
 
 		return this;
+
+	}
+
+	/**
+	 * Sets the x and y component of the vector at the given index based on the values of the given vector.
+	 *
+	 * @param {number} index - The index into the buffer attribute.
+	 * @param {Vector2} vector - The vector to set.
+	 * @return {BufferAttribute} A reference to this instance.
+	 */
+	setFromVector2( index, vector ) {
+
+		return this.setXY( index, vector.x, vector.y );
+
+	}
+
+	/**
+	 * Sets the x, y and z component of the vector at the given index based on the values of the given vector.
+	 *
+	 * @param {number} index - The index into the buffer attribute.
+	 * @param {Vector3} vector - The vector to set.
+	 * @return {BufferAttribute} A reference to this instance.
+	 */
+	setFromVector3( index, vector ) {
+
+		return this.setXYZ( index, vector.x, vector.y, vector.z );
+
+	}
+
+	/**
+	 * Sets the x, y, z and w component of the vector at the given index based on the values of the given vector.
+	 *
+	 * @param {number} index - The index into the buffer attribute.
+	 * @param {Vector4} vector - The vector to set.
+	 * @return {BufferAttribute} A reference to this instance.
+	 */
+	setFromVector4( index, vector ) {
+
+		return this.setXYZW( index, vector.x, vector.y, vector.z, vector.w );
+
+	}
+
+	/**
+	 * Sets the x, y and z component of the vector at the given index based on the r, g and b values of the given color.
+	 *
+	 * @param {number} index - The index into the buffer attribute.
+	 * @param {Color} color - The color to set.
+	 * @return {BufferAttribute} A reference to this instance.
+	 */
+	setFromColor( index, color ) {
+
+		return this.setXYZ( index, color.r, color.g, color.b );
 
 	}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1040,9 +1040,9 @@ class BufferGeometry extends EventDispatcher {
 					nB.add( cb );
 					nC.add( cb );
 
-					normalAttribute.setXYZ( vA, nA.x, nA.y, nA.z );
-					normalAttribute.setXYZ( vB, nB.x, nB.y, nB.z );
-					normalAttribute.setXYZ( vC, nC.x, nC.y, nC.z );
+					normalAttribute.setFromVector3( vA, nA );
+					normalAttribute.setFromVector3( vB, nB );
+					normalAttribute.setFromVector3( vC, nC );
 
 				}
 
@@ -1060,9 +1060,9 @@ class BufferGeometry extends EventDispatcher {
 					ab.subVectors( pA, pB );
 					cb.cross( ab );
 
-					normalAttribute.setXYZ( i + 0, cb.x, cb.y, cb.z );
-					normalAttribute.setXYZ( i + 1, cb.x, cb.y, cb.z );
-					normalAttribute.setXYZ( i + 2, cb.x, cb.y, cb.z );
+					normalAttribute.setFromVector3( i + 0, cb );
+					normalAttribute.setFromVector3( i + 1, cb );
+					normalAttribute.setFromVector3( i + 2, cb );
 
 				}
 
@@ -1090,7 +1090,7 @@ class BufferGeometry extends EventDispatcher {
 
 			_vector.normalize();
 
-			normals.setXYZ( i, _vector.x, _vector.y, _vector.z );
+			normals.setFromVector3( i, _vector );
 
 		}
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -120,7 +120,7 @@ class InterleavedBufferAttribute {
 
 			_vector.applyMatrix4( m );
 
-			this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+			this.setFromVector3( i, _vector );
 
 		}
 
@@ -143,7 +143,7 @@ class InterleavedBufferAttribute {
 
 			_vector.applyNormalMatrix( m );
 
-			this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+			this.setFromVector3( i, _vector );
 
 		}
 
@@ -166,7 +166,7 @@ class InterleavedBufferAttribute {
 
 			_vector.transformDirection( m );
 
-			this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+			this.setFromVector3( i, _vector );
 
 		}
 
@@ -425,6 +425,58 @@ class InterleavedBufferAttribute {
 		this.data.array[ index + 3 ] = w;
 
 		return this;
+
+	}
+
+	/**
+	 * Sets the x and y component of the vector at the given index based on the values of the given vector.
+	 *
+	 * @param {number} index - The index into the buffer attribute.
+	 * @param {Vector2} vector - The vector to set.
+	 * @return {InterleavedBufferAttribute} A reference to this instance.
+	 */
+	setFromVector2( index, vector ) {
+
+		return this.setXY( index, vector.x, vector.y );
+
+	}
+
+	/**
+	 * Sets the x, y and z component of the vector at the given index based on the values of the given vector.
+	 *
+	 * @param {number} index - The index into the buffer attribute.
+	 * @param {Vector3} vector - The vector to set.
+	 * @return {InterleavedBufferAttribute} A reference to this instance.
+	 */
+	setFromVector3( index, vector ) {
+
+		return this.setXYZ( index, vector.x, vector.y, vector.z );
+
+	}
+
+	/**
+	 * Sets the x, y, z and w component of the vector at the given index based on the values of the given vector.
+	 *
+	 * @param {number} index - The index into the buffer attribute.
+	 * @param {Vector4} vector - The vector to set.
+	 * @return {InterleavedBufferAttribute} A reference to this instance.
+	 */
+	setFromVector4( index, vector ) {
+
+		return this.setXYZW( index, vector.x, vector.y, vector.z, vector.w );
+
+	}
+
+	/**
+	 * Sets the x, y and z component of the vector at the given index based on the r, g and b values of the given color.
+	 *
+	 * @param {number} index - The index into the buffer attribute.
+	 * @param {Color} color - The color to set.
+	 * @return {InterleavedBufferAttribute} A reference to this instance.
+	 */
+	setFromColor( index, color ) {
+
+		return this.setXYZ( index, color.r, color.g, color.b );
 
 	}
 

--- a/src/helpers/CameraHelper.js
+++ b/src/helpers/CameraHelper.js
@@ -172,50 +172,50 @@ class CameraHelper extends LineSegments {
 
 		// near
 
-		colorAttribute.setXYZ( 0, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 1, frustum.r, frustum.g, frustum.b ); // n1, n2
-		colorAttribute.setXYZ( 2, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 3, frustum.r, frustum.g, frustum.b ); // n2, n4
-		colorAttribute.setXYZ( 4, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 5, frustum.r, frustum.g, frustum.b ); // n4, n3
-		colorAttribute.setXYZ( 6, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 7, frustum.r, frustum.g, frustum.b ); // n3, n1
+		colorAttribute.setFromColor( 0, frustum ); colorAttribute.setFromColor( 1, frustum ); // n1, n2
+		colorAttribute.setFromColor( 2, frustum ); colorAttribute.setFromColor( 3, frustum ); // n2, n4
+		colorAttribute.setFromColor( 4, frustum ); colorAttribute.setFromColor( 5, frustum ); // n4, n3
+		colorAttribute.setFromColor( 6, frustum ); colorAttribute.setFromColor( 7, frustum ); // n3, n1
 
 		// far
 
-		colorAttribute.setXYZ( 8, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 9, frustum.r, frustum.g, frustum.b ); // f1, f2
-		colorAttribute.setXYZ( 10, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 11, frustum.r, frustum.g, frustum.b ); // f2, f4
-		colorAttribute.setXYZ( 12, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 13, frustum.r, frustum.g, frustum.b ); // f4, f3
-		colorAttribute.setXYZ( 14, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 15, frustum.r, frustum.g, frustum.b ); // f3, f1
+		colorAttribute.setFromColor( 8, frustum ); colorAttribute.setFromColor( 9, frustum ); // f1, f2
+		colorAttribute.setFromColor( 10, frustum ); colorAttribute.setFromColor( 11, frustum ); // f2, f4
+		colorAttribute.setFromColor( 12, frustum ); colorAttribute.setFromColor( 13, frustum ); // f4, f3
+		colorAttribute.setFromColor( 14, frustum ); colorAttribute.setFromColor( 15, frustum ); // f3, f1
 
 		// sides
 
-		colorAttribute.setXYZ( 16, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 17, frustum.r, frustum.g, frustum.b ); // n1, f1
-		colorAttribute.setXYZ( 18, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 19, frustum.r, frustum.g, frustum.b ); // n2, f2
-		colorAttribute.setXYZ( 20, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 21, frustum.r, frustum.g, frustum.b ); // n3, f3
-		colorAttribute.setXYZ( 22, frustum.r, frustum.g, frustum.b ); colorAttribute.setXYZ( 23, frustum.r, frustum.g, frustum.b ); // n4, f4
+		colorAttribute.setFromColor( 16, frustum ); colorAttribute.setFromColor( 17, frustum ); // n1, f1
+		colorAttribute.setFromColor( 18, frustum ); colorAttribute.setFromColor( 19, frustum ); // n2, f2
+		colorAttribute.setFromColor( 20, frustum ); colorAttribute.setFromColor( 21, frustum ); // n3, f3
+		colorAttribute.setFromColor( 22, frustum ); colorAttribute.setFromColor( 23, frustum ); // n4, f4
 
 		// cone
 
-		colorAttribute.setXYZ( 24, cone.r, cone.g, cone.b ); colorAttribute.setXYZ( 25, cone.r, cone.g, cone.b ); // p, n1
-		colorAttribute.setXYZ( 26, cone.r, cone.g, cone.b ); colorAttribute.setXYZ( 27, cone.r, cone.g, cone.b ); // p, n2
-		colorAttribute.setXYZ( 28, cone.r, cone.g, cone.b ); colorAttribute.setXYZ( 29, cone.r, cone.g, cone.b ); // p, n3
-		colorAttribute.setXYZ( 30, cone.r, cone.g, cone.b ); colorAttribute.setXYZ( 31, cone.r, cone.g, cone.b ); // p, n4
+		colorAttribute.setFromColor( 24, cone ); colorAttribute.setFromColor( 25, cone ); // p, n1
+		colorAttribute.setFromColor( 26, cone ); colorAttribute.setFromColor( 27, cone ); // p, n2
+		colorAttribute.setFromColor( 28, cone ); colorAttribute.setFromColor( 29, cone ); // p, n3
+		colorAttribute.setFromColor( 30, cone ); colorAttribute.setFromColor( 31, cone ); // p, n4
 
 		// up
 
-		colorAttribute.setXYZ( 32, up.r, up.g, up.b ); colorAttribute.setXYZ( 33, up.r, up.g, up.b ); // u1, u2
-		colorAttribute.setXYZ( 34, up.r, up.g, up.b ); colorAttribute.setXYZ( 35, up.r, up.g, up.b ); // u2, u3
-		colorAttribute.setXYZ( 36, up.r, up.g, up.b ); colorAttribute.setXYZ( 37, up.r, up.g, up.b ); // u3, u1
+		colorAttribute.setFromColor( 32, up ); colorAttribute.setFromColor( 33, up ); // u1, u2
+		colorAttribute.setFromColor( 34, up ); colorAttribute.setFromColor( 35, up ); // u2, u3
+		colorAttribute.setFromColor( 36, up ); colorAttribute.setFromColor( 37, up ); // u3, u1
 
 		// target
 
-		colorAttribute.setXYZ( 38, target.r, target.g, target.b ); colorAttribute.setXYZ( 39, target.r, target.g, target.b ); // c, t
-		colorAttribute.setXYZ( 40, cross.r, cross.g, cross.b ); colorAttribute.setXYZ( 41, cross.r, cross.g, cross.b ); // p, c
+		colorAttribute.setFromColor( 38, target ); colorAttribute.setFromColor( 39, target ); // c, t
+		colorAttribute.setFromColor( 40, cross ); colorAttribute.setFromColor( 41, cross ); // p, c
 
 		// cross
 
-		colorAttribute.setXYZ( 42, cross.r, cross.g, cross.b ); colorAttribute.setXYZ( 43, cross.r, cross.g, cross.b ); // cn1, cn2
-		colorAttribute.setXYZ( 44, cross.r, cross.g, cross.b ); colorAttribute.setXYZ( 45, cross.r, cross.g, cross.b ); // cn3, cn4
+		colorAttribute.setFromColor( 42, cross ); colorAttribute.setFromColor( 43, cross ); // cn1, cn2
+		colorAttribute.setFromColor( 44, cross ); colorAttribute.setFromColor( 45, cross ); // cn3, cn4
 
-		colorAttribute.setXYZ( 46, cross.r, cross.g, cross.b ); colorAttribute.setXYZ( 47, cross.r, cross.g, cross.b ); // cf1, cf2
-		colorAttribute.setXYZ( 48, cross.r, cross.g, cross.b ); colorAttribute.setXYZ( 49, cross.r, cross.g, cross.b ); // cf3, cf4
+		colorAttribute.setFromColor( 46, cross ); colorAttribute.setFromColor( 47, cross ); // cf1, cf2
+		colorAttribute.setFromColor( 48, cross ); colorAttribute.setFromColor( 49, cross ); // cf3, cf4
 
 		colorAttribute.needsUpdate = true;
 
@@ -334,7 +334,7 @@ function setPoint( point, pointMap, geometry, camera, x, y, z ) {
 
 		for ( let i = 0, l = points.length; i < l; i ++ ) {
 
-			position.setXYZ( points[ i ], _vector.x, _vector.y, _vector.z );
+			position.setFromVector3( points[ i ], _vector );
 
 		}
 

--- a/src/helpers/HemisphereLightHelper.js
+++ b/src/helpers/HemisphereLightHelper.js
@@ -110,7 +110,7 @@ class HemisphereLightHelper extends Object3D {
 
 				const color = ( i < ( l / 2 ) ) ? _color1 : _color2;
 
-				colors.setXYZ( i, color.r, color.g, color.b );
+				colors.setFromColor( i, color );
 
 			}
 

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -113,11 +113,11 @@ class SkeletonHelper extends LineSegments {
 
 				_boneMatrix.multiplyMatrices( _matrixWorldInv, bone.matrixWorld );
 				_vector.setFromMatrixPosition( _boneMatrix );
-				position.setXYZ( j, _vector.x, _vector.y, _vector.z );
+				position.setFromVector3( j, _vector );
 
 				_boneMatrix.multiplyMatrices( _matrixWorldInv, bone.parent.matrixWorld );
 				_vector.setFromMatrixPosition( _boneMatrix );
-				position.setXYZ( j + 1, _vector.x, _vector.y, _vector.z );
+				position.setFromVector3( j + 1, _vector );
 
 				j += 2;
 
@@ -145,8 +145,8 @@ class SkeletonHelper extends LineSegments {
 
 		for ( let i = 0; i < colorAttribute.count; i += 2 ) {
 
-			colorAttribute.setXYZ( i, color1.r, color1.g, color1.b );
-			colorAttribute.setXYZ( i + 1, color2.r, color2.g, color2.b );
+			colorAttribute.setFromColor( i, color1 );
+			colorAttribute.setFromColor( i + 1, color2 );
 
 		}
 

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -281,7 +281,7 @@ class SkinnedMesh extends Mesh {
 
 			}
 
-			skinWeight.setXYZW( i, vector.x, vector.y, vector.z, vector.w );
+			skinWeight.setFromVector4( i, vector );
 
 		}
 

--- a/test/unit/src/core/BufferAttribute.tests.js
+++ b/test/unit/src/core/BufferAttribute.tests.js
@@ -13,6 +13,10 @@ import {
 
 import { DynamicDrawUsage } from '../../../../src/constants.js';
 import { toHalfFloat, fromHalfFloat } from '../../../../src/extras/DataUtils.js';
+import { Vector2 } from '../../../../src/math/Vector2.js';
+import { Vector3 } from '../../../../src/math/Vector3.js';
+import { Vector4 } from '../../../../src/math/Vector4.js';
+import { Color } from '../../../../src/math/Color.js';
 
 export default QUnit.module( 'Core', () => {
 
@@ -157,6 +161,54 @@ export default QUnit.module( 'Core', () => {
 			const expected = new Float32Array( [ - 1, - 2, - 3, - 4 ] );
 
 			a.setXYZW( 0, - 1, - 2, - 3, - 4 );
+
+			assert.deepEqual( a.array, expected, 'Check for the correct values' );
+
+		} );
+
+		QUnit.test( 'setFromVector2', ( assert ) => {
+
+			const f32a = new Float32Array( [ 1, 2, 3, 4 ] );
+			const a = new BufferAttribute( f32a, 2, false );
+			const expected = new Float32Array( [ - 1, - 2, 3, 4 ] );
+
+			a.setFromVector2( 0, new Vector2( - 1, - 2 ) );
+
+			assert.deepEqual( a.array, expected, 'Check for the correct values' );
+
+		} );
+
+		QUnit.test( 'setFromVector3', ( assert ) => {
+
+			const f32a = new Float32Array( [ 1, 2, 3, 4, 5, 6 ] );
+			const a = new BufferAttribute( f32a, 3, false );
+			const expected = new Float32Array( [ 1, 2, 3, - 4, - 5, - 6 ] );
+
+			a.setFromVector3( 1, new Vector3( - 4, - 5, - 6 ) );
+
+			assert.deepEqual( a.array, expected, 'Check for the correct values' );
+
+		} );
+
+		QUnit.test( 'setFromVector4', ( assert ) => {
+
+			const f32a = new Float32Array( [ 1, 2, 3, 4 ] );
+			const a = new BufferAttribute( f32a, 4, false );
+			const expected = new Float32Array( [ - 1, - 2, - 3, - 4 ] );
+
+			a.setFromVector4( 0, new Vector4( - 1, - 2, - 3, - 4 ) );
+
+			assert.deepEqual( a.array, expected, 'Check for the correct values' );
+
+		} );
+
+		QUnit.test( 'setFromColor', ( assert ) => {
+
+			const f32a = new Float32Array( [ 1, 2, 3, 4, 5, 6 ] );
+			const a = new BufferAttribute( f32a, 3, false );
+			const expected = new Float32Array( [ 1, 2, 3, - 4, - 5, - 6 ] );
+
+			a.setFromColor( 1, new Color( - 4, - 5, - 6 ) );
 
 			assert.deepEqual( a.array, expected, 'Check for the correct values' );
 
@@ -478,6 +530,54 @@ export default QUnit.module( 'Core', () => {
 			const expected = new Float32Array( [ - 1, - 2, - 3, - 4 ] );
 
 			a.setXYZW( 0, - 1, - 2, - 3, - 4 );
+
+			assert.deepEqual( fromHalfFloatArray( a.array ), expected, 'Check for the correct values' );
+
+		} );
+
+		QUnit.test( 'setFromVector2', ( assert ) => {
+
+			const f32a = new Float32Array( [ 1, 2, 3, 4 ] );
+			const a = new Float16BufferAttribute( toHalfFloatArray( f32a ), 2, false );
+			const expected = new Float32Array( [ - 1, - 2, 3, 4 ] );
+
+			a.setFromVector2( 0, new Vector2( - 1, - 2 ) );
+
+			assert.deepEqual( fromHalfFloatArray( a.array ), expected, 'Check for the correct values' );
+
+		} );
+
+		QUnit.test( 'setFromVector3', ( assert ) => {
+
+			const f32a = new Float32Array( [ 1, 2, 3, 4, 5, 6 ] );
+			const a = new Float16BufferAttribute( toHalfFloatArray( f32a ), 3, false );
+			const expected = new Float32Array( [ 1, 2, 3, - 4, - 5, - 6 ] );
+
+			a.setFromVector3( 1, new Vector3( - 4, - 5, - 6 ) );
+
+			assert.deepEqual( fromHalfFloatArray( a.array ), expected, 'Check for the correct values' );
+
+		} );
+
+		QUnit.test( 'setFromVector4', ( assert ) => {
+
+			const f32a = new Float32Array( [ 1, 2, 3, 4 ] );
+			const a = new Float16BufferAttribute( toHalfFloatArray( f32a ), 4, false );
+			const expected = new Float32Array( [ - 1, - 2, - 3, - 4 ] );
+
+			a.setFromVector4( 0, new Vector4( - 1, - 2, - 3, - 4 ) );
+
+			assert.deepEqual( fromHalfFloatArray( a.array ), expected, 'Check for the correct values' );
+
+		} );
+
+		QUnit.test( 'setFromColor', ( assert ) => {
+
+			const f32a = new Float32Array( [ 1, 2, 3, 4, 5, 6 ] );
+			const a = new Float16BufferAttribute( toHalfFloatArray( f32a ), 3, false );
+			const expected = new Float32Array( [ 1, 2, 3, - 4, - 5, - 6 ] );
+
+			a.setFromColor( 1, new Color( - 4, - 5, - 6 ) );
 
 			assert.deepEqual( fromHalfFloatArray( a.array ), expected, 'Check for the correct values' );
 


### PR DESCRIPTION
**Description**

This PR adds new convenience methods to `BufferAttribute` & `InterleavedBufferAttribute`.

* `setVector2()`
* `setVector3()`
* `setVector4()`
* `setColor()`

These helps simplify setting vectors and colors which seem to be a quite common pattern as most instances of `setXYZ` are possible to change into these new convenience methods.

Before:
```
const v = new THREE.Vector3(1, 2, 3);
attribute.setXYZ(0, v.x, v.y, v.z);

const c = new THREE.Color(0.1, 0.2, 0.3);
attribute.setXYZ(1, c.r, c.g, c.b);
```

After:
```
const v = new THREE.Vector3(1, 2, 3);
attribute.setVector3(0, v);

const c = new THREE.Color(0.1, 0.2, 0.3);
attribute.setColor(1, c);
```

**Advantages**

* Shorter code
* Helps prevent hard to spot mistakes. For example: `attribute.setXYZ(0, v.x, v.x, v.z);`

**Discussion points**

* Other possible names are `setXYZFromVector3` and `setXYZFromColorRGB`. Would these names be preferred to make it clearer that these are convenience methods for `setXYZ`?
* Right now these methods simply call their respective `setXYZ` methods. The extra function call might introduce a small performance overhead. 