### PR TITLE
XRManager: Use `foveateBoundTexture()` to enable foveation.

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -14,7 +14,7 @@ import { CylinderGeometry } from '../../geometries/CylinderGeometry.js';
 import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
 import { MeshBasicMaterial } from '../../materials/MeshBasicMaterial.js';
 import { Mesh } from '../../objects/Mesh.js';
-import { warn } from '../../utils.js';
+import { warn, warnOnce } from '../../utils.js';
 import { renderOutput } from '../../nodes/display/RenderOutputNode.js';
 
 const _cameraLPos = /*@__PURE__*/ new Vector3();
@@ -591,6 +591,20 @@ class XRManager extends EventDispatcher {
 
 	}
 
+	/**
+	 * Returns the current base layer.
+	 *
+	 * This is an `XRProjectionLayer` when the targeted XR device supports the
+	 * WebXR Layers API, or an `XRWebGLLayer` otherwise.
+	 *
+	 * @return {?(XRWebGLLayer|XRProjectionLayer)} The XR base layer.
+	 */
+	getBaseLayer() {
+
+		return this._glProjLayer !== null ? this._glProjLayer : this._glBaseLayer;
+
+	}
+
 
 	/**
 	 * Returns the current XR binding.
@@ -609,6 +623,44 @@ class XRManager extends EventDispatcher {
 		}
 
 		return this._glBinding;
+
+	}
+
+	/**
+	 * Applies WebXR fixed foveation to the currently bound post-processing texture
+	 * that is used by the first XR render pass before compositing into a projection layer.
+	 *
+	 * Browser-side `XRWebGLBinding.foveateBoundTexture()` failures are treated as
+	 * non-fatal so they do not interrupt rendering.
+	 *
+	 * @param {Texture} texture - The currently bound texture.
+	 * @param {GLenum} glTextureType - The bound texture target.
+	 */
+	foveateBoundTexture( texture, glTextureType ) {
+
+		if ( texture.isRenderTargetTexture !== true ) return;
+		if ( texture.renderTarget.isPostProcessingRenderTarget !== true ) return;
+		if ( this.isPresenting !== true ) return;
+
+		const outputRenderTarget = this._renderer.getOutputRenderTarget();
+		const baseLayer = this.getBaseLayer();
+
+		if ( outputRenderTarget === null || outputRenderTarget.isXRRenderTarget !== true ) return;
+		if ( baseLayer === null || baseLayer.textureWidth === undefined ) return;
+
+		const glBinding = this.getBinding();
+
+		if ( glBinding === null || typeof glBinding.foveateBoundTexture !== 'function' ) return;
+
+		try {
+
+			glBinding.foveateBoundTexture( glTextureType, this.getFoveation() );
+
+		} catch ( error ) {
+
+			warnOnce( `XRManager: Unable to foveate bound XR post-processing texture. ${error.name}: ${error.message}` );
+
+		}
 
 	}
 

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -627,30 +627,43 @@ class XRManager extends EventDispatcher {
 	}
 
 	/**
-	 * Applies WebXR fixed foveation to the currently bound post-processing texture
-	 * that is used by the first XR render pass before compositing into a projection layer.
+	 * Applies WebXR fixed foveation to the internal post-processing render target
+	 * used by the first XR render pass before compositing into a projection layer.
 	 *
 	 * Browser-side `XRWebGLBinding.foveateBoundTexture()` failures are treated as
 	 * non-fatal so they do not interrupt rendering.
 	 *
-	 * @param {Texture} texture - The currently bound texture.
-	 * @param {GLenum} glTextureType - The bound texture target.
+	 * @param {RenderTarget} renderTarget - The internal render target.
 	 */
-	foveateBoundTexture( texture, glTextureType ) {
+	foveateBoundTexture( renderTarget ) {
 
-		if ( texture.isRenderTargetTexture !== true ) return;
-		if ( texture.renderTarget.isPostProcessingRenderTarget !== true ) return;
+		if ( renderTarget.isPostProcessingRenderTarget !== true ) return;
 		if ( this.isPresenting !== true ) return;
+		if ( this._glProjLayer === null ) return;
+
+		const backend = this._renderer.backend;
+
+		if ( backend === undefined || backend.isWebGLBackend !== true ) return;
+		if ( backend.state === null ) return;
 
 		const outputRenderTarget = this._renderer.getOutputRenderTarget();
-		const baseLayer = this.getBaseLayer();
 
 		if ( outputRenderTarget === null || outputRenderTarget.isXRRenderTarget !== true ) return;
-		if ( baseLayer === null || baseLayer.textureWidth === undefined ) return;
 
 		const glBinding = this.getBinding();
 
 		if ( glBinding === null || typeof glBinding.foveateBoundTexture !== 'function' ) return;
+
+		this._renderer._textures.updateRenderTarget( renderTarget );
+
+		const { textureGPU, glTextureType } = backend.get( renderTarget.texture );
+
+		if ( textureGPU === undefined || glTextureType === undefined ) return;
+		if ( renderTarget._xrFoveationTextureGPU === textureGPU ) return;
+
+		renderTarget._xrFoveationTextureGPU = textureGPU;
+
+		backend.state.bindTexture( glTextureType, textureGPU );
 
 		try {
 
@@ -659,6 +672,10 @@ class XRManager extends EventDispatcher {
 		} catch ( error ) {
 
 			warnOnce( `XRManager: Unable to foveate bound XR post-processing texture. ${error.name}: ${error.message}` );
+
+		} finally {
+
+			backend.state.unbindTexture();
 
 		}
 
@@ -1703,6 +1720,9 @@ function onAnimationFrame( time, frame ) {
 		}
 
 		renderer.setOutputRenderTarget( this._xrRenderTarget );
+
+		const frameBufferTarget = renderer._getFrameBufferTarget();
+		renderer.xr.foveateBoundTexture( frameBufferTarget );
 
 	}
 

--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -456,8 +456,6 @@ class WebGLTextureUtils {
 
 		}
 
-		backend.renderer.xr.foveateBoundTexture( texture, glTextureType );
-
 		backend.set( texture, {
 			textureGPU,
 			glTextureType,

--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -456,6 +456,8 @@ class WebGLTextureUtils {
 
 		}
 
+		backend.renderer.xr.foveateBoundTexture( texture, glTextureType );
+
 		backend.set( texture, {
 			textureGPU,
 			glTextureType,


### PR DESCRIPTION
Use foveateBoundTexture to enable foveation on the texture/framebuffer created by three.js. WebGPURenderer has a 2 pass renderer so we need to foveate the first pass.

Also  treat browser-side XRWebGLBinding.foveateBoundTexture() failures as non-fatal so XR rendering continues for browser version where this call had a bug.


*This contribution is funded by [Meta](https://meta.com)*
