### PR TITLE
Docs: Fix code example generation.

### DIFF
--- a/utils/docs/template/publish.js
+++ b/utils/docs/template/publish.js
@@ -874,17 +874,19 @@ exports.publish = ( taffyData, opts, tutorials ) => {
 
 			}
 
-			// Extract code example from classdesc
+			// Extract code example from classdesc, but only if there is exactly one
+			// code block. Class descriptions with multiple snippets lack a clear
+			// "the" example, and picking one arbitrarily produces out-of-context output.
 			if ( doclet.classdesc ) {
 
-				const codeBlockRegex = /<pre class="prettyprint source[^"]*"><code>([\s\S]*?)<\/code><\/pre>/;
-				const match = doclet.classdesc.match( codeBlockRegex );
+				const codeBlockRegex = /<pre class="prettyprint source[^"]*"><code>([\s\S]*?)<\/code><\/pre>/g;
+				const matches = doclet.classdesc.match( codeBlockRegex );
 
-				if ( match ) {
+				if ( matches && matches.length === 1 ) {
 
-					doclet.codeExample = match[ 0 ];
+					doclet.codeExample = matches[ 0 ];
 					// Remove the code example from classdesc
-					doclet.classdesc = doclet.classdesc.replace( codeBlockRegex, '' ).trim();
+					doclet.classdesc = doclet.classdesc.replace( matches[ 0 ], '' ).trim();
 
 				}
 


### PR DESCRIPTION
Related issue: #32036

**Description**

The current way the doc template generates code examples is incorrect since it makes wrong assumptions about how many code listings are present in class descriptions. There are not always 0 or 1. There can be multiple code listings and the current approach picks an arbitrary listing, often out of context and with inappropriate formatting. E.g.

https://threejs.org/docs/#ImageBitmapLoader
https://threejs.org/docs/#Matrix2

The PR makes sure if there is more than one code listing, no code example is generated.