### PR TITLE
WebGPURenderer: Make structs work in vertex shader with WebGL.

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -946,7 +946,7 @@ ${ flowData.code }
 
 		}
 
-		if ( outputSnippet.length === 0 ) {
+		if ( shaderStage === 'fragment' && outputSnippet.length === 0 ) {
 
 			outputSnippet.push( 'layout( location = 0 ) out vec4 fragColor;' );
 
@@ -1389,6 +1389,9 @@ ${shaderData.extensions}
 
 // precision
 ${ defaultPrecisions }
+
+// structs
+${shaderData.structs}
 
 // uniforms
 ${shaderData.uniforms}


### PR DESCRIPTION
Fixed #33504.

**Description**

The PR makes sure structs work in vertex shader with WebGL like in the fragment shader.

- The vertex shader template had not `${shaderData.structs}` slot.
- The default output snippet is only allowed to be written in the `fragment` stage.