### PR TITLE
PassNode: Fix implicit depth texture creation when `depthBuffer: false`

### DIFF
--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -582,7 +582,7 @@ class PassNode extends TempNode {
 
 			if ( name === 'depth' ) {
 
-				throw new Error( 'PassNode: Depth texture is not available for this pass.' );
+				throw new Error( 'THREE.PassNode: Depth texture is not available for this pass.' );
 
 			}
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -580,6 +580,12 @@ class PassNode extends TempNode {
 
 		if ( texture === undefined ) {
 
+			if ( name === 'depth' ) {
+
+				throw new Error( 'PassNode: Depth texture is not available for this pass.' );
+
+			}
+
 			const refTexture = this.renderTarget.texture;
 
 			texture = refTexture.clone();

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -267,7 +267,6 @@ class PassNode extends TempNode {
 
 		}
 
-
 		/**
 		 * The pass's render target.
 		 *

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -251,14 +251,22 @@ class PassNode extends TempNode {
 		 */
 		this._height = 1;
 
-		const depthTexture = new DepthTexture();
-		depthTexture.isRenderTargetTexture = true;
-		//depthTexture.type = FloatType;
-		depthTexture.name = 'depth';
-
 		const renderTarget = new RenderTarget( this._width * this._pixelRatio, this._height * this._pixelRatio, { type: HalfFloatType, ...options, } );
 		renderTarget.texture.name = 'output';
-		renderTarget.depthTexture = depthTexture;
+
+		let depthTexture = null;
+
+		if ( PassNode.DEPTH || options.depthBuffer !== false ) {
+
+			depthTexture = new DepthTexture();
+			depthTexture.isRenderTargetTexture = true;
+			//depthTexture.type = FloatType;
+			depthTexture.name = 'depth';
+
+			renderTarget.depthTexture = depthTexture;
+
+		}
+
 
 		/**
 		 * The pass's render target.
@@ -310,12 +318,17 @@ class PassNode extends TempNode {
 		 * A dictionary holding the internal result textures.
 		 *
 		 * @private
-		 * @type {Object<string, Texture>}
+		 * @type {{ output: Texture, depth?: DepthTexture }}
 		 */
 		this._textures = {
-			output: renderTarget.texture,
-			depth: depthTexture
+			output: renderTarget.texture
 		};
+
+		if ( depthTexture !== null ) {
+
+			this._textures.depth = depthTexture;
+
+		}
 
 		/**
 		 * A dictionary holding the internal texture nodes.
@@ -757,7 +770,7 @@ class PassNode extends TempNode {
 
 		this.renderTarget.texture.type = renderer.getOutputBufferType();
 
-		if ( renderer.reversedDepthBuffer === true ) {
+		if ( renderer.reversedDepthBuffer === true && this.renderTarget.depthTexture !== null ) {
 
 			this.renderTarget.depthTexture.type = FloatType;
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -256,7 +256,7 @@ class PassNode extends TempNode {
 
 		let depthTexture = null;
 
-		if ( PassNode.DEPTH || options.depthBuffer !== false ) {
+		if ( this.scope === PassNode.DEPTH || options.depthBuffer !== false ) {
 
 			depthTexture = new DepthTexture();
 			depthTexture.isRenderTargetTexture = true;

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -71,7 +71,7 @@ class Textures extends DataMap {
 		const mipWidth = size.width >> activeMipmapLevel;
 		const mipHeight = size.height >> activeMipmapLevel;
 
-		const useDepthTexture = renderTarget.depthBuffer === true || renderTarget.stencilBuffer === true;
+		const useDepthTexture = renderTarget.depthTexture !== null || renderTarget.depthBuffer === true || renderTarget.stencilBuffer === true;
 		let depthTexture = null;
 
 		let textureNeedsUpdate = false;

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -71,7 +71,7 @@ class Textures extends DataMap {
 		const mipWidth = size.width >> activeMipmapLevel;
 		const mipHeight = size.height >> activeMipmapLevel;
 
-		const useDepthTexture = renderTarget.depthTexture !== null || renderTarget.depthBuffer === true || renderTarget.stencilBuffer === true;
+		const useDepthTexture = renderTarget.depthBuffer === true || renderTarget.stencilBuffer === true;
 		let depthTexture = null;
 
 		let textureNeedsUpdate = false;

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -71,30 +71,24 @@ class Textures extends DataMap {
 		const mipWidth = size.width >> activeMipmapLevel;
 		const mipHeight = size.height >> activeMipmapLevel;
 
+		let depthTexture = renderTarget.depthTexture || depthTextureMips[ activeMipmapLevel ];
 		const useDepthTexture = renderTarget.depthBuffer === true || renderTarget.stencilBuffer === true;
-		let depthTexture = null;
 
 		let textureNeedsUpdate = false;
 
-		if ( useDepthTexture ) {
+		if ( depthTexture === undefined && useDepthTexture ) {
 
-			depthTexture = renderTarget.depthTexture || depthTextureMips[ activeMipmapLevel ];
+			depthTexture = new DepthTexture();
 
-			if ( depthTexture === undefined ) {
+			depthTexture.format = renderTarget.stencilBuffer ? DepthStencilFormat : DepthFormat;
+			depthTexture.type = renderTarget.stencilBuffer ? UnsignedInt248Type : UnsignedIntType; // FloatType
+			depthTexture.image.width = mipWidth;
+			depthTexture.image.height = mipHeight;
+			depthTexture.image.depth = size.depth;
+			depthTexture.renderTarget = renderTarget;
+			depthTexture.isArrayTexture = renderTarget.multiview === true && size.depth > 1;
 
-				depthTexture = new DepthTexture();
-
-				depthTexture.format = renderTarget.stencilBuffer ? DepthStencilFormat : DepthFormat;
-				depthTexture.type = renderTarget.stencilBuffer ? UnsignedInt248Type : UnsignedIntType; // FloatType
-				depthTexture.image.width = mipWidth;
-				depthTexture.image.height = mipHeight;
-				depthTexture.image.depth = size.depth;
-				depthTexture.renderTarget = renderTarget;
-				depthTexture.isArrayTexture = renderTarget.multiview === true && size.depth > 1;
-
-				depthTextureMips[ activeMipmapLevel ] = depthTexture;
-
-			}
+			depthTextureMips[ activeMipmapLevel ] = depthTexture;
 
 		}
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -71,24 +71,30 @@ class Textures extends DataMap {
 		const mipWidth = size.width >> activeMipmapLevel;
 		const mipHeight = size.height >> activeMipmapLevel;
 
-		let depthTexture = renderTarget.depthTexture || depthTextureMips[ activeMipmapLevel ];
 		const useDepthTexture = renderTarget.depthBuffer === true || renderTarget.stencilBuffer === true;
+		let depthTexture = null;
 
 		let textureNeedsUpdate = false;
 
-		if ( depthTexture === undefined && useDepthTexture ) {
+		if ( useDepthTexture ) {
 
-			depthTexture = new DepthTexture();
+			depthTexture = renderTarget.depthTexture || depthTextureMips[ activeMipmapLevel ];
 
-			depthTexture.format = renderTarget.stencilBuffer ? DepthStencilFormat : DepthFormat;
-			depthTexture.type = renderTarget.stencilBuffer ? UnsignedInt248Type : UnsignedIntType; // FloatType
-			depthTexture.image.width = mipWidth;
-			depthTexture.image.height = mipHeight;
-			depthTexture.image.depth = size.depth;
-			depthTexture.renderTarget = renderTarget;
-			depthTexture.isArrayTexture = renderTarget.multiview === true && size.depth > 1;
+			if ( depthTexture === undefined ) {
 
-			depthTextureMips[ activeMipmapLevel ] = depthTexture;
+				depthTexture = new DepthTexture();
+
+				depthTexture.format = renderTarget.stencilBuffer ? DepthStencilFormat : DepthFormat;
+				depthTexture.type = renderTarget.stencilBuffer ? UnsignedInt248Type : UnsignedIntType; // FloatType
+				depthTexture.image.width = mipWidth;
+				depthTexture.image.height = mipHeight;
+				depthTexture.image.depth = size.depth;
+				depthTexture.renderTarget = renderTarget;
+				depthTexture.isArrayTexture = renderTarget.multiview === true && size.depth > 1;
+
+				depthTextureMips[ activeMipmapLevel ] = depthTexture;
+
+			}
 
 		}
 


### PR DESCRIPTION
Follow up to [#33239.](https://github.com/mrdoob/three.js/pull/33239)

Fixes a regression in the AO example by restoring support for explicit depthTextures on render targets created with `depthBuffer: false`, which `TRAANode` uses to store previous-frame depth.

Also makes `PassNode.getTexture( 'depth' )` throw an error when depth is not available for a pass, instead of silently cloning the color texture and creating an invalid `'depth'` entry.