### PR TITLE
NodeObjectLoader: Fix `parseAsync()`.

### DIFF
--- a/src/loaders/nodes/NodeObjectLoader.js
+++ b/src/loaders/nodes/NodeObjectLoader.js
@@ -90,6 +90,24 @@ class NodeObjectLoader extends ObjectLoader {
 	}
 
 	/**
+	 * Async version of {@link NodeObjectLoader#parse}.
+	 *
+	 * @param {Object} json - The JSON definition
+	 * @return {Promise<Object3D>} A Promise that resolves with the parsed 3D object.
+	 */
+	async parseAsync( json ) {
+
+		this._nodesJSON = json.nodes;
+
+		const data = await super.parseAsync( json );
+
+		this._nodesJSON = null; // dispose
+
+		return data;
+
+	}
+
+	/**
 	 * Parses the node objects from the given JSON and textures.
 	 *
 	 * @param {Object[]} json - The JSON definition


### PR DESCRIPTION
Fixed #33376.

**Description**

The PR makes sure `parseAsync()` is functional when using it with `NodeObjectLoader`. Previously the version of `ObjectLoader` was used.