### PR TITLE
WebGPURenderer: Fix texture disposal for render targets.

### DIFF
--- a/src/renderers/common/Sampler.js
+++ b/src/renderers/common/Sampler.js
@@ -24,30 +24,14 @@ class Sampler extends Binding {
 		 * @private
 		 * @type {?Texture}
 		 */
-		this._texture = null;
-
-		/**
-		 * An event listener which is added to {@link texture}'s dispose event.
-		 *
-		 * @private
-		 * @type {Function}
-		 */
-		this._onTextureDispose = () => {
-
-			this.generation = null;
-			this.version = - 1;
-
-		};
-
-		// Assignment to the texture via a setter must occur after "_onTextureDispose" is initialized.
-		this.texture = texture;
+		this._texture = texture;
 
 		/**
 		 * The binding's version.
 		 *
 		 * @type {number}
 		 */
-		this.version = texture ? texture.version : - 1;
+		this.version = - 1;
 
 		/**
 		 * The binding's generation which is an additional version
@@ -86,22 +70,9 @@ class Sampler extends Binding {
 
 		if ( this._texture === value ) return;
 
-		if ( this._texture ) {
-
-			this._texture.removeEventListener( 'dispose', this._onTextureDispose );
-
-		}
-
 		this._texture = value;
 
-		this.generation = null;
-		this.version = - 1;
-
-		if ( this._texture ) {
-
-			this._texture.addEventListener( 'dispose', this._onTextureDispose );
-
-		}
+		this.reset();
 
 	}
 
@@ -137,26 +108,14 @@ class Sampler extends Binding {
 
 	}
 
+	/**
+	 * Resets the version and generation. This is used when the texture
+	 * the binding is pointing to is disposed or exchanged.
+	 */
+	reset() {
 
-	clone() {
-
-		const clonedSampler = super.clone();
-
-		// fix dispose handler for cloned instances
-		// TODO: Find better solution, see #31747
-
-		clonedSampler._texture = null;
-
-		clonedSampler._onTextureDispose = () => {
-
-			clonedSampler.generation = null;
-			clonedSampler.version = - 1;
-
-		};
-
-		clonedSampler.texture = this.texture;
-
-		return clonedSampler;
+		this.generation = null;
+		this.version = - 1;
 
 	}
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -610,7 +610,7 @@ class Textures extends DataMap {
 					bindingsData.groups = undefined;
 					bindingsData.versions = undefined;
 
-					// go through all bindings an if one points to the destroyed texture, trigger dispose as well
+					// go through all bindings and if one points to the destroyed texture, trigger dispose as well
 
 					for ( const binding of bindGroup.bindings ) {
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -616,7 +616,7 @@ class Textures extends DataMap {
 
 						if ( binding.isSampler && binding.texture === texture ) {
 
-							binding._onTextureDispose();
+							binding.reset();
 
 						}
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -610,6 +610,18 @@ class Textures extends DataMap {
 					bindingsData.groups = undefined;
 					bindingsData.versions = undefined;
 
+					// go through all bindings an if one points to the destroyed texture, trigger dispose as well
+
+					for ( const binding of bindGroup.bindings ) {
+
+						if ( binding.isSampler && binding.texture === texture ) {
+
+							binding._onTextureDispose();
+
+						}
+
+					}
+
 				}
 
 			}


### PR DESCRIPTION
Fixed #30766.

**Description**

The PR makes sure when `dispose()` is called on render targets, their textures are properly cleaned up.  https://github.com/mrdoob/three.js/pull/33011 only fixed this issue partly. It made sure cached bind groups that pointed to destroyed textures were removed. But to ensure the binding objects (instances of the `Sampler` class) correctly detect the need for an updated, they must be disposed of as well. That already happens for normal textures but not for render target textures because calling `dispose()` on a render target does _not_ trigger `dispose()` on textures. Hence, we must make sure `_onTextureDispose()` is called explicitly.
