### PR TITLE
WebGPUBackend: toggle comment causing import to appear in build

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1,6 +1,5 @@
-/*// debugger tools
-import 'https://greggman.github.io/webgpu-avoid-redundant-state-setting/webgpu-check-redundant-state-setting.js';
-//*/
+// debugger tools
+// import 'https://greggman.github.io/webgpu-avoid-redundant-state-setting/webgpu-check-redundant-state-setting.js';
 
 import { GPUFeatureName, GPULoadOp, GPUStoreOp, GPUIndexFormat, GPUTextureViewDimension, GPUFeatureMap, GPUShaderStage } from './utils/WebGPUConstants.js';
 


### PR DESCRIPTION
Related issue: #33444

**Description**

The toggle comment block in WebGPUBackend.js causes the debug import to leak into the production build, breaking Vite. Changed to plain line comments to prevent this while keeping the reference for local dev use.