### PR TITLE
LineMaterial: Fix trimSegment() with reversed depth buffer.

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -77,7 +77,10 @@ ShaderLib[ 'line' ] = {
 			// conservative estimate of the near plane
 			float a = projectionMatrix[ 2 ][ 2 ]; // 3nd entry in 3th column
 			float b = projectionMatrix[ 3 ][ 2 ]; // 3nd entry in 4th column
-			float nearEstimate = - 0.5 * b / a;
+			
+			// we need different nearEstimate formular for reversed and default depth buffer
+			// a is positive with a reversed depth buffer so it can be used for controlling the code flow
+			float nearEstimate = ( a > 0.0 ) ? ( - b / ( a + 1.0 ) ) : ( - 0.5 * b / a );
 
 			float alpha = ( nearEstimate - start.z ) / ( end.z - start.z );
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -78,7 +78,7 @@ ShaderLib[ 'line' ] = {
 			float a = projectionMatrix[ 2 ][ 2 ]; // 3nd entry in 3th column
 			float b = projectionMatrix[ 3 ][ 2 ]; // 3nd entry in 4th column
 			
-			// we need different nearEstimate formular for reversed and default depth buffer
+			// we need different nearEstimate formula for reversed and default depth buffer
 			// a is positive with a reversed depth buffer so it can be used for controlling the code flow
 			float nearEstimate = ( a > 0.0 ) ? ( - b / ( a + 1.0 ) ) : ( - 0.5 * b / a );
 

--- a/src/materials/nodes/Line2NodeMaterial.js
+++ b/src/materials/nodes/Line2NodeMaterial.js
@@ -141,7 +141,11 @@ class Line2NodeMaterial extends NodeMaterial {
 
 			const a = cameraProjectionMatrix.element( 2 ).element( 2 ); // 3nd entry in 3th column
 			const b = cameraProjectionMatrix.element( 3 ).element( 2 ); // 3nd entry in 4th column
-			const nearEstimate = b.mul( - 0.5 ).div( a );
+
+			// we need different nearEstimate formular for reversed and default depth buffer
+			// a is positive with a reversed depth buffer so it can be used for controlling the code flow
+
+			const nearEstimate = a.greaterThan( 0 ).select( b.negate().div( a.add( 1 ) ), b.mul( - 0.5 ).div( a ) );
 
 			const alpha = nearEstimate.sub( start.z ).div( end.z.sub( start.z ) );
 

--- a/src/materials/nodes/Line2NodeMaterial.js
+++ b/src/materials/nodes/Line2NodeMaterial.js
@@ -142,7 +142,7 @@ class Line2NodeMaterial extends NodeMaterial {
 			const a = cameraProjectionMatrix.element( 2 ).element( 2 ); // 3nd entry in 3th column
 			const b = cameraProjectionMatrix.element( 3 ).element( 2 ); // 3nd entry in 4th column
 
-			// we need different nearEstimate formular for reversed and default depth buffer
+			// we need different nearEstimate formula for reversed and default depth buffer
 			// a is positive with a reversed depth buffer so it can be used for controlling the code flow
 
 			const nearEstimate = a.greaterThan( 0 ).select( b.negate().div( a.add( 1 ) ), b.mul( - 0.5 ).div( a ) );


### PR DESCRIPTION
Fixed #33570.

**Description**

The PR make sure `trimSegment()` of `LineMaterial` and `Line2NodeMaterial` support a reversed depth buffer. 

The clipping bugs that appear in `webgl_lines_fat` and `webgpu_lines_fat` when enabling a reversed depth buffer and when zooming into the line structure disappear with this fix.