### PR TITLE
USDZExporter: Fix opacity regression.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -855,7 +855,8 @@ function buildMaterial( material, textures, quickLookCompatible = false ) {
 
 		if ( color !== undefined ) {
 
-			textureNode.addProperty( `float4 inputs:scale = ${buildColor4( color )}` );
+			const alpha = ( mapType === 'diffuse' ) ? material.opacity : 1;
+			textureNode.addProperty( `float4 inputs:scale = ${buildColor4( color, alpha )}` );
 
 		}
 
@@ -1146,9 +1147,9 @@ function buildColor( color ) {
 
 }
 
-function buildColor4( color ) {
+function buildColor4( color, alpha = 1 ) {
 
-	return `(${color.r}, ${color.g}, ${color.b}, 1.0)`;
+	return `(${color.r}, ${color.g}, ${color.b}, ${alpha})`;
 
 }
 


### PR DESCRIPTION
Fixed #24748.

**Description**

The PR fixes a regression that has been introduced via #23588. 

When a material has both `material.map` and `material.transparent = true`, the exporter currently ignores `material.opacity`. To fix that, we must integrate the opacity value into the color value that scales the diffuse texture's color. 

This fixes the glass asset from #24748.

<img width="1017" height="1008" alt="image" src="https://github.com/user-attachments/assets/6bc45246-d4e4-42cc-80dd-d5dd40eb33f9" />

But also retains the visuals from #23588's test asset. 

<img width="1014" height="403" alt="image" src="https://github.com/user-attachments/assets/be979593-eb12-4520-bdb3-944acc131467" />

