### PR TITLE
AudioLoader: Fix race condition with loading manager.

### DIFF
--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -60,11 +60,21 @@ class AudioLoader extends Loader {
 				const bufferCopy = buffer.slice( 0 );
 
 				const context = AudioContext.getContext();
+
+				const decodeUrl = url + '#decode';
+				scope.manager.itemStart( decodeUrl );
+
 				context.decodeAudioData( bufferCopy, function ( audioBuffer ) {
 
 					onLoad( audioBuffer );
+					scope.manager.itemEnd( decodeUrl );
 
-				} ).catch( handleError );
+				} ).catch( function ( e ) {
+
+					handleError( e );
+					scope.manager.itemEnd( decodeUrl );
+
+				} );
 
 			} catch ( e ) {
 

--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -62,7 +62,7 @@ class AudioLoader extends Loader {
 				const context = AudioContext.getContext();
 
 				const decodeUrl = url + '#decode';
-				scope.manager.itemStart( decodeUrl );
+				scope.manager.itemStart( decodeUrl ); // prevent loading manager from completing too early, see #33378
 
 				context.decodeAudioData( bufferCopy, function ( audioBuffer ) {
 


### PR DESCRIPTION
Fixed #10706.

**Description**

Another attempt to fix #10706. I've realized there is a much cleaner approach to fix the race condition in `AudioLoader` that potentially occurs when used with `LoadingManager`. 

To recap: `LoadingManager` can fire too early when the audio isn't decoded yet so if you attempt to playback such an audio you run into runtime errors. However, by using a separate "decode item", it's possible to keep the `LoadingManager` waiting until the decode has finished.

This change requires no changes in `FileLoader` which was a blocker of previous PRs.