### PR TITLE
LightProbeGrid: Avoid redundant matrixWorld updates during bake.

### DIFF
--- a/examples/jsm/lighting/LightProbeGrid.js
+++ b/examples/jsm/lighting/LightProbeGrid.js
@@ -45,8 +45,8 @@ let _batchTargetProbes = 0;
 // Reusable temp objects
 const _position = /*@__PURE__*/ new Vector3();
 const _size = /*@__PURE__*/ new Vector3();
-const _savedViewport = /*@__PURE__*/ new Vector4();
-const _savedScissor = /*@__PURE__*/ new Vector4();
+const _currentViewport = /*@__PURE__*/ new Vector4();
+const _currentScissor = /*@__PURE__*/ new Vector4();
 
 // Number of padding texels added at each boundary of every sub-volume in the atlas.
 const ATLAS_PADDING = 1;
@@ -231,10 +231,10 @@ class LightProbeGrid extends Object3D {
 		const batchTarget = _ensureBatchTarget( totalProbes );
 
 		// Save renderer state
-		const savedRenderTarget = renderer.getRenderTarget();
-		renderer.getViewport( _savedViewport );
-		renderer.getScissor( _savedScissor );
-		const savedScissorTest = renderer.getScissorTest();
+		const currentRenderTarget = renderer.getRenderTarget();
+		renderer.getViewport( _currentViewport );
+		renderer.getScissor( _currentScissor );
+		const currentScissorTest = renderer.getScissorTest();
 
 		// Clear pooled batch target so skipped probes read as zero
 		batchTarget.scissorTest = false;
@@ -250,7 +250,7 @@ class LightProbeGrid extends Object3D {
 
 		// Disable shadow map auto-update during bake — lights don't move between probes.
 		// Force one shadow update on the first render so maps are initialized.
-		const savedShadowAutoUpdate = renderer.shadowMap.autoUpdate;
+		const currentShadowAutoUpdate = renderer.shadowMap.autoUpdate;
 		renderer.shadowMap.autoUpdate = false;
 		renderer.shadowMap.needsUpdate = true;
 
@@ -280,7 +280,7 @@ class LightProbeGrid extends Object3D {
 
 		}
 
-		renderer.shadowMap.autoUpdate = savedShadowAutoUpdate;
+		renderer.shadowMap.autoUpdate = currentShadowAutoUpdate;
 
 		// Phase 2: Repack SH data from batch target into the atlas 3D texture (GPU-to-GPU).
 		//
@@ -330,10 +330,10 @@ class LightProbeGrid extends Object3D {
 		}
 
 		// Restore renderer state
-		renderer.setRenderTarget( savedRenderTarget );
-		renderer.setViewport( _savedViewport );
-		renderer.setScissor( _savedScissor );
-		renderer.setScissorTest( savedScissorTest );
+		renderer.setRenderTarget( currentRenderTarget );
+		renderer.setViewport( _currentViewport );
+		renderer.setScissor( _currentScissor );
+		renderer.setScissorTest( currentScissorTest );
 
 		// console.log( `LightProbeGrid: bake complete ${ ( performance.now() - t0 ).toFixed( 1 ) }ms` );
 

--- a/examples/jsm/lighting/LightProbeGrid.js
+++ b/examples/jsm/lighting/LightProbeGrid.js
@@ -236,6 +236,15 @@ class LightProbeGrid extends Object3D {
 		renderer.getScissor( _currentScissor );
 		const currentScissorTest = renderer.getScissorTest();
 
+		// Scene is static across the bake — update once and disable per-render auto updates.
+		const currentMatrixWorldAutoUpdate = scene.matrixWorldAutoUpdate;
+		if ( currentMatrixWorldAutoUpdate === true ) {
+
+			scene.updateMatrixWorld( true );
+			scene.matrixWorldAutoUpdate = false;
+
+		}
+
 		// Clear pooled batch target so skipped probes read as zero
 		batchTarget.scissorTest = false;
 		batchTarget.viewport.set( 0, 0, 9, totalProbes );
@@ -334,6 +343,8 @@ class LightProbeGrid extends Object3D {
 		renderer.setViewport( _currentViewport );
 		renderer.setScissor( _currentScissor );
 		renderer.setScissorTest( currentScissorTest );
+
+		scene.matrixWorldAutoUpdate = currentMatrixWorldAutoUpdate;
 
 		// console.log( `LightProbeGrid: bake complete ${ ( performance.now() - t0 ).toFixed( 1 ) }ms` );
 


### PR DESCRIPTION
**Description**

`LightProbeGrid.bake()` triggers many `renderer.render()` calls per probe (6 cube faces + SH projection + repack). Each one runs `scene.updateMatrixWorld()`, even though the scene cannot have changed during the bake.

Snapshot `scene.matrixWorldAutoUpdate`, do one `scene.updateMatrixWorld(true)` upfront, disable auto-update for the duration of the bake, and restore the user's value at the end. If the user already had `matrixWorldAutoUpdate = false`, nothing is touched.

Measured `Object3D.updateMatrixWorld` calls per bake:

| Example | Before | After |
|---|---|---|
| `webgl_lightprobes_sponza` | 98,596 | 1,686 |
| `webgl_lightprobes_complex` | 85,032 | 4,742 |