### PR TITLE
MemberNode: fix getMemberType for nested struct member access

### DIFF
--- a/src/nodes/utils/MemberNode.js
+++ b/src/nodes/utils/MemberNode.js
@@ -91,7 +91,17 @@ class MemberNode extends Node {
 		}
 
 		const type = this.getNodeType( builder );
-		const struct = builder.getStructTypeNode( type );
+		let struct = builder.getStructTypeNode( type );
+
+		if ( struct === null ) {
+
+			// The inner struct type may not yet be registered in the builder when
+			// getMemberType is called on a nested MemberNode (e.g. outer.get('inner').get('x')).
+			// Triggering build() on the structNode runs setup(), which registers the type.
+			this.structNode.build( builder );
+			struct = builder.getStructTypeNode( type );
+
+		}
 
 		return struct.getMemberType( builder, name );
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -470,7 +470,12 @@ ${ flowData.code }
 	 */
 	generateTextureLoad( texture, textureProperty, uvIndexSnippet, levelSnippet, depthSnippet, offsetSnippet ) {
 
+		// texelFetch() in GLSL2 requires the LOD argument to be an int.
+		// When textureLoad() is called from TSL with e.g. int(0), the GLSL codegen
+		// may emit a float literal (0.0) for the level — wrapping in int() ensures
+		// the correct type regardless of what the TSL node resolves to.
 		if ( levelSnippet === null ) levelSnippet = '0';
+		else levelSnippet = `int( ${ levelSnippet } )`;
 
 		let snippet;
 


### PR DESCRIPTION
Related issue: #33341

**Description**

When getMemberType() is called on a MemberNode whose structNode is itself a MemberNode (e.g. outer.get('inner').get('x')), the inner struct type may not yet be registered in the builder because setup() has not been executed for it yet. getStructTypeNode() returns null in this case, causing: TypeError: Cannot read properties of null (reading 'getMemberType')

**Fix**

Detect the null return from getStructTypeNode() and call build() on the structNode to trigger setup(), which registers the inner struct type in the builder. Node build caching makes this idempotent.

Fixes #33341