### PR TITLE
StorageTextureNode: Bypass UV matrix transforms

### DIFF
--- a/src/nodes/accessors/StorageTextureNode.js
+++ b/src/nodes/accessors/StorageTextureNode.js
@@ -99,6 +99,20 @@ class StorageTextureNode extends TextureNode {
 
 	}
 
+	/**
+	 * Overwrites the default implementation since storage texture
+	 * coordinates are texel coordinates and should not be transformed
+	 * by the texture uv matrix.
+	 *
+	 * @param {Node} uvNode - The uv node.
+	 * @return {Node} The unmodified uv node.
+	 */
+	getTransformedUV( uvNode ) {
+
+		return uvNode;
+
+	}
+
 	setup( builder ) {
 
 		super.setup( builder );


### PR DESCRIPTION
Since StorageTextureNode extends TextureNode it would inherit it's UV transform path which applies the texture UV matrix to the texture coordinates. This causes the generated WGSL to bring in several mat3x3 uniforms and wrap all `textureLoad()` / `textureStore()`  texel coordinates in unnecessary mat3x3 transforms.

```wgsl
struct objectStruct {
nodeUniform1 : mat3x3,
nodeUniform3 : mat3x3,
nodeUniform5 : f32,
nodeUniform6 : f32,
nodeUniform10 : mat3x3,
nodeUniform11 : mat3x3,
nodeUniform12 : mat3x3,
nodeUniform13 : mat3x3,
nodeUniform14 : f32,
nodeUniform18 : f32,
nodeUniform19 : mat3x3
};

textureLoad( nodeUniform0, vec2<i32>( ( object.nodeUniform1 * vec3<f32>( vec2<f32>( nodeConst2 ), 1.0 ) ).xy ) );

textureStore( nodeUniform2, vec2<u32>( ( object.nodeUniform3 * vec3<f32>( vec2<f32>( nodeConst2 ), 1.0 ) ).xy ), vec4<f32>( 0.0, 0.0, 0.0, min( 0.0, ( nodeVar0.w + render.nodeUniform4 ) ) ) );
```
The fix here is simple. Just override the `getTransformedUV()` call in the StorageTextureNode class.

```js
	/**
	 * Overwrites the default implementation since storage texture
	 * coordinates are texel coordinates and should not be transformed
	 * by the texture uv matrix.
	 *
	 * @param {Node} uvNode - The uv node.
	 * @return {Node} The unmodified uv node.
	 */
	getTransformedUV( uvNode ) {

		return uvNode;

	}
```