### PR TITLE
AsciiEffect: Add `escapeHTML()`.

### DIFF
--- a/examples/jsm/effects/AsciiEffect.js
+++ b/examples/jsm/effects/AsciiEffect.js
@@ -119,6 +119,19 @@ class AsciiEffect {
 
 		}
 
+		const htmlEscapes = {
+			'&': '&amp;',
+			'<': '&lt;',
+			'>': '&gt;',
+		};
+
+		const reUnescapedHtml = /[&<>]/g;
+
+		function escapeHTML( s ) {
+
+			return s.replace( reUnescapedHtml, ( ch ) => htmlEscapes[ ch ] );
+
+		}
 
 		const strFont = 'courier new, monospace';
 
@@ -141,7 +154,7 @@ class AsciiEffect {
 		let aCharList;
 		if ( charSet ) {
 
-			aCharList = ( charSet ).split( '' );
+			aCharList = ( charSet ).split( '' ).map( escapeHTML );
 
 		} else {
 


### PR DESCRIPTION
Fixed #33566.

**Description**

Certain chars need to be escaped so the effect does not break the DOM. I was hoping users could escape before passing the charset to `AsciiEffect` but then the escaped char sequence is treated as individual chars. So we must do this internally in the Addon.

The PR ports over the approach from lodash for this purpose.