### PR TITLE
TSL: Cache function nodes per renderer's backend

### DIFF
--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -506,13 +506,15 @@ class ShaderCallNodeInternal extends Node {
 
 		if ( shaderNode.layout ) {
 
-			let functionNodesCacheMap = nodeBuilderFunctionsCacheMap.get( builder.constructor );
+			const backend = builder.renderer.backend;
+
+			let functionNodesCacheMap = nodeBuilderFunctionsCacheMap.get( backend );
 
 			if ( functionNodesCacheMap === undefined ) {
 
 				functionNodesCacheMap = new WeakMap();
 
-				nodeBuilderFunctionsCacheMap.set( builder.constructor, functionNodesCacheMap );
+				nodeBuilderFunctionsCacheMap.set( backend, functionNodesCacheMap );
 
 			}
 


### PR DESCRIPTION
Fixes #33342

**Description**

TSL function nodes with layouts were being cached at the module level (using the NodeBuilder constructor). This caused cache conflicts in SPAs with multiple sequential renderers. 

This PR changes the cache key in `TSLCore.js` to use `builder.renderer.backend` as scope for the cache.

/cc @shotamatsuda
