### PR TITLE
CSMShadowNode: Fix inconsistency in frustum split

### DIFF
--- a/examples/jsm/csm/CSMFrustum.js
+++ b/examples/jsm/csm/CSMFrustum.js
@@ -161,7 +161,7 @@ class CSMFrustum {
 
 				for ( let j = 0; j < 4; j ++ ) {
 
-					cascade.vertices.near[ j ].lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], breaks[ i - 1 ] );
+					cascade.vertices.near[ j ].copy( this.vertices.far[ j ] ).multiplyScalar( breaks[ i - 1 ] );
 
 				}
 
@@ -179,7 +179,7 @@ class CSMFrustum {
 
 				for ( let j = 0; j < 4; j ++ ) {
 
-					cascade.vertices.far[ j ].lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], breaks[ i ] );
+					cascade.vertices.far[ j ].copy( this.vertices.far[ j ] ).multiplyScalar( breaks[ i ] );
 
 				}
 

--- a/examples/jsm/csm/CSMFrustum.js
+++ b/examples/jsm/csm/CSMFrustum.js
@@ -145,6 +145,9 @@ class CSMFrustum {
 
 		target.length = breaks.length;
 
+		const near = this.vertices.near[ 0 ].z;
+		const far = this.vertices.far[ 0 ].z;
+
 		for ( let i = 0; i < breaks.length; i ++ ) {
 
 			const cascade = target[ i ];
@@ -159,9 +162,11 @@ class CSMFrustum {
 
 			} else {
 
+				const alpha = ( breaks[ i - 1 ] * far - near ) / ( far - near );
+
 				for ( let j = 0; j < 4; j ++ ) {
 
-					cascade.vertices.near[ j ].copy( this.vertices.far[ j ] ).multiplyScalar( breaks[ i - 1 ] );
+					cascade.vertices.near[ j ].lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], alpha );
 
 				}
 
@@ -177,9 +182,11 @@ class CSMFrustum {
 
 			} else {
 
+				const alpha = ( breaks[ i ] * far - near ) / ( far - near );
+
 				for ( let j = 0; j < 4; j ++ ) {
 
-					cascade.vertices.far[ j ].copy( this.vertices.far[ j ] ).multiplyScalar( breaks[ i ] );
+					cascade.vertices.far[ j ].lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], alpha );
 
 				}
 


### PR DESCRIPTION
**Description**

This PR fixes an inconsistency in the computation of CSMShadowNode's `breaks` and CSMFrustum's `split()`. 

The `breaks` in CSMShadowNode maps 0 to the view origin and 1 to the far plane, whereas CSMFrustum splits as if `breaks` maps 0 to the near plane and 1 to the far plane. This inconsistency is negligible when the camera near is close to 0, but not when it is closer to the far plane.

It would be much simpler if we change the `breaks` instead of `split()`, because `uniformSplit` would be just `i / amount`. But `customSplitsCallback` is a public API, so the changes in this PR seem more appropriate.

Below are screenshots with `mode == 'uniform'`. The same applies to `'logarithmic'` and `'practical'`.

||Before|PR|
|-|-|-|
|Camera near = 0.01 far|<img alt="image" src="https://github.com/user-attachments/assets/6938f4e9-71db-4e38-9b40-2cbdc146693b" />|<img alt="image" src="https://github.com/user-attachments/assets/ecb1ae58-7c94-4171-9e18-7bb207105d02" />|
|Camera near = 0.5 far|<img alt="image" src="https://github.com/user-attachments/assets/f705e82c-afbe-49a7-9192-3f56d8879e09" />|<img alt="image" src="https://github.com/user-attachments/assets/dff62946-238a-43d6-bcad-1c5377daba22" />|