### PR TITLE
CubeCamera: Avoid redundant matrixWorld updates across face renders.

### DIFF
--- a/examples/jsm/lighting/LightProbeGrid.js
+++ b/examples/jsm/lighting/LightProbeGrid.js
@@ -236,6 +236,15 @@ class LightProbeGrid extends Object3D {
 		renderer.getScissor( _savedScissor );
 		const savedScissorTest = renderer.getScissorTest();
 
+		// Scene is static across the bake — update once and disable per-render auto updates.
+		const savedMatrixWorldAutoUpdate = scene.matrixWorldAutoUpdate;
+		if ( savedMatrixWorldAutoUpdate === true ) {
+
+			scene.updateMatrixWorld( true );
+			scene.matrixWorldAutoUpdate = false;
+
+		}
+
 		// Clear pooled batch target so skipped probes read as zero
 		batchTarget.scissorTest = false;
 		batchTarget.viewport.set( 0, 0, 9, totalProbes );
@@ -334,6 +343,8 @@ class LightProbeGrid extends Object3D {
 		renderer.setViewport( _savedViewport );
 		renderer.setScissor( _savedScissor );
 		renderer.setScissorTest( savedScissorTest );
+
+		scene.matrixWorldAutoUpdate = savedMatrixWorldAutoUpdate;
 
 		// console.log( `LightProbeGrid: bake complete ${ ( performance.now() - t0 ).toFixed( 1 ) }ms` );
 


### PR DESCRIPTION
**Description**

`CubeCamera.update()` calls `renderer.render()` 6 times in a row (one per face). Each call does a full `scene.updateMatrixWorld()` traversal, even though the scene can't have changed between faces.

Snapshot `scene.matrixWorldAutoUpdate`, do one `scene.updateMatrixWorld(true)` upfront, disable auto-update for the 6 renders, and restore the user's value afterwards. If the user already had `matrixWorldAutoUpdate = false`, nothing is touched.

Measured on the WebGL light probe examples:

| Example | `updateMatrixWorld` calls |  |
|---|---|---|
| `webgl_lightprobes_sponza` | 98,596 → 17,746 | −82% |
| `webgl_lightprobes_complex` | 85,032 → 18,072 | −79% |

Wall clock is unchanged on these static glTF scenes — the eliminated calls were near-free tree walks where every `matrixWorldNeedsUpdate` was already false. The win shows up on profiles, on battery, and on scenes with skinned meshes / deep transform hierarchies / many auto-updating movers, where each call does real work.