### PR TITLE
ImageBitmapLoader: Improve docs.

### DIFF
--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -86,6 +86,9 @@ class ImageBitmapLoader extends Loader {
 	 * Sets the given loader options. The structure of the object must match the `options` parameter of
 	 * [createImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap).
 	 *
+	 * Note: When caching is enabled, the cache key is based on the URL only. Loading the same URL with
+	 * different options will return the cached result of the first request.
+	 *
 	 * @param {Object} options - The loader options to set.
 	 * @return {ImageBitmapLoader} A reference to this image bitmap loader.
 	 */


### PR DESCRIPTION
Fixed #16196.

**Description**

`ImageBitmapLoader` only caches files via URL, it does not honor the options definitions. However, as previously stated in https://github.com/mrdoob/three.js/issues/16196#issuecomment-480910316 this is more of a theoretical issue since you _normally_ don't unpack the same image data in different ways. Seven years with zero developer complaints is strong evidence that this is true.

To avoid potential confusion though the documentation is improved like suggested in https://github.com/mrdoob/three.js/issues/16196#issuecomment-480914219.