### PR TITLE
TSL: Make not() on vector produce component-wise logical not

### DIFF
--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -332,7 +332,7 @@ class OperatorNode extends TempNode {
 
 			} else if ( op === '!' ) {
 
-				if ( isGLSL ) {
+				if ( isGLSL && builder.isVector( typeA ) ) {
 
 					return builder.format( `not( ${a} )`, output );
 

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -346,7 +346,7 @@ class OperatorNode extends TempNode {
 
 			} else if ( op === '~' ) {
 
-				return builder.format( `(${op}${a})`, typeA, output );
+				return builder.format( `( ${op} ${a} )`, typeA, output );
 
 			} else if ( fnOpSnippet ) {
 

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -344,7 +344,7 @@ class OperatorNode extends TempNode {
 
 				} else {
 
-					// WGSL
+					// WGSL and scalars on GLSL
 
 					return builder.format( `( ${op} ${a} )`, typeA, output );
 

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -132,7 +132,13 @@ class OperatorNode extends TempNode {
 
 			return 'bool';
 
-		} else if ( op === '!' || op === '==' || op === '!=' || op === '<' || op === '>' || op === '<=' || op === '>=' ) {
+		} else if ( op === '!' ) {
+
+			const typeLength = builder.getTypeLength( typeA );
+
+			return typeLength > 1 ? `bvec${ typeLength }` : 'bool';
+
+		} else if ( op === '==' || op === '!=' || op === '<' || op === '>' || op === '<=' || op === '>=' ) {
 
 			const typeLength = Math.max( builder.getTypeLength( typeA ), builder.getTypeLength( typeB ) );
 

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -128,11 +128,11 @@ class OperatorNode extends TempNode {
 
 			return builder.getIntegerType( typeA );
 
-		} else if ( op === '!' || op === '&&' || op === '||' || op === '^^' ) {
+		} else if ( op === '&&' || op === '||' || op === '^^' ) {
 
 			return 'bool';
 
-		} else if ( op === '==' || op === '!=' || op === '<' || op === '>' || op === '<=' || op === '>=' ) {
+		} else if ( op === '!' || op === '==' || op === '!=' || op === '<' || op === '>' || op === '<=' || op === '>=' ) {
 
 			const typeLength = Math.max( builder.getTypeLength( typeA ), builder.getTypeLength( typeB ) );
 
@@ -330,7 +330,21 @@ class OperatorNode extends TempNode {
 
 				}
 
-			} else if ( op === '!' || op === '~' ) {
+			} else if ( op === '!' ) {
+
+				if ( isGLSL ) {
+
+					return builder.format( `not( ${a} )`, output );
+
+				} else {
+
+					// WGSL
+
+					return builder.format( `( ${op} ${a} )`, typeA, output );
+
+				}
+
+			} else if ( op === '~' ) {
 
 				return builder.format( `(${op}${a})`, typeA, output );
 


### PR DESCRIPTION
Fixes: #33385

**Description**

This PR changes the behavior of TSL's `not` to generate component-wise logical not.