### PR TITLE
TRAANode: Add support for reversed/logarithmic depth buffers and orthograhic cameras

### DIFF
--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -496,7 +496,7 @@ class TRAANode extends TempNode {
 		} );
 
 		// Samples 3×3 neighborhood pixels and returns the closest and farthest depths.
-		const sampleCurrentDepth = Fn( ( [ positionTexel ], builder ) => {
+		const sampleCurrentDepth = Fn( ( [ positionTexel ] ) => {
 
 			const closestDepth = float( 2 ).toVar();
 			const closestPositionTexel = vec2( 0 ).toVar();

--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -1,5 +1,5 @@
 import { HalfFloatType, Vector2, RenderTarget, RendererUtils, QuadMesh, NodeMaterial, TempNode, NodeUpdateType, Matrix4, DepthTexture, FloatType } from 'three/webgpu';
-import { add, float, If, Fn, max, texture, uniform, uv, vec2, vec4, luminance, convertToTexture, passTexture, velocity, getViewPosition, viewZToPerspectiveDepth, struct, ivec2, mix } from 'three/tsl';
+import { add, float, If, Fn, max, texture, uniform, uv, vec2, vec4, luminance, convertToTexture, passTexture, velocity, getViewPosition, viewZToPerspectiveDepth, struct, ivec2, mix, logarithmicDepthToViewZ } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -481,11 +481,9 @@ class TRAANode extends TempNode {
 
 		const logarithmicToPerspectiveDepth = ( depth ) => {
 
-			// r = (far / near) ^ depth
-			// far * (r - 1) / (r * (far - near))
 			const { x: near, y: far } = this._cameraNearFar;
-			const r = far.div( near ).pow( depth );
-			return far.mul( r.sub( 1 ) ).div( r.mul( far.sub( near ) ) );
+			const viewZ = logarithmicDepthToViewZ( depth, near, far );
+			return viewZToPerspectiveDepth( viewZ, near, far );
 
 		};
 

--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -1,4 +1,4 @@
-import { HalfFloatType, Vector2, RenderTarget, RendererUtils, QuadMesh, NodeMaterial, TempNode, NodeUpdateType, Matrix4, DepthTexture } from 'three/webgpu';
+import { HalfFloatType, Vector2, RenderTarget, RendererUtils, QuadMesh, NodeMaterial, TempNode, NodeUpdateType, Matrix4, DepthTexture, FloatType } from 'three/webgpu';
 import { add, float, If, Fn, max, texture, uniform, uv, vec2, vec4, luminance, convertToTexture, passTexture, velocity, getViewPosition, viewZToPerspectiveDepth, struct, ivec2, mix } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
@@ -463,6 +463,12 @@ class TRAANode extends TempNode {
 
 		}
 
+		if ( builder.renderer.reversedDepthBuffer === true ) {
+
+			this._historyRenderTarget.depthTexture.type = FloatType;
+
+		}
+
 		if ( builder.context.velocity !== undefined ) {
 
 			this._velocityNode = builder.context.velocity;
@@ -473,6 +479,16 @@ class TRAANode extends TempNode {
 
 		}
 
+		const logarithmicToPerspectiveDepth = ( depth ) => {
+
+			// r = (far / near) ^ depth
+			// far * (r - 1) / (r * (far - near))
+			const { x: near, y: far } = this._cameraNearFar;
+			const r = far.div( near ).pow( depth );
+			return far.mul( r.sub( 1 ) ).div( r.mul( far.sub( near ) ) );
+
+		};
+
 		const currentDepthStruct = struct( {
 
 			closestDepth: 'float',
@@ -482,7 +498,7 @@ class TRAANode extends TempNode {
 		} );
 
 		// Samples 3×3 neighborhood pixels and returns the closest and farthest depths.
-		const sampleCurrentDepth = Fn( ( [ positionTexel ] ) => {
+		const sampleCurrentDepth = Fn( ( [ positionTexel ], builder ) => {
 
 			const closestDepth = float( 2 ).toVar();
 			const closestPositionTexel = vec2( 0 ).toVar();
@@ -493,7 +509,10 @@ class TRAANode extends TempNode {
 				for ( let y = - 1; y <= 1; ++ y ) {
 
 					const neighbor = positionTexel.add( vec2( x, y ) ).toVar();
-					const depth = this.depthNode.load( neighbor ).r.toVar();
+					let depth = this.depthNode.load( neighbor ).r;
+					if ( builder.renderer.reversedDepthBuffer ) depth = depth.oneMinus();
+					if ( builder.renderer.logarithmicDepthBuffer ) depth = logarithmicToPerspectiveDepth( depth );
+					depth = depth.toVar();
 
 					If( depth.lessThan( closestDepth ), () => {
 
@@ -519,7 +538,8 @@ class TRAANode extends TempNode {
 		// Samples a previous depth and reproject it using the current camera matrices.
 		const samplePreviousDepth = ( uv ) => {
 
-			const depth = this._previousDepthNode.sample( uv ).r;
+			let depth = this._previousDepthNode.sample( uv ).r;
+			if ( builder.renderer.logarithmicDepthBuffer ) depth = logarithmicToPerspectiveDepth( depth );
 			const positionView = getViewPosition( uv, depth, this._previousCameraProjectionMatrixInverse );
 			const positionWorld = this._previousCameraWorldMatrix.mul( vec4( positionView, 1 ) ).xyz;
 			const viewZ = this._cameraWorldMatrixInverse.mul( vec4( positionWorld, 1 ) ).z;

--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -1,5 +1,5 @@
 import { HalfFloatType, Vector2, RenderTarget, RendererUtils, QuadMesh, NodeMaterial, TempNode, NodeUpdateType, Matrix4, DepthTexture, FloatType } from 'three/webgpu';
-import { add, float, If, Fn, max, texture, uniform, uv, vec2, vec4, luminance, convertToTexture, passTexture, velocity, getViewPosition, viewZToPerspectiveDepth, struct, ivec2, mix, logarithmicDepthToViewZ } from 'three/tsl';
+import { add, float, If, Fn, max, texture, uniform, uv, vec2, vec4, luminance, convertToTexture, passTexture, velocity, getViewPosition, viewZToPerspectiveDepth, struct, ivec2, mix, logarithmicDepthToViewZ, viewZToOrthographicDepth } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -541,7 +541,9 @@ class TRAANode extends TempNode {
 			const positionView = getViewPosition( uv, depth, this._previousCameraProjectionMatrixInverse );
 			const positionWorld = this._previousCameraWorldMatrix.mul( vec4( positionView, 1 ) ).xyz;
 			const viewZ = this._cameraWorldMatrixInverse.mul( vec4( positionWorld, 1 ) ).z;
-			return viewZToPerspectiveDepth( viewZ, this._cameraNearFar.x, this._cameraNearFar.y );
+			return this.camera.isOrthographicCamera
+				? viewZToOrthographicDepth( viewZ, this._cameraNearFar.x, this._cameraNearFar.y )
+				: viewZToPerspectiveDepth( viewZ, this._cameraNearFar.x, this._cameraNearFar.y );
 
 		};
 


### PR DESCRIPTION
**Description**

This PR adds support for reversed depth buffer and logarithmic depth buffer, as well as orthographic cameras in TRAANode.

For simplicity, both depth types are first converted to perspective depth and pass through the same code path.