### PR TITLE
WebGPUTextureUtils: Fix `copyTextureToBuffer()` dispose buffer

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -692,7 +692,9 @@ class WebGPUTextureUtils {
 
 		await readBuffer.mapAsync( GPUMapMode.READ );
 
-		const buffer = readBuffer.getMappedRange();
+		const buffer = readBuffer.getMappedRange().slice();
+
+		readBuffer.destroy();
 
 		return new typedArrayType( buffer );
 


### PR DESCRIPTION
Related issue: N/A

**Description**

Fixed a memory leak by destroying the buffer after use.
