### PR TITLE
ArcballControls: Document correct usage of `adjustNearFar`.

### DIFF
--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -265,6 +265,10 @@ class ArcballControls extends Controls {
 		 * performed trying to maintain the same visible portion given by initial near and far
 		 * values. Only works with perspective cameras.
 		 *
+		 * This feature only works as expected if the camera's initial state (position, near and far values)
+		 * is correctly configured before creating the controls. Otherwise {@link ArcballControls#setCamera}
+		 * must be called by the application.
+		 *
 		 * @type {boolean}
 		 * @default false
 		 */


### PR DESCRIPTION
Fixed #29417

**Description**

The error "this._nearPos0 < 0" mentioned in #29417 can indeed occur in `ArcballControls` when the controls are created before the camera is correctly positioned or before the "final" near and far values are configured. 

However, invalid `_nearPos0` and `_farPos0` only affect the controls when `adjustNearFar` is set to `true`, so not the default usage. Documenting this restriction seems sufficient especially since there is no obvious other way to derive reference values for near and far positions.