### PR TITLE
StorageTextureNode: Set referenceNode & add .store() function

### DIFF
--- a/src/nodes/accessors/StorageTextureNode.js
+++ b/src/nodes/accessors/StorageTextureNode.js
@@ -213,6 +213,27 @@ class StorageTextureNode extends TextureNode {
 	}
 
 	/**
+	 * Stores a value in this storage texture at the given coordinates.
+	 *
+	 * @param {Node<vec2|vec3>} uvNode - The storage texture coordinates.
+	 * @param {?Node} [storeNode=null] - The value node that should be stored in the texture.
+	 * @return {StorageTextureNode} A storage texture node representing the store operation.
+	 */
+	store( uvNode, storeNode ) {
+
+		const node = this.clone();
+
+		node.referenceNode = this.getBase();
+		node.uvNode = uvNode;
+		node.storeNode = storeNode;
+
+		if ( storeNode !== null ) node.toStack();
+
+		return node;
+
+	}
+
+	/**
 	 * Generates the code snippet of the storage texture node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
@@ -266,7 +287,7 @@ export const storageTexture = /*@__PURE__*/ nodeProxy( StorageTextureNode ).setP
  *
  * @tsl
  * @function
- * @param {StorageTexture} value - The storage texture.
+ * @param {StorageTexture|StorageTextureNode} value - The storage texture.
  * @param {Node<vec2|vec3>} uvNode - The uv node.
  * @param {?Node} [storeNode=null] - The value node that should be stored in the texture.
  * @returns {StorageTextureNode}
@@ -277,18 +298,15 @@ export const textureStore = ( value, uvNode, storeNode ) => {
 
 	if ( value.isStorageTextureNode === true ) {
 
-		// Derive new storage texture node from existing one
-		node = value.clone();
-		node.uvNode = uvNode;
-		node.storeNode = storeNode;
+		node = value.store( uvNode, storeNode );
 
 	} else {
 
 		node = storageTexture( value, uvNode, storeNode );
 
-	}
+		if ( storeNode !== null ) node.toStack();
 
-	if ( storeNode !== null ) node.toStack();
+	}
 
 	return node;
 


### PR DESCRIPTION
With StorageTextureNode, when using `textureStore()` it would make a local clone of the StorageTextureNode but would not set `node.referenceNode` this meant that if changing `StorageTextureNode.value` after initialisation, all textureStore nodes would then be pointing at the wrong or even destroyed StorageTexture. 

This PR fixes this by making textureStore set `node.referenceNode = this.getBase()` so that if `StorageTextureNode.value` changes, any textureStore nodes get their value updated also. Additionally, to add parity with the `storageTexture.load()` function I added a `storageTexture.store()` function. `textureStore()` will continue to work as normal but now uses the `.store()` function internally. This change is not essential and more of just a nicety, the main fix here is ensuring that `node.referenceNode` gets set.
