### PR TITLE
Editor: Make light targets editable.

### DIFF
--- a/editor/js/Menubar.Add.js
+++ b/editor/js/Menubar.Add.js
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { UIPanel, UIRow } from './libs/ui.js';
 
 import { AddObjectCommand } from './commands/AddObjectCommand.js';
+import { MultiCmdsCommand } from './commands/MultiCmdsCommand.js';
 
 import { FontLoader } from 'three/addons/loaders/FontLoader.js';
 import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
@@ -419,7 +420,10 @@ function MenubarAdd( editor ) {
 
 		light.position.set( 5, 10, 7.5 );
 
-		editor.execute( new AddObjectCommand( editor, light ) );
+		editor.execute( new MultiCmdsCommand( editor, [
+			new AddObjectCommand( editor, light.target ),
+			new AddObjectCommand( editor, light )
+		] ) );
 
 	} );
 	lightSubmenu.add( option );
@@ -483,7 +487,10 @@ function MenubarAdd( editor ) {
 
 		light.position.set( 5, 10, 7.5 );
 
-		editor.execute( new AddObjectCommand( editor, light ) );
+		editor.execute( new MultiCmdsCommand( editor, [
+			new AddObjectCommand( editor, light.target ),
+			new AddObjectCommand( editor, light )
+		] ) );
 
 	} );
 	lightSubmenu.add( option );

--- a/editor/js/Menubar.Edit.js
+++ b/editor/js/Menubar.Edit.js
@@ -4,6 +4,7 @@ import { clone } from 'three/addons/utils/SkeletonUtils.js';
 import { UIPanel, UIRow, UIHorizontalRule, UIText } from './libs/ui.js';
 
 import { AddObjectCommand } from './commands/AddObjectCommand.js';
+import { MultiCmdsCommand } from './commands/MultiCmdsCommand.js';
 import { RemoveObjectCommand } from './commands/RemoveObjectCommand.js';
 import { SetPositionCommand } from './commands/SetPositionCommand.js';
 
@@ -129,7 +130,16 @@ function MenubarEdit( editor ) {
 
 		const object = editor.selected;
 
-		if ( object !== null && object.parent !== null ) {
+		if ( object === null || object.parent === null ) return;
+
+		if ( object.isSpotLight || object.isDirectionalLight ) {
+
+			editor.execute( new MultiCmdsCommand( editor, [
+				new RemoveObjectCommand( editor, object ),
+				new RemoveObjectCommand( editor, object.target )
+			] ) );
+
+		} else {
 
 			editor.execute( new RemoveObjectCommand( editor, object ) );
 

--- a/editor/js/Sidebar.Settings.Shortcuts.js
+++ b/editor/js/Sidebar.Settings.Shortcuts.js
@@ -1,5 +1,6 @@
 import { UIPanel, UIText, UIRow, UIInput } from './libs/ui.js';
 
+import { MultiCmdsCommand } from './commands/MultiCmdsCommand.js';
 import { RemoveObjectCommand } from './commands/RemoveObjectCommand.js';
 
 function SidebarSettingsShortcuts( editor ) {
@@ -109,10 +110,20 @@ function SidebarSettingsShortcuts( editor ) {
 
 				const object = editor.selected;
 
-				if ( object === null ) return;
+				if ( object === null || object.parent === null ) return;
 
-				const parent = object.parent;
-				if ( parent !== null ) editor.execute( new RemoveObjectCommand( editor, object ) );
+				if ( object.isSpotLight || object.isDirectionalLight ) {
+
+					editor.execute( new MultiCmdsCommand( editor, [
+						new RemoveObjectCommand( editor, object ),
+						new RemoveObjectCommand( editor, object.target )
+					] ) );
+
+				} else {
+
+					editor.execute( new RemoveObjectCommand( editor, object ) );
+
+				}
 
 				break;
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -498,6 +498,20 @@ function Viewport( editor ) {
 
 		}
 
+		// update light helper when light target is changed
+
+		for ( const id in editor.helpers ) {
+
+			const helper = editor.helpers[ id ];
+
+			if ( helper.light && helper.light.target === object ) {
+
+				helper.update();
+
+			}
+
+		}
+
 		initPT();
 		render();
 


### PR DESCRIPTION
Fixed #9508.

**Description**

Light targets can be serialized/deserialized since r166, see #28696. So only a few additions were required to make light targets editable in the editor. This is a welcome change for all scene designers who need more flexibility in configuring their directional and spot lights.

https://github.com/user-attachments/assets/9aa60dc9-1246-4960-ae99-515a6c0b5703

