### PR TITLE
WebGPURenderer: Restore framebuffer after clear.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -832,6 +832,14 @@ class WebGLBackend extends Backend {
 
 				if ( setFrameBuffer && resolveRenderTarget ) this._resolveRenderTarget( descriptor );
 
+				// Restore the framebuffer of the active render pass when clearing an unrelated
+				// render target, so subsequent draws in the pass don't bind to the cleared target.
+				if ( setFrameBuffer && this._currentContext !== null && this._currentContext !== descriptor ) {
+
+					this._setFramebuffer( this._currentContext );
+
+				}
+
 			}
 
 		}


### PR DESCRIPTION
Related issue: -

**Description**

I've noticed flickering when using the WebGL 2 backend with `webgpu_mirror.html`. Turns out the WebGL backend does not restore the frame buffer during a clear operation which produces an invalid state for the remaining frame (problematic for nested renderings). 
