### PR TITLE
RenderObject: Guard against undefined geometry attribute in getAttributes()

### DIFF
--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -511,7 +511,12 @@ class RenderObject {
 
 				// geometry attribute
 				attribute = geometry.getAttribute( nodeAttribute.name );
-				attributesId[ nodeAttribute.name ] = attribute.id;
+
+				if ( attribute !== undefined ) {
+
+					attributesId[ nodeAttribute.name ] = attribute.id;
+
+				}
 
 			}
 


### PR DESCRIPTION
In `getAttributes()`, when `nodeAttribute` is a geometry attribute, the code reads `attribute.id` immediately after `geometry.getAttribute(...)` — but `getAttribute` returns `undefined` if the geometry is missing that attribute. The `if ( attribute === undefined ) continue;` check runs one line too late, so the crash fires first:

```
Cannot read properties of undefined (reading 'id')
```

This happens in practice when a node material references an attribute the geometry doesn't provide (e.g. a vertex color attribute that was sanitized out).

Fix: only write to `attributesId` when the attribute actually exists.

Note: #32700 recently changed `.version` → `.id` on this line, but the bug predates that — `attribute.version` on `undefined` would have thrown the same way.

*This contribution is funded by [Spawn](https://spawn.co)*