### PR TITLE
GLTFLoader: Add KHR_mesh_primitive_restart

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -101,7 +101,7 @@ import { clone } from '../utils/SkeletonUtils.js';
  * - EXT_materials_bump
  * - EXT_meshopt_compression
  * - EXT_mesh_gpu_instancing
- * - EXT_mesh_primitive_restart
+ * - KHR_mesh_primitive_restart
  * - EXT_texture_avif
  * - EXT_texture_webp
  *
@@ -530,7 +530,7 @@ class GLTFLoader extends Loader {
 						extensions[ extensionName ] = new GLTFMeshQuantizationExtension();
 						break;
 
-					case EXTENSIONS.EXT_MESH_PRIMITIVE_RESTART:
+					case EXTENSIONS.KHR_MESH_PRIMITIVE_RESTART:
 						extensions[ extensionName ] = new GLTFMeshPrimitiveRestartExtension();
 						break;
 
@@ -654,7 +654,7 @@ const EXTENSIONS = {
 	EXT_MESHOPT_COMPRESSION: 'EXT_meshopt_compression',
 	KHR_MESHOPT_COMPRESSION: 'KHR_meshopt_compression',
 	EXT_MESH_GPU_INSTANCING: 'EXT_mesh_gpu_instancing',
-	EXT_MESH_PRIMITIVE_RESTART: 'EXT_mesh_primitive_restart'
+	KHR_MESH_PRIMITIVE_RESTART: 'KHR_mesh_primitive_restart'
 };
 
 /**
@@ -2074,7 +2074,7 @@ class GLTFMeshQuantizationExtension {
 /**
  * Mesh Primitive Restart Extension
  *
- * Specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_mesh_primitive_restart
+ * Specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/KHR_mesh_primitive_restart
  *
  * @private
  */
@@ -2082,7 +2082,7 @@ class GLTFMeshPrimitiveRestartExtension {
 
 	constructor() {
 
-		this.name = EXTENSIONS.EXT_MESH_PRIMITIVE_RESTART;
+		this.name = EXTENSIONS.KHR_MESH_PRIMITIVE_RESTART;
 
 	}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -101,6 +101,7 @@ import { clone } from '../utils/SkeletonUtils.js';
  * - EXT_materials_bump
  * - EXT_meshopt_compression
  * - EXT_mesh_gpu_instancing
+ * - EXT_mesh_primitive_restart
  * - EXT_texture_avif
  * - EXT_texture_webp
  *
@@ -529,6 +530,10 @@ class GLTFLoader extends Loader {
 						extensions[ extensionName ] = new GLTFMeshQuantizationExtension();
 						break;
 
+					case EXTENSIONS.EXT_MESH_PRIMITIVE_RESTART:
+						extensions[ extensionName ] = new GLTFMeshPrimitiveRestartExtension();
+						break;
+
 					default:
 
 						if ( extensionsRequired.indexOf( extensionName ) >= 0 && plugins[ extensionName ] === undefined ) {
@@ -648,7 +653,8 @@ const EXTENSIONS = {
 	EXT_TEXTURE_AVIF: 'EXT_texture_avif',
 	EXT_MESHOPT_COMPRESSION: 'EXT_meshopt_compression',
 	KHR_MESHOPT_COMPRESSION: 'KHR_meshopt_compression',
-	EXT_MESH_GPU_INSTANCING: 'EXT_mesh_gpu_instancing'
+	EXT_MESH_GPU_INSTANCING: 'EXT_mesh_gpu_instancing',
+	EXT_MESH_PRIMITIVE_RESTART: 'EXT_mesh_primitive_restart'
 };
 
 /**
@@ -2064,6 +2070,24 @@ class GLTFMeshQuantizationExtension {
 	}
 
 }
+
+/**
+ * Mesh Primitive Restart Extension
+ *
+ * Specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_mesh_primitive_restart
+ *
+ * @private
+ */
+class GLTFMeshPrimitiveRestartExtension {
+
+	constructor() {
+
+		this.name = EXTENSIONS.EXT_MESH_PRIMITIVE_RESTART;
+
+	}
+
+}
+
 
 /*********************************/
 /********** INTERPOLATION ********/

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -850,18 +850,32 @@ function toTrianglesDrawMode( geometry, drawMode ) {
 
 		//
 
-		const numberOfTriangles = index.count - 2;
+		const restartIndex = getPrimitiveRestartIndex( index.array );
 		const newIndices = [];
 
 		if ( drawMode === TriangleFanDrawMode ) {
 
 			// gl.TRIANGLE_FAN
 
-			for ( let i = 1; i <= numberOfTriangles; i ++ ) {
+			let fanStartIndex = 0;
 
-				newIndices.push( index.getX( 0 ) );
-				newIndices.push( index.getX( i ) );
-				newIndices.push( index.getX( i + 1 ) );
+			for ( let i = 1, il = index.count - 2; i <= il; i ++ ) {
+
+				const a = index.getX( fanStartIndex );
+				const b = index.getX( i );
+				const c = index.getX( i + 1 );
+
+				if ( c === restartIndex ) {
+
+					i++;
+
+					fanStartIndex = i + 1;
+
+				} else {
+
+					newIndices.push( a, b, c );
+
+				}
 
 			}
 
@@ -869,29 +883,27 @@ function toTrianglesDrawMode( geometry, drawMode ) {
 
 			// gl.TRIANGLE_STRIP
 
-			for ( let i = 0; i < numberOfTriangles; i ++ ) {
+			for ( let i = 0, il = index.count - 2; i < il; i ++ ) {
 
-				if ( i % 2 === 0 ) {
+				const a = index.getX( i );
+				const b = index.getX( i + 1 );
+				const c = index.getX( i + 2 );
 
-					newIndices.push( index.getX( i ) );
-					newIndices.push( index.getX( i + 1 ) );
-					newIndices.push( index.getX( i + 2 ) );
+				if ( c === restartIndex ) {
+
+					i += 2;
+
+				} else if ( i % 2 === 0 ) {
+
+					newIndices.push( a, b, c );
 
 				} else {
 
-					newIndices.push( index.getX( i + 2 ) );
-					newIndices.push( index.getX( i + 1 ) );
-					newIndices.push( index.getX( i ) );
+					newIndices.push( c, b, a );
 
 				}
 
 			}
-
-		}
-
-		if ( ( newIndices.length / 3 ) !== numberOfTriangles ) {
-
-			console.error( 'THREE.BufferGeometryUtils.toTrianglesDrawMode(): Unable to generate correct amount of triangles.' );
 
 		}
 
@@ -907,6 +919,36 @@ function toTrianglesDrawMode( geometry, drawMode ) {
 
 		console.error( 'THREE.BufferGeometryUtils.toTrianglesDrawMode(): Unknown draw mode:', drawMode );
 		return geometry;
+
+	}
+
+}
+
+/**
+ * Returns the primitive restart index associated with a given index array type.
+ *
+ * @param {TypedArrayConstructor} array
+ * @returns {number}
+ */
+function getPrimitiveRestartIndex( array ) {
+
+	switch ( array.constructor ) {
+
+		case Uint32Array:
+
+			return 0xffffffff;
+
+		case Uint16Array:
+
+			return 0xffff;
+
+		case Uint8Array:
+
+			return 0xff;
+
+		default:
+
+			throw new Error('THREE.BufferGeometryUtils: Unknown index type: ' + array.constructor.name );
 
 	}
 


### PR DESCRIPTION
For discussion of a proposed glTF extension, supporting primitive restart values in line loop, line strip, triangle strip, and triangle fan topologies:

- https://github.com/KhronosGroup/glTF/pull/2569

Because three.js requires WebGL 2, no actual rendering changes are required, this PR just ensures that GLTFLoader recognizes the extension name. The `KHR_mesh_primitive_restart` proposal is meant to replace the existing [`EXT_mesh_primitive_restart`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_primitive_restart) extension, which would be more complex and less efficient to support in three.js.

<img width="1600" height="1075" alt="image" src="https://github.com/user-attachments/assets/f70c0ba5-05b9-4ef1-a064-322af0836dcb" />

> **Figure:** A [Hilbert space-filling curve](https://en.wikipedia.org/wiki/Hilbert_curve), rendered in 3D. The asset is structured as a glTF scene and a single mesh primitive, containing a series of LINE_STRIP topologies separated by primitive restart values. Created with glTF Transform.

*This contribution is funded by Bentley Systems.*
