### PR TITLE
SSAAPassNode: Make clear color handling more consistent.

### DIFF
--- a/examples/jsm/tsl/display/SSAAPassNode.js
+++ b/examples/jsm/tsl/display/SSAAPassNode.js
@@ -1,9 +1,8 @@
-import { AdditiveBlending, Color, Vector2, RendererUtils, PassNode, QuadMesh, NodeMaterial } from 'three/webgpu';
+import { AdditiveBlending, Color, Vector2, PassNode, QuadMesh, NodeMaterial } from 'three/webgpu';
 import { uniform, mrt, texture, getTextureIndex, unpremultiplyAlpha } from 'three/tsl';
 
 const _size = /*@__PURE__*/ new Vector2();
-
-let _rendererState;
+const _clearColor = /*@__PURE__*/ new Color();
 
 /**
  * A special render pass node that renders the scene with SSAA (Supersampling Anti-Aliasing).
@@ -62,22 +61,6 @@ class SSAAPassNode extends PassNode {
 		this.unbiased = true;
 
 		/**
-		 * The clear color of the pass.
-		 *
-		 * @type {Color}
-		 * @default 0x000000
-		 */
-		this.clearColor = new Color( 0x000000 );
-
-		/**
-		 * The clear alpha of the pass.
-		 *
-		 * @type {number}
-		 * @default 0
-		 */
-		this.clearAlpha = 0;
-
-		/**
 		 * A uniform node representing the sample weight.
 		 *
 		 * @type {UniformNode<float>}
@@ -114,8 +97,6 @@ class SSAAPassNode extends PassNode {
 		const { renderer } = frame;
 		const { scene, camera } = this;
 
-		_rendererState = RendererUtils.resetRendererState( renderer, _rendererState );
-
 		//
 
 		this._pixelRatio = renderer.getPixelRatio();
@@ -129,6 +110,12 @@ class SSAAPassNode extends PassNode {
 
 		this._cameraNear.value = camera.near;
 		this._cameraFar.value = camera.far;
+
+		const currentRenderTarget = renderer.getRenderTarget();
+		const currentMRT = renderer.getMRT();
+		const currentAutoClear = renderer.autoClear;
+		const currentClearColor = renderer.getClearColor( _clearColor );
+		const currentClearAlpha = renderer.getClearAlpha();
 
 		renderer.setMRT( this.getMRT() );
 		renderer.autoClear = false;
@@ -186,7 +173,6 @@ class SSAAPassNode extends PassNode {
 
 			}
 
-			renderer.setClearColor( this.clearColor, this.clearAlpha );
 			renderer.setRenderTarget( this._sampleRenderTarget );
 			renderer.clear();
 			renderer.render( scene, camera );
@@ -199,6 +185,8 @@ class SSAAPassNode extends PassNode {
 
 				renderer.setClearColor( 0x000000, 0.0 );
 				renderer.clear();
+
+				renderer.setClearColor( currentClearColor, currentClearAlpha );
 
 			}
 
@@ -228,9 +216,9 @@ class SSAAPassNode extends PassNode {
 
 		}
 
-		//
-
-		RendererUtils.restoreRendererState( renderer, _rendererState );
+		renderer.setRenderTarget( currentRenderTarget );
+		renderer.setMRT( currentMRT );
+		renderer.autoClear = currentAutoClear;
 
 	}
 

--- a/examples/webgpu_postprocessing_ssaa.html
+++ b/examples/webgpu_postprocessing_ssaa.html
@@ -194,8 +194,7 @@
 
 				}
 
-				ssaaRenderPass.clearColor.set( newColor );
-				ssaaRenderPass.clearAlpha = params.clearAlpha;
+				renderer.setClearColor( newColor, params.clearAlpha );
 
 				ssaaRenderPass.sampleLevel = params.sampleLevel;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33437#issuecomment-4324403897

**Description**

The PR makes sure `SSAAPassNode` handles clear colors similar to `PassNode`.

When I have ported over the SSAA from `SSAARenderPass`, I've adopted clear color properties which are no good fit for the new post processing architecture. This change aligns `SSAAPassNode` to how clear colors are supposed to be handled meaning the actual renderer and scene settings are honored.
