### PR TITLE
TSL: Introduce `nodeProxyConstructor`

### DIFF
--- a/src/nodes/accessors/Arrays.js
+++ b/src/nodes/accessors/Arrays.js
@@ -16,9 +16,9 @@ export const attributeArray = ( count, type = 'float' ) => {
 
 	let itemSize, typedArray;
 
-	if ( type.isStruct === true ) {
+	if ( type.isStructTypeNode === true ) {
 
-		itemSize = type.layout.getLength();
+		itemSize = type.getLength();
 		typedArray = getTypedArrayFromType( 'float' );
 
 	} else {
@@ -48,9 +48,9 @@ export const instancedArray = ( count, type = 'float' ) => {
 
 	let itemSize, typedArray;
 
-	if ( type.isStruct === true ) {
+	if ( type.isStructTypeNode === true ) {
 
-		itemSize = type.layout.getLength();
+		itemSize = type.getLength();
 		typedArray = getTypedArrayFromType( 'float' );
 
 	} else {

--- a/src/nodes/accessors/StorageBufferNode.js
+++ b/src/nodes/accessors/StorageBufferNode.js
@@ -55,10 +55,10 @@ class StorageBufferNode extends BufferNode {
 
 		let nodeType, structTypeNode = null;
 
-		if ( bufferType && bufferType.isStruct ) {
+		if ( bufferType && bufferType.isStructTypeNode ) {
 
 			nodeType = 'struct';
-			structTypeNode = bufferType.layout;
+			structTypeNode = bufferType;
 
 			if ( value.isStorageBufferAttribute || value.isStorageInstancedBufferAttribute ) {
 

--- a/src/nodes/code/FunctionNode.js
+++ b/src/nodes/code/FunctionNode.js
@@ -1,4 +1,5 @@
 import CodeNode from './CodeNode.js';
+import { nodeProxyConstructor } from '../tsl/TSLCore.js';
 
 /**
  * This class represents a native shader function. It can be used to implement
@@ -155,26 +156,11 @@ export default FunctionNode;
 
 const nativeFn = ( code, includes = [], language = '' ) => {
 
-	for ( let i = 0; i < includes.length; i ++ ) {
-
-		const include = includes[ i ];
-
-		// TSL Function: glslFn, wgslFn
-
-		if ( typeof include === 'function' ) {
-
-			includes[ i ] = include.functionNode;
-
-		}
-
-	}
-
 	const functionNode = new FunctionNode( code, includes, language );
 
 	const fn = ( ...params ) => functionNode.call( ...params );
-	fn.functionNode = functionNode;
 
-	return fn;
+	return nodeProxyConstructor( fn, functionNode );
 
 };
 

--- a/src/nodes/core/StructNode.js
+++ b/src/nodes/core/StructNode.js
@@ -1,5 +1,6 @@
 import Node from './Node.js';
 import StructTypeNode from './StructTypeNode.js';
+import { nodeProxyConstructor } from '../tsl/TSLCore.js';
 
 /**
  * StructNode allows to create custom structures with multiple members.
@@ -94,7 +95,7 @@ export default StructNode;
  */
 export const struct = ( membersLayout, name = null ) => {
 
-	const structLayout = new StructTypeNode( membersLayout, name );
+	const structType = new StructTypeNode( membersLayout, name );
 
 	const struct = ( ...params ) => {
 
@@ -122,13 +123,10 @@ export const struct = ( membersLayout, name = null ) => {
 
 		}
 
-		return new StructNode( structLayout, values );
+		return new StructNode( structType, values );
 
 	};
 
-	struct.layout = structLayout;
-	struct.isStruct = true;
-
-	return struct;
+	return nodeProxyConstructor( struct, structType );
 
 };

--- a/src/nodes/core/StructTypeNode.js
+++ b/src/nodes/core/StructTypeNode.js
@@ -74,7 +74,7 @@ class StructTypeNode extends Node {
 		 * @readonly
 		 * @default true
 		 */
-		this.isStructLayoutNode = true;
+		this.isStructTypeNode = true;
 
 	}
 

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -985,6 +985,26 @@ export const nodeProxy = ( NodeClass, scope = null, factor = null, settings = nu
 export const nodeImmutable = ( NodeClass, ...params ) => new ShaderNodeImmutable( NodeClass, ...params );
 export const nodeProxyIntent = ( NodeClass, scope = null, factor = null, settings = {} ) => new ShaderNodeProxy( NodeClass, scope, factor, { ...settings, intent: true } );
 
+export const nodeProxyConstructor = ( constructorFunction, nodeInstance ) => {
+
+	return new Proxy( constructorFunction, {
+
+		get( target, prop, receiver ) {
+
+			return Reflect.get( nodeInstance, prop, receiver );
+
+		},
+
+		set( target, prop, value ) {
+
+			return Reflect.set( nodeInstance, prop, value );
+
+		}
+
+	} );
+
+};
+
 let fnId = 0;
 
 class FnNode extends Node {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/33041

**Description**

Create a proxy for Node for functions used in the declaration of TSL instances, currently `StructTypeNode` when using `struct()` and `FunctionNode` when using `Fn`. This should simplify the code and make the use of nodes more consistent.

The idea was inspired by @gkjohnson issue  I ended up opting for `Proxy` instead of `Object.setPrototypeOf()` to make a direct reference to the instance properties instead of prototype chain which could result in properties not being mirrored.
