### PR TITLE
GLSLNodeBuilder: cast levelSnippet to int in generateTextureLoad

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -470,7 +470,12 @@ ${ flowData.code }
 	 */
 	generateTextureLoad( texture, textureProperty, uvIndexSnippet, levelSnippet, depthSnippet, offsetSnippet ) {
 
+		// texelFetch() in GLSL2 requires the LOD argument to be an int.
+		// When textureLoad() is called from TSL with e.g. int(0), the GLSL codegen
+		// may emit a float literal (0.0) for the level — wrapping in int() ensures
+		// the correct type regardless of what the TSL node resolves to.
 		if ( levelSnippet === null ) levelSnippet = '0';
+		else levelSnippet = `int( ${ levelSnippet } )`;
 
 		let snippet;
 


### PR DESCRIPTION
Related issue: #33394

**Description**

When `textureLoad()` is called from TSL with an integer LOD argument (e.g. `int(0)`), the GLSL codegen in `WebGLBackend` emits a float literal for the level parameter of `texelFetch`:

```glsl
// Generated (broken):
nodeVar18 = texelFetch( nodeUniform4, ivec2( nodeVar16 ), 0.0 );
```

GLSL2's `texelFetch()` requires the LOD argument to be an `int`, not a `float`. This causes the fragment shader to fail compilation with:

```
ERROR: 'texelFetch' : no matching overloaded function found
ERROR: '=' : dimension mismatch
```

Followed by `WebGL: INVALID_OPERATION: useProgram: program not valid` on every draw call, breaking the entire render path.

The same TSL graph compiles cleanly on the WebGPU backend — only the GLSL2 codegen via `WebGLBackend` is affected.

**Fix**

In `generateTextureLoad()`, wrap any externally-supplied `levelSnippet` in `int()` before it is interpolated into the `texelFetch` / `texelFetchOffset` calls. This ensures the correct integer type regardless of what the TSL node resolves to:

```glsl
// Generated (fixed):
nodeVar18 = texelFetch( nodeUniform4, ivec2( nodeVar16 ), int( 0.0 ) );
```

The existing internal caller (`generatePBO`) passes the string literal `'0'` directly — it now becomes `int( 0 )` which is equally valid GLSL2, so there is no regression.