### PR TITLE
NodeUniformBuffer: Fix `byteLength` to follow overridden `buffer` getter

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -159,7 +159,7 @@ class PMREMGenerator {
 	/**
 	 * Generates a PMREM from an cubemap texture, which can be either LDR
 	 * or HDR. The ideal input cube size is 256 x 256, as this matches best
-	 * with the 256 x 256 cubemap output. The minimum supported input cube 
+	 * with the 256 x 256 cubemap output. The minimum supported input cube
 	 * size is 16 x 16 per face.
 	 *
 	 * @param {Texture} cubemap - The cubemap texture to be converted.

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -267,7 +267,7 @@ class PMREMGenerator {
 	/**
 	 * Generates a PMREM from an cubemap texture, which can be either LDR
 	 * or HDR. The ideal input cube size is 256 x 256, as this matches best
-	 * with the 256 x 256 cubemap output. The minimum supported input cube 
+	 * with the 256 x 256 cubemap output. The minimum supported input cube
 	 * size is 16 x 16 per face.
 	 *
 	 * @param {Texture} cubemap - The cubemap texture to be converted.

--- a/src/renderers/common/nodes/NodeUniformBuffer.js
+++ b/src/renderers/common/nodes/NodeUniformBuffer.js
@@ -1,4 +1,5 @@
 import UniformBuffer from '../UniformBuffer.js';
+import { getFloatLength } from '../BufferUtils.js';
 
 let _id = 0;
 
@@ -86,6 +87,18 @@ class NodeUniformBuffer extends UniformBuffer {
 	clearUpdateRanges() {
 
 		this.nodeUniform.clearUpdateRanges();
+
+	}
+
+	/**
+	 * The buffer's byte length.
+	 *
+	 * @type {number}
+	 * @readonly
+	 */
+	get byteLength() {
+
+		return getFloatLength( this.buffer.byteLength );
 
 	}
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -190,8 +190,6 @@ class WebGPUBindingUtils {
 		const array = binding.buffer; // cpu
 		const buffer = backend.get( binding ).buffer; // gpu
 
-		if ( buffer === undefined ) return; // see #33461
-
 		const updateRanges = binding.updateRanges;
 
 		if ( updateRanges.length === 0 ) {


### PR DESCRIPTION
Related, better alternative fix to #33461.

### Description

`NodeUniformBuffer` overrides the `buffer` getter to return `this.nodeUniform.value`, but inherits `byteLength` from the base `Buffer` class which reads `this._buffer.byteLength`. This is inconsistent — `byteLength` should follow the same source as `buffer`.

The crash occurs at `WebGPUBackend.createUniformBuffer()` when a binding goes through this lifecycle:

1. Binding created — `_buffer` is set in constructor (line 22: `super(name, nodeUniform.value)`)
2. Binding released by `Bindings._destroyBindings()` — `binding.release()` sets `_buffer = null`
3. Same binding reused by `_createBindings()` — calls `createUniformBuffer(binding)` → `binding.byteLength` → `this._buffer.byteLength` → **crash**

The crash:
```
TypeError: Cannot read properties of null (reading 'byteLength')
    at get byteLength (Buffer.js)
    at WebGPUBackend.createUniformBuffer (WebGPUBackend.js:2452)
    at Bindings._createBindings (Bindings.js:196)
```

### Fix

Override `byteLength` on `NodeUniformBuffer` to use `this.buffer` (which returns `nodeUniform.value`) instead of `this._buffer`. This makes the class internally consistent, both getters now read from the same source, and naturally handles the post-`release()` state since `nodeUniform.value` is owned by the node and outlives the binding's `_buffer` field.

The guard added in #33461 is reverted as part of this PR, the present fix addresses the root cause at the binding level, so the downstream guard in `updateBinding()` is no longer needed.