### PR TITLE
RapierPhysics: Add `applyImpulse()`.

### DIFF
--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -281,6 +281,20 @@ async function RapierPhysics() {
 
 	}
 
+	function applyImpulse( mesh, impulse, index = 0 ) {
+
+		let { body } = meshMap.get( mesh );
+
+		if ( mesh.isInstancedMesh ) {
+
+			body = body[ index ];
+
+		}
+
+		body.applyImpulse( impulse, true );
+
+	}
+
 	function addHeightfield( mesh, width, depth, heights, scale ) {
 
 		const shape = RAPIER.ColliderDesc.heightfield( width, depth, heights, scale );
@@ -414,7 +428,7 @@ async function RapierPhysics() {
 
 		/**
 		 * Adds a heightfield terrain to the physics simulation.
-		 * 
+		 *
 		 * @method
 		 * @name RapierPhysics#addHeightfield
 		 * @param {Mesh} mesh - The Three.js mesh representing the terrain.
@@ -427,7 +441,18 @@ async function RapierPhysics() {
 		 * @param {number} scale.z - Scale factor for depth.
 		 * @returns {RigidBody} The created Rapier rigid body for the heightfield.
 		 */
-		addHeightfield: addHeightfield
+		addHeightfield: addHeightfield,
+
+		/**
+		 * Applies an impulse to the given mesh which is part of the physics simulation.
+		 *
+		 * @method
+		 * @name RapierPhysics#applyImpulse
+		 * @param {Mesh} mesh - The mesh to apply the impulse to.
+		 * @param {Vector3} impulse - The impulse to apply.
+		 * @param {number} [index=0] - If the mesh is instanced, the index represents the instanced ID.
+		 */
+		applyImpulse: applyImpulse
 
 	};
 

--- a/examples/physics_rapier_instancing.html
+++ b/examples/physics_rapier_instancing.html
@@ -9,7 +9,8 @@
 	<body>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> physics - <a href="https://github.com/dimforge/rapier.js" target="_blank">rapier</a> instancing
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> physics - <a href="https://github.com/dimforge/rapier.js" target="_blank">rapier</a> instancing<br />
+			<button id="shake" style="margin-top: 25px;">SHAKE</button>
 		</div>
 
 		<script type="importmap">
@@ -139,6 +140,28 @@
 				const controls = new OrbitControls( camera, renderer.domElement );
 				controls.target.y = 0.5;
 				controls.update();
+
+				document.querySelector( 'button#shake' ).addEventListener( 'click', () => {
+
+					const impulse = new THREE.Vector3();
+
+					for ( let i = 0; i < spheres.count; i ++ ) {
+
+						impulse.set( ( Math.random() - 0.5 ) * 5, Math.random() * 5, ( Math.random() - 0.5 ) * 5 );
+
+						physics.applyImpulse( spheres, impulse, i );
+
+					}
+
+					for ( let i = 0; i < boxes.count; i ++ ) {
+
+						impulse.set( ( Math.random() - 0.5 ) * 5, Math.random() * 5, ( Math.random() - 0.5 ) * 5 );
+
+						physics.applyImpulse( boxes, impulse, i );
+
+					}
+
+				} );
 
 				setInterval( () => {
 


### PR DESCRIPTION
Related issue: #28203

**Description**

#28203 changed `RapierPhysics` quite fundamentally which made it hard to approve the PR. This PR extracts a fun bit and adds it to `RapierPhysics` and the `physics_rapier_instancing` demo without any breaking changes. There is now `applyImpulse()` that let you implement shakes like in the below video.

https://github.com/user-attachments/assets/e092f9c1-854e-4d2d-be21-9f8a11820c73