### PR TITLE
USDZLoader: Reorder quaternion components in USDA quatf[] array parsing.

### DIFF
--- a/examples/jsm/loaders/usd/USDAParser.js
+++ b/examples/jsm/loaders/usd/USDAParser.js
@@ -711,7 +711,28 @@ class USDAParser {
 				// Flatten nested arrays for types like point3f[]
 				if ( Array.isArray( parsed ) && Array.isArray( parsed[ 0 ] ) ) {
 
-					return parsed.flat();
+					const flat = parsed.flat();
+
+					// Quaternion arrays (quatf[], quatd[], quath[]):
+					// USDA text format stores each quat as (w, x, y, z),
+					// but Three.js/USDComposer expects (x, y, z, w).
+					// Scalar quatf already gets reordered below, but the array
+					// path used to skip reordering — causing animation deformation.
+					if ( valueType.startsWith( 'quat' ) ) {
+
+						for ( let i = 0; i < flat.length; i += 4 ) {
+
+							const w = flat[ i ];
+							flat[ i ] = flat[ i + 1 ];
+							flat[ i + 1 ] = flat[ i + 2 ];
+							flat[ i + 2 ] = flat[ i + 3 ];
+							flat[ i + 3 ] = w;
+
+						}
+
+					}
+
+					return flat;
 
 				}
 

--- a/examples/jsm/loaders/usd/USDAParser.js
+++ b/examples/jsm/loaders/usd/USDAParser.js
@@ -699,6 +699,8 @@ class USDAParser {
 		// Array types
 		if ( valueType.endsWith( '[]' ) ) {
 
+			let result;
+
 			// Parse JSON-like arrays
 			try {
 
@@ -709,40 +711,13 @@ class USDAParser {
 				const parsed = JSON.parse( cleaned );
 
 				// Flatten nested arrays for types like point3f[]
-				if ( Array.isArray( parsed ) && Array.isArray( parsed[ 0 ] ) ) {
-
-					const flat = parsed.flat();
-
-					// Quaternion arrays (quatf[], quatd[], quath[]):
-					// USDA text format stores each quat as (w, x, y, z),
-					// but Three.js/USDComposer expects (x, y, z, w).
-					// Scalar quatf already gets reordered below, but the array
-					// path used to skip reordering — causing animation deformation.
-					if ( valueType.startsWith( 'quat' ) ) {
-
-						for ( let i = 0; i < flat.length; i += 4 ) {
-
-							const w = flat[ i ];
-							flat[ i ] = flat[ i + 1 ];
-							flat[ i + 1 ] = flat[ i + 2 ];
-							flat[ i + 2 ] = flat[ i + 3 ];
-							flat[ i + 3 ] = w;
-
-						}
-
-					}
-
-					return flat;
-
-				}
-
-				return parsed;
+				result = Array.isArray( parsed ) && Array.isArray( parsed[ 0 ] ) ? parsed.flat() : parsed;
 
 			} catch ( e ) {
 
 				// Try simple array parsing
 				const cleaned = str.replace( /[\[\]]/g, '' );
-				return cleaned.split( ',' ).map( s => {
+				result = cleaned.split( ',' ).map( s => {
 
 					const trimmed = s.trim();
 					const num = parseFloat( trimmed );
@@ -751,6 +726,23 @@ class USDAParser {
 				} );
 
 			}
+
+			//reorder (w, x, y, z) to (x, y, z, w)
+			if ( valueType.startsWith( 'quat' ) ) {
+
+				for ( let i = 0; i < result.length; i += 4 ) {
+
+					const w = result[ i ];
+					result[ i ] = result[ i + 1 ];
+					result[ i + 1 ] = result[ i + 2 ];
+					result[ i + 2 ] = result[ i + 3 ];
+					result[ i + 3 ] = w;
+
+				}
+
+			}
+
+			return result;
 
 		}
 


### PR DESCRIPTION
Related issue: None

Description

In USDAParser._parseAttributeValue(), the quatf[] array parsing path flattens nested arrays without reordering quaternion components from USDA's (w, x, y, z) convention to Three.js's (x, y, z, w) convention. The scalar quatf path (around line 736) correctly reorders components via valueType.startsWith('quat'), but the array path (around line 693) returns parsed.flat() directly, skipping reordering.

This causes skinned animation deformation when loading USDA files that contain SkelAnimation rotations (stored as quatf[] type), because each frame's per-joint quaternion has its components in the wrong order. The static pose renders correctly since xformOp:orient uses scalar quatf which takes the correct reorder path. USDC files are unaffected because their binary format serializes Quatf in (x, y, z, w) order natively.

Fix: After flattening the parsed array, detect quatf[], quatd[], and quath[] types and swap every 4 consecutive elements from (w, x, y, z) to (x, y, z, w), consistent with the existing scalar quaternion handling.
