### PR TITLE
Prevent xss in `AsciiEffect`

### DIFF
--- a/examples/jsm/effects/AsciiEffect.js
+++ b/examples/jsm/effects/AsciiEffect.js
@@ -259,8 +259,14 @@ class AsciiEffect {
 
 					let strThisChar = aCharList[ iCharIdx ];
 
-					if ( strThisChar === undefined || strThisChar == ' ' )
+					if ( strThisChar === undefined )
+						strThisChar = ' ';
+					if ( strThisChar == '&' )
+						strThisChar = '&amp;';
+					else if ( strThisChar == ' ' )
 						strThisChar = '&nbsp;';
+					else if ( strThisChar == '<' )
+						strThisChar = '&lt;';
 
 					if ( bColor ) {
 


### PR DESCRIPTION
**Description**

In the current state an attacker could provide a certain charater set input to embed arbitrary code into the DOM.

could also make every char wrapped in a `pre` element but this is very costly, or restrict using `<` which is not ideal