### PR TITLE
LightProbeGrid: Improve docs.

### DIFF
--- a/examples/jsm/lighting/LightProbeGrid.js
+++ b/examples/jsm/lighting/LightProbeGrid.js
@@ -55,6 +55,9 @@ const ATLAS_PADDING = 1;
  * A 3D grid of L2 Spherical Harmonic irradiance probes that provides
  * position-dependent diffuse global illumination.
  *
+ * Note that this class can only be used with {@link WebGLRenderer}.
+ * A version for {@link WebGPURenderer} will be added at a later point.
+ *
  * All seven packed SH sub-volumes are stored in a **single** RGBA
  * `WebGL3DRenderTarget` using a texture-atlas layout along the Z axis.
  * Each sub-volume occupies `( nz + 2 )` atlas slices: one padding slice at


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/how-to-create-a-comparable-light-probes-webgl-vs-webgpu

**Description**

Devs already want to use `LightProbeGrid` with `WebGPURenderer`. The PR adds a note that this class is only compatible with `WebGLRenderer`.

Thinking about the port: How about moving `LightProbeGrid` into the core? `WebGLRenderer` has dependencies to `LightProbeGrid` anyway. Also similar to `PMREMGenerator`, we can provide a WebGPU version in the WebGPU builds with the same class name. 

In general, it seems reasonable to treat  `LightProbeGrid` and `PMREMGenerator` equally since they both require renderer specific code and potentially have similar relevance.
