### PR TITLE
Raycaster: Fix `setFromCamera()`  with ortho cameras.

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -2,6 +2,7 @@ import { Matrix4 } from '../math/Matrix4.js';
 import { Ray } from '../math/Ray.js';
 import { Layers } from './Layers.js';
 import { error } from '../utils.js';
+import { WebGPUCoordinateSystem } from '../constants.js';
 
 const _matrix = /*@__PURE__*/ new Matrix4();
 
@@ -126,7 +127,23 @@ class Raycaster {
 
 		} else if ( camera.isOrthographicCamera ) {
 
-			this.ray.origin.set( coords.x, coords.y, ( camera.near + camera.far ) / ( camera.near - camera.far ) ).unproject( camera ); // set origin in plane of camera
+			let coordsZ;
+
+			if ( camera.reversedDepth ) {
+
+				coordsZ = camera.far / ( camera.far - camera.near );
+
+			} else if ( camera.coordinateSystem === WebGPUCoordinateSystem ) {
+
+				coordsZ = camera.near / ( camera.near - camera.far );
+
+			} else {
+
+				coordsZ = ( camera.near + camera.far ) / ( camera.near - camera.far );
+
+			}
+
+			this.ray.origin.set( coords.x, coords.y, coordsZ ).unproject( camera ); // set origin in plane of camera
 			this.ray.direction.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld );
 			this.camera = camera;
 

--- a/test/unit/src/core/Raycaster.tests.js
+++ b/test/unit/src/core/Raycaster.tests.js
@@ -7,6 +7,7 @@ import { Line } from '../../../../src/objects/Line.js';
 import { Points } from '../../../../src/objects/Points.js';
 import { PerspectiveCamera } from '../../../../src/cameras/PerspectiveCamera.js';
 import { OrthographicCamera } from '../../../../src/cameras/OrthographicCamera.js';
+import { WebGPUCoordinateSystem } from '../../../../src/constants.js';
 
 function checkRayDirectionAgainstReferenceVector( rayDirection, refVector, assert ) {
 
@@ -187,6 +188,106 @@ export default QUnit.module( 'Core', () => {
 				assert.ok( intersections[ i ].distance <= intersections[ i + 1 ].distance, 'intersections are sorted' );
 
 			}
+
+		} );
+
+		QUnit.test( 'intersectObject (Perspective, WebGPU coordinate system)', ( assert ) => {
+
+			const camera = new PerspectiveCamera( 90, 1, 0.1, 100 );
+			camera.coordinateSystem = WebGPUCoordinateSystem;
+			camera.updateProjectionMatrix();
+
+			const front = getSphere();
+			front.position.set( 0, 0, - 5 );
+			front.updateMatrixWorld();
+
+			const behind = getSphere();
+			behind.position.set( 0, 0, 5 );
+			behind.updateMatrixWorld();
+
+			const raycaster = new Raycaster();
+			raycaster.setFromCamera( { x: 0, y: 0 }, camera );
+
+			assert.strictEqual( raycaster.intersectObject( front ).length, 1,
+				'Sphere in front of the perspective camera is intersected under WebGPU coordinate system.' );
+
+			assert.strictEqual( raycaster.intersectObject( behind ).length, 0,
+				'Sphere behind the perspective camera is not intersected under WebGPU coordinate system.' );
+
+		} );
+
+		QUnit.test( 'intersectObject (Orthographic, WebGPU coordinate system)', ( assert ) => {
+
+			const camera = new OrthographicCamera( - 1, 1, 1, - 1, 0.1, 10 );
+			camera.coordinateSystem = WebGPUCoordinateSystem;
+			camera.updateProjectionMatrix();
+
+			const front = getSphere();
+			front.position.set( 0, 0, - 5 );
+			front.updateMatrixWorld();
+
+			const behind = getSphere();
+			behind.position.set( 0, 0, 5 );
+			behind.updateMatrixWorld();
+
+			const raycaster = new Raycaster();
+			raycaster.setFromCamera( { x: 0, y: 0 }, camera );
+
+			assert.strictEqual( raycaster.intersectObject( front ).length, 1,
+				'Sphere in front of the orthographic camera is intersected under WebGPU coordinate system.' );
+
+			assert.strictEqual( raycaster.intersectObject( behind ).length, 0,
+				'Sphere behind the orthographic camera is not intersected under WebGPU coordinate system.' );
+
+		} );
+
+		QUnit.test( 'intersectObject (Perspective, reversed depth)', ( assert ) => {
+
+			const camera = new PerspectiveCamera( 90, 1, 0.1, 100 );
+			camera._reversedDepth = true;
+			camera.updateProjectionMatrix();
+
+			const front = getSphere();
+			front.position.set( 0, 0, - 5 );
+			front.updateMatrixWorld();
+
+			const behind = getSphere();
+			behind.position.set( 0, 0, 5 );
+			behind.updateMatrixWorld();
+
+			const raycaster = new Raycaster();
+			raycaster.setFromCamera( { x: 0, y: 0 }, camera );
+
+			assert.strictEqual( raycaster.intersectObject( front ).length, 1,
+				'Sphere in front of the perspective camera is intersected with reversed depth.' );
+
+			assert.strictEqual( raycaster.intersectObject( behind ).length, 0,
+				'Sphere behind the perspective camera is not intersected with reversed depth.' );
+
+		} );
+
+		QUnit.test( 'intersectObject (Orthographic, reversed depth)', ( assert ) => {
+
+			const camera = new OrthographicCamera( - 1, 1, 1, - 1, 0.1, 10 );
+			camera._reversedDepth = true;
+			camera.updateProjectionMatrix();
+
+			const front = getSphere();
+			front.position.set( 0, 0, - 5 );
+			front.updateMatrixWorld();
+
+			const behind = getSphere();
+			behind.position.set( 0, 0, 5 );
+			behind.updateMatrixWorld();
+
+			const raycaster = new Raycaster();
+			raycaster.setFromCamera( { x: 0, y: 0 }, camera );
+
+			assert.strictEqual( raycaster.intersectObject( front ).length, 1,
+				'Sphere in front of the orthographic camera is intersected with reversed depth.' );
+
+			assert.strictEqual( raycaster.intersectObject( behind ).length, 0,
+				'Sphere behind the orthographic camera is not intersected with reversed depth.' );
 
 		} );
 


### PR DESCRIPTION
Related issue: -

**Description**

I've noticed a strange ray casting behavior with orthographic cameras and `WebGPURenderer`. For some reasons, objects behind the camera were intersected. That did only happen with the WebGPU backend. The WebGL backend is fine as well as `WebGLRenderer`. The bug is demonstrated with below fiddle:

https://jsfiddle.net/reuLy4gf/1/

There are two boxes, one in front and one behind the camera. When you check the browser console, both boxes intersect with the ray although that should only happen with the front (green) box.

Turns out the computation in `setFromCamera()` that computes the NDC z component is wrong for the WebGPU coordinates system when using orthographic cameras. It is also wrong when using a reversed depth buffer. When you turn on reversed depth in the fiddle, no intersection happen for both WebGPU and WebGL.

The PR adds a bunch of unit tests to check for the different permutations.