### PR TITLE
TSL Compute: Fix needsUpdate

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -106,13 +106,20 @@ class Bindings extends DataMap {
 		const bindings = this.nodes.getForCompute( computeNode ).bindings;
 		const computeNodeData = this.get( computeNode );
 
-		if ( computeNodeData.initialized !== true ) {
+		if ( computeNodeData.initialized !== true || computeNodeData.bindings !== bindings ) {
 
-			// bind groups are created once per object
+			// bind groups are created once per compute node version
+
+			if ( computeNodeData.bindings !== undefined ) {
+
+				this._destroyBindings( computeNodeData.bindings );
+
+			}
 
 			this._createBindings( bindings );
 
 			computeNodeData.initialized = true;
+			computeNodeData.bindings = bindings;
 
 		}
 
@@ -149,7 +156,8 @@ class Bindings extends DataMap {
 	 */
 	deleteForCompute( computeNode ) {
 
-		const bindings = this.nodes.getForCompute( computeNode ).bindings;
+		const computeNodeData = this.get( computeNode );
+		const bindings = computeNodeData.bindings || this.nodes.getForCompute( computeNode ).bindings;
 
 		this._destroyBindings( bindings );
 

--- a/src/renderers/common/nodes/NodeManager.js
+++ b/src/renderers/common/nodes/NodeManager.js
@@ -444,7 +444,7 @@ class NodeManager extends DataMap {
 
 		let nodeBuilderState = computeData.nodeBuilderState;
 
-		if ( nodeBuilderState === undefined ) {
+		if ( nodeBuilderState === undefined || computeData.version !== computeNode.version ) {
 
 			const nodeBuilder = this.backend.createNodeBuilder( computeNode, this.renderer );
 			nodeBuilder.build();
@@ -452,6 +452,7 @@ class NodeManager extends DataMap {
 			nodeBuilderState = this._createNodeBuilderState( nodeBuilder );
 
 			computeData.nodeBuilderState = nodeBuilderState;
+			computeData.version = computeNode.version;
 
 		}
 


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/33061

**Description**

When setting `computeNode.needsUpdate = true`, Pipelines.js would correctly detect that the compute node version had changed and attempt to refresh the compute pipeline. However, `NodeManager.getForCompute()` would return the cached `nodeBuilderState`, which would only be created once at initialisation. As a result, any changes to the compute node graph before calling `.needsUpdate = true` would be ignored.

This PR fixes that by making the compute `nodeBuilderState` track `computeNode.version`. When the version changes, `NodeManager` rebuilds the compute `nodeBuilderState`, and `Bindings` recreates compute bind groups if the rebuilt state provides a new bindings array.