### PR TITLE
TSL: Make sure structs are built when compiling functions.

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -35,6 +35,7 @@ import { warn, error, yieldToMain } from '../../utils.js';
 let _id = 0;
 
 const _bindingGroupsCache = new WeakMap();
+const _functionNodeCache = new WeakMap();
 
 const sharedNodeData = new WeakMap();
 
@@ -2378,15 +2379,34 @@ class NodeBuilder {
 	 */
 	buildFunctionNode( shaderNode ) {
 
-		const fn = new FunctionNode();
+		const backend = this.renderer.backend;
 
-		const previous = this.currentFunctionNode;
+		let cache = _functionNodeCache.get( backend );
 
-		this.currentFunctionNode = fn;
+		if ( cache === undefined ) {
 
-		fn.code = this.buildFunctionCode( shaderNode );
+			cache = new WeakMap();
+			_functionNodeCache.set( backend, cache );
 
-		this.currentFunctionNode = previous;
+		}
+
+		let fn = cache.get( shaderNode );
+
+		if ( fn === undefined ) {
+
+			fn = new FunctionNode();
+
+			const previous = this.currentFunctionNode;
+
+			this.currentFunctionNode = fn;
+
+			fn.code = this.buildFunctionCode( shaderNode );
+
+			this.currentFunctionNode = previous;
+
+			cache.set( shaderNode, fn );
+
+		}
 
 		return fn;
 

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -528,11 +528,7 @@ class ShaderCallNodeInternal extends Node {
 
 					for ( const param of rawInputs ) {
 
-						if ( param && param.isStructNode ) {
-
-							param.structTypeNode.build( builder );
-
-						}
+						param.build( builder );
 
 					}
 

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -522,13 +522,25 @@ class ShaderCallNodeInternal extends Node {
 
 			if ( functionNode === undefined ) {
 
-				// Build struct types referenced by the call inputs first
+				// build inputs first
 
 				if ( rawInputs ) {
 
 					for ( const param of rawInputs ) {
 
-						param.build( builder );
+						if ( param.isNode ) {
+
+							param.build( builder );
+
+						} else if ( typeof param === 'object' ) {
+
+							for ( const key in param ) {
+
+							 	param[ key ].build( builder );
+
+							}
+
+						}
 
 					}
 

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -291,8 +291,6 @@ Object.defineProperties( Node.prototype, proto );
 
 // --- FINISH ---
 
-const nodeBuilderFunctionsCacheMap = new WeakMap();
-
 const ShaderNodeObject = function ( obj, altType = null ) {
 
 	const type = getValueType( obj );
@@ -506,37 +504,23 @@ class ShaderCallNodeInternal extends Node {
 
 		if ( shaderNode.layout ) {
 
-			const backend = builder.renderer.backend;
+			// build inputs first
 
-			let functionNodesCacheMap = nodeBuilderFunctionsCacheMap.get( backend );
+			if ( rawInputs ) {
 
-			if ( functionNodesCacheMap === undefined ) {
+				for ( const param of rawInputs ) {
 
-				functionNodesCacheMap = new WeakMap();
+					if ( param.isNode ) {
 
-				nodeBuilderFunctionsCacheMap.set( backend, functionNodesCacheMap );
+						param.build( builder );
 
-			}
+					} else if ( typeof param === 'object' ) {
 
-			let functionNode = functionNodesCacheMap.get( shaderNode );
+						for ( const key in param ) {
 
-			if ( functionNode === undefined ) {
+							if ( param[ key ].isNode ) {
 
-				// build inputs first
-
-				if ( rawInputs ) {
-
-					for ( const param of rawInputs ) {
-
-						if ( param.isNode ) {
-
-							param.build( builder );
-
-						} else if ( typeof param === 'object' ) {
-
-							for ( const key in param ) {
-
-							 	param[ key ].build( builder );
+								param[ key ].build( builder );
 
 							}
 
@@ -546,11 +530,9 @@ class ShaderCallNodeInternal extends Node {
 
 				}
 
-				functionNode = nodeObject( builder.buildFunctionNode( shaderNode ) );
-
-				functionNodesCacheMap.set( shaderNode, functionNode );
-
 			}
+
+			const functionNode = nodeObject( builder.buildFunctionNode( shaderNode ) );
 
 			builder.addInclude( functionNode );
 

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -522,6 +522,22 @@ class ShaderCallNodeInternal extends Node {
 
 			if ( functionNode === undefined ) {
 
+				// Build struct types referenced by the call inputs first
+
+				if ( rawInputs ) {
+
+					for ( const param of rawInputs ) {
+
+						if ( param && param.isStructNode ) {
+
+							param.structTypeNode.build( builder );
+
+						}
+
+					}
+
+				}
+
 				functionNode = nodeObject( builder.buildFunctionNode( shaderNode ) );
 
 				functionNodesCacheMap.set( shaderNode, functionNode );

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -508,21 +508,37 @@ class ShaderCallNodeInternal extends Node {
 
 			if ( rawInputs ) {
 
-				for ( const param of rawInputs ) {
+				// use layout inputs to ensure that no extra parameters are built
 
-					if ( param.isNode ) {
+				const inputs = shaderNode.layout.inputs;
 
-						param.build( builder );
+				if ( isArrayAsParameter( rawInputs ) ) {
 
-					} else if ( typeof param === 'object' ) {
+					const rawArrayParameters = rawInputs;
 
-						for ( const key in param ) {
+					for ( let i = 0; i < inputs.length; i ++ ) {
 
-							if ( param[ key ].isNode ) {
+						const rawParameter = rawArrayParameters[ i ];
 
-								param[ key ].build( builder );
+						if ( rawParameter && rawParameter.isNode ) {
 
-							}
+							rawParameter.build( builder );
+
+						}
+
+					}
+
+				} else {
+
+					const rawObjectParameters = rawInputs[ 0 ];
+
+					for ( const param of inputs ) {
+
+						const rawParameter = rawObjectParameters[ param.name ];
+
+						if ( rawParameter && rawParameter.isNode ) {
+
+							rawParameter.build( builder );
 
 						}
 
@@ -532,7 +548,7 @@ class ShaderCallNodeInternal extends Node {
 
 			}
 
-			const functionNode = nodeObject( builder.buildFunctionNode( shaderNode ) );
+			const functionNode = builder.buildFunctionNode( shaderNode );
 
 			builder.addInclude( functionNode );
 
@@ -540,7 +556,7 @@ class ShaderCallNodeInternal extends Node {
 
 			const inputs = rawInputs ? getLayoutParameters( rawInputs ) : null;
 
-			result = nodeObject( functionNode.call( inputs ) );
+			result = functionNode.call( inputs );
 
 		} else {
 
@@ -687,15 +703,19 @@ class ShaderCallNodeInternal extends Node {
 
 }
 
+function isArrayAsParameter( params ) {
+
+	return params[ 0 ] && ( params[ 0 ].isNode || Object.getPrototypeOf( params[ 0 ] ) !== Object.prototype );
+
+}
+
 function getLayoutParameters( params ) {
 
 	let output;
 
 	nodeObjects( params );
 
-	const isArrayAsParameter = params[ 0 ] && ( params[ 0 ].isNode || Object.getPrototypeOf( params[ 0 ] ) !== Object.prototype );
-
-	if ( isArrayAsParameter ) {
+	if ( isArrayAsParameter( params ) ) {
 
 		output = [ ...params ];
 


### PR DESCRIPTION
Fixed #33345.

**Description**

The root cause why #33345 fails is that structs used as function parameters are not yet built when the function body is compiled. Meaning during the build `builder.getStructTypeNode('S')` returns `null`.

The PR fixes that issue by making sure structs are built before `buildFunctionNode()` is executed. The TSL function:

```js
const f = Fn( ( [ s ] ) => {

    return s.get( 'v' ).x;

} ).setLayout( {
    name: 'f',
    type: 'float',
    inputs: [ { name: 's', type: 'S' } ]
 } );
```
Now compiles to:
```
fn f ( s : S ) -> f32 {

    return s.v.x;

}
```
