### PR TITLE
Manual: Use event delegation for links to prevent overlapping UI

### DIFF
--- a/manual/resources/lesson.js
+++ b/manual/resources/lesson.js
@@ -6,30 +6,29 @@
 	if ( window.frameElement ) {
 
 		// in iframe
-		document.querySelectorAll( 'a' ).forEach( a => {
+		// Use event delegation to handle all links, including dynamically added ones
+		// (e.g. from threejs-material-table.js), otherwise they navigate inside
+		// the iframe causing overlapping sidebars.
+		document.addEventListener( 'click', e => {
 
-			// we have to send all links to the parent
-			// otherwise we'll end up with 3rd party
-			// sites under the frame.
-			a.addEventListener( 'click', e => {
+			const a = e.target.closest( 'a' );
+			if ( ! a ) return;
 
-				// opening a new tab?
-				if ( a.target === '_blank' ) {
+			// opening a new tab?
+			if ( a.target === '_blank' ) {
 
-					return;
+				return;
 
-				}
+			}
 
-				// change changing hashes?
-				if ( a.origin !== window.location.origin || a.pathname !== window.location.pathname ) {
+			// change changing hashes?
+			if ( a.origin !== window.location.origin || a.pathname !== window.location.pathname ) {
 
-					e.preventDefault();
+				e.preventDefault();
 
-				}
+			}
 
-				window.parent.setUrl( a.href );
-
-			} );
+			window.parent.setUrl( a.href );
 
 		} );
 		window.parent.setTitle( document.title );


### PR DESCRIPTION
Related issue: #33483

This PR fixes an issue in the three.js manual where certain links (specifically those generated dynamically by scripts, such as in the Material Feature Table) would load the documentation page inside the manual's iframe instead of navigating the top-level window. This resulted in an "overlapping UI" bug where the documentation header and sidebar appeared twice.

Changes:

1. Modified manual/resources/lesson.js to use event delegation for link handling.
2. Replaced individual click listeners on <a> tags with a single listener on the document.
3. This ensures that all links, including those added to the DOM after the initial page load, are correctly intercepted and handled by window.parent.setUrl().
