### PR TITLE
Plane: Add `clampToLine` to `intersectLine()`.

### DIFF
--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -210,9 +210,10 @@ class Plane {
 	 *
 	 * @param {Line3} line - The line to compute the intersection for.
 	 * @param {Vector3} target - The target vector that is used to store the method's result.
-	 * @return {?Vector3} The intersection point.
+	 * @param {boolean} [clampToLine=true] - Whether to clamp the intersection to the line segment.
+	 * @return {?Vector3} The intersection point. Returns `null` if no intersection is detected.
 	 */
-	intersectLine( line, target ) {
+	intersectLine( line, target, clampToLine = true ) {
 
 		const direction = line.delta( _vector1 );
 
@@ -234,7 +235,7 @@ class Plane {
 
 		const t = - ( line.start.dot( this.normal ) + this.constant ) / denominator;
 
-		if ( t < 0 || t > 1 ) {
+		if ( ( clampToLine === true ) && ( t < 0 || t > 1 ) ) {
 
 			return null;
 

--- a/test/unit/src/math/Plane.tests.js
+++ b/test/unit/src/math/Plane.tests.js
@@ -229,6 +229,17 @@ export default QUnit.module( 'Maths', () => {
 			a.intersectLine( l1, point );
 			assert.ok( point.equals( new Vector3( 3, 0, 0 ) ), 'Passed!' );
 
+			// plane lies outside the segment's endpoints
+			a = new Plane( new Vector3( 1, 0, 0 ), - 20 );
+			const l2 = new Line3( new Vector3( - 10, 0, 0 ), new Vector3( 10, 0, 0 ) );
+
+			assert.strictEqual( a.intersectLine( l2, point ), null, 'Default clamps to segment and returns null' );
+			assert.strictEqual( a.intersectLine( l2, point, true ), null, 'Explicit clampToLine=true returns null' );
+
+			const result = a.intersectLine( l2, point, false );
+			assert.ok( result === point, 'clampToLine=false returns the target vector' );
+			assert.ok( point.equals( new Vector3( 20, 0, 0 ) ), 'clampToLine=false returns infinite-line intersection' );
+
 		} );
 
 		QUnit.test( 'intersectsBox', ( assert ) => {


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/11474.

**Description**

As suggested in https://github.com/mrdoob/three.js/issues/11474#issuecomment-307644002, the PR adds a `clampToLine` parameter to `Plane.intersectLine()`. When `true`, the intersection is clamped to the line segment. The default is `true` so the change is fully backward compatible. By setting it to `false`, the use case of #11474 will work.
