### PR TITLE
WebGPURenderer: Mesh can override UniformGroups

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -97,7 +97,7 @@ class Mesh extends Object3D {
 		/**
 		 * TSL override for uniform groups
 		 * Put uniforms here
-		 * 
+		 *
 		 * this.uniGroups = {
          *      uTintGroup: {
          *          tintColor: uniform(new THREE.Color(1.0, 0.0, 0.0),

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -95,6 +95,30 @@ class Mesh extends Object3D {
 		this.morphTargetInfluences = undefined;
 
 		/**
+		 * TSL override for uniform groups
+		 * Put uniforms here
+		 * 
+		 * this.uniGroups = {
+         *      uTintGroup: {
+         *          tintColor: uniform(new THREE.Color(1.0, 0.0, 0.0),
+         *          tintAlpha: uniform(.3).setName('tintAlpha')
+         *      }
+         *  };
+		 *
+		 * @type {Object|undefined}
+		 * @default undefined
+		 */
+		this.uniGroups = undefined;
+
+		/**
+		 * Cache for special objects in "uniGroups"
+		 *
+		 * @type {Object|undefined}
+		 * @default undefined
+		 */
+		this._uniGroupCache = undefined;
+
+		/**
 		 * The number of instances of this mesh.
 		 * Can only be used with {@link WebGPURenderer}.
 		 *

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -397,9 +397,16 @@ class RenderObject {
 	 * @return {Array<BindGroup>} The bindings.
 	 */
 	getBindings() {
+		if (this._bindings) {
+            return this._bindings;
+        }
+    
+		if (this.object.uniGroups && !this.object._cacheUniGroups) {
+			this.object._cacheUniGroups = {}
+		}
 
-		return this._bindings || ( this._bindings = this.getNodeBuilderState().createBindings() );
-
+        this._bindings = this.getNodeBuilderState().createBindings(this.object.uniGroups, this.object._cacheUniGroups)
+        return this._bindings;
 	}
 
 	/**

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -397,16 +397,22 @@ class RenderObject {
 	 * @return {Array<BindGroup>} The bindings.
 	 */
 	getBindings() {
-		if (this._bindings) {
-            return this._bindings;
-        }
-    
-		if (this.object.uniGroups && !this.object._cacheUniGroups) {
-			this.object._cacheUniGroups = {}
+
+		if ( this._bindings ) {
+
+			return this._bindings;
+
 		}
 
-        this._bindings = this.getNodeBuilderState().createBindings(this.object.uniGroups, this.object._cacheUniGroups)
-        return this._bindings;
+		if ( this.object.uniGroups && ! this.object._cacheUniGroups ) {
+
+			this.object._cacheUniGroups = {};
+
+		}
+
+		this._bindings = this.getNodeBuilderState().createBindings( this.object.uniGroups, this.object._cacheUniGroups );
+		return this._bindings;
+
 	}
 
 	/**

--- a/src/renderers/common/nodes/NodeBuilderState.js
+++ b/src/renderers/common/nodes/NodeBuilderState.js
@@ -1,4 +1,6 @@
-import BindGroup from '../BindGroup.js';
+import BindGroup from '../BindGroup.js'
+import UniformGroupNode from '../../../nodes/core/UniformGroupNode.js';
+import NodeUniformsGroup from './NodeUniformsGroup.js';
 
 /**
  * This module represents the state of a node builder after it was
@@ -113,10 +115,13 @@ class NodeBuilderState {
 	 * This method is used to create a array of bind groups based
 	 * on the existing bind groups of this state. Shared groups are
 	 * not cloned.
+	 * 
+	 * @param {} uniGroups TSL uniforms
+	 * @param {} _uniGroupCache cache object
 	 *
 	 * @return {Array<BindGroup>} A array of bind groups.
 	 */
-	createBindings() {
+	createBindings(uniGroups, uniGroupCache) {
 
 		const bindings = [];
 
@@ -130,9 +135,25 @@ class NodeBuilderState {
 				bindings.push( bindingsGroup );
 
 				for ( const instanceBinding of instanceGroup.bindings ) {
-
-					bindingsGroup.bindings.push( instanceBinding.clone() );
-
+					const name = instanceBinding.name
+					let overrideGroup = uniGroups?.[name]
+					if (overrideGroup) {
+						const cached = uniGroupCache[name]
+                        if (cached) {
+							bindingsGroup.bindings.push(cached)
+                        } else {
+                            const newNode = new UniformGroupNode(name)
+                            const newNug = new NodeUniformsGroup(name, newNode)
+                            for (let uni of instanceBinding.uniforms) {
+                                let overrideUni = overrideGroup[uni.name]
+								newNug.uniforms.push(overrideUni ? uni.cloneAndWrap(overrideUni) : uni )
+                            }
+                            uniGroupCache[name] = newNug
+                            bindingsGroup.bindings.push(newNug)
+                        }
+					} else {
+						bindingsGroup.bindings.push( instanceBinding.clone() );
+					}				
 				}
 
 			} else {

--- a/src/renderers/common/nodes/NodeBuilderState.js
+++ b/src/renderers/common/nodes/NodeBuilderState.js
@@ -139,18 +139,18 @@ class NodeBuilderState {
 					let overrideGroup = uniGroups?.[name]
 					if (overrideGroup) {
 						const cached = uniGroupCache[name]
-                        if (cached) {
+						if (cached) {
 							bindingsGroup.bindings.push(cached)
-                        } else {
-                            const newNode = new UniformGroupNode(name)
-                            const newNug = new NodeUniformsGroup(name, newNode)
-                            for (let uni of instanceBinding.uniforms) {
-                                let overrideUni = overrideGroup[uni.name]
+						} else {
+							const newNode = new UniformGroupNode(name)
+							const newNug = new NodeUniformsGroup(name, newNode)
+							for (let uni of instanceBinding.uniforms) {
+								let overrideUni = overrideGroup[uni.name]
 								newNug.uniforms.push(overrideUni ? uni.cloneAndWrap(overrideUni) : uni )
-                            }
-                            uniGroupCache[name] = newNug
-                            bindingsGroup.bindings.push(newNug)
-                        }
+							}
+							uniGroupCache[name] = newNug
+							bindingsGroup.bindings.push(newNug)
+						}
 					} else {
 						bindingsGroup.bindings.push( instanceBinding.clone() );
 					}				

--- a/src/renderers/common/nodes/NodeBuilderState.js
+++ b/src/renderers/common/nodes/NodeBuilderState.js
@@ -1,4 +1,4 @@
-import BindGroup from '../BindGroup.js'
+import BindGroup from '../BindGroup.js';
 import UniformGroupNode from '../../../nodes/core/UniformGroupNode.js';
 import NodeUniformsGroup from './NodeUniformsGroup.js';
 
@@ -115,13 +115,13 @@ class NodeBuilderState {
 	 * This method is used to create a array of bind groups based
 	 * on the existing bind groups of this state. Shared groups are
 	 * not cloned.
-	 * 
-	 * @param {} uniGroups TSL uniforms
-	 * @param {} _uniGroupCache cache object
+	 *
+	 * @param {Object|undefined} uniGroups TSL uniforms
+	 * @param {Object|undefined} _uniGroupCache cache object
 	 *
 	 * @return {Array<BindGroup>} A array of bind groups.
 	 */
-	createBindings(uniGroups, uniGroupCache) {
+	createBindings( uniGroups, uniGroupCache ) {
 
 		const bindings = [];
 
@@ -135,25 +135,38 @@ class NodeBuilderState {
 				bindings.push( bindingsGroup );
 
 				for ( const instanceBinding of instanceGroup.bindings ) {
-					const name = instanceBinding.name
-					let overrideGroup = uniGroups?.[name]
-					if (overrideGroup) {
-						const cached = uniGroupCache[name]
-						if (cached) {
-							bindingsGroup.bindings.push(cached)
+
+					const name = instanceBinding.name;
+					const overrideGroup = uniGroups?.[ name ];
+					if ( overrideGroup ) {
+
+						const cached = uniGroupCache[ name ];
+						if ( cached ) {
+
+							bindingsGroup.bindings.push( cached );
+
 						} else {
-							const newNode = new UniformGroupNode(name)
-							const newNug = new NodeUniformsGroup(name, newNode)
-							for (let uni of instanceBinding.uniforms) {
-								let overrideUni = overrideGroup[uni.name]
-								newNug.uniforms.push(overrideUni ? uni.cloneAndWrap(overrideUni) : uni )
+
+							const newNode = new UniformGroupNode( name );
+							const newNug = new NodeUniformsGroup( name, newNode );
+							for ( const uni of instanceBinding.uniforms ) {
+
+								const overrideUni = overrideGroup[ uni.name ];
+								newNug.uniforms.push( overrideUni ? uni.cloneAndWrap( overrideUni ) : uni );
+
 							}
-							uniGroupCache[name] = newNug
-							bindingsGroup.bindings.push(newNug)
+
+							uniGroupCache[ name ] = newNug;
+							bindingsGroup.bindings.push( newNug );
+
 						}
+
 					} else {
+
 						bindingsGroup.bindings.push( instanceBinding.clone() );
-					}				
+
+					}
+
 				}
 
 			} else {

--- a/src/renderers/common/nodes/NodeUniform.js
+++ b/src/renderers/common/nodes/NodeUniform.js
@@ -58,11 +58,14 @@ class NumberNodeUniform extends NumberUniform {
 	 * @param {UniformNode} swappedNode - swapped uniform
 	 * @return {NumberNodeUniform} cloned obj
 	 */
-	cloneAndWrap(swappedNode) {
-		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
-			swappedNode)
-		return new NumberNodeUniform(nodeUniform)
+	cloneAndWrap( swappedNode ) {
+
+		const nodeUniform = new NodeUniform( this.nodeUniform.name, this.nodeUniform.type,
+			swappedNode );
+		return new NumberNodeUniform( nodeUniform );
+
 	}
+
 }
 
 /**
@@ -119,11 +122,14 @@ class Vector2NodeUniform extends Vector2Uniform {
 	 * @param {UniformNode} swappedNode - swapped uniform
 	 * @return {Vector2NodeUniform} cloned obj
 	 */
-	cloneAndWrap(swappedNode) {
-		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
-			swappedNode)
-		return new Vector2NodeUniform(nodeUniform)
+	cloneAndWrap( swappedNode ) {
+
+		const nodeUniform = new NodeUniform( this.nodeUniform.name, this.nodeUniform.type,
+			swappedNode );
+		return new Vector2NodeUniform( nodeUniform );
+
 	}
+
 }
 
 /**
@@ -181,11 +187,14 @@ class Vector3NodeUniform extends Vector3Uniform {
 	 * @param {UniformNode} swappedNode - swapped uniform
 	 * @return {Vector3NodeUniform} cloned obj
 	 */
-	cloneAndWrap(swappedNode) {
-		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
-			swappedNode)
-		return new Vector3NodeUniform(nodeUniform)
+	cloneAndWrap( swappedNode ) {
+
+		const nodeUniform = new NodeUniform( this.nodeUniform.name, this.nodeUniform.type,
+			swappedNode );
+		return new Vector3NodeUniform( nodeUniform );
+
 	}
+
 }
 
 /**
@@ -242,11 +251,14 @@ class Vector4NodeUniform extends Vector4Uniform {
 	 * @param {UniformNode} swappedNode - swapped uniform
 	 * @return {Vector4NodeUniform} cloned obj
 	 */
-	cloneAndWrap(swappedNode) {
-		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
-			swappedNode)
-		return new Vector4NodeUniform(nodeUniform)
+	cloneAndWrap( swappedNode ) {
+
+		const nodeUniform = new NodeUniform( this.nodeUniform.name, this.nodeUniform.type,
+			swappedNode );
+		return new Vector4NodeUniform( nodeUniform );
+
 	}
+
 }
 
 /**
@@ -303,11 +315,14 @@ class ColorNodeUniform extends ColorUniform {
 	 * @param {UniformNode} swappedNode - swapped uniform
 	 * @return {ColorNodeUniform} cloned obj
 	 */
-	cloneAndWrap(swappedNode) {
-		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
-			swappedNode)
-		return new ColorNodeUniform(nodeUniform)
+	cloneAndWrap( swappedNode ) {
+
+		const nodeUniform = new NodeUniform( this.nodeUniform.name, this.nodeUniform.type,
+			swappedNode );
+		return new ColorNodeUniform( nodeUniform );
+
 	}
+
 }
 
 
@@ -365,11 +380,14 @@ class Matrix2NodeUniform extends Matrix2Uniform {
 	 * @param {UniformNode} swappedNode - swapped uniform
 	 * @return {Matrix2NodeUniform} cloned obj
 	 */
-	cloneAndWrap(swappedNode) {
-		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
-			swappedNode)
-		return new Matrix2NodeUniform(nodeUniform)
+	cloneAndWrap( swappedNode ) {
+
+		const nodeUniform = new NodeUniform( this.nodeUniform.name, this.nodeUniform.type,
+			swappedNode );
+		return new Matrix2NodeUniform( nodeUniform );
+
 	}
+
 }
 
 /**
@@ -426,11 +444,14 @@ class Matrix3NodeUniform extends Matrix3Uniform {
 	 * @param {UniformNode} swappedNode - swapped uniform
 	 * @return {Matrix3NodeUniform} cloned obj
 	 */
-	cloneAndWrap(swappedNode) {
-		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
-			swappedNode)
-		return new Matrix3NodeUniform(nodeUniform)
+	cloneAndWrap( swappedNode ) {
+
+		const nodeUniform = new NodeUniform( this.nodeUniform.name, this.nodeUniform.type,
+			swappedNode );
+		return new Matrix3NodeUniform( nodeUniform );
+
 	}
+
 }
 
 /**
@@ -487,11 +508,14 @@ class Matrix4NodeUniform extends Matrix4Uniform {
 	 * @param {UniformNode} swappedNode - swapped uniform
 	 * @return {Matrix4NodeUniform} cloned obj
 	 */
-	cloneAndWrap(swappedNode) {
-		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
-			swappedNode)
-		return new Matrix4NodeUniform(nodeUniform)
+	cloneAndWrap( swappedNode ) {
+
+		const nodeUniform = new NodeUniform( this.nodeUniform.name, this.nodeUniform.type,
+			swappedNode );
+		return new Matrix4NodeUniform( nodeUniform );
+
 	}
+
 }
 
 export {

--- a/src/renderers/common/nodes/NodeUniform.js
+++ b/src/renderers/common/nodes/NodeUniform.js
@@ -2,6 +2,7 @@ import {
 	NumberUniform, Vector2Uniform, Vector3Uniform, Vector4Uniform,
 	ColorUniform, Matrix2Uniform, Matrix3Uniform, Matrix4Uniform
 } from '../Uniform.js';
+import NodeUniform from '../../../nodes/core/NodeUniform.js';
 
 /**
  * A special form of Number uniform binding type.
@@ -52,6 +53,16 @@ class NumberNodeUniform extends NumberUniform {
 
 	}
 
+	/**
+	 * Returns the node uniform data type.
+	 * @param {UniformNode} swappedNode - swapped uniform
+	 * @return {NumberNodeUniform} cloned obj
+	 */
+	cloneAndWrap(swappedNode) {
+		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
+			swappedNode)
+		return new NumberNodeUniform(nodeUniform)
+	}
 }
 
 /**
@@ -103,6 +114,16 @@ class Vector2NodeUniform extends Vector2Uniform {
 
 	}
 
+	/**
+	 * Returns the node uniform data type.
+	 * @param {UniformNode} swappedNode - swapped uniform
+	 * @return {Vector2NodeUniform} cloned obj
+	 */
+	cloneAndWrap(swappedNode) {
+		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
+			swappedNode)
+		return new Vector2NodeUniform(nodeUniform)
+	}
 }
 
 /**
@@ -154,6 +175,17 @@ class Vector3NodeUniform extends Vector3Uniform {
 
 	}
 
+
+	/**
+	 * Returns the node uniform data type.
+	 * @param {UniformNode} swappedNode - swapped uniform
+	 * @return {Vector3NodeUniform} cloned obj
+	 */
+	cloneAndWrap(swappedNode) {
+		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
+			swappedNode)
+		return new Vector3NodeUniform(nodeUniform)
+	}
 }
 
 /**
@@ -205,6 +237,16 @@ class Vector4NodeUniform extends Vector4Uniform {
 
 	}
 
+	/**
+	 * Returns the node uniform data type.
+	 * @param {UniformNode} swappedNode - swapped uniform
+	 * @return {Vector4NodeUniform} cloned obj
+	 */
+	cloneAndWrap(swappedNode) {
+		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
+			swappedNode)
+		return new Vector4NodeUniform(nodeUniform)
+	}
 }
 
 /**
@@ -256,6 +298,16 @@ class ColorNodeUniform extends ColorUniform {
 
 	}
 
+	/**
+	 * Returns the node uniform data type.
+	 * @param {UniformNode} swappedNode - swapped uniform
+	 * @return {ColorNodeUniform} cloned obj
+	 */
+	cloneAndWrap(swappedNode) {
+		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
+			swappedNode)
+		return new ColorNodeUniform(nodeUniform)
+	}
 }
 
 
