### PR TITLE
NodeMaterialObserver: Reuse `lightsData` cache entry per frame.

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -216,7 +216,7 @@ class NodeMaterialObserver {
 
 			}
 
-			data.lights = this.getLightsData( renderObject.lightsNode.getLights() );
+			data.lights = this.getLightsData( renderObject.lightsNode.getLights(), [] );
 
 			this.renderObjects.set( renderObject, data );
 
@@ -629,9 +629,9 @@ class NodeMaterialObserver {
 	 * @param {Array<Light>} materialLights - The material lights.
 	 * @return {Array<Object>} The lights data for the given material lights.
 	 */
-	getLightsData( materialLights ) {
+	getLightsData( materialLights, lights ) {
 
-		const lights = [];
+		lights.length = 0;
 
 		for ( const light of materialLights ) {
 
@@ -658,23 +658,25 @@ class NodeMaterialObserver {
 	 */
 	getLights( lightsNode, renderId ) {
 
-		if ( _lightsCache.has( lightsNode ) ) {
+		let cached = _lightsCache.get( lightsNode );
 
-			const cached = _lightsCache.get( lightsNode );
+		if ( cached === undefined ) {
 
-			if ( cached.renderId === renderId ) {
-
-				return cached.lightsData;
-
-			}
+			cached = { renderId: - 1, lightsData: [] };
+			_lightsCache.set( lightsNode, cached );
 
 		}
 
-		const lightsData = this.getLightsData( lightsNode.getLights() );
+		if ( cached.renderId === renderId ) {
 
-		_lightsCache.set( lightsNode, { renderId, lightsData } );
+			return cached.lightsData;
 
-		return lightsData;
+		}
+
+		cached.renderId = renderId;
+		this.getLightsData( lightsNode.getLights(), cached.lightsData );
+
+		return cached.lightsData;
 
 	}
 


### PR DESCRIPTION
Related: #33419

**Description**

`NodeMaterialObserver.getLights` allocated a fresh `{ renderId, lightsData }` cache entry every frame (whenever `renderId` changed, i.e. always). Mutate the cached entry's fields in place instead, so after frame 1 the cache-miss path allocates nothing.                                                                                             
                                                                                                                       
`getLightsData` additionally allocated a fresh `const lights = []` per call, even when the scene has no spot lights (the common case). Change the signature to accept the output array so the caller reuses the same one.                  
                                                                                                     
## Before / after — `webgpu_backdrop_water`, 10 s, 1 KB sampling, Inspector stripped, 3-run average
                                                                                                                       
| metric (sites touched by this PR only) | dev | this PR | Δ |
|---|---:|---:|---:|                                                                                                   
| `needsRefresh @ NodeMaterialObserver.js:687` (the frame that calls getLights) | 0.71 KB | 0.00 KB | **−0.71 KB** |
| `getLights`-attributed samples in top-30 allocators | yes | no | eliminated |                                        
| `getLightsData`'s `const lights = []` allocation | 1/call | 0/call | structural |                                    
| `{ renderId, lightsData }` allocation per frame | 1/frame | 0/frame | structural |                                   
                                                                                     

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Spawn](https://spawn.co)*
