### PR TITLE
USDZExporter: Support `mimeType` setting via `Texture.userData`.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -284,11 +284,14 @@ class USDZExporter {
 				texture.flipY,
 				options.maxTextureSize
 			);
+
+			const mimeType = ( texture.userData.mimeType === 'image/jpeg' ) ? 'image/jpeg' : 'image/png';
+
 			const blob = await new Promise( ( resolve ) =>
-				canvas.toBlob( resolve, 'image/png', 1 )
+				canvas.toBlob( resolve, mimeType )
 			);
 
-			files[ `textures/Texture_${id}.png` ] = new Uint8Array(
+			files[ `textures/Texture_${id}.${getTextureExtension( texture )}` ] = new Uint8Array(
 				await blob.arrayBuffer()
 			);
 
@@ -360,6 +363,12 @@ function getName( object, namesSet ) {
 	namesSet.add( name );
 
 	return name;
+
+}
+
+function getTextureExtension( texture ) {
+
+	return texture.userData.mimeType === 'image/jpeg' ? 'jpg' : 'png';
 
 }
 
@@ -839,7 +848,7 @@ function buildMaterial( material, textures, quickLookCompatible = false ) {
 			'Shader'
 		);
 		textureNode.addProperty( 'uniform token info:id = "UsdUVTexture"' );
-		textureNode.addProperty( `asset inputs:file = @textures/Texture_${id}.png@` );
+		textureNode.addProperty( `asset inputs:file = @textures/Texture_${id}.${getTextureExtension( texture )}@` );
 		textureNode.addProperty(
 			`float2 inputs:st.connect = </Materials/Material_${material.id}/Transform2d_${mapType}.outputs:result>`
 		);


### PR DESCRIPTION
Fixed #21590.

**Description**

The PR applies the same mimeType export logic from `GLTFExporter` to `USDZExporter`. That means when textures define a mimeType field in their `userData` object, it is used for the image export. Only `image/jpeg` is supported right now next to the default `image/png`. 

`GlassTable.glb` (the asset from  #21590) has 1.6 MB and when reexported to USDZ, we end up with 3.4 MB now. Before this PR, the file was 7.8 MB big.

Side note: We can further reduce the file size by exporting geometry data to USDC. This would bring the file size closer to the glb. But the by far biggest win comes from JPG support so the PR focuses on that topic.