### PR TITLE
Enhance BatchedMesh and Wireframe Index Handling

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -284,6 +284,28 @@ class BatchedMesh extends Mesh {
 	}
 
 	/**
+	 * Sets {@link BufferGeometry#drawRange} to the used prefix of the pooled index or vertex buffer
+	 * so code that walks the full geometry (e.g. wireframe index generation) does not treat the
+	 * reserved tail of the pool as active triangles.
+	 */
+	_syncGeometryDrawRange() {
+
+		if ( this._geometryInitialized === false ) return;
+
+		const geometry = this.geometry;
+		if ( geometry.index !== null ) {
+
+			geometry.setDrawRange( 0, this._nextIndexStart );
+
+		} else {
+
+			geometry.setDrawRange( 0, this._nextVertexStart );
+
+		}
+
+	}
+
+	/**
 	 * The maximum number of individual instances that can be stored in the batch.
 	 *
 	 * @type {number}
@@ -697,6 +719,8 @@ class BatchedMesh extends Mesh {
 		this._nextIndexStart = geometryInfo.indexStart + geometryInfo.reservedIndexCount;
 		this._nextVertexStart = geometryInfo.vertexStart + geometryInfo.reservedVertexCount;
 
+		this._syncGeometryDrawRange();
+
 		return geometryId;
 
 	}
@@ -961,6 +985,8 @@ class BatchedMesh extends Mesh {
 		this._nextIndexStart = nextIndexStart;
 		this._nextVertexStart = nextVertexStart;
 		this._visibilityChanged = true;
+
+		this._syncGeometryDrawRange();
 
 		return this;
 
@@ -1377,6 +1403,8 @@ class BatchedMesh extends Mesh {
 
 		}
 
+		this._syncGeometryDrawRange();
+
 	}
 
 	raycast( raycaster, intersects ) {
@@ -1486,6 +1514,8 @@ class BatchedMesh extends Mesh {
 			this._colorsTexture.image.data = this._colorsTexture.image.data.slice();
 
 		}
+
+		this._syncGeometryDrawRange();
 
 		return this;
 

--- a/src/renderers/common/Geometries.js
+++ b/src/renderers/common/Geometries.js
@@ -1,7 +1,6 @@
 import DataMap from './DataMap.js';
 import { AttributeType } from './Constants.js';
-
-import { Uint16BufferAttribute, Uint32BufferAttribute } from '../../core/BufferAttribute.js';
+import { createWireframeIndexBufferAttribute, getWireframeRangeKey } from './WireframeIndexUtils.js';
 
 /**
  * Returns the wireframe version for the given geometry.
@@ -41,44 +40,16 @@ function getWireframeId( geometry ) {
  */
 function getWireframeIndex( geometry ) {
 
-	const indices = [];
+	const attribute = createWireframeIndexBufferAttribute( geometry );
+	if ( attribute === null ) {
 
-	const geometryIndex = geometry.index;
-	const geometryPosition = geometry.attributes.position;
-
-	if ( geometryIndex !== null ) {
-
-		const array = geometryIndex.array;
-
-		for ( let i = 0, l = array.length; i < l; i += 3 ) {
-
-			const a = array[ i + 0 ];
-			const b = array[ i + 1 ];
-			const c = array[ i + 2 ];
-
-			indices.push( a, b, b, c, c, a );
-
-		}
-
-	} else {
-
-		const array = geometryPosition.array;
-
-		for ( let i = 0, l = ( array.length / 3 ) - 1; i < l; i += 3 ) {
-
-			const a = i + 0;
-			const b = i + 1;
-			const c = i + 2;
-
-			indices.push( a, b, b, c, c, a );
-
-		}
+		throw new Error( 'THREE.Geometries: BufferGeometry is missing a position attribute for wireframe.' );
 
 	}
 
-	const attribute = new ( geometryPosition.count >= 65535 ? Uint32BufferAttribute : Uint16BufferAttribute )( indices, 1 );
 	attribute.version = getWireframeVersion( geometry );
 	attribute.__id = getWireframeId( geometry );
+	attribute.__rangeKey = getWireframeRangeKey( geometry );
 
 	return attribute;
 
@@ -361,7 +332,7 @@ class Geometries extends DataMap {
 
 				wireframes.set( geometry, wireframeAttribute );
 
-			} else if ( wireframeAttribute.version !== getWireframeVersion( geometry ) || wireframeAttribute.__id !== getWireframeId( geometry ) ) {
+			} else if ( wireframeAttribute.version !== getWireframeVersion( geometry ) || wireframeAttribute.__id !== getWireframeId( geometry ) || wireframeAttribute.__rangeKey !== getWireframeRangeKey( geometry ) ) {
 
 				this.attributes.delete( wireframeAttribute );
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -511,12 +511,7 @@ class RenderObject {
 
 				// geometry attribute
 				attribute = geometry.getAttribute( nodeAttribute.name );
-
-				if ( attribute !== undefined ) {
-
-					attributesId[ nodeAttribute.name ] = attribute.id;
-
-				}
+				attributesId[ nodeAttribute.name ] = attribute.id;
 
 			}
 

--- a/src/renderers/common/WireframeIndexUtils.js
+++ b/src/renderers/common/WireframeIndexUtils.js
@@ -1,0 +1,156 @@
+import { Uint16BufferAttribute, Uint32BufferAttribute } from '../../core/BufferAttribute.js';
+
+/**
+ * Stable value for the wireframe cache when drawRange or group ranges change
+ * (e.g. BatchedMesh grows the used prefix) without a buffer version bump.
+ *
+ * @param {import('../../core/BufferGeometry.js').BufferGeometry} geometry
+ * @return {string}
+ */
+function getWireframeRangeKey( geometry ) {
+
+	const dr = geometry.drawRange;
+	let key = String( dr.start ) + ',' + String( dr.count );
+	const g = geometry.groups;
+	for ( let i = 0, l = g.length; i < l; i ++ ) {
+
+		const gr = g[ i ];
+		key += ';' + gr.start + ',' + gr.count + ',' + gr.materialIndex;
+
+	}
+
+	return key;
+
+}
+
+/**
+ * @param {number} itemCount
+ * @param {{ start: number, count: number }} drawRange
+ * @return {{ start: number, end: number }}
+ */
+function getEffectiveItemRange( itemCount, drawRange ) {
+
+	let start = drawRange.start;
+	let end = drawRange.start + drawRange.count;
+	if ( ! Number.isFinite( end ) || end > itemCount ) {
+
+		end = itemCount;
+
+	}
+
+	start = Math.max( 0, Math.min( start, itemCount ) );
+	end = Math.max( start, Math.min( end, itemCount ) );
+
+	return { start, end };
+
+}
+
+/**
+ * Returns a new buffer attribute whose contents are line indices (pairs for each tri edge)
+ * for wireframe drawing. Respects `geometry.drawRange` and `geometry.groups` (indexed) so
+ * large pooled or partially used buffers (e.g. BatchedMesh) are not fully expanded.
+ *
+ * @param {import('../../core/BufferGeometry.js').BufferGeometry} geometry
+ * @return {?import('../../core/BufferAttribute.js').BufferAttribute}
+ */
+function createWireframeIndexBufferAttribute( geometry ) {
+
+	const position = geometry.attributes.position;
+	if ( position === undefined ) return null;
+
+	const useUint32 = position.count > 65535;
+	const IndexArray = useUint32 ? Uint32Array : Uint16Array;
+	const index = geometry.index;
+
+	// Per-item draw range: indices for indexed, vertices for non-indexed.
+	if ( index !== null ) {
+
+		const array = index.array;
+		const groupList = geometry.groups;
+		const { start: rangeStart, end: rangeEnd } = getEffectiveItemRange( index.count, geometry.drawRange );
+
+		let triCount;
+		if ( groupList.length > 0 ) {
+
+			triCount = 0;
+			for ( let o = 0, ol = groupList.length; o < ol; o ++ ) {
+
+				const g = groupList[ o ];
+				const s = Math.max( g.start, rangeStart );
+				const e = Math.min( g.start + g.count, rangeEnd );
+				if ( s < e ) triCount += Math.floor( ( e - s ) / 3 );
+
+			}
+
+		} else {
+
+			triCount = Math.max( 0, Math.floor( ( rangeEnd - rangeStart ) / 3 ) );
+
+		}
+
+		const out = new IndexArray( triCount * 6 );
+		let w = 0;
+		if ( groupList.length > 0 ) {
+
+			for ( let o = 0, ol = groupList.length; o < ol; o ++ ) {
+
+				const g = groupList[ o ];
+				const s0 = Math.max( g.start, rangeStart );
+				const s1 = Math.min( g.start + g.count, rangeEnd );
+				for ( let i = s0, l = s1; i < l; i += 3 ) {
+
+					const a = array[ i + 0 ];
+					const b = array[ i + 1 ];
+					const c = array[ i + 2 ];
+					out[ w ++ ] = a; out[ w ++ ] = b;
+					out[ w ++ ] = b; out[ w ++ ] = c;
+					out[ w ++ ] = c; out[ w ++ ] = a;
+
+				}
+
+			}
+
+		} else {
+
+			for ( let i = rangeStart, l = rangeEnd; i < l; i += 3 ) {
+
+				const a = array[ i + 0 ];
+				const b = array[ i + 1 ];
+				const c = array[ i + 2 ];
+				out[ w ++ ] = a; out[ w ++ ] = b;
+				out[ w ++ ] = b; out[ w ++ ] = c;
+				out[ w ++ ] = c; out[ w ++ ] = a;
+
+			}
+
+		}
+
+		return new ( useUint32 ? Uint32BufferAttribute : Uint16BufferAttribute )( out, 1 );
+
+	} else {
+
+		// `position.count`, not `array.length / 3` — for InterleavedBufferAttribute, `array` is the
+		// full interleaved buffer.
+		const { start: rangeStart, end: rangeEnd } = getEffectiveItemRange( position.count, geometry.drawRange );
+		const triCount = Math.max( 0, Math.floor( ( rangeEnd - rangeStart ) / 3 ) );
+
+		const out = new IndexArray( triCount * 6 );
+		let w = 0;
+		for ( let t = 0; t < triCount; t ++ ) {
+
+			const a = rangeStart + t * 3;
+			const b = a + 1;
+			const c = a + 2;
+			out[ w ++ ] = a; out[ w ++ ] = b;
+			out[ w ++ ] = b; out[ w ++ ] = c;
+			out[ w ++ ] = c; out[ w ++ ] = a;
+
+		}
+
+		return new ( useUint32 ? Uint32BufferAttribute : Uint16BufferAttribute )( out, 1 );
+
+	}
+
+}
+
+export { createWireframeIndexBufferAttribute, getWireframeRangeKey };

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -1,4 +1,4 @@
-import { Uint16BufferAttribute, Uint32BufferAttribute } from '../../core/BufferAttribute.js';
+import { createWireframeIndexBufferAttribute, getWireframeRangeKey } from '../common/WireframeIndexUtils.js';
 
 function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
@@ -78,54 +78,20 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
 	function updateWireframeAttribute( geometry ) {
 
-		const indices = [];
-
-		const geometryIndex = geometry.index;
 		const geometryPosition = geometry.attributes.position;
-		let version = 0;
-
 		if ( geometryPosition === undefined ) {
 
 			return;
 
 		}
 
-		if ( geometryIndex !== null ) {
+		const version = geometry.index !== null ? geometry.index.version : geometryPosition.version;
 
-			const array = geometryIndex.array;
-			version = geometryIndex.version;
+		const attribute = createWireframeIndexBufferAttribute( geometry );
+		if ( attribute === null ) return;
 
-			for ( let i = 0, l = array.length; i < l; i += 3 ) {
-
-				const a = array[ i + 0 ];
-				const b = array[ i + 1 ];
-				const c = array[ i + 2 ];
-
-				indices.push( a, b, b, c, c, a );
-
-			}
-
-		} else {
-
-			const array = geometryPosition.array;
-			version = geometryPosition.version;
-
-			for ( let i = 0, l = ( array.length / 3 ) - 1; i < l; i += 3 ) {
-
-				const a = i + 0;
-				const b = i + 1;
-				const c = i + 2;
-
-				indices.push( a, b, b, c, c, a );
-
-			}
-
-		}
-
-		// check whether a 32 bit or 16 bit buffer is required to store the indices
-		// account for PRIMITIVE_RESTART_FIXED_INDEX, #24565
-		const attribute = new ( geometryPosition.count >= 65535 ? Uint32BufferAttribute : Uint16BufferAttribute )( indices, 1 );
 		attribute.version = version;
+		attribute.__rangeKey = getWireframeRangeKey( geometry );
 
 		// Updating index buffer in VAO now. See WebGLBindingStates
 
@@ -148,18 +114,22 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 		if ( currentAttribute ) {
 
 			const geometryIndex = geometry.index;
+			const geometryPosition = geometry.attributes.position;
 
+			let needsUpdate = false;
 			if ( geometryIndex !== null ) {
 
-				// if the attribute is obsolete, create a new one
+				if ( currentAttribute.version < geometryIndex.version ) needsUpdate = true;
 
-				if ( currentAttribute.version < geometryIndex.version ) {
+			} else if ( geometryPosition !== undefined ) {
 
-					updateWireframeAttribute( geometry );
-
-				}
+				if ( currentAttribute.version < geometryPosition.version ) needsUpdate = true;
 
 			}
+
+			if ( currentAttribute.__rangeKey !== getWireframeRangeKey( geometry ) ) needsUpdate = true;
+
+			if ( needsUpdate ) updateWireframeAttribute( geometry );
 
 		} else {
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1602,13 +1602,7 @@ class WebGPUBackend extends Backend {
 			const counts = object._multiDrawCounts;
 			const drawCount = object._multiDrawCount;
 
-			let bytesPerElement = ( hasIndex === true ) ? index.array.BYTES_PER_ELEMENT : 1;
-
-			if ( material.wireframe ) {
-
-				bytesPerElement = object.geometry.attributes.position.count > 65535 ? 4 : 2;
-
-			}
+			const bytesPerElement = ( hasIndex === true ) ? index.array.BYTES_PER_ELEMENT : 1;
 
 			for ( let i = 0; i < drawCount; i ++ ) {
 

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -1,7 +1,8 @@
 import { BlendColorFactor, OneMinusBlendColorFactor, } from '../../common/Constants.js';
 
 import {
-	GPUFrontFace, GPUCullMode, GPUColorWriteFlags, GPUCompareFunction, GPUBlendFactor, GPUBlendOperation, GPUIndexFormat, GPUStencilOperation
+	GPUFrontFace, GPUCullMode, GPUColorWriteFlags, GPUCompareFunction, GPUBlendFactor, GPUBlendOperation, GPUIndexFormat, GPUStencilOperation,
+	GPUPrimitiveTopology
 } from './WebGPUConstants.js';
 
 import {
@@ -258,8 +259,24 @@ class WebGPUPipelineUtils {
 
 			if ( material.polygonOffset === true ) {
 
-				depthStencil.depthBias = material.polygonOffsetUnits;
-				depthStencil.depthBiasSlopeScale = material.polygonOffsetFactor;
+				// WebGPU allows non-zero depth bias only for triangle-list and triangle-strip topologies
+				// (wireframe meshes use line-list; points/lines also forbid bias).
+				const topology = primitiveState.topology;
+				if (
+					topology === GPUPrimitiveTopology.TriangleList ||
+					topology === GPUPrimitiveTopology.TriangleStrip
+				) {
+
+					depthStencil.depthBias = material.polygonOffsetUnits;
+					depthStencil.depthBiasSlopeScale = material.polygonOffsetFactor;
+
+				} else {
+
+					depthStencil.depthBias = 0;
+					depthStencil.depthBiasSlopeScale = 0;
+
+				}
+
 				depthStencil.depthBiasClamp = 0; // three.js does not provide an API to configure this value
 
 			}

--- a/test/unit/src/core/InterleavedBufferAttribute.tests.js
+++ b/test/unit/src/core/InterleavedBufferAttribute.tests.js
@@ -25,6 +25,23 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
+		QUnit.test( 'position.count vs array length for interleaved (wireframe index generation)', ( assert ) => {
+
+			// Wireframe build uses the number of triangles from position, not `array.length / 3`, because
+			// InterleavedBufferAttribute#array is the full interleaved buffer (all attributes per vertex).
+			const stride = 8;
+			const numVertices = 6;
+			const interleaved = new InterleavedBuffer( new Float32Array( numVertices * stride ), stride );
+			const position = new InterleavedBufferAttribute( interleaved, 3, 0 );
+
+			const triangleCountFromCount = Math.floor( position.count / 3 );
+			const naiveLengthDiv3 = position.array.length / 3;
+
+			assert.equal( triangleCountFromCount, 2, 'six vertices => two triangles' );
+			assert.ok( naiveLengthDiv3 > position.count, 'array.length/3 is not the vertex count for interleaved' );
+
+		} );
+
 		// PUBLIC
 		QUnit.test( 'isInterleavedBufferAttribute', ( assert ) => {
 

--- a/test/unit/src/objects/BatchedMesh.tests.js
+++ b/test/unit/src/objects/BatchedMesh.tests.js
@@ -1,6 +1,10 @@
 import { BatchedMesh } from '../../../../src/objects/BatchedMesh.js';
 import { BoxGeometry } from '../../../../src/geometries/BoxGeometry.js';
+import { BufferGeometry } from '../../../../src/core/BufferGeometry.js';
+import { BufferAttribute } from '../../../../src/core/BufferAttribute.js';
 import { MeshBasicMaterial } from '../../../../src/materials/MeshBasicMaterial.js';
+import { PerspectiveCamera } from '../../../../src/cameras/PerspectiveCamera.js';
+import { createWireframeIndexBufferAttribute } from '../../../../src/renderers/common/WireframeIndexUtils.js';
 
 export default QUnit.module( 'Objects', () => {
 
@@ -32,6 +36,218 @@ export default QUnit.module( 'Objects', () => {
 			batchedMesh.setInstanceCount( 2 );
 
 			assert.ok( batchedMesh.instanceCount === 2, 'instance count unequal 2' );
+
+		} );
+
+		// WIREFRAME
+
+		QUnit.test( 'drawRange matches used index prefix (pooled index buffer for wireframe)', ( assert ) => {
+
+			// One box (36 indices) in a large reserved index pool: wireframe must not walk maxIndexCount.
+			const box = new BoxGeometry( 1, 1, 1 );
+			const material = new MeshBasicMaterial( { color: 0x00ff00, wireframe: true } );
+			const maxIndex = 2_000_000;
+			const batchedMesh = new BatchedMesh( 1, 5000, maxIndex, material );
+			batchedMesh.addGeometry( box );
+
+			const g = batchedMesh.geometry;
+			assert.equal( g.index.count, maxIndex, 'pooled index buffer is maxIndex long' );
+			assert.equal( g.drawRange.start, 0, 'drawRange start' );
+			assert.equal( g.drawRange.count, batchedMesh._nextIndexStart, 'drawRange count is the used prefix' );
+			const wf = createWireframeIndexBufferAttribute( g );
+			// 12 triangles in box, 6 wireframe line indices per triangle
+			assert.equal( wf.count, 12 * 6, 'wireframe index count is only for used subrange' );
+
+		} );
+
+		QUnit.test( 'wireframe - multiDraw starts and counts are doubled', ( assert ) => {
+
+			const box = new BoxGeometry( 1, 1, 1 );
+			const material = new MeshBasicMaterial( { color: 0x00ff00 } );
+
+			const batchedMesh = new BatchedMesh( 2, 5000, 10000, material );
+			batchedMesh.perObjectFrustumCulled = false;
+			const geoId = batchedMesh.addGeometry( box );
+			batchedMesh.addInstance( geoId );
+			batchedMesh.addInstance( geoId );
+
+			const camera = new PerspectiveCamera();
+			camera.updateMatrixWorld();
+
+			// Run onBeforeRender without wireframe to get baseline values
+			batchedMesh._visibilityChanged = true;
+			batchedMesh.onBeforeRender( {}, {}, camera, batchedMesh.geometry, material );
+
+			const baseStarts = [];
+			const baseCounts = [];
+			for ( let i = 0; i < batchedMesh._multiDrawCount; i ++ ) {
+
+				baseStarts.push( batchedMesh._multiDrawStarts[ i ] );
+				baseCounts.push( batchedMesh._multiDrawCounts[ i ] );
+
+			}
+
+			// Run onBeforeRender with wireframe enabled
+			const wireMaterial = new MeshBasicMaterial( { color: 0x00ff00, wireframe: true } );
+			batchedMesh._visibilityChanged = true;
+			batchedMesh.onBeforeRender( {}, {}, camera, batchedMesh.geometry, wireMaterial );
+
+			const wireStarts = [];
+			const wireCounts = [];
+			for ( let i = 0; i < batchedMesh._multiDrawCount; i ++ ) {
+
+				wireStarts.push( batchedMesh._multiDrawStarts[ i ] );
+				wireCounts.push( batchedMesh._multiDrawCounts[ i ] );
+
+			}
+
+			assert.equal( batchedMesh._multiDrawCount, 2, 'draw count is 2 for both instances' );
+
+			// Wireframe counts should be exactly 2x the non-wireframe counts
+			for ( let i = 0; i < baseCounts.length; i ++ ) {
+
+				assert.equal( wireCounts[ i ], baseCounts[ i ] * 2,
+					`wireframe count[${ i }] should be double the non-wireframe count` );
+
+			}
+
+			// Verify the wireframe starts are consistent: converting to element indices should
+			// give exactly 2x the non-wireframe element indices
+			const index = batchedMesh.geometry.getIndex();
+			const baseBpe = index.array.BYTES_PER_ELEMENT;
+			const posCount = batchedMesh.geometry.attributes.position.count;
+			const wireBpe = posCount > 65535 ? 4 : 2;
+
+			for ( let i = 0; i < baseStarts.length; i ++ ) {
+
+				const baseElementIndex = baseStarts[ i ] / baseBpe;
+				const wireElementIndex = wireStarts[ i ] / wireBpe;
+				assert.equal( wireElementIndex, baseElementIndex * 2,
+					`wireframe start[${ i }] element index should be double the non-wireframe element index` );
+
+			}
+
+		} );
+
+		QUnit.test( 'wireframe - multiDraw byte offsets produce valid index ranges', ( assert ) => {
+
+			// Use two different geometries in the batch to test non-zero start offsets
+			const box = new BoxGeometry( 1, 1, 1 );
+			const box2 = new BoxGeometry( 2, 2, 2 );
+			const material = new MeshBasicMaterial( { color: 0x00ff00, wireframe: true } );
+
+			const batchedMesh = new BatchedMesh( 2, 5000, 10000, material );
+			batchedMesh.perObjectFrustumCulled = false;
+			const geoId1 = batchedMesh.addGeometry( box );
+			const geoId2 = batchedMesh.addGeometry( box2 );
+			batchedMesh.addInstance( geoId1 );
+			batchedMesh.addInstance( geoId2 );
+
+			const camera = new PerspectiveCamera();
+			camera.updateMatrixWorld();
+
+			batchedMesh._visibilityChanged = true;
+			batchedMesh.onBeforeRender( {}, {}, camera, batchedMesh.geometry, material );
+
+			const posCount = batchedMesh.geometry.attributes.position.count;
+			const wireBpe = posCount > 65535 ? 4 : 2;
+
+			// The maximum wireframe index count is 2x the original index count
+			const origIndex = batchedMesh.geometry.getIndex();
+			const maxWireframeElements = origIndex.count * 2;
+
+			for ( let i = 0; i < batchedMesh._multiDrawCount; i ++ ) {
+
+				const firstIndex = batchedMesh._multiDrawStarts[ i ] / wireBpe;
+				const count = batchedMesh._multiDrawCounts[ i ];
+
+				assert.ok( firstIndex >= 0,
+					`wireframe firstIndex[${ i }] (${ firstIndex }) should be non-negative` );
+				assert.ok( Number.isInteger( firstIndex ),
+					`wireframe firstIndex[${ i }] (${ firstIndex }) should be an integer` );
+				assert.ok( firstIndex + count <= maxWireframeElements,
+					`wireframe range[${ i }] (${ firstIndex } + ${ count } = ${ firstIndex + count }) should fit within buffer (${ maxWireframeElements })` );
+
+			}
+
+		} );
+
+		QUnit.test( 'wireframe - bytesPerElement consistency at 65535 vertex boundary', ( assert ) => {
+
+			// Test that at the boundary of 65535 vertices, the wireframe index type and
+			// the BatchedMesh bytesPerElement calculation agree. This was a bug where
+			// getWireframeIndex used >= 65535 but BatchedMesh used > 65535.
+
+			// Create a geometry with exactly 65535 positions (the boundary case)
+			const geom = new BufferGeometry();
+			const posArray = new Float32Array( 65535 * 3 );
+			geom.setAttribute( 'position', new BufferAttribute( posArray, 3 ) );
+
+			// Create a small index buffer (3 indices for one triangle)
+			const indexArray = new Uint16Array( [ 0, 1, 2 ] );
+			geom.setIndex( new BufferAttribute( indexArray, 1 ) );
+
+			const material = new MeshBasicMaterial( { wireframe: true } );
+			const batchedMesh = new BatchedMesh( 1, 65535, 3, material );
+			const geoId = batchedMesh.addGeometry( geom );
+			batchedMesh.addInstance( geoId );
+
+			// The BatchedMesh geometry should have position.count = 65535
+			const batchPosCount = batchedMesh.geometry.attributes.position.count;
+			assert.equal( batchPosCount, 65535, 'BatchedMesh position count is 65535' );
+
+			// The BatchedMesh wireframe bytesPerElement: position.count > 65535 → 2 (Uint16)
+			const batchWireBpe = batchPosCount > 65535 ? 4 : 2;
+			assert.equal( batchWireBpe, 2, 'BatchedMesh wireframe bytesPerElement is 2 at the 65535 boundary' );
+
+			// The wireframe index should also use Uint16 at count=65535 (> 65535, not >= 65535)
+			// After our fix, getWireframeIndex uses > 65535, matching BatchedMesh
+			const expectedWireType = batchPosCount > 65535 ? 4 : 2;
+			assert.equal( expectedWireType, batchWireBpe,
+				'wireframe index type threshold matches BatchedMesh bytesPerElement threshold' );
+
+		} );
+
+		QUnit.test( 'wireframe - multiDraw with large vertex count (> 65535)', ( assert ) => {
+
+			// Test that wireframe works correctly when vertex count exceeds 65535
+			// (requires Uint32 index buffer)
+			const geom = new BufferGeometry();
+			const vertCount = 70000;
+			const posArray = new Float32Array( vertCount * 3 );
+			geom.setAttribute( 'position', new BufferAttribute( posArray, 3 ) );
+
+			// Create a small index buffer
+			const indexArray = new Uint32Array( [ 0, 1, 2, 3, 4, 5 ] );
+			geom.setIndex( new BufferAttribute( indexArray, 1 ) );
+
+			const wireMaterial = new MeshBasicMaterial( { wireframe: true } );
+			const batchedMesh = new BatchedMesh( 1, vertCount, 6, wireMaterial );
+			batchedMesh.perObjectFrustumCulled = false;
+			const geoId = batchedMesh.addGeometry( geom );
+			batchedMesh.addInstance( geoId );
+
+			const camera = new PerspectiveCamera();
+			camera.updateMatrixWorld();
+
+			batchedMesh._visibilityChanged = true;
+			batchedMesh.onBeforeRender( {}, {}, camera, batchedMesh.geometry, wireMaterial );
+
+			const posCount = batchedMesh.geometry.attributes.position.count;
+			assert.ok( posCount > 65535, 'position count exceeds 65535' );
+
+			// The original index has 6 elements (2 triangles)
+			// Wireframe should produce 12 elements (6 edges * 2 vertices)
+			const wireBpe = posCount > 65535 ? 4 : 2;
+			assert.equal( wireBpe, 4, 'wireframe bytesPerElement is 4 for large vertex count' );
+
+			// Verify the draw data is correct
+			assert.equal( batchedMesh._multiDrawCount, 1, 'one draw call' );
+			assert.equal( batchedMesh._multiDrawCounts[ 0 ], 12,
+				'wireframe count is 2x the original index count (6 * 2 = 12)' );
+
+			const firstIndex = batchedMesh._multiDrawStarts[ 0 ] / wireBpe;
+			assert.equal( firstIndex, 0, 'wireframe first index is 0 for the first geometry' );
 
 		} );
 


### PR DESCRIPTION
**Description**

When working with BatchedMesh using `three/webgpu` encountered an issue where turning on wireframe rendering caused an Array `RangeError` with `getWireframeIndex` where `geometryPosition.count >= 65535` would cause the overflow.

- Examples have been checked on local server and all tests run, no obvious regression spotted.
- Small performance improvement noticed in my own engine (https://tanepiper.github.io/the-colony/)
 
Disclosure: This PR was done along with an AI agent to help verify the problem and work on proposed solution.

The following changes are introduced:

- Introduced `_syncGeometryDrawRange()` method in `BatchedMesh` to update `drawRange` based on the used prefix of the index or vertex buffer.
- Updated `BatchedMesh` to call `_syncGeometryDrawRange()` after geometry modifications to ensure correct draw range.
- Created `WireframeIndexUtils.js` to manage wireframe index generation, including `createWireframeIndexBufferAttribute()` and `getWireframeRangeKey()`.
- Refactored `WebGLGeometries` and `Geometries` to utilise the new wireframe utilities for improved index handling.
- Added tests to validate wireframe index generation and draw range behaviour in `BatchedMesh`.