### PR TITLE
Material: Fixed setValues() to honor Euler and Vector2 types.

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -580,15 +580,11 @@ class Material extends EventDispatcher {
 
 				currentValue.set( newValue );
 
-			} else if ( ( currentValue && currentValue.isVector2 ) && ( newValue && newValue.isVector2 ) ) {
-
-				currentValue.copy( newValue );
-
-			} else if ( ( currentValue && currentValue.isEuler ) && ( newValue && newValue.isEuler ) ) {
-
-				currentValue.copy( newValue );
-
-			} else if ( ( currentValue && currentValue.isVector3 ) && ( newValue && newValue.isVector3 ) ) {
+			} else if (
+				( ( currentValue && currentValue.isVector2 ) && ( newValue && newValue.isVector2 ) ) ||
+				( ( currentValue && currentValue.isEuler ) && ( newValue && newValue.isEuler ) ) ||
+				( ( currentValue && currentValue.isVector3 ) && ( newValue && newValue.isVector3 ) )
+			) {
 
 				currentValue.copy( newValue );
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -580,13 +580,13 @@ class Material extends EventDispatcher {
 
 				currentValue.set( newValue );
 
-			} else if ( currentValue && currentValue.isVector2 && Array.isArray( newValue ) ) {
+			} else if ( ( currentValue && currentValue.isVector2 ) && ( newValue && newValue.isVector2 ) ) {
 
-				currentValue.fromArray( newValue );
+				currentValue.copy( newValue );
 
-			} else if ( currentValue && currentValue.isEuler && Array.isArray( newValue ) ) {
+			} else if ( ( currentValue && currentValue.isEuler ) && ( newValue && newValue.isEuler ) ) {
 
-				currentValue.fromArray( newValue );
+				currentValue.copy( newValue );
 
 			} else if ( ( currentValue && currentValue.isVector3 ) && ( newValue && newValue.isVector3 ) ) {
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -580,7 +580,15 @@ class Material extends EventDispatcher {
 
 				currentValue.set( newValue );
 
-			} else if ( ( currentValue && currentValue.isVector3 ) && ( newValue && newValue.isVector3 ) ) {
+			} else if ( currentValue && currentValue.isVector2 && Array.isArray( newValue ) ) {
+
+				currentValue.fromArray( newValue );
+
+			} else if ( currentValue && currentValue.isEuler && Array.isArray( newValue ) ) {
+				
+				currentValue.fromArray( newValue );
+				
+			}  else if ( ( currentValue && currentValue.isVector3 ) && ( newValue && newValue.isVector3 ) ) {
 
 				currentValue.copy( newValue );
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -585,10 +585,10 @@ class Material extends EventDispatcher {
 				currentValue.fromArray( newValue );
 
 			} else if ( currentValue && currentValue.isEuler && Array.isArray( newValue ) ) {
-				
+
 				currentValue.fromArray( newValue );
-				
-			}  else if ( ( currentValue && currentValue.isVector3 ) && ( newValue && newValue.isVector3 ) ) {
+
+			} else if ( ( currentValue && currentValue.isVector3 ) && ( newValue && newValue.isVector3 ) ) {
 
 				currentValue.copy( newValue );
 


### PR DESCRIPTION
**Description**

`Material.prototype.toJSON()` serializes `envMapRotation` (Euler) and `normalScale` / `clearcoatNormalScale` (Vector2) into arrays. When these arrays were later passed back to `Material.prototype.setValues()` (e.g. via `MaterialLoader` or `new Material(json)`), they were assigned directly, breaking the original type and causing a crash on the next `toJSON()` call:

TypeError: this.envMapRotation.toArray is not a function

**Changes**

Added `isEuler` and `isVector2` branches to `setValues()` so that arrays are restored via `fromArray()` instead of being overwritten.

**Affected materials**

- `MeshBasicMaterial`
- `MeshLambertMaterial`
- `MeshPhongMaterial`
- `MeshStandardMaterial`
- `MeshPhysicalMaterial`

All of these define `envMapRotation` as an `Euler`. The latter four also define `normalScale` as a `Vector2`, and `MeshPhysicalMaterial` additionally defines `clearcoatNormalScale` as a `Vector2`.

**Reproduction**

```js
const mat = new THREE.MeshStandardMaterial();
const json = mat.toJSON();
const mat2 = new THREE.MeshStandardMaterial(json);
mat2.toJSON(); // TypeError before this fix
```