### PR TITLE
CCDIKSolver: Fix limitation handling.

### DIFF
--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -204,7 +204,11 @@ class CCDIKSolver {
 
 					if ( c > 1.0 ) c = 1.0;
 
-					const c2 = math.sqrt( 1 - c * c );
+					// preserve sign of the rotation along the limitation axis,
+					// otherwise negative rotations get mirrored to positive
+					const dot = link.quaternion.x * limitation.x + link.quaternion.y * limitation.y + link.quaternion.z * limitation.z;
+					const sign = dot < 0 ? - 1 : 1;
+					const c2 = sign * math.sqrt( 1 - c * c );
 					link.quaternion.set( limitation.x * c2,
 					                     limitation.y * c2,
 					                     limitation.z * c2,


### PR DESCRIPTION
Fixed #25338.

**Description**

The PR fixes a sign-loss bug in `CCDIKSolver`'s limitation handling. The previous code rebuilt the quaternion using `√(1−w²)`, which is always non-negative, so any rotation past 0° around the limitation axis got mirrored to the positive side (you can clearly see this buggy behavior in https://github.com/mrdoob/three.js/issues/25338#issuecomment-1501225868).

The PR projects the  quaternion's vector part onto the limitation axis and preserves that sign, so negative rotations stay negative. This restores the expected +-range when `limitation` is combined with `rotationMin`/`rotationMax`.

I've migrated the old example code so it was possible to do a test and with the fix in place. The demo works now as expected.

https://github.com/user-attachments/assets/9e11fc33-1765-44b7-80c9-cd31ba850c19
