### PR TITLE
WebGLRenderer: Fix stale scratch framebuffers after context restore

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -297,7 +297,7 @@ class WebGLRenderer {
 
 		// scratch framebuffers
 
-		let _scratchFrameBuffer = null;
+		let _scratchFramebuffer = null;
 		let _srcFramebuffer = null;
 		let _dstFramebuffer = null;
 
@@ -444,7 +444,7 @@ class WebGLRenderer {
 
 			}
 
-			_scratchFrameBuffer = _gl.createFramebuffer();
+			_scratchFramebuffer = _gl.createFramebuffer();
 			_srcFramebuffer = _gl.createFramebuffer();
 			_dstFramebuffer = _gl.createFramebuffer();
 
@@ -3012,7 +3012,7 @@ class WebGLRenderer {
 			// being bound that are different sizes.
 			if ( activeMipmapLevel !== 0 ) {
 
-				framebuffer = _scratchFrameBuffer;
+				framebuffer = _scratchFramebuffer;
 
 			}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -295,8 +295,6 @@ class WebGLRenderer {
 		let _isContextLost = false;
 		let _nodesHandler = null;
 
-		// scratch framebuffers
-
 		let _scratchFramebuffer = null;
 		let _srcFramebuffer = null;
 		let _dstFramebuffer = null;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -295,6 +295,12 @@ class WebGLRenderer {
 		let _isContextLost = false;
 		let _nodesHandler = null;
 
+		// scratch framebuffers
+
+		let _scratchFrameBuffer = null;
+		let _srcFramebuffer = null;
+		let _dstFramebuffer = null;
+
 		// internal state cache
 
 		this._outputColorSpace = SRGBColorSpace;
@@ -437,6 +443,10 @@ class WebGLRenderer {
 				state.buffers.depth.setReversed( true );
 
 			}
+
+			_scratchFrameBuffer = _gl.createFramebuffer();
+			_srcFramebuffer = _gl.createFramebuffer();
+			_dstFramebuffer = _gl.createFramebuffer();
 
 			info = new WebGLInfo( _gl );
 			properties = new WebGLProperties();
@@ -2870,8 +2880,6 @@ class WebGLRenderer {
 
 		};
 
-		const _scratchFrameBuffer = _gl.createFramebuffer();
-
 		/**
 		 * Sets the active rendertarget.
 		 *
@@ -3247,8 +3255,6 @@ class WebGLRenderer {
 
 		};
 
-		const _srcFramebuffer = _gl.createFramebuffer();
-		const _dstFramebuffer = _gl.createFramebuffer();
 
 		/**
 		 * Copies data of the given source texture into a destination texture.


### PR DESCRIPTION
Fixed #33532

**Description**

After context loss and restore, the scratch framebuffers (`_srcFramebuffer`, `_dstFramebuffer`, `_scratchFrameBuffer`) created inside the `WebGLRenderer` were not recreated with the new context. This caused the functions using these (e.g. `copyTextureToTexture`) to fail in certain cases.

This fix moves the initialization of these framebuffers into the internal `initGLContext` function so they are correctly recreated during a context restore. 
Note: Also changed the name of `_scratchFrameBuffer` to `_scratchFramebuffer` to match the other two.