### PR TITLE
DRACOLoader: Use relative file urls by default.

### DIFF
--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -13,6 +13,10 @@ import {
 
 const _taskCache = new WeakMap();
 
+const WASM_BIN_URL = new URL( '../libs/draco/draco_decoder.wasm', import.meta.url ).toString();
+const WASM_JS_URL = new URL( '../libs/draco/draco_wasm_wrapper.js', import.meta.url ).toString();
+const JS_URL = new URL( '../libs/draco/draco_decoder.js', import.meta.url ).toString();
+
 /**
  * A loader for the Draco format.
  *
@@ -358,14 +362,31 @@ class DRACOLoader extends Loader {
 		const useJS = typeof WebAssembly !== 'object' || this.decoderConfig.type === 'js';
 		const librariesPending = [];
 
-		if ( useJS ) {
+		if ( this.decoderPath === '' ) {
 
-			librariesPending.push( this._loadLibrary( 'draco_decoder.js', 'text' ) );
+			if ( useJS ) {
+
+				librariesPending.push( this._loadLibrary( JS_URL, 'text' ) );
+
+			} else {
+
+				librariesPending.push( this._loadLibrary( WASM_JS_URL, 'text' ) );
+				librariesPending.push( this._loadLibrary( WASM_BIN_URL, 'arraybuffer' ) );
+
+			}
 
 		} else {
 
-			librariesPending.push( this._loadLibrary( 'draco_wasm_wrapper.js', 'text' ) );
-			librariesPending.push( this._loadLibrary( 'draco_decoder.wasm', 'arraybuffer' ) );
+			if ( useJS ) {
+
+				librariesPending.push( this._loadLibrary( 'draco_decoder.js', 'text' ) );
+
+			} else {
+
+				librariesPending.push( this._loadLibrary( 'draco_wasm_wrapper.js', 'text' ) );
+				librariesPending.push( this._loadLibrary( 'draco_decoder.wasm', 'arraybuffer' ) );
+
+			}
 
 		}
 

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -119,8 +119,6 @@
 					.setPath( 'textures/equirectangular/' );
 
 				const dracoLoader = new DRACOLoader();
-				dracoLoader.setDecoderPath( 'jsm/libs/draco/gltf/' );
-
 				const gltfLoader = new GLTFLoader();
 				gltfLoader.setDRACOLoader( dracoLoader );
 				gltfLoader.setPath( 'models/gltf/' );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33140#issuecomment-4030974828, #31446

Fixed #26403.

**Description**

This PR allows `DRACOLoader` to be used without calling `setDecoderPath` by using `new URL( 'filename.js', import.meta.url ).toString()` approach, which all modern bundlers support, to enable specifying a relative path to the /libs files. This will improve the ergonomics of using class, which is currently quite difficult with a number of bundlers or (more commonly) requires pointing to a CDN. The PR is structured to backwards compatibility and allow for users to continue specifying their own config paths if needed.

**Some open questions (though not blocking)**
- Perhaps not specifically related to this PR, but Is it reasonable to consider dropping support for the non-WASM path?
- Would we want to consider deprecating the "setDecoderPath" function?

**Once merged I can submit future PRs for**

- Update remaining examples, editor, and docs to remove calls to "setDecoderPath".
- Update KTX2Loader to mirror this approach.