@@ -308,6 +360,16 @@ class Matrix2NodeUniform extends Matrix2Uniform {
 
 	}
 
+	/**
+	 * Returns the node uniform data type.
+	 * @param {UniformNode} swappedNode - swapped uniform
+	 * @return {Matrix2NodeUniform} cloned obj
+	 */
+	cloneAndWrap(swappedNode) {
+		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
+			swappedNode)
+		return new Matrix2NodeUniform(nodeUniform)
+	}
 }
 
 /**
@@ -359,6 +421,16 @@ class Matrix3NodeUniform extends Matrix3Uniform {
 
 	}
 
+	/**
+	 * Returns the node uniform data type.
+	 * @param {UniformNode} swappedNode - swapped uniform
+	 * @return {Matrix3NodeUniform} cloned obj
+	 */
+	cloneAndWrap(swappedNode) {
+		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
+			swappedNode)
+		return new Matrix3NodeUniform(nodeUniform)
+	}
 }
 
 /**
@@ -410,6 +482,16 @@ class Matrix4NodeUniform extends Matrix4Uniform {
 
 	}
 
+	/**
+	 * Returns the node uniform data type.
+	 * @param {UniformNode} swappedNode - swapped uniform
+	 * @return {Matrix4NodeUniform} cloned obj
+	 */
+	cloneAndWrap(swappedNode) {
+		const nodeUniform = new NodeUniform(this.nodeUniform.name, this.nodeUniform.type, 
+			swappedNode)
+		return new Matrix4NodeUniform(nodeUniform)
+	}
 }
 
 export {


### PR DESCRIPTION
Related issue: #33428

**Description**

1. Added cloning of `ColorUniformNode -> NodeUniform->UniformNode` line.

in future, `isColorUniform` and other booleans better to be converted to single ENUM. This is like one of worst OOP patterns.

2. Added hack in NodeBuilderState

I've tested it on with reflections, so multiple RenderObject work fine

Possible problems:

- [x] multipass / water reflections
- [ ] add a simple demo in codepen/codesandbox/whatever
- [ ] need better UniformGroup (currently its an object)
- [ ] check that updates in UniformGroup work fine
- [ ] refactor Cache object per-UniformGroup
- [ ] add support of textures and storage buffers
- [ ] add guards, check what user passed as a UniformGroup
- [ ] add types