### PR TITLE
Revert "PassNode: Fix depthTexture creation when `depthBuffer: false`"

### DIFF
--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -251,22 +251,14 @@ class PassNode extends TempNode {
 		 */
 		this._height = 1;
 
+		const depthTexture = new DepthTexture();
+		depthTexture.isRenderTargetTexture = true;
+		//depthTexture.type = FloatType;
+		depthTexture.name = 'depth';
+
 		const renderTarget = new RenderTarget( this._width * this._pixelRatio, this._height * this._pixelRatio, { type: HalfFloatType, ...options, } );
 		renderTarget.texture.name = 'output';
-
-		let depthTexture = null;
-
-		if ( this.scope === PassNode.DEPTH || options.depthBuffer !== false ) {
-
-			depthTexture = new DepthTexture();
-			depthTexture.isRenderTargetTexture = true;
-			//depthTexture.type = FloatType;
-			depthTexture.name = 'depth';
-
-			renderTarget.depthTexture = depthTexture;
-
-		}
-
+		renderTarget.depthTexture = depthTexture;
 
 		/**
 		 * The pass's render target.
@@ -318,17 +310,12 @@ class PassNode extends TempNode {
 		 * A dictionary holding the internal result textures.
 		 *
 		 * @private
-		 * @type {{ output: Texture, depth?: DepthTexture }}
+		 * @type {Object<string, Texture>}
 		 */
 		this._textures = {
-			output: renderTarget.texture
+			output: renderTarget.texture,
+			depth: depthTexture
 		};
-
-		if ( depthTexture !== null ) {
-
-			this._textures.depth = depthTexture;
-
-		}
 
 		/**
 		 * A dictionary holding the internal texture nodes.
@@ -770,7 +757,7 @@ class PassNode extends TempNode {
 
 		this.renderTarget.texture.type = renderer.getOutputBufferType();
 
-		if ( renderer.reversedDepthBuffer === true && this.renderTarget.depthTexture !== null ) {
+		if ( renderer.reversedDepthBuffer === true ) {
 
 			this.renderTarget.depthTexture.type = FloatType;
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -78,30 +78,24 @@ class Textures extends DataMap {
 		const mipWidth = size.width >> activeMipmapLevel;
 		const mipHeight = size.height >> activeMipmapLevel;
 
+		let depthTexture = renderTarget.depthTexture || depthTextureMips[ activeMipmapLevel ];
 		const useDepthTexture = renderTarget.depthBuffer === true || renderTarget.stencilBuffer === true;
-		let depthTexture = null;
 
 		let textureNeedsUpdate = false;
 
-		if ( useDepthTexture ) {
+		if ( depthTexture === undefined && useDepthTexture ) {
 
-			depthTexture = renderTarget.depthTexture || depthTextureMips[ activeMipmapLevel ];
+			depthTexture = new DepthTexture();
 
-			if ( depthTexture === undefined ) {
+			depthTexture.format = renderTarget.stencilBuffer ? DepthStencilFormat : DepthFormat;
+			depthTexture.type = renderTarget.stencilBuffer ? UnsignedInt248Type : UnsignedIntType; // FloatType
+			depthTexture.image.width = mipWidth;
+			depthTexture.image.height = mipHeight;
+			depthTexture.image.depth = size.depth;
+			depthTexture.renderTarget = renderTarget;
+			depthTexture.isArrayTexture = renderTarget.multiview === true && size.depth > 1;
 
-				depthTexture = new DepthTexture();
-
-				depthTexture.format = renderTarget.stencilBuffer ? DepthStencilFormat : DepthFormat;
-				depthTexture.type = renderTarget.stencilBuffer ? UnsignedInt248Type : UnsignedIntType; // FloatType
-				depthTexture.image.width = mipWidth;
-				depthTexture.image.height = mipHeight;
-				depthTexture.image.depth = size.depth;
-				depthTexture.renderTarget = renderTarget;
-				depthTexture.isArrayTexture = renderTarget.multiview === true && size.depth > 1;
-
-				depthTextureMips[ activeMipmapLevel ] = depthTexture;
-
-			}
+			depthTextureMips[ activeMipmapLevel ] = depthTexture;
 
 		}
 


### PR DESCRIPTION
Reverts mrdoob/three.js#33239

Reverting for now due to breakge in the AO demo.