### PR TITLE
MathUtils: Add lerpAngle().

### DIFF
--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -138,6 +138,24 @@ function damp( x, y, lambda, dt ) {
 }
 
 /**
+ * Linearly interpolates between two angles (in radians), taking the shortest
+ * path around the circle. For example, lerping from `5.8` rad to `0.5` rad
+ * goes forward through `0`/`2π` rather than the long way round through `π`.
+ *
+ * @param {number} a - The start angle in radians.
+ * @param {number} b - The end angle in radians.
+ * @param {number} t - The interpolation factor in the closed interval `[0, 1]`.
+ * @return {number} The interpolated angle in radians.
+ */
+function lerpAngle( a, b, t ) {
+
+	// Wrap the angular delta into (-π, π] so we always take the shorter arc.
+	const delta = euclideanModulo( b - a + Math.PI, Math.PI * 2 ) - Math.PI;
+	return a + delta * clamp( t, 0, 1 );
+
+}
+
+/**
  * Returns a value that alternates between `0` and the given `length` parameter.
  *
  * @param {number} x - The value to pingpong.
@@ -565,6 +583,19 @@ const MathUtils = {
 	 */
 	damp: damp,
 	/**
+	 * Linearly interpolates between two angles (in radians), taking the shortest
+	 * path around the circle. For example, lerping from `5.8` rad to `0.5` rad
+	 * goes forward through `0`/`2π` rather than the long way round through `π`.
+	 *
+	 * @static
+	 * @method
+	 * @param {number} a - The start angle in radians.
+	 * @param {number} b - The end angle in radians.
+	 * @param {number} t - The interpolation factor in the closed interval `[0, 1]`.
+	 * @return {number} The interpolated angle in radians.
+	 */
+	lerpAngle: lerpAngle,
+	/**
 	 * Returns a value that alternates between `0` and the given `length` parameter.
 	 *
 	 * @static
@@ -732,6 +763,7 @@ export {
 	inverseLerp,
 	lerp,
 	damp,
+	lerpAngle,
 	pingpong,
 	smoothstep,
 	smootherstep,

--- a/test/unit/src/math/MathUtils.tests.js
+++ b/test/unit/src/math/MathUtils.tests.js
@@ -67,6 +67,35 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( 'lerpAngle', ( assert ) => {
+
+			const PI = Math.PI;
+			const TWO_PI = Math.PI * 2;
+			const eps = 1e-10;
+
+			// Basic endpoints
+			assert.strictEqual( MathUtils.lerpAngle( 0, PI / 2, 0 ), 0, 't=0 returns start angle' );
+			assert.strictEqual( MathUtils.lerpAngle( 0, PI / 2, 1 ), PI / 2, 't=1 returns end angle' );
+
+			// Midpoint of a simple range
+			assert.ok( Math.abs( MathUtils.lerpAngle( 0, PI / 2, 0.5 ) - PI / 4 ) < eps, 'Midpoint of 0 → π/2 is π/4' );
+
+			// Shortest path: 350° → 10° should pass through 0°, not through 180°
+			// In radians: ~6.109 → ~0.175. Midpoint should be near 0 (or 2π), not near π.
+			const a = MathUtils.degToRad( 350 );
+			const b = MathUtils.degToRad( 10 );
+			const mid = MathUtils.lerpAngle( a, b, 0.5 );
+			assert.ok( mid < 0.2 || mid > TWO_PI - 0.2, 'Shortest path: 350°→10° midpoint is near 0°, not 180°' );
+
+			// t is clamped — values outside [0,1] should not overshoot
+			assert.strictEqual( MathUtils.lerpAngle( 0, 1, - 0.5 ), 0, 't < 0 clamps to start' );
+			assert.strictEqual( MathUtils.lerpAngle( 0, 1, 1.5 ), 1, 't > 1 clamps to end' );
+
+			// Same angle — result should equal input regardless of t
+			assert.ok( Math.abs( MathUtils.lerpAngle( PI / 3, PI / 3, 0.5 ) - PI / 3 ) < eps, 'Same start and end returns that angle' );
+
+		} );
+
 		QUnit.test( 'pingpong', ( assert ) => {
 
 			assert.strictEqual( MathUtils.pingpong( 2.5 ), 0.5, 'Value at 2.5 is 0.5' );


### PR DESCRIPTION
Related issue: N/A

**Description**

Adds `MathUtils.lerpAngle( a, b, t )` — linearly interpolates between two angles in radians, always taking the **shortest arc** around the circle.

### The problem with regular `lerp`

When angles wrap around the 0/2π boundary, `lerp` takes the long path:

```js
// Lerping from 350° → 10° — should travel 20° through 0°
MathUtils.lerp( degToRad(350), degToRad(10), 0.5 )
// → ~3.14 rad (180°) ✗ went the wrong way

MathUtils.lerpAngle( degToRad(350), degToRad(10), 0.5 )
// → ~0.0 rad (0°)   ✓ shortest path
```

This is a frequent pain point for anyone animating camera yaw, compass bearings, turret rotation, or any angle that can cross 0°/360°.

### Implementation

Wraps the angular delta into `(-π, π]` using `euclideanModulo`, then lerps. `t` is clamped to `[0, 1]`.

```js
function lerpAngle( a, b, t ) {
    const delta = euclideanModulo( b - a + Math.PI, Math.PI * 2 ) - Math.PI;
    return a + delta * clamp( t, 0, 1 );
}
```

Equivalent to `Mathf.LerpAngle` (Unity) and `lerp_angle` (Godot).

**Changes**

- `src/math/MathUtils.js` — adds `lerpAngle()` function, MathUtils entry, and export
- `test/unit/src/math/MathUtils.tests.js` — unit tests (all pass, 0 failures)