### PR TITLE
USDZLoader: Preserve attribute connections when a direct value follows.

### DIFF
--- a/examples/jsm/loaders/usd/USDAParser.js
+++ b/examples/jsm/loaders/usd/USDAParser.js
@@ -675,12 +675,23 @@ class USDAParser {
 					// Parse value based on type
 					const parsedValue = this._parseAttributeValue( valueType, rawValue );
 
-					// Store as attribute spec
+					// Store as attribute spec, preserving any existing fields
+					// (e.g. connectionPaths set by an earlier `.connect` form)
 					const attrPath = path + '.' + attrName;
-					specsByPath[ attrPath ] = {
-						specType: SpecType.Attribute,
-						fields: { default: parsedValue, typeName: valueType }
-					};
+
+					if ( specsByPath[ attrPath ] ) {
+
+						specsByPath[ attrPath ].fields.default = parsedValue;
+						specsByPath[ attrPath ].fields.typeName = valueType;
+
+					} else {
+
+						specsByPath[ attrPath ] = {
+							specType: SpecType.Attribute,
+							fields: { default: parsedValue, typeName: valueType }
+						};
+
+					}
 
 				}
 


### PR DESCRIPTION
Related issue: #33580

**Description**

While testing #33580, I've noticed `USDZLoader` is not able to properly load the alpha blend mode test asset from https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/AlphaBlendModeTest. When exporting with `USDZExporter`, macOS preview renders the asset as expected. But in three.js the asset had no transparency. With this fix, the asset is rendered as expected

Prod:

<img width="2560" height="1192" alt="Bildschirmfoto 2026-05-15 um 15 07 17" src="https://github.com/user-attachments/assets/e088ff81-34b9-43ad-a89a-f08b65874041" />

PR:

<img width="2560" height="1192" alt="Bildschirmfoto 2026-05-15 um 15 07 05" src="https://github.com/user-attachments/assets/671a9b66-6648-4763-8f52-7c0714477e4c" />
