### PR TITLE
WebGPUBindingUtils: Guard updateBinding() against destroyed GPU buffer

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -190,7 +190,7 @@ class WebGPUBindingUtils {
 		const array = binding.buffer; // cpu
 		const buffer = backend.get( binding ).buffer; // gpu
 
-		if ( buffer === undefined ) return;
+		if ( buffer === undefined ) return; // see #33461
 
 		const updateRanges = binding.updateRanges;
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -190,6 +190,8 @@ class WebGPUBindingUtils {
 		const array = binding.buffer; // cpu
 		const buffer = backend.get( binding ).buffer; // gpu
 
+		if ( buffer === undefined ) return;
+
 		const updateRanges = binding.updateRanges;
 
 		if ( updateRanges.length === 0 ) {


### PR DESCRIPTION
`updateBinding()` crashes when the GPU buffer has been destroyed via `_destroyBindings()` but the binding is accessed before `_createBindings()` re-creates it. `backend.get(binding).buffer` is `undefined` after `destroyUniformBuffer()` deletes the backend data, causing `device.queue.writeBuffer(undefined, ...)` to fail.

This is a race between binding destruction and re-creation that surfaces when render objects sharing bind groups are disposed and re-created across frames.

Fix: early return from `updateBinding()` when the GPU buffer doesn't exist. The buffer will be re-created on the next `_createBindings()` pass via `getForRender()`.

*This contribution is funded by [Spawn](https://spawn.co)*