### PR TITLE
Examples: Make wave speed frame rate independent in `webgl_shaders_ocean`.

### DIFF
--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -33,7 +33,6 @@
 			import { Water } from 'three/addons/objects/Water.js';
 			import { Sky } from 'three/addons/objects/Sky.js';
 			import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
-			import { Timer } from 'three';
 
 			let container, stats, timer;
 			let camera, scene, renderer;
@@ -42,8 +41,6 @@
 			init();
 
 			function init() {
-
-				timer = new Timer();
 
 				container = document.getElementById( 'container' );
 
@@ -69,6 +66,8 @@
 
 				camera = new THREE.PerspectiveCamera( 55, window.innerWidth / window.innerHeight, 1, 20000 );
 				camera.position.set( 30, 30, 100 );
+
+				timer = new THREE.Timer();
 
 				//
 

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -33,14 +33,17 @@
 			import { Water } from 'three/addons/objects/Water.js';
 			import { Sky } from 'three/addons/objects/Sky.js';
 			import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+			import { Timer } from 'three';
 
-			let container, stats;
+			let container, stats, timer;
 			let camera, scene, renderer;
 			let controls, water, sun, sky, mesh, bloomPass;
 
 			init();
 
 			function init() {
+
+				timer = new Timer();
 
 				container = document.getElementById( 'container' );
 
@@ -217,6 +220,7 @@
 
 			function animate() {
 
+				timer.update();
 				render();
 				stats.update();
 
@@ -230,7 +234,9 @@
 				mesh.rotation.x = time * 0.5;
 				mesh.rotation.z = time * 0.51;
 
-				water.material.uniforms[ 'time' ].value += 1.0 / 60.0;
+				const delta = timer.getDelta();
+
+				water.material.uniforms[ 'time' ].value += delta;
 				sky.material.uniforms[ 'time' ].value = time;
 
 				renderer.render( scene, camera );


### PR DESCRIPTION
I updated the value in the render function from 
water.material.uniforms[ 'time' ].value += 1.0 / 60.0 
to 
const delta = timer.getDelta();
water.material.uniforms[ 'time' ].value += delta;

Changed this for the WebGL Ocean sample

I noticed that I got different wave speeds on screens with different refresh rates. 
I have a 165hz monitor and the wave speed was very fast since the time value was locked at 1/60 the frame time. 

Introducing the delta time fixes the problem and lets the wave speed adjust on monitors with faster refresh rates. 