### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/jsm/helpers/LightProbeGridHelper.js
+++ b/examples/jsm/helpers/LightProbeGridHelper.js
@@ -9,7 +9,7 @@ import {
 
 /**
  * Visualizes an {@link LightProbeGrid} by rendering a sphere at each
- * probe position, shaded with the probe's L1 spherical harmonics.
+ * probe position, shaded with the probe's L2 spherical harmonics.
  *
  * Uses a single `InstancedMesh` draw call for all probes.
  *

--- a/examples/webgl_lightprobes.html
+++ b/examples/webgl_lightprobes.html
@@ -10,7 +10,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - light probe volume<br/>
-			Position-dependent diffuse global illumination via L1 SH probe grid
+			Position-dependent diffuse global illumination via L2 SH probe grid
 		</div>
 
 		<script type="importmap">


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/global-illumination/91243/5

**Description**

A user in the forum noticed an inconsistency in the examples and docs. The Light Probe Grid uses L2, not L1 probes.
