### PR TITLE
UniformsGroup: Pool per-uniform update-range objects.

### DIFF
--- a/src/renderers/common/UniformsGroup.js
+++ b/src/renderers/common/UniformsGroup.js
@@ -55,6 +55,15 @@ class UniformsGroup extends UniformBuffer {
 		 */
 		this._updateRangeCache = new Map();
 
+		/**
+		 * Uniform indices whose range has already been pushed into `updateRanges`
+		 * during the current update cycle. Reset on `clearUpdateRanges()`.
+		 *
+		 * @private
+		 * @type {Set<number>}
+		 */
+		this._addedIndices = new Set();
+
 	}
 
 	/**
@@ -65,21 +74,23 @@ class UniformsGroup extends UniformBuffer {
 	addUniformUpdateRange( uniform ) {
 
 		const index = uniform.index;
+
+		if ( this._addedIndices.has( index ) ) return;
+
 		let range = this._updateRangeCache.get( index );
 
 		if ( range === undefined ) {
 
-			range = { start: uniform.offset, count: uniform.itemSize, added: false };
+			range = { start: 0, count: 0 };
 			this._updateRangeCache.set( index, range );
 
 		}
 
-		if ( range.added === false ) {
+		range.start = uniform.offset;
+		range.count = uniform.itemSize;
 
-			range.added = true;
-			this.updateRanges.push( range );
-
-		}
+		this._addedIndices.add( index );
+		this.updateRanges.push( range );
 
 	}
 
@@ -88,11 +99,7 @@ class UniformsGroup extends UniformBuffer {
 	 */
 	clearUpdateRanges() {
 
-		for ( const range of this._updateRangeCache.values() ) {
-
-			range.added = false;
-
-		}
+		this._addedIndices.clear();
 
 		super.clearUpdateRanges();
 

--- a/src/renderers/common/UniformsGroup.js
+++ b/src/renderers/common/UniformsGroup.js
@@ -65,19 +65,19 @@ class UniformsGroup extends UniformBuffer {
 	addUniformUpdateRange( uniform ) {
 
 		const index = uniform.index;
+		let range = this._updateRangeCache.get( index );
 
-		if ( this._updateRangeCache.has( index ) !== true ) {
+		if ( range === undefined ) {
 
-			const updateRanges = this.updateRanges;
-
-			const start = uniform.offset;
-			const count = uniform.itemSize;
-
-			const range = { start, count };
-
-			updateRanges.push( range );
-
+			range = { start: uniform.offset, count: uniform.itemSize, added: false };
 			this._updateRangeCache.set( index, range );
+
+		}
+
+		if ( range.added === false ) {
+
+			range.added = true;
+			this.updateRanges.push( range );
 
 		}
 
@@ -88,7 +88,11 @@ class UniformsGroup extends UniformBuffer {
 	 */
 	clearUpdateRanges() {
 
-		this._updateRangeCache.clear();
+		for ( const range of this._updateRangeCache.values() ) {
+
+			range.added = false;
+
+		}
 
 		super.clearUpdateRanges();
 


### PR DESCRIPTION
Related: #33419
**Description**

`UniformsGroup.addUniformUpdateRange` allocated a fresh `{ start, count }` object every frame for every uniform whose value changed. Keep the range objects in `_updateRangeCache` across frames; mark each as `added: false` in `clearUpdateRanges()` so the next frame pushes the same cached object onto `updateRanges` rather than allocating a new one.
                                                                                                                       
## Before / after — `webgpu_backdrop_water`, 10 s, 1 KB sampling, Inspector stripped, 3-run average

| metric | dev | this PR | Δ |                                                                                         
|---|---:|---:|---:|
| `updateNumber @ UniformsGroup.js:267` (caller) | 0.70 KB | 0.00 KB | −0.70 KB |                                      
| `{ start, count }` allocations per frame | N/uniform | 0 after first use | structural |                              
| **Total sampled heap** | 408.99 KB | 400.75 KB | −2.0% |     


*This contribution is funded by [Spawn](https://spawn.co)*
