### PR TITLE
ParameterNode: fix vector swizzle dropped on struct member in layout function

### DIFF
--- a/src/nodes/core/ParameterNode.js
+++ b/src/nodes/core/ParameterNode.js
@@ -1,6 +1,7 @@
 import { error } from '../../utils.js';
 import StackTrace from '../core/StackTrace.js';
 import PropertyNode from './PropertyNode.js';
+import { structTypeNodeRegistry } from './StructNode.js';
 
 /**
  * Special version of {@link PropertyNode} which is used for parameters.
@@ -46,7 +47,12 @@ class ParameterNode extends PropertyNode {
 	getMemberType( builder, name ) {
 
 		const type = this.getNodeType( builder );
-		const struct = builder.getStructTypeNode( type );
+
+		// First try the builder registry (populated after setup() runs).
+		// Fall back to the global struct registry for named structs — this handles
+		// cases where the struct type hasn't been built in the current shader stage
+		// yet (e.g. accessing s.get('v').x inside a layout function before setup).
+		const struct = builder.getStructTypeNode( type ) ?? structTypeNodeRegistry.get( type ) ?? null;
 
 		let memberType;
 

--- a/src/nodes/core/StructNode.js
+++ b/src/nodes/core/StructNode.js
@@ -84,6 +84,16 @@ class StructNode extends Node {
 export default StructNode;
 
 /**
+ * A global registry that maps struct type names to their StructTypeNode.
+ * Populated when a named struct is created via `struct()`. Used by
+ * ParameterNode to resolve member types before the struct has been built
+ * in the current shader stage.
+ *
+ * @type {Map<string, StructTypeNode>}
+ */
+export const structTypeNodeRegistry = new Map();
+
+/**
  * TSL function for creating a struct node.
  *
  * @tsl
@@ -128,6 +138,10 @@ export const struct = ( membersLayout, name = null ) => {
 
 	struct.layout = structLayout;
 	struct.isStruct = true;
+
+	// Register named structs globally so ParameterNode can resolve member
+	// types before the struct has been built in the current shader stage.
+	if ( name !== null ) structTypeNodeRegistry.set( name, structLayout );
 
 	return struct;
 

--- a/src/nodes/utils/MemberNode.js
+++ b/src/nodes/utils/MemberNode.js
@@ -91,7 +91,17 @@ class MemberNode extends Node {
 		}
 
 		const type = this.getNodeType( builder );
-		const struct = builder.getStructTypeNode( type );
+		let struct = builder.getStructTypeNode( type );
+
+		if ( struct === null ) {
+
+			// The inner struct type may not yet be registered in the builder when
+			// getMemberType is called on a nested MemberNode (e.g. outer.get('inner').get('x')).
+			// Triggering build() on the structNode runs setup(), which registers the type.
+			this.structNode.build( builder );
+			struct = builder.getStructTypeNode( type );
+
+		}
 
 		return struct.getMemberType( builder, name );
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -470,7 +470,12 @@ ${ flowData.code }
 	 */
 	generateTextureLoad( texture, textureProperty, uvIndexSnippet, levelSnippet, depthSnippet, offsetSnippet ) {
 
+		// texelFetch() in GLSL2 requires the LOD argument to be an int.
+		// When textureLoad() is called from TSL with e.g. int(0), the GLSL codegen
+		// may emit a float literal (0.0) for the level — wrapping in int() ensures
+		// the correct type regardless of what the TSL node resolves to.
 		if ( levelSnippet === null ) levelSnippet = '0';
+		else levelSnippet = `int( ${ levelSnippet } )`;
 
 		let snippet;
 


### PR DESCRIPTION
Related issue: #33345

**Description**

When a struct is used as a layout function parameter and a vector component is accessed on one of its members, the swizzle is silently dropped — generating `s.v` instead of the expected `s.v.x`:

```js
const S = struct({ v: 'vec3' }, 'S')
const f = Fn(([s]) => {
  return s.get('v').x  // Expected: s.v.x — Actual: s.v
}).setLayout({ name: 'f', type: 'float', inputs: [{ name: 's', type: 'S' }] })
```

**Root cause**

`SplitNode.generate()` decides whether to append the swizzle by checking `nodeTypeLength`. It gets this by calling `MemberNode.generateNodeType()` → `ParameterNode.getMemberType()`, which calls `builder.getStructTypeNode(type)`.

Inside the layout function's `flowStagesNode()`, the named struct type `'S'` has not yet been registered in the builder (registration happens when `StructTypeNode.setup()` runs during the outer struct's build). So `getStructTypeNode()` returns `null`, `getMemberType()` falls back to `'float'` (length 1), and `SplitNode` skips the swizzle entirely.

**Fix**

Export a module-level `Map` (`structTypeNodeRegistry`) from `StructNode.js` that maps struct names to their `StructTypeNode`, populated when `struct()` creates a named struct. `ParameterNode.getMemberType()` falls back to this registry when the builder lookup returns `null`, ensuring member types are always resolved correctly regardless of build stage ordering.