### PR TITLE
MikkTSpace: Add `dispose()`, cache promise.

### DIFF
--- a/examples/jsm/libs/mikktspace.module.js
+++ b/examples/jsm/libs/mikktspace.module.js
@@ -117,17 +117,37 @@ export let wasm;
 
 export let isReady = false;
 
-export async function ready() {
-    const res = await fetch(wasmDataURI);
-    const buffer = await res.arrayBuffer();
-    const result = await WebAssembly.instantiate(buffer, {
-        './mikktspace_module_bg.js': { __wbindgen_string_new, __wbindgen_rethrow }
-    });
-    wasm = result.instance.exports;
-    isReady = true;
+let readyPromise = null;
+
+function initialize() {
+
+	return fetch( wasmDataURI )
+		.then( ( res ) => res.arrayBuffer() )
+		.then( ( buffer ) => WebAssembly.instantiate( buffer, {
+			'./mikktspace_module_bg.js': { __wbindgen_string_new, __wbindgen_rethrow }
+		} ) )
+		.then( ( result ) => {
+
+			wasm = result.instance.exports;
+			isReady = true;
+
+		} );
+
 }
 
+export const ready = {
+	then: function ( onFulfilled, onRejected ) {
+
+		if ( readyPromise === null ) readyPromise = initialize();
+		return readyPromise.then( onFulfilled, onRejected );
+
+	}
+};
+
 export function dispose() {
-    wasm = null;
-    isReady = false;
+
+	wasm = null;
+	isReady = false;
+	readyPromise = null;
+
 }

--- a/examples/jsm/libs/mikktspace.module.js
+++ b/examples/jsm/libs/mikktspace.module.js
@@ -117,12 +117,17 @@ export let wasm;
 
 export let isReady = false;
 
-export const ready = fetch(wasmDataURI)
-    .then((res) => res.arrayBuffer())
-    .then((buffer) => WebAssembly.instantiate(buffer, {
-        './mikktspace_module_bg.js': {__wbindgen_string_new, __wbindgen_rethrow}
-    }))
-    .then((result) => {
-        wasm = result.instance.exports;
-        isReady = true;
+export const ready = async function() {
+    const res = await fetch(wasmDataURI);
+    const buffer = await res.arrayBuffer();
+    const result = await WebAssembly.instantiate(buffer, {
+        './mikktspace_module_bg.js': { __wbindgen_string_new, __wbindgen_rethrow }
     });
+    wasm = result.instance.exports;
+    isReady = true;
+}
+
+export const dispose = function() {
+    wasm = null;
+    isReady = false;
+}

--- a/examples/jsm/libs/mikktspace.module.js
+++ b/examples/jsm/libs/mikktspace.module.js
@@ -117,7 +117,7 @@ export let wasm;
 
 export let isReady = false;
 
-export const ready = async function() {
+export async function ready() {
     const res = await fetch(wasmDataURI);
     const buffer = await res.arrayBuffer();
     const result = await WebAssembly.instantiate(buffer, {
@@ -127,7 +127,7 @@ export const ready = async function() {
     isReady = true;
 }
 
-export const dispose = function() {
+export function dispose() {
     wasm = null;
     isReady = false;
 }


### PR DESCRIPTION
Fixed #33500

**Description**

Attempting to fix the MikktSpace Buffer memory leak, providing a dispose method, and converting the read global promise to an async function so that it can be instantiated multiple times
