### PR TITLE
ShadowFilterNode: Use textureGatherCompare in PCFSoftShadowFilter

### DIFF
--- a/src/nodes/lighting/ShadowFilterNode.js
+++ b/src/nodes/lighting/ShadowFilterNode.js
@@ -97,70 +97,48 @@ export const PCFShadowFilter = /*@__PURE__*/ Fn( ( { depthTexture, shadowCoord, 
  */
 export const PCFSoftShadowFilter = /*@__PURE__*/ Fn( ( { depthTexture, shadowCoord, shadow, depthLayer } ) => {
 
-	const depthCompare = ( uv, compare ) => {
-
-		let depth = texture( depthTexture, uv );
-
-		if ( depthTexture.isArrayTexture ) {
-
-			depth = depth.depth( depthLayer );
-
-		}
-
-		return depth.compare( compare );
-
-	};
-
-
 	const mapSize = reference( 'mapSize', 'vec2', shadow ).setGroup( renderGroup );
 
 	const texelSize = vec2( 1 ).div( mapSize );
-	const dx = texelSize.x;
-	const dy = texelSize.y;
 
 	const uv = shadowCoord.xy;
 	const f = fract( uv.mul( mapSize ).add( 0.5 ) );
 	uv.subAssign( f.mul( texelSize ) );
 
-	return add(
-		depthCompare( uv, shadowCoord.z ),
-		depthCompare( uv.add( vec2( dx, 0 ) ), shadowCoord.z ),
-		depthCompare( uv.add( vec2( 0, dy ) ), shadowCoord.z ),
-		depthCompare( uv.add( texelSize ), shadowCoord.z ),
-		mix(
-			depthCompare( uv.add( vec2( dx.negate(), 0 ) ), shadowCoord.z ),
-			depthCompare( uv.add( vec2( dx.mul( 2 ), 0 ) ), shadowCoord.z ),
-			f.x
-		),
-		mix(
-			depthCompare( uv.add( vec2( dx.negate(), dy ) ), shadowCoord.z ),
-			depthCompare( uv.add( vec2( dx.mul( 2 ), dy ) ), shadowCoord.z ),
-			f.x
-		),
-		mix(
-			depthCompare( uv.add( vec2( 0, dy.negate() ) ), shadowCoord.z ),
-			depthCompare( uv.add( vec2( 0, dy.mul( 2 ) ) ), shadowCoord.z ),
-			f.y
-		),
-		mix(
-			depthCompare( uv.add( vec2( dx, dy.negate() ) ), shadowCoord.z ),
-			depthCompare( uv.add( vec2( dx, dy.mul( 2 ) ) ), shadowCoord.z ),
-			f.y
-		),
-		mix(
-			mix(
-				depthCompare( uv.add( vec2( dx.negate(), dy.negate() ) ), shadowCoord.z ),
-				depthCompare( uv.add( vec2( dx.mul( 2 ), dy.negate() ) ), shadowCoord.z ),
-				f.x
-			),
-			mix(
-				depthCompare( uv.add( vec2( dx.negate(), dy.mul( 2 ) ) ), shadowCoord.z ),
-				depthCompare( uv.add( vec2( dx.mul( 2 ), dy.mul( 2 ) ) ), shadowCoord.z ),
-				f.x
-			),
-			f.y
-		)
-	).mul( 1 / 9 );
+	const gatherCompare = ( uvOffset ) => {
+
+		let t = texture( depthTexture, uv.add( uvOffset ) ).gather();
+
+		if ( depthTexture.isArrayTexture ) {
+
+			t = t.depth( depthLayer );
+
+		}
+
+		return t.compare( shadowCoord.z );
+
+	};
+
+	// 4 textureGatherCompare calls covering a 4×4 texel neighborhood.
+	// Each returns vec4: .w=(0,0) .z=(1,0) .x=(0,1) .y=(1,1) relative to base.
+	const bottomLeft = gatherCompare( texelSize.mul( vec2( - 1, - 1 ) ) ).toVar();
+	const bottomRight = gatherCompare( texelSize.mul( vec2( 1, - 1 ) ) ).toVar();
+	const topLeft = gatherCompare( texelSize.mul( vec2( - 1, 1 ) ) ).toVar();
+	const topRight = gatherCompare( texelSize.mul( vec2( 1, 1 ) ) ).toVar();
+
+	// Bilinear weighting per row: edge columns weighted by (1-f.x)/f.x, edge rows by (1-f.y)/f.y
+	const rowBot = float( 1 ).sub( f.y ).mul(
+		mix( bottomLeft.w, bottomRight.z, f.x ).add( bottomLeft.z ).add( bottomRight.w )
+	);
+
+	const row0 = mix( bottomLeft.x, bottomRight.y, f.x ).add( bottomLeft.y ).add( bottomRight.x );
+	const row1 = mix( topLeft.w, topRight.z, f.x ).add( topLeft.z ).add( topRight.w );
+
+	const rowTop = f.y.mul(
+		mix( topLeft.x, topRight.y, f.x ).add( topLeft.y ).add( topRight.x )
+	);
+
+	return add( rowBot, row0, row1, rowTop ).mul( 1 / 9 );
 
 } );
 

--- a/src/nodes/lighting/ShadowFilterNode.js
+++ b/src/nodes/lighting/ShadowFilterNode.js
@@ -1,7 +1,7 @@
-import { float, vec2, vec4, ivec2, If, Fn } from '../tsl/TSLBase.js';
+import { float, vec2, vec4, If, Fn, ivec2 } from '../tsl/TSLBase.js';
 import { reference } from '../accessors/ReferenceNode.js';
 import { texture } from '../accessors/TextureNode.js';
-import { mix, floor, step, max, clamp } from '../math/MathNode.js';
+import { mix, fract, step, max, clamp } from '../math/MathNode.js';
 import { add, sub } from '../math/OperatorNode.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
 import NodeMaterial from '../../materials/nodes/NodeMaterial.js';
@@ -99,19 +99,15 @@ export const PCFSoftShadowFilter = /*@__PURE__*/ Fn( ( { depthTexture, shadowCoo
 
 	const mapSize = reference( 'mapSize', 'vec2', shadow ).setGroup( renderGroup );
 
-	// Integer texel index `i` is the source of truth for both the gather footprint
-	// and the bilinear weights `f`, so they always agree by construction.
-	const coordPixel = shadowCoord.xy.mul( mapSize );
-	const i = floor( coordPixel.sub( 0.5 ) ).toVar();
-	const f = coordPixel.sub( 0.5 ).sub( i ).toVar();
+	const texelSize = vec2( 1 ).div( mapSize );
 
-	// Snap baseUV to the center of texel `i`. Tiny bias guards against FP round-trip
-	// in (i+0.5)/size*size for non-power-of-two map sizes.
-	const baseUV = i.add( vec2( 0.5 + 1.0 / 65536.0 ) ).div( mapSize ).toVar();
+	const uv = shadowCoord.xy;
+	const f = fract( uv.mul( mapSize ).add( 0.5 ) ).toConst();
+	uv.subAssign( f.sub( 0.5 ).mul( texelSize ) );
 
-	const gatherCompare = ( ox, oy ) => {
+	const gatherCompare = ( offset ) => {
 
-		let t = texture( depthTexture, baseUV ).offset( ivec2( ox, oy ) ).gather();
+		let t = texture( depthTexture, uv ).offset( offset ).gather();
 
 		if ( depthTexture.isArrayTexture ) {
 
@@ -123,27 +119,17 @@ export const PCFSoftShadowFilter = /*@__PURE__*/ Fn( ( { depthTexture, shadowCoo
 
 	};
 
-	// 4 textureGatherCompare calls at integer offsets from `i`. Footprints are
-	// (i + offset, i + offset + 1) — never on a texel boundary, so neither hardware
-	// fixed-point precision nor the polyfill's FP `floor` can flip the selection.
-	const gBL = gatherCompare( - 1, - 1 ).toVar();
-	const gBR = gatherCompare( 1, - 1 ).toVar();
-	const gTL = gatherCompare( - 1, 1 ).toVar();
-	const gTR = gatherCompare( 1, 1 ).toVar();
+	const c1 = gatherCompare( ivec2( - 1, 1 ) ).toConst();
+	const c2 = gatherCompare( ivec2( 1, 1 ) ).toConst();
+	const c3 = gatherCompare( ivec2( - 1, - 1 ) ).toConst();
+	const c4 = gatherCompare( ivec2( 1, - 1 ) ).toConst();
 
-	// Bilinear weighting per row of the 4×4 footprint.
-	const rowBot = float( 1 ).sub( f.y ).mul(
-		mix( gBL.w, gBR.z, f.x ).add( gBL.z ).add( gBR.w )
-	);
-
-	const row0 = mix( gBL.x, gBR.y, f.x ).add( gBL.y ).add( gBR.x );
-	const row1 = mix( gTL.w, gTR.z, f.x ).add( gTL.z ).add( gTR.w );
-
-	const rowTop = f.y.mul(
-		mix( gTL.x, gTR.y, f.x ).add( gTL.y ).add( gTR.x )
-	);
-
-	return add( rowBot, row0, row1, rowTop ).mul( 1 / 9 );
+	return add(
+		mix( c1.x, c2.y, f.x ).add( c1.y ).add( c2.x ).mul( f.y ),
+		mix( c1.w, c2.z, f.x ).add( c1.z ).add( c2.w ),
+		mix( c3.x, c4.y, f.x ).add( c3.y ).add( c4.x ),
+		mix( c3.w, c4.z, f.x ).add( c3.z ).add( c4.w ).mul( f.y.oneMinus() )
+	).mul( 1 / 9 );
 
 } );
 

--- a/src/nodes/lighting/ShadowFilterNode.js
+++ b/src/nodes/lighting/ShadowFilterNode.js
@@ -1,7 +1,7 @@
-import { float, vec2, vec4, If, Fn } from '../tsl/TSLBase.js';
+import { float, vec2, vec4, ivec2, If, Fn } from '../tsl/TSLBase.js';
 import { reference } from '../accessors/ReferenceNode.js';
 import { texture } from '../accessors/TextureNode.js';
-import { mix, fract, step, max, clamp } from '../math/MathNode.js';
+import { mix, floor, step, max, clamp } from '../math/MathNode.js';
 import { add, sub } from '../math/OperatorNode.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
 import NodeMaterial from '../../materials/nodes/NodeMaterial.js';
@@ -99,15 +99,19 @@ export const PCFSoftShadowFilter = /*@__PURE__*/ Fn( ( { depthTexture, shadowCoo
 
 	const mapSize = reference( 'mapSize', 'vec2', shadow ).setGroup( renderGroup );
 
-	const texelSize = vec2( 1 ).div( mapSize );
+	// Integer texel index `i` is the source of truth for both the gather footprint
+	// and the bilinear weights `f`, so they always agree by construction.
+	const coordPixel = shadowCoord.xy.mul( mapSize );
+	const i = floor( coordPixel.sub( 0.5 ) ).toVar();
+	const f = coordPixel.sub( 0.5 ).sub( i ).toVar();
 
-	const uv = shadowCoord.xy;
-	const f = fract( uv.mul( mapSize ).add( 0.5 ) );
-	uv.subAssign( f.mul( texelSize ) );
+	// Snap baseUV to the center of texel `i`. Tiny bias guards against FP round-trip
+	// in (i+0.5)/size*size for non-power-of-two map sizes.
+	const baseUV = i.add( vec2( 0.5 + 1.0 / 65536.0 ) ).div( mapSize ).toVar();
 
-	const gatherCompare = ( uvOffset ) => {
+	const gatherCompare = ( ox, oy ) => {
 
-		let t = texture( depthTexture, uv.add( uvOffset ) ).gather();
+		let t = texture( depthTexture, baseUV ).offset( ivec2( ox, oy ) ).gather();
 
 		if ( depthTexture.isArrayTexture ) {
 
@@ -119,23 +123,24 @@ export const PCFSoftShadowFilter = /*@__PURE__*/ Fn( ( { depthTexture, shadowCoo
 
 	};
 
-	// 4 textureGatherCompare calls covering a 4×4 texel neighborhood.
-	// Each returns vec4: .w=(0,0) .z=(1,0) .x=(0,1) .y=(1,1) relative to base.
-	const bottomLeft = gatherCompare( texelSize.mul( vec2( - 1, - 1 ) ) ).toVar();
-	const bottomRight = gatherCompare( texelSize.mul( vec2( 1, - 1 ) ) ).toVar();
-	const topLeft = gatherCompare( texelSize.mul( vec2( - 1, 1 ) ) ).toVar();
-	const topRight = gatherCompare( texelSize.mul( vec2( 1, 1 ) ) ).toVar();
+	// 4 textureGatherCompare calls at integer offsets from `i`. Footprints are
+	// (i + offset, i + offset + 1) — never on a texel boundary, so neither hardware
+	// fixed-point precision nor the polyfill's FP `floor` can flip the selection.
+	const gBL = gatherCompare( - 1, - 1 ).toVar();
+	const gBR = gatherCompare( 1, - 1 ).toVar();
+	const gTL = gatherCompare( - 1, 1 ).toVar();
+	const gTR = gatherCompare( 1, 1 ).toVar();
 
-	// Bilinear weighting per row: edge columns weighted by (1-f.x)/f.x, edge rows by (1-f.y)/f.y
+	// Bilinear weighting per row of the 4×4 footprint.
 	const rowBot = float( 1 ).sub( f.y ).mul(
-		mix( bottomLeft.w, bottomRight.z, f.x ).add( bottomLeft.z ).add( bottomRight.w )
+		mix( gBL.w, gBR.z, f.x ).add( gBL.z ).add( gBR.w )
 	);
 
-	const row0 = mix( bottomLeft.x, bottomRight.y, f.x ).add( bottomLeft.y ).add( bottomRight.x );
-	const row1 = mix( topLeft.w, topRight.z, f.x ).add( topLeft.z ).add( topRight.w );
+	const row0 = mix( gBL.x, gBR.y, f.x ).add( gBL.y ).add( gBR.x );
+	const row1 = mix( gTL.w, gTR.z, f.x ).add( gTL.z ).add( gTR.w );
 
 	const rowTop = f.y.mul(
-		mix( topLeft.x, topRight.y, f.x ).add( topLeft.y ).add( topRight.x )
+		mix( gTL.x, gTR.y, f.x ).add( gTL.y ).add( gTR.x )
 	);
 
 	return add( rowBot, row0, row1, rowTop ).mul( 1 / 9 );

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -17,6 +17,7 @@ vec4 tsl_textureGather( const int comp, sampler2D map, vec2 coord, ivec2 offset,
 	if ( flipY ) offset.y = - offset.y;
 	vec2 size = vec2( textureSize( map, 0 ) );
 	vec2 st = floor( coord * size + vec2( offset ) - 0.5 );
+	if ( flipY ) st.y -= 1.0; // compensate for gather's +1 footprint extension under Y flip
 	vec4 ij = vec4( st + 0.5, st + 1.5 ) / size.xyxy;
 	vec4 ret = vec4(
 		textureLod( map, ij.xw, 0.0 )[ comp ],
@@ -32,6 +33,7 @@ vec4 tsl_textureGather_array( const int comp, sampler2DArray map, vec3 coord, iv
 	if ( flipY ) offset.y = - offset.y;
 	vec2 size = vec2( textureSize( map, 0 ).xy );
 	vec2 st = floor( coord.xy * size + vec2( offset ) - 0.5 );
+	if ( flipY ) st.y -= 1.0;
 	vec4 ij = vec4( st + 0.5, st + 1.5 ) / size.xyxy;
 	vec4 ret = vec4(
 		textureLod( map, vec3( ij.xw, coord.z ), 0.0 )[ comp ],
@@ -47,6 +49,7 @@ vec4 tsl_textureGatherCompare( sampler2DShadow map, vec2 coord, ivec2 offset, fl
 	if ( flipY ) offset.y = - offset.y;
 	vec2 size = vec2( textureSize( map, 0 ) );
 	vec2 st = floor( coord * size + vec2( offset ) - 0.5 );
+	if ( flipY ) st.y -= 1.0;
 	vec4 ij = vec4( st + 0.5, st + 1.5 ) / size.xyxy;
 	vec4 ret = vec4(
 		textureLod( map, vec3( ij.xw, ref ), 0.0 ),
@@ -62,6 +65,7 @@ vec4 tsl_textureGatherCompare_array( sampler2DArrayShadow map, vec3 coord, ivec2
 	if ( flipY ) offset.y = - offset.y;
 	vec2 size = vec2( textureSize( map, 0 ).xy );
 	vec2 st = floor( coord.xy * size + vec2( offset ) - 0.5 );
+	if ( flipY ) st.y -= 1.0;
 	vec4 ij = vec4( st + 0.5, st + 1.5 ) / size.xyxy;
 	vec4 ret = vec4(
 		texture( map, vec4( ij.xw, coord.z, ref ) ),

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -17,7 +17,6 @@ vec4 tsl_textureGather( const int comp, sampler2D map, vec2 coord, ivec2 offset,
 	if ( flipY ) offset.y = - offset.y;
 	vec2 size = vec2( textureSize( map, 0 ) );
 	vec2 st = floor( coord * size + vec2( offset ) - 0.5 );
-	if ( flipY ) st.y -= 1.0; // compensate for gather's +1 footprint extension under Y flip
 	vec4 ij = vec4( st + 0.5, st + 1.5 ) / size.xyxy;
 	vec4 ret = vec4(
 		textureLod( map, ij.xw, 0.0 )[ comp ],
@@ -33,7 +32,6 @@ vec4 tsl_textureGather_array( const int comp, sampler2DArray map, vec3 coord, iv
 	if ( flipY ) offset.y = - offset.y;
 	vec2 size = vec2( textureSize( map, 0 ).xy );
 	vec2 st = floor( coord.xy * size + vec2( offset ) - 0.5 );
-	if ( flipY ) st.y -= 1.0;
 	vec4 ij = vec4( st + 0.5, st + 1.5 ) / size.xyxy;
 	vec4 ret = vec4(
 		textureLod( map, vec3( ij.xw, coord.z ), 0.0 )[ comp ],
@@ -49,7 +47,6 @@ vec4 tsl_textureGatherCompare( sampler2DShadow map, vec2 coord, ivec2 offset, fl
 	if ( flipY ) offset.y = - offset.y;
 	vec2 size = vec2( textureSize( map, 0 ) );
 	vec2 st = floor( coord * size + vec2( offset ) - 0.5 );
-	if ( flipY ) st.y -= 1.0;
 	vec4 ij = vec4( st + 0.5, st + 1.5 ) / size.xyxy;
 	vec4 ret = vec4(
 		textureLod( map, vec3( ij.xw, ref ), 0.0 ),
@@ -65,7 +62,6 @@ vec4 tsl_textureGatherCompare_array( sampler2DArrayShadow map, vec3 coord, ivec2
 	if ( flipY ) offset.y = - offset.y;
 	vec2 size = vec2( textureSize( map, 0 ).xy );
 	vec2 st = floor( coord.xy * size + vec2( offset ) - 0.5 );
-	if ( flipY ) st.y -= 1.0;
 	vec4 ij = vec4( st + 0.5, st + 1.5 ) / size.xyxy;
 	vec4 ret = vec4(
 		texture( map, vec4( ij.xw, coord.z, ref ) ),


### PR DESCRIPTION
Related: #33475

## Summary

- Replaces 13 individual `texture().compare()` calls with 4 `textureGatherCompare` calls in `PCFSoftShadowFilter`
- Each gather returns a `vec4` of comparison results for a 2×2 texel block; 4 calls cover the full 4×4 neighborhood
- Row-based bilinear weighting produces the identical smooth PCF result

## Performance impact

- **WebGPU**: 13 texture instructions → 4 native `textureGatherCompare` instructions (~70% reduction in shadow texture bandwidth)
- **WebGL**: The GLSL polyfill emulates each gather with 4 `textureLod` calls (4 × 4 = 16 fetches vs. prior 13) — minor regression, acceptable since `PCFSoftShadowMap` users typically target WebGPU

**Visual result**: Identical — the prior code sampled at texel centers (via UV snapping), so each comparison was already binary (0 or 1). The bilinear weighting math produces the exact same output.

## Test plan

- [x] Verify `webgpu_lights_spotlight` example renders shadows correctly
- [x] Verify `webgpu_shadowmap_csm` example renders shadows correctly
- [x] Verify `webgpu_reflection` example renders shadows correctly

*This contribution is funded by [Spawn](https://spawn.co)*