### PR TITLE
EXRLoader: Remove buggy `getBigInt64()` fallback.

### DIFF
--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -2082,17 +2082,7 @@ class EXRLoader extends DataTextureLoader {
 
 		const parseInt64 = function ( dataView, offset ) {
 
-			let int;
-
-			if ( 'getBigInt64' in DataView.prototype ) {
-
-				int = Number( dataView.getBigInt64( offset.value, true ) );
-
-			} else {
-
-				int = dataView.getUint32( offset.value + 4, true ) + Number( dataView.getUint32( offset.value, true ) << 32 );
-
-			}
+			const int = Number( dataView.getBigInt64( offset.value, true ) );
 
 			offset.value += ULONG_SIZE;
 


### PR DESCRIPTION
Related issue: -

**Description**

While working on `EXRLoader` lately I've seen there is a fallback for `getBigInt64()` in place. However, this method is now widely available (see https://caniuse.com/mdn-javascript_builtins_dataview_getbigint64) so we can remove it.

The fallback was actually buggy since the bitshift `<< 32` is wrong.