### PR TITLE
Examples: Fix final alpha issues

### DIFF
--- a/examples/webgpu_lines_fat.html
+++ b/examples/webgpu_lines_fat.html
@@ -110,7 +110,7 @@
 					linewidth: 5, // in world units with size attenuation, pixels otherwise
 					vertexColors: true,
 					dashed: false,
-					alphaToCoverage: true,
+					alphaToCoverage: false,
 
 				} );
 
@@ -209,7 +209,7 @@
 					'line type': 0,
 					'world units': false,
 					'width': 5,
-					'alphaToCoverage': true,
+					'alphaToCoverage': false,
 					'dashed': false,
 					'dash offset': 0,
 					'dash scale': 1,

--- a/examples/webgpu_lines_fat_wireframe.html
+++ b/examples/webgpu_lines_fat_wireframe.html
@@ -139,8 +139,6 @@
 
 				// main scene
 
-				renderer.setClearColor( 0x000000, 0 );
-
 				renderer.setViewport( 0, 0, window.innerWidth, window.innerHeight );
 
 				renderer.autoClear = true;


### PR DESCRIPTION
Related to #33452, #33437

**Description**

Fixes some issues missed in #33452 in order to normalize issues for fixes related to #33369.

- Disable alpha to coverage default in webgpu_lines_fat to avoid blending issues relating to a2c.
- Remove unnecessary background alpha adjustment in webgpu_lines_fat_wireframe.
