### PR TITLE
ArcballControls: Fix swapped X/Y gizmo ring orientations.

### DIFF
--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -2012,8 +2012,8 @@ class ArcballControls extends Controls {
 		const gizmoZ = new Line( curveGeometry, curveMaterialZ );
 
 		const rotation = Math.PI * 0.5;
-		gizmoX.rotation.x = rotation;
-		gizmoY.rotation.y = rotation;
+		gizmoX.rotation.y = rotation;
+		gizmoY.rotation.x = rotation;
 
 
 		//setting state


### PR DESCRIPTION
## Description                                                                                                                                                                                         
In `ArcballControls`, the red and green rotation gizmo rings were swapped relative to the three.js R/G/B = X/Y/Z convention used by `AxesHelper`, `TransformControls`, etc.                            
 
The base `EllipseCurve` produces a circle in the XY plane. Rotating it 90° **about X** sends it to the **XZ** plane (normal = Y), so the ring named/colored *X* was actually the rotation handle for   
the *Y* axis, and vice versa. The blue (Z) ring was already correct.
                                                                                                                                                                                                       
You can see it immediately by adding `scene.add( new THREE.AxesHelper( 1 ) )` to the `misc_controls_arcball` example: the red ring lines up perpendicular to the green axis line and vice versa.       
 
## Fix                                                                                                                                                                                                 
                
Swapped the rotation axes in `makeGizmos` so each ring's plane has the same-colored axis as its normal:                                                                                                
 
```js                                                                                                                                                                                                  
gizmoX.rotation.y = rotation; // → YZ plane, rotation around X
gizmoY.rotation.x = rotation; // → XZ plane, rotation around Y                                                                                                                                         
// gizmoZ stays in XY plane, rotation around Z                                                                                                                                                         
```                                                                                                                                                                                      
