### PR TITLE
Backend: Introduce `createUniformBuffer()`

### DIFF
--- a/examples/jsm/inspector/tabs/Timeline.js
+++ b/examples/jsm/inspector/tabs/Timeline.js
@@ -1044,11 +1044,29 @@ class Timeline extends Tab {
 			case 'updateBindings': {
 
 				const bindGroup = args[ 0 ];
-				const details = { group: bindGroup.name || 'unknown' };
 
-				if ( bindGroup.bindings ) {
+				const details = {
+					group: bindGroup.name || 'unknown',
+					count: bindGroup.bindings.length
+				};
 
-					details.count = bindGroup.bindings.length;
+				return details;
+
+			}
+
+			case 'createUniformBuffer':
+			case 'destroyUniformBuffer': {
+
+				const binding = args[ 0 ];
+
+				const details = {
+					group: binding.groupNode.name || 'unknown',
+					size: binding.byteLength + ' bytes'
+				};
+
+				if ( binding.name !== details.group ) {
+
+					details.name = binding.name;
 
 				}
 

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -393,17 +393,17 @@ class Backend {
 	 * Creates a uniform buffer.
 	 *
 	 * @abstract
-	 * @param {Buffer} binding - The buffer binding.
+	 * @param {Buffer} uniformBuffer - The uniform buffer.
 	 */
-	createUniformBuffer( /*binding*/ ) { }
+	createUniformBuffer( /*uniformBuffer*/ ) { }
 
 	/**
 	 * Destroys a uniform buffer.
 	 *
 	 * @abstract
-	 * @param {Buffer} binding - The buffer binding.
+	 * @param {Buffer} uniformBuffer - The uniform buffer.
 	 */
-	destroyUniformBuffer( /*binding*/ ) { }
+	destroyUniformBuffer( /*uniformBuffer*/ ) { }
 
 	/**
 	 * Updates the GPU buffer of a shader attribute.

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -398,6 +398,14 @@ class Backend {
 	createUniformBuffer( /*binding*/ ) { }
 
 	/**
+	 * Destroys a uniform buffer.
+	 *
+	 * @abstract
+	 * @param {Buffer} binding - The buffer binding.
+	 */
+	destroyUniformBuffer( /*binding*/ ) { }
+
+	/**
 	 * Updates the GPU buffer of a shader attribute.
 	 *
 	 * @abstract

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -390,6 +390,14 @@ class Backend {
 	createStorageAttribute( /*attribute*/ ) { }
 
 	/**
+	 * Creates a uniform buffer.
+	 *
+	 * @abstract
+	 * @param {Buffer} binding - The buffer binding.
+	 */
+	createUniformBuffer( /*binding*/ ) { }
+
+	/**
 	 * Updates the GPU buffer of a shader attribute.
 	 *
 	 * @abstract

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -77,27 +77,7 @@ class Bindings extends DataMap {
 	 */
 	getForRender( renderObject ) {
 
-		const bindings = renderObject.getBindings();
-
-		for ( const bindGroup of bindings ) {
-
-			const groupData = this.get( bindGroup );
-
-			if ( groupData.bindGroup === undefined ) {
-
-				// each object defines an array of bindings (ubos, textures, samplers etc.)
-
-				this._init( bindGroup );
-
-				this.backend.createBindings( bindGroup, bindings, 0 );
-
-				groupData.bindGroup = bindGroup;
-
-			}
-
-		}
-
-		return bindings;
+		return this._getBindings( renderObject, renderObject.getBindings() );
 
 	}
 
@@ -109,7 +89,27 @@ class Bindings extends DataMap {
 	 */
 	getForCompute( computeNode ) {
 
-		const bindings = this.nodes.getForCompute( computeNode ).bindings;
+		return this._getBindings( computeNode, this.nodes.getForCompute( computeNode ).bindings );
+
+	}
+
+	_getBindings( object, bindings ) {
+
+		const data = this.get( object );
+
+		if ( data.bindings !== bindings ) {
+
+			if ( data.bindings !== undefined ) {
+
+				this._updateReferenceBindings( data.bindings, - 1 );
+
+			}
+
+			this._updateReferenceBindings( bindings, 1 );
+
+			data.bindings = bindings;
+
+		}
 
 		for ( const bindGroup of bindings ) {
 
@@ -160,14 +160,7 @@ class Bindings extends DataMap {
 	 */
 	deleteForCompute( computeNode ) {
 
-		const bindings = this.nodes.getForCompute( computeNode ).bindings;
-
-		for ( const bindGroup of bindings ) {
-
-			this.backend.deleteBindGroupData( bindGroup );
-			this.delete( bindGroup );
-
-		}
+		this._deleteBindings( computeNode );
 
 	}
 
@@ -178,12 +171,57 @@ class Bindings extends DataMap {
 	 */
 	deleteForRender( renderObject ) {
 
-		const bindings = renderObject.getBindings();
+		this._deleteBindings( renderObject );
+
+	}
+
+	_deleteBindings( object ) {
+
+		const data = this.get( object );
+
+		if ( data.bindings !== undefined ) {
+
+			this._updateReferenceBindings( data.bindings, - 1 );
+
+			data.bindings = undefined;
+
+		}
+
+	}
+
+	_updateReferenceBindings( bindings, delta ) {
 
 		for ( const bindGroup of bindings ) {
 
-			this.backend.deleteBindGroupData( bindGroup );
-			this.delete( bindGroup );
+			const groupData = this.get( bindGroup );
+
+			groupData.usedTimes = ( groupData.usedTimes || 0 ) + delta;
+
+			for ( const binding of bindGroup.bindings ) {
+
+				if ( binding.isUniformBuffer ) {
+
+					const bindingData = this.get( binding );
+
+					bindingData.usedTimes = ( bindingData.usedTimes || 0 ) + delta;
+
+					if ( bindingData.usedTimes === 0 ) {
+
+						this.backend.destroyUniformBuffer( binding );
+						this.delete( binding );
+
+					}
+
+				}
+
+			}
+
+			if ( groupData.usedTimes === 0 ) {
+
+				this.backend.deleteBindGroupData( bindGroup );
+				this.delete( bindGroup );
+
+			}
 
 		}
 

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -213,7 +213,11 @@ class Bindings extends DataMap {
 
 		for ( const binding of bindGroup.bindings ) {
 
-			if ( binding.isSampledTexture ) {
+			if ( binding.isUniformBuffer ) {
+
+				this.backend.createUniformBuffer( binding );
+
+			} else if ( binding.isSampledTexture ) {
 
 				this.textures.updateTexture( binding.texture );
 

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -101,11 +101,11 @@ class Bindings extends DataMap {
 
 			if ( data.bindings !== undefined ) {
 
-				this._updateReferenceBindings( data.bindings, - 1 );
+				this._updateBindingsUsage( data.bindings, - 1 );
 
 			}
 
-			this._updateReferenceBindings( bindings, 1 );
+			this._updateBindingsUsage( bindings, 1 );
 
 			data.bindings = bindings;
 
@@ -181,7 +181,7 @@ class Bindings extends DataMap {
 
 		if ( data.bindings !== undefined ) {
 
-			this._updateReferenceBindings( data.bindings, - 1 );
+			this._updateBindingsUsage( data.bindings, - 1 );
 
 			data.bindings = undefined;
 
@@ -189,7 +189,7 @@ class Bindings extends DataMap {
 
 	}
 
-	_updateReferenceBindings( bindings, delta ) {
+	_updateBindingsUsage( bindings, delta ) {
 
 		for ( const bindGroup of bindings ) {
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1834,7 +1834,7 @@ class WebGLBackend extends Backend {
 			if ( binding.isUniformsGroup || binding.isUniformBuffer ) {
 
 				const array = binding.buffer;
-				const bufferGPU = this.get( array ).bufferGPU;
+				const bufferGPU = map.bufferGPU;
 
 				gl.bindBuffer( gl.UNIFORM_BUFFER, bufferGPU );
 
@@ -1867,8 +1867,6 @@ class WebGLBackend extends Backend {
 					}
 
 				}
-
-				map.bufferGPU = bufferGPU;
 
 				this.set( binding, map );
 
@@ -1943,21 +1941,34 @@ class WebGLBackend extends Backend {
 	 */
 	createUniformBuffer( binding ) {
 
-		const array = binding.buffer;
-		let { bufferGPU } = this.get( array );
+		const bindingData = this.get( binding );
 
-		if ( bufferGPU === undefined ) {
+		if ( bindingData.bufferGPU === undefined ) {
 
 			const gl = this.gl;
+			const array = binding.buffer;
 
-			bufferGPU = gl.createBuffer();
+			bindingData.bufferGPU = gl.createBuffer();
 
-			gl.bindBuffer( gl.UNIFORM_BUFFER, bufferGPU );
+			gl.bindBuffer( gl.UNIFORM_BUFFER, bindingData.bufferGPU );
 			gl.bufferData( gl.UNIFORM_BUFFER, array.byteLength, gl.DYNAMIC_DRAW );
 
-			this.set( array, { bufferGPU } );
-
 		}
+
+	}
+
+	/**
+	 * Destroys the GPU data for the given uniform buffer.
+	 *
+	 * @param {Buffer} binding - The buffer binding.
+	 */
+	destroyUniformBuffer( binding ) {
+
+		const bindingData = this.get( binding );
+
+		this.gl.deleteBuffer( bindingData.bufferGPU );
+
+		this.delete( binding );
 
 	}
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1834,24 +1834,9 @@ class WebGLBackend extends Backend {
 			if ( binding.isUniformsGroup || binding.isUniformBuffer ) {
 
 				const array = binding.buffer;
-				let { bufferGPU } = this.get( array );
+				const bufferGPU = this.get( array ).bufferGPU;
 
-				if ( bufferGPU === undefined ) {
-
-					// create
-
-					bufferGPU = gl.createBuffer();
-
-					gl.bindBuffer( gl.UNIFORM_BUFFER, bufferGPU );
-					gl.bufferData( gl.UNIFORM_BUFFER, array.byteLength, gl.DYNAMIC_DRAW );
-
-					this.set( array, { bufferGPU } );
-
-				} else {
-
-					gl.bindBuffer( gl.UNIFORM_BUFFER, bufferGPU );
-
-				}
+				gl.bindBuffer( gl.UNIFORM_BUFFER, bufferGPU );
 
 				// update
 
@@ -1950,6 +1935,31 @@ class WebGLBackend extends Backend {
 	}
 
 	// attributes
+
+	/**
+	 * Creates a uniform buffer.
+	 *
+	 * @param {Buffer} binding - The buffer binding.
+	 */
+	createUniformBuffer( binding ) {
+
+		const array = binding.buffer;
+		let { bufferGPU } = this.get( array );
+
+		if ( bufferGPU === undefined ) {
+
+			const gl = this.gl;
+
+			bufferGPU = gl.createBuffer();
+
+			gl.bindBuffer( gl.UNIFORM_BUFFER, bufferGPU );
+			gl.bufferData( gl.UNIFORM_BUFFER, array.byteLength, gl.DYNAMIC_DRAW );
+
+			this.set( array, { bufferGPU } );
+
+		}
+
+	}
 
 	/**
 	 * Creates the GPU buffer of an indexed shader attribute.

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1937,20 +1937,20 @@ class WebGLBackend extends Backend {
 	/**
 	 * Creates a uniform buffer.
 	 *
-	 * @param {Buffer} binding - The buffer binding.
+	 * @param {Buffer} uniformBuffer - The uniform buffer.
 	 */
-	createUniformBuffer( binding ) {
+	createUniformBuffer( uniformBuffer ) {
 
-		const bindingData = this.get( binding );
+		const uniformBufferData = this.get( uniformBuffer );
 
-		if ( bindingData.bufferGPU === undefined ) {
+		if ( uniformBufferData.bufferGPU === undefined ) {
 
 			const gl = this.gl;
-			const array = binding.buffer;
+			const array = uniformBuffer.buffer;
 
-			bindingData.bufferGPU = gl.createBuffer();
+			uniformBufferData.bufferGPU = gl.createBuffer();
 
-			gl.bindBuffer( gl.UNIFORM_BUFFER, bindingData.bufferGPU );
+			gl.bindBuffer( gl.UNIFORM_BUFFER, uniformBufferData.bufferGPU );
 			gl.bufferData( gl.UNIFORM_BUFFER, array.byteLength, gl.DYNAMIC_DRAW );
 
 		}
@@ -1960,15 +1960,15 @@ class WebGLBackend extends Backend {
 	/**
 	 * Destroys the GPU data for the given uniform buffer.
 	 *
-	 * @param {Buffer} binding - The buffer binding.
+	 * @param {Buffer} uniformBuffer - The uniform buffer.
 	 */
-	destroyUniformBuffer( binding ) {
+	destroyUniformBuffer( uniformBuffer ) {
 
-		const bindingData = this.get( binding );
+		const uniformBufferData = this.get( uniformBuffer );
 
-		this.gl.deleteBuffer( bindingData.bufferGPU );
+		this.gl.deleteBuffer( uniformBufferData.bufferGPU );
 
-		this.delete( binding );
+		this.delete( uniformBuffer );
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2,7 +2,7 @@
 import 'https://greggman.github.io/webgpu-avoid-redundant-state-setting/webgpu-check-redundant-state-setting.js';
 //*/
 
-import { GPUFeatureName, GPULoadOp, GPUStoreOp, GPUIndexFormat, GPUTextureViewDimension, GPUFeatureMap } from './utils/WebGPUConstants.js';
+import { GPUFeatureName, GPULoadOp, GPUStoreOp, GPUIndexFormat, GPUTextureViewDimension, GPUFeatureMap, GPUShaderStage } from './utils/WebGPUConstants.js';
 
 import WGSLNodeBuilder from './nodes/WGSLNodeBuilder.js';
 import Backend from '../common/Backend.js';
@@ -2180,6 +2180,55 @@ class WebGPUBackend extends Backend {
 	}
 
 	// bindings
+
+	/**
+	 * Creates a uniform buffer.
+	 *
+	 * @param {Buffer} binding - The buffer binding.
+	 */
+	createUniformBuffer( binding ) {
+
+		const bindingData = this.get( binding );
+
+		if ( bindingData.buffer === undefined ) {
+
+			const byteLength = binding.byteLength;
+
+			const usage = GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST;
+
+			const visibilities = [];
+
+			if ( binding.visibility & GPUShaderStage.VERTEX ) {
+
+				visibilities.push( 'vertex' );
+
+			}
+
+			if ( binding.visibility & GPUShaderStage.FRAGMENT ) {
+
+				visibilities.push( 'fragment' );
+
+			}
+
+			if ( binding.visibility & GPUShaderStage.COMPUTE ) {
+
+				visibilities.push( 'compute' );
+
+			}
+
+			const bufferVisibility = `(${visibilities.join( ',' )})`;
+
+			const bufferGPU = this.device.createBuffer( {
+				label: `bindingBuffer${binding.id}_${binding.name}_${bufferVisibility}`,
+				size: byteLength,
+				usage: usage
+			} );
+
+			bindingData.buffer = bufferGPU;
+
+		}
+
+	}
 
 	/**
 	 * Creates bindings from the given bind group definition.

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2184,33 +2184,33 @@ class WebGPUBackend extends Backend {
 	/**
 	 * Creates a uniform buffer.
 	 *
-	 * @param {Buffer} binding - The buffer binding.
+	 * @param {Buffer} uniformBuffer - The uniform buffer.
 	 */
-	createUniformBuffer( binding ) {
+	createUniformBuffer( uniformBuffer ) {
 
-		const bindingData = this.get( binding );
+		const uniformBufferData = this.get( uniformBuffer );
 
-		if ( bindingData.buffer === undefined ) {
+		if ( uniformBufferData.buffer === undefined ) {
 
-			const byteLength = binding.byteLength;
+			const byteLength = uniformBuffer.byteLength;
 
 			const usage = GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST;
 
 			const visibilities = [];
 
-			if ( binding.visibility & GPUShaderStage.VERTEX ) {
+			if ( uniformBuffer.visibility & GPUShaderStage.VERTEX ) {
 
 				visibilities.push( 'vertex' );
 
 			}
 
-			if ( binding.visibility & GPUShaderStage.FRAGMENT ) {
+			if ( uniformBuffer.visibility & GPUShaderStage.FRAGMENT ) {
 
 				visibilities.push( 'fragment' );
 
 			}
 
-			if ( binding.visibility & GPUShaderStage.COMPUTE ) {
+			if ( uniformBuffer.visibility & GPUShaderStage.COMPUTE ) {
 
 				visibilities.push( 'compute' );
 
@@ -2219,12 +2219,12 @@ class WebGPUBackend extends Backend {
 			const bufferVisibility = `(${visibilities.join( ',' )})`;
 
 			const bufferGPU = this.device.createBuffer( {
-				label: `bindingBuffer${binding.id}_${binding.name}_${bufferVisibility}`,
+				label: `bindingBuffer${uniformBuffer.id}_${uniformBuffer.name}_${bufferVisibility}`,
 				size: byteLength,
 				usage: usage
 			} );
 
-			bindingData.buffer = bufferGPU;
+			uniformBufferData.buffer = bufferGPU;
 
 		}
 
@@ -2233,15 +2233,15 @@ class WebGPUBackend extends Backend {
 	/**
 	 * Destroys the GPU data for the given uniform buffer.
 	 *
-	 * @param {Buffer} binding - The buffer binding.
+	 * @param {Buffer} uniformBuffer - The uniform buffer.
 	 */
-	destroyUniformBuffer( binding ) {
+	destroyUniformBuffer( uniformBuffer ) {
 
-		const bindingData = this.get( binding );
+		const uniformBufferData = this.get( uniformBuffer );
 
-		bindingData.buffer.destroy();
+		uniformBufferData.buffer.destroy();
 
-		this.delete( binding );
+		this.delete( uniformBuffer );
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2231,6 +2231,21 @@ class WebGPUBackend extends Backend {
 	}
 
 	/**
+	 * Destroys the GPU data for the given uniform buffer.
+	 *
+	 * @param {Buffer} binding - The buffer binding.
+	 */
+	destroyUniformBuffer( binding ) {
+
+		const bindingData = this.get( binding );
+
+		bindingData.buffer.destroy();
+
+		this.delete( binding );
+
+	}
+
+	/**
 	 * Creates bindings from the given bind group definition.
 	 *
 	 * @param {BindGroup} bindGroup - The bind group.

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -283,43 +283,6 @@ class WebGPUBindingUtils {
 
 				const bindingData = backend.get( binding );
 
-				if ( bindingData.buffer === undefined ) {
-
-					const byteLength = binding.byteLength;
-
-					const usage = GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST;
-
-					const visibilities = [];
-					if ( binding.visibility & GPUShaderStage.VERTEX ) {
-
-						visibilities.push( 'vertex' );
-
-					}
-
-					if ( binding.visibility & GPUShaderStage.FRAGMENT ) {
-
-						visibilities.push( 'fragment' );
-
-					}
-
-					if ( binding.visibility & GPUShaderStage.COMPUTE ) {
-
-						visibilities.push( 'compute' );
-
-					}
-
-					const bufferVisibility = `(${visibilities.join( ',' )})`;
-
-					const bufferGPU = device.createBuffer( {
-						label: `bindingBuffer${binding.id}_${binding.name}_${bufferVisibility}`,
-						size: byteLength,
-						usage: usage
-					} );
-
-					bindingData.buffer = bufferGPU;
-
-				}
-
 				entriesGPU.push( { binding: bindingPoint, resource: { buffer: bindingData.buffer } } );
 
 			} else if ( binding.isStorageBuffer ) {


### PR DESCRIPTION
Related issue: N/A

**Description**

The idea as a whole should bring more clarity to the backend calls, including the management of removal in groups of shared and non-shared uniform buffers.

