### PR TITLE
Global: Harmonize errors.

### DIFF
--- a/examples/jsm/exporters/DRACOExporter.js
+++ b/examples/jsm/exporters/DRACOExporter.js
@@ -146,7 +146,7 @@ class DRACOExporter {
 
 		} else {
 
-			throw new Error( 'DRACOExporter: Unsupported object type.' );
+			throw new Error( 'THREE.DRACOExporter: Unsupported object type.' );
 
 		}
 

--- a/examples/jsm/inspector/extensions/tsl-graph/TSLGraphEditor.js
+++ b/examples/jsm/inspector/extensions/tsl-graph/TSLGraphEditor.js
@@ -306,7 +306,7 @@ class TSLGraphEditor extends Extension {
 
 				if ( ! this._pending.has( requestId ) ) return;
 				this._pending.delete( requestId );
-				reject( new Error( `Timeout for ${type}` ) );
+				reject( new Error( `THREE.TSLGraphEditor: Timeout for ${type}` ) );
 
 			}, 5000 );
 

--- a/examples/jsm/inspector/extensions/tsl-graph/TSLGraphLoader.js
+++ b/examples/jsm/inspector/extensions/tsl-graph/TSLGraphLoader.js
@@ -236,7 +236,7 @@ export class TSLGraphLoader extends FileLoader {
 
 		if ( ! json.codes || ! json.graphs ) {
 
-			throw new Error( 'TSLGraph: Invalid import file structure.' );
+			throw new Error( 'TSLGraphLoader: Invalid import file structure.' );
 
 		}
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -276,7 +276,7 @@ class EXRLoader extends DataTextureLoader {
 
 					if ( p.value - inOffset.value > ni ) {
 
-						throw new Error( 'Something wrong with hufUnpackEncTable' );
+						throw new Error( 'THREE.EXRLoader: Something wrong with hufUnpackEncTable' );
 
 					}
 
@@ -288,7 +288,7 @@ class EXRLoader extends DataTextureLoader {
 
 					if ( im + zerun > iM + 1 ) {
 
-						throw new Error( 'Something wrong with hufUnpackEncTable' );
+						throw new Error( 'THREE.EXRLoader: Something wrong with hufUnpackEncTable' );
 
 					}
 
@@ -302,7 +302,7 @@ class EXRLoader extends DataTextureLoader {
 
 					if ( im + zerun > iM + 1 ) {
 
-						throw new Error( 'Something wrong with hufUnpackEncTable' );
+						throw new Error( 'THREE.EXRLoader: Something wrong with hufUnpackEncTable' );
 
 					}
 
@@ -339,7 +339,7 @@ class EXRLoader extends DataTextureLoader {
 
 				if ( c >> l ) {
 
-					throw new Error( 'Invalid table entry' );
+					throw new Error( 'THREE.EXRLoader: Invalid table entry' );
 
 				}
 
@@ -349,7 +349,7 @@ class EXRLoader extends DataTextureLoader {
 
 					if ( pl.len ) {
 
-						throw new Error( 'Invalid table entry' );
+						throw new Error( 'THREE.EXRLoader: Invalid table entry' );
 
 					}
 
@@ -384,7 +384,7 @@ class EXRLoader extends DataTextureLoader {
 
 						if ( pl.len || pl.p ) {
 
-							throw new Error( 'Invalid table entry' );
+							throw new Error( 'THREE.EXRLoader: Invalid table entry' );
 
 						}
 
@@ -673,7 +673,7 @@ class EXRLoader extends DataTextureLoader {
 
 						if ( ! pl.p ) {
 
-							throw new Error( 'hufDecode issues' );
+							throw new Error( 'THREE.EXRLoader: hufDecode issues' );
 
 						}
 
@@ -713,7 +713,7 @@ class EXRLoader extends DataTextureLoader {
 
 						if ( j == pl.lit ) {
 
-							throw new Error( 'hufDecode issues' );
+							throw new Error( 'THREE.EXRLoader: hufDecode issues' );
 
 						}
 
@@ -743,7 +743,7 @@ class EXRLoader extends DataTextureLoader {
 
 				} else {
 
-					throw new Error( 'hufDecode issues' );
+					throw new Error( 'THREE.EXRLoader: hufDecode issues' );
 
 				}
 
@@ -769,7 +769,7 @@ class EXRLoader extends DataTextureLoader {
 
 			if ( im < 0 || im >= HUF_ENCSIZE || iM < 0 || iM >= HUF_ENCSIZE ) {
 
-				throw new Error( 'Something wrong with HUF_ENCSIZE' );
+				throw new Error( 'THREE.EXRLoader: Something wrong with HUF_ENCSIZE' );
 
 			}
 
@@ -784,7 +784,7 @@ class EXRLoader extends DataTextureLoader {
 
 			if ( nBits > 8 * ( nCompressed - ( inOffset.value - initialInOffset ) ) ) {
 
-				throw new Error( 'Something wrong with hufUncompress' );
+				throw new Error( 'THREE.EXRLoader: Something wrong with hufUncompress' );
 
 			}
 
@@ -1415,7 +1415,7 @@ class EXRLoader extends DataTextureLoader {
 
 			if ( maxNonZero >= BITMAP_SIZE ) {
 
-				throw new Error( 'Something is wrong with PIZ_COMPRESSION BITMAP_SIZE' );
+				throw new Error( 'THREE.EXRLoader: Something is wrong with PIZ_COMPRESSION BITMAP_SIZE' );
 
 			}
 
@@ -1781,7 +1781,7 @@ class EXRLoader extends DataTextureLoader {
 			};
 
 			if ( dwaHeader.version < 2 )
-				throw new Error( 'EXRLoader.parse: ' + EXRHeader.compression + ' version ' + dwaHeader.version + ' is unsupported' );
+				throw new Error( 'THREE.EXRLoader: ' + EXRHeader.compression + ' version ' + dwaHeader.version + ' is unsupported' );
 
 			// Read channel ruleset information
 			const channelRules = new Array();
@@ -1979,7 +1979,7 @@ class EXRLoader extends DataTextureLoader {
 						break;
 
 					default:
-						throw new Error( 'EXRLoader.parse: unsupported channel compression' );
+						throw new Error( 'THREE.EXRLoader: unsupported channel compression' );
 
 				}
 
@@ -2608,7 +2608,7 @@ class EXRLoader extends DataTextureLoader {
 				}
 
 				default:
-					throw new Error( 'EXRLoader.parse: ' + compression + ' is unsupported for deep data' );
+					throw new Error( 'THREE.EXRLoader: ' + compression + ' is unsupported for deep data' );
 
 			}
 
@@ -2948,7 +2948,7 @@ class EXRLoader extends DataTextureLoader {
 					break;
 
 				default:
-					throw new Error( 'EXRLoader.parse: ' + EXRHeader.compression + ' is unsupported' );
+					throw new Error( 'THREE.EXRLoader: ' + EXRHeader.compression + ' is unsupported' );
 
 			}
 
@@ -2991,7 +2991,7 @@ class EXRLoader extends DataTextureLoader {
 
 			} else {
 
-				throw new Error( 'EXRLoader.parse: file contains unsupported data channels.' );
+				throw new Error( 'THREE.EXRLoader: file contains unsupported data channels.' );
 
 			}
 
@@ -3070,7 +3070,7 @@ class EXRLoader extends DataTextureLoader {
 
 			}
 
-			if ( invalidOutput ) throw new Error( 'EXRLoader.parse: invalid output format for specified file.' );
+			if ( invalidOutput ) throw new Error( 'THREE.EXRLoader: invalid output format for specified file.' );
 
 			// Luminance/chroma images always decode to RGBA; override whatever the output-format switch selected.
 			if ( EXRDecoder.yCbCr ) {
@@ -3113,7 +3113,7 @@ class EXRLoader extends DataTextureLoader {
 
 			} else {
 
-				throw new Error( 'EXRLoader.parse: unsupported pixelType ' + EXRDecoder.type + ' for ' + EXRHeader.compression + '.' );
+				throw new Error( 'THREE.EXRLoader: unsupported pixelType ' + EXRDecoder.type + ' for ' + EXRHeader.compression + '.' );
 
 			}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -644,7 +644,7 @@ class LDrawParsedCache {
 
 		}
 
-		throw new Error( 'LDrawLoader: Subobject "' + fileName + '" could not be loaded.' );
+		throw new Error( 'THREE.LDrawLoader: Subobject "' + fileName + '" could not be loaded.' );
 
 	}
 
@@ -1060,7 +1060,7 @@ class LDrawParsedCache {
 					break;
 
 				default:
-					throw new Error( 'LDrawLoader: Unknown line type "' + lineType + '"' + lp.getLineNumberString() + '.' );
+					throw new Error( 'THREE.LDrawLoader: Unknown line type "' + lineType + '"' + lp.getLineNumberString() + '.' );
 
 			}
 
@@ -2217,7 +2217,7 @@ class LDrawLoader extends Loader {
 		const name = lineParser.getToken();
 		if ( ! name ) {
 
-			throw new Error( 'LDrawLoader: Material name was expected after "!COLOUR tag' + lineParser.getLineNumberString() + '.' );
+			throw new Error( 'THREE.LDrawLoader: Material name was expected after "!COLOUR tag' + lineParser.getLineNumberString() + '.' );
 
 		}
 
@@ -2251,7 +2251,7 @@ class LDrawLoader extends Loader {
 
 						} else if ( ! fillColor.startsWith( '#' ) ) {
 
-							throw new Error( 'LDrawLoader: Invalid color while parsing material' + lineParser.getLineNumberString() + '.' );
+							throw new Error( 'THREE.LDrawLoader: Invalid color while parsing material' + lineParser.getLineNumberString() + '.' );
 
 						}
 
@@ -2270,7 +2270,7 @@ class LDrawLoader extends Loader {
 							edgeMaterial = this.getMaterial( edgeColor );
 							if ( ! edgeMaterial ) {
 
-								throw new Error( 'LDrawLoader: Invalid edge color while parsing material' + lineParser.getLineNumberString() + '.' );
+								throw new Error( 'THREE.LDrawLoader: Invalid edge color while parsing material' + lineParser.getLineNumberString() + '.' );
 
 							}
 
@@ -2287,7 +2287,7 @@ class LDrawLoader extends Loader {
 
 						if ( isNaN( alpha ) ) {
 
-							throw new Error( 'LDrawLoader: Invalid alpha value in material definition' + lineParser.getLineNumberString() + '.' );
+							throw new Error( 'THREE.LDrawLoader: Invalid alpha value in material definition' + lineParser.getLineNumberString() + '.' );
 
 						}
 
@@ -2305,7 +2305,7 @@ class LDrawLoader extends Loader {
 
 						if ( ! parseLuminance( lineParser.getToken() ) ) {
 
-							throw new Error( 'LDrawLoader: Invalid luminance value in material definition' + lineParser.getLineNumberString() + '.' );
+							throw new Error( 'THREE.LDrawLoader: Invalid luminance value in material definition' + lineParser.getLineNumberString() + '.' );
 
 						}
 
@@ -2337,7 +2337,7 @@ class LDrawLoader extends Loader {
 						break;
 
 					default:
-						throw new Error( 'LDrawLoader: Unknown token "' + token + '" while parsing material' + lineParser.getLineNumberString() + '.' );
+						throw new Error( 'THREE.LDrawLoader: Unknown token "' + token + '" while parsing material' + lineParser.getLineNumberString() + '.' );
 
 				}
 

--- a/examples/jsm/loaders/LUT3dlLoader.js
+++ b/examples/jsm/loaders/LUT3dlLoader.js
@@ -114,7 +114,7 @@ export class LUT3dlLoader extends Loader {
 
 		if ( result === null ) {
 
-			throw new Error( 'LUT3dlLoader: Missing grid information' );
+			throw new Error( 'THREE.LUT3dlLoader: Missing grid information' );
 
 		}
 
@@ -127,7 +127,7 @@ export class LUT3dlLoader extends Loader {
 
 			if ( gridStep !== ( gridLines[ i ] - gridLines[ i - 1 ] ) ) {
 
-				throw new Error( 'LUT3dlLoader: Inconsistent grid size' );
+				throw new Error( 'THREE.LUT3dlLoader: Inconsistent grid size' );
 
 			}
 

--- a/examples/jsm/loaders/LUTCubeLoader.js
+++ b/examples/jsm/loaders/LUTCubeLoader.js
@@ -118,7 +118,7 @@ export class LUTCubeLoader extends Loader {
 
 		if ( result === null ) {
 
-			throw new Error( 'LUTCubeLoader: Missing LUT_3D_SIZE information' );
+			throw new Error( 'THREE.LUTCubeLoader: Missing LUT_3D_SIZE information' );
 
 		}
 
@@ -147,7 +147,7 @@ export class LUTCubeLoader extends Loader {
 
 		if ( domainMin.x > domainMax.x || domainMin.y > domainMax.y || domainMin.z > domainMax.z ) {
 
-			throw new Error( 'LUTCubeLoader: Invalid input domain' );
+			throw new Error( 'THREE.LUTCubeLoader: Invalid input domain' );
 
 		}
 

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -223,13 +223,13 @@ class NRRDLoader extends Loader {
 
 			if ( ! headerObject.isNrrd ) {
 
-				throw new Error( 'Not an NRRD file' );
+				throw new Error( 'THREE.NRRDLoader: Not an NRRD file' );
 
 			}
 
 			if ( headerObject.encoding === 'bz2' || headerObject.encoding === 'bzip2' ) {
 
-				throw new Error( 'Bzip is not supported' );
+				throw new Error( 'THREE.NRRDLoader: Bzip is not supported' );
 
 			}
 
@@ -598,7 +598,7 @@ const _fieldFunctions = {
 				this.__array = Float64Array;
 				break;
 			default:
-				throw new Error( 'Unsupported NRRD data type: ' + data );
+				throw new Error( 'THREE.NRRDLoader: Unsupported NRRD data type: ' + data );
 
 		}
 

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -188,8 +188,8 @@ class PCDLoader extends Loader {
 				if ( ctrl < ( 1 << 5 ) ) {
 
 					ctrl ++;
-					if ( outPtr + ctrl > outLength ) throw new Error( 'Output buffer is not large enough' );
-					if ( inPtr + ctrl > inLength ) throw new Error( 'Invalid compressed data' );
+					if ( outPtr + ctrl > outLength ) throw new Error( 'THREE.PCDLoader: Output buffer is not large enough' );
+					if ( inPtr + ctrl > inLength ) throw new Error( 'THREE.PCDLoader: Invalid compressed data' );
 					do {
 
 						outData[ outPtr ++ ] = inData[ inPtr ++ ];
@@ -200,18 +200,18 @@ class PCDLoader extends Loader {
 
 					len = ctrl >> 5;
 					ref = outPtr - ( ( ctrl & 0x1f ) << 8 ) - 1;
-					if ( inPtr >= inLength ) throw new Error( 'Invalid compressed data' );
+					if ( inPtr >= inLength ) throw new Error( 'THREE.PCDLoader: Invalid compressed data' );
 					if ( len === 7 ) {
 
 						len += inData[ inPtr ++ ];
-						if ( inPtr >= inLength ) throw new Error( 'Invalid compressed data' );
+						if ( inPtr >= inLength ) throw new Error( 'THREE.PCDLoader: Invalid compressed data' );
 
 					}
 
 					ref -= inData[ inPtr ++ ];
-					if ( outPtr + len + 2 > outLength ) throw new Error( 'Output buffer is not large enough' );
-					if ( ref < 0 ) throw new Error( 'Invalid compressed data' );
-					if ( ref >= outPtr ) throw new Error( 'Invalid compressed data' );
+					if ( outPtr + len + 2 > outLength ) throw new Error( 'THREE.PCDLoader: Output buffer is not large enough' );
+					if ( ref < 0 ) throw new Error( 'THREE.PCDLoader: Invalid compressed data' );
+					if ( ref >= outPtr ) throw new Error( 'THREE.PCDLoader: Invalid compressed data' );
 					do {
 
 						outData[ outPtr ++ ] = outData[ ref ++ ];

--- a/examples/jsm/loaders/USDLoader.js
+++ b/examples/jsm/loaders/USDLoader.js
@@ -269,7 +269,7 @@ class USDLoader extends Loader {
 
 			if ( ! file ) {
 
-				throw new Error( 'USDLoader: Invalid USDZ package. The first ZIP entry must be a USD layer (.usd/.usda/.usdc).' );
+				throw new Error( 'THREE.USDLoader: Invalid USDZ package. The first ZIP entry must be a USD layer (.usd/.usda/.usdc).' );
 
 			}
 
@@ -277,7 +277,7 @@ class USDLoader extends Loader {
 			const data = assets[ filename ];
 			if ( ! data ) {
 
-				throw new Error( 'USDLoader: Failed to parse root layer "' + filename + '".' );
+				throw new Error( 'THREE.USDLoader: Failed to parse root layer "' + filename + '".' );
 
 			}
 

--- a/examples/jsm/loaders/usd/USDCParser.js
+++ b/examples/jsm/loaders/usd/USDCParser.js
@@ -552,7 +552,7 @@ class USDCParser {
 		const magic = reader.readString( 8 );
 		if ( magic !== 'PXR-USDC' ) {
 
-			throw new Error( 'Not a valid USDC file' );
+			throw new Error( 'THREE.USDCParser: Not a valid USDC file.' );
 
 		}
 

--- a/examples/jsm/misc/Volume.js
+++ b/examples/jsm/misc/Volume.js
@@ -122,7 +122,7 @@ class Volume {
 				case 'unsigned long long int' :
 				case 'uint64' :
 				case 'uint64_t' :
-					throw new Error( 'Error in Volume constructor : this type is not supported in JavaScript' );
+					throw new Error( 'THREE.Volume: type is not supported in JavaScript.' );
 				case 'Float32' :
 				case 'float32' :
 				case 'float' :
@@ -140,7 +140,7 @@ class Volume {
 
 			if ( this.data.length !== this.xLength * this.yLength * this.zLength ) {
 
-				throw new Error( 'Error in Volume constructor, lengths are not matching arrayBuffer size' );
+				throw new Error( 'THREE.Volume: lengths are not matching arrayBuffer size.' );
 
 			}
 

--- a/examples/jsm/objects/GroundedSkybox.js
+++ b/examples/jsm/objects/GroundedSkybox.js
@@ -32,7 +32,7 @@ class GroundedSkybox extends Mesh {
 
 		if ( height <= 0 || radius <= 0 || resolution <= 0 ) {
 
-			throw new Error( 'GroundedSkybox height, radius, and resolution must be positive.' );
+			throw new Error( 'THREE.GroundedSkybox: height, radius, and resolution must be positive.' );
 
 		}
 

--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -677,7 +677,7 @@ class GLSLDecoder {
 
 			params.push( new FunctionParameter( type, name, qualifier, immutable ) );
 
-			if ( tokens[ i ] && tokens[ i ].str !== ',' ) throw new Error( 'Expected ","' );
+			if ( tokens[ i ] && tokens[ i ].str !== ',' ) throw new Error( 'THREE.GLSLDecoder: Expected ","' );
 
 		}
 
@@ -789,7 +789,7 @@ class GLSLDecoder {
 
 		if ( tokens[ 2 ].str !== '{' ) {
 
-			throw new Error( 'Expected \'{\' after struct name ' );
+			throw new Error( 'THREE.GLSLDecoder: Expected \'{\' after struct name ' );
 
 		}
 
@@ -801,13 +801,13 @@ class GLSLDecoder {
 
 			if ( typeToken.type != 'literal' || nameToken.type != 'literal' ) {
 
-				throw new Error( 'Invalid struct declaration' );
+				throw new Error( 'THREE.GLSLDecoder: Invalid struct declaration' );
 
 			}
 
 			if ( tokens[ i + 2 ].str !== ';' ) {
 
-				throw new Error( 'Missing \';\' after struct member name' );
+				throw new Error( 'THREE.GLSLDecoder: Missing \';\' after struct member name' );
 
 			}
 
@@ -818,7 +818,7 @@ class GLSLDecoder {
 
 		if ( tokens[ tokens.length - 2 ].str !== '}' ) {
 
-			throw new Error( 'Missing closing \'}\' for struct ' + structName );
+			throw new Error( 'THREE.GLSLDecoder: Missing closing \'}\' for struct ' + structName );
 
 		}
 
@@ -921,7 +921,7 @@ class GLSLDecoder {
 		// Validate curly braces
 		if ( this.getToken().str !== '{' ) {
 
-			throw new Error( 'Expected \'{\' after switch(...) ' );
+			throw new Error( 'THREE.GLSLDecoder: Expected \'{\' after switch(...) ' );
 
 		}
 

--- a/examples/jsm/transpiler/Linker.js
+++ b/examples/jsm/transpiler/Linker.js
@@ -49,7 +49,7 @@ class Linker {
 
 		if ( this.block === null || this.block.node !== node ) {
 
-			throw new Error( 'No block to remove or block mismatch.' );
+			throw new Error( 'THREE.Linker: No block to remove or block mismatch.' );
 
 		}
 

--- a/examples/jsm/tsl/display/GodraysNode.js
+++ b/examples/jsm/tsl/display/GodraysNode.js
@@ -434,7 +434,7 @@ class GodraysNode extends TempNode {
 
 			} else {
 
-				throw new Error( 'GodraysNode: Unsupported light type.' );
+				throw new Error( 'THREE.GodraysNode: Unsupported light type.' );
 
 			}
 

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -147,7 +147,7 @@ class SSRNode extends TempNode {
 
 			} else {
 
-				throw new Error( 'THREE.TSL: No camera found. ssr() requires a camera.' );
+				throw new Error( 'THREE.SSRNode: No camera found. ssr() requires a camera.' );
 
 			}
 

--- a/examples/jsm/tsl/shadows/TileShadowNodeHelper.js
+++ b/examples/jsm/tsl/shadows/TileShadowNodeHelper.js
@@ -18,7 +18,7 @@ class TileShadowNodeHelper extends Group {
 
 		if ( ! tileShadowNode ) {
 
-			throw new Error( 'TileShadowNode instance is required for TileShadowNodeHelper.' );
+			throw new Error( 'THREE.TileShadowNode instance is required for TileShadowNodeHelper.' );
 
 		}
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -39,13 +39,13 @@ function computeMikkTSpaceTangents( geometry, MikkTSpace, negateSign = true ) {
 
 	if ( ! MikkTSpace || ! MikkTSpace.isReady ) {
 
-		throw new Error( 'BufferGeometryUtils: Initialized MikkTSpace library required.' );
+		throw new Error( 'THREE.BufferGeometryUtils: Initialized MikkTSpace library required.' );
 
 	}
 
 	if ( ! geometry.hasAttribute( 'position' ) || ! geometry.hasAttribute( 'normal' ) || ! geometry.hasAttribute( 'uv' ) ) {
 
-		throw new Error( 'BufferGeometryUtils: Tangents require "position", "normal", and "uv" attributes.' );
+		throw new Error( 'THREE.BufferGeometryUtils: Tangents require "position", "normal", and "uv" attributes.' );
 
 	}
 

--- a/examples/jsm/utils/SceneOptimizer.js
+++ b/examples/jsm/utils/SceneOptimizer.js
@@ -442,7 +442,7 @@ class SceneOptimizer {
 	 */
 	toInstancingMesh() {
 
-		throw new Error( 'InstancedMesh optimization not implemented yet' );
+		throw new Error( 'THREE.SceneOptimizer: InstancedMesh optimization not implemented yet' );
 
 	}
 

--- a/examples/jsm/webxr/WebGLXRFallback.js
+++ b/examples/jsm/webxr/WebGLXRFallback.js
@@ -60,7 +60,7 @@ function setupWebGLXRFallback( renderer, createFallbackRenderer, onFallback = ()
 
 		if ( fallbackRenderer.backend.isWebGLBackend !== true ) {
 
-			throw new Error( 'WebGLXRFallback: createFallbackRenderer() must return a renderer with a WebGL backend.' );
+			throw new Error( 'THREE.WebGLXRFallback: createFallbackRenderer() must return a renderer with a WebGL backend.' );
 
 		}
 

--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -353,7 +353,7 @@ class XRControllerModelFactory {
 
 					if ( ! this.gltfLoader ) {
 
-						throw new Error( 'GLTFLoader not set.' );
+						throw new Error( 'THREE.XRControllerModelFactory: GLTFLoader not set.' );
 
 					}
 
@@ -372,7 +372,7 @@ class XRControllerModelFactory {
 					null,
 					() => {
 
-						throw new Error( `Asset ${controllerModel.motionController.assetUrl} missing or malformed.` );
+						throw new Error( `THREE.XRControllerModelFactory: Asset ${controllerModel.motionController.assetUrl} missing or malformed.` );
 
 					} );
 

--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -212,7 +212,7 @@ class PropertyBinding {
 
 		if ( matches === null ) {
 
-			throw new Error( 'PropertyBinding: Cannot parse trackName: ' + trackName );
+			throw new Error( 'THREE.PropertyBinding: Cannot parse trackName: ' + trackName );
 
 		}
 
@@ -246,7 +246,7 @@ class PropertyBinding {
 
 		if ( results.propertyName === null || results.propertyName.length === 0 ) {
 
-			throw new Error( 'PropertyBinding: can not parse propertyName from trackName: ' + trackName );
+			throw new Error( 'THREE.PropertyBinding: can not parse propertyName from trackName: ' + trackName );
 
 		}
 

--- a/src/extras/TextureUtils.js
+++ b/src/extras/TextureUtils.js
@@ -224,7 +224,7 @@ function getTextureTypeByteLength( type ) {
 
 	}
 
-	throw new Error( `Unknown texture type ${type}.` );
+	throw new Error( `THREE.TextureUtils: Unknown texture type ${type}.` );
 
 }
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -180,7 +180,7 @@ class ObjectLoader extends Loader {
 
 		} catch ( e ) {
 
-			throw new Error( 'ObjectLoader: Can\'t parse ' + url + '. ' + e.message );
+			throw new Error( 'THREE.ObjectLoader: Can\'t parse ' + url + '. ' + e.message );
 
 		}
 

--- a/src/math/Interpolant.js
+++ b/src/math/Interpolant.js
@@ -297,7 +297,7 @@ class Interpolant {
 	 */
 	interpolate_( /* i1, t0, t, t1 */ ) {
 
-		throw new Error( 'call to abstract method' );
+		throw new Error( 'THREE.Interpolant: Call to abstract method.' );
 		// implementations shall return this.resultBuffer
 
 	}

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -419,7 +419,7 @@ function denormalize( value, array ) {
 
 		default:
 
-			throw new Error( 'Invalid component type.' );
+			throw new Error( 'THREE.MathUtils: Invalid component type.' );
 
 	}
 
@@ -466,7 +466,7 @@ function normalize( value, array ) {
 
 		default:
 
-			throw new Error( 'Invalid component type.' );
+			throw new Error( 'THREE.MathUtils: Invalid component type.' );
 
 	}
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -170,7 +170,7 @@ class Vector2 {
 
 			case 0: this.x = value; break;
 			case 1: this.y = value; break;
-			default: throw new Error( 'index is out of range: ' + index );
+			default: throw new Error( 'THREE.Vector2: index is out of range: ' + index );
 
 		}
 
@@ -190,7 +190,7 @@ class Vector2 {
 
 			case 0: return this.x;
 			case 1: return this.y;
-			default: throw new Error( 'index is out of range: ' + index );
+			default: throw new Error( 'THREE.Vector2: index is out of range: ' + index );
 
 		}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -165,7 +165,7 @@ class Vector3 {
 			case 0: this.x = value; break;
 			case 1: this.y = value; break;
 			case 2: this.z = value; break;
-			default: throw new Error( 'index is out of range: ' + index );
+			default: throw new Error( 'THREE.Vector3: index is out of range: ' + index );
 
 		}
 
@@ -186,7 +186,7 @@ class Vector3 {
 			case 0: return this.x;
 			case 1: return this.y;
 			case 2: return this.z;
-			default: throw new Error( 'index is out of range: ' + index );
+			default: throw new Error( 'THREE.Vector3: index is out of range: ' + index );
 
 		}
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -222,7 +222,7 @@ class Vector4 {
 			case 1: this.y = value; break;
 			case 2: this.z = value; break;
 			case 3: this.w = value; break;
-			default: throw new Error( 'index is out of range: ' + index );
+			default: throw new Error( 'THREE.Vector4: index is out of range: ' + index );
 
 		}
 
@@ -245,7 +245,7 @@ class Vector4 {
 			case 1: return this.y;
 			case 2: return this.z;
 			case 3: return this.w;
-			default: throw new Error( 'index is out of range: ' + index );
+			default: throw new Error( 'THREE.Vector4: index is out of range: ' + index );
 
 		}
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -955,7 +955,7 @@ class NodeBuilder {
 
 		if ( lastChain !== node ) {
 
-			throw new Error( 'NodeBuilder: Invalid node chaining!' );
+			throw new Error( 'THREE.NodeBuilder: Invalid node chaining!' );
 
 		}
 
@@ -1386,7 +1386,7 @@ class NodeBuilder {
 
 		}
 
-		throw new Error( `NodeBuilder: Type '${type}' not found in generate constant attempt.` );
+		throw new Error( `THREE.NodeBuilder: Type '${type}' not found in generate constant attempt.` );
 
 	}
 
@@ -1753,7 +1753,7 @@ class NodeBuilder {
 
 		} else {
 
-			throw new Error( 'NodeBuilder: Invalid active stack removal.' );
+			throw new Error( 'THREE.NodeBuilder: Invalid active stack removal.' );
 
 		}
 
@@ -3245,7 +3245,7 @@ class NodeBuilder {
 			else if ( type === 'mat4' ) node = new Matrix4NodeUniform( uniformNode );
 			else {
 
-				throw new Error( `Uniform "${ type }" not implemented.` );
+				throw new Error( `THREE.NodeBuilder: Uniform "${ type }" not implemented.` );
 
 			}
 

--- a/src/nodes/parsers/GLSLNodeFunction.js
+++ b/src/nodes/parsers/GLSLNodeFunction.js
@@ -95,7 +95,7 @@ const parse = ( source ) => {
 
 	} else {
 
-		throw new Error( 'FunctionNode: Function is not a GLSL code.' );
+		throw new Error( 'THREE.FunctionNode: Function is not a GLSL code.' );
 
 	}
 

--- a/src/nodes/utils/FunctionOverloadingNode.js
+++ b/src/nodes/utils/FunctionOverloadingNode.js
@@ -97,7 +97,7 @@ class FunctionOverloadingNode extends Node {
 
 				if ( layout === null ) {
 
-					throw new Error( 'FunctionOverloadingNode: FunctionNode must be a layout.' );
+					throw new Error( 'THREE.FunctionOverloadingNode: FunctionNode must be a layout.' );
 
 				}
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1277,7 +1277,7 @@ class BatchedMesh extends Mesh {
 		// throw an error if it can't be shrunk to the desired size
 		if ( maxInstanceCount < instanceInfo.length ) {
 
-			throw new Error( `BatchedMesh: Instance ids outside the range ${ maxInstanceCount } are being used. Cannot shrink instance count.` );
+			throw new Error( `THREE.BatchedMesh: Instance ids outside the range ${ maxInstanceCount } are being used. Cannot shrink instance count.` );
 
 		}
 
@@ -1329,7 +1329,7 @@ class BatchedMesh extends Mesh {
 		const requiredVertexLength = Math.max( ...validRanges.map( range => range.vertexStart + range.reservedVertexCount ) );
 		if ( requiredVertexLength > maxVertexCount ) {
 
-			throw new Error( `BatchedMesh: Geometry vertex values are being used outside the range ${ maxIndexCount }. Cannot shrink further.` );
+			throw new Error( `THREE.BatchedMesh: Geometry vertex values are being used outside the range ${ maxIndexCount }. Cannot shrink further.` );
 
 		}
 
@@ -1339,7 +1339,7 @@ class BatchedMesh extends Mesh {
 			const requiredIndexLength = Math.max( ...validRanges.map( range => range.indexStart + range.reservedIndexCount ) );
 			if ( requiredIndexLength > maxIndexCount ) {
 
-				throw new Error( `BatchedMesh: Geometry index values are being used outside the range ${ maxIndexCount }. Cannot shrink further.` );
+				throw new Error( `THREE.BatchedMesh: Geometry index values are being used outside the range ${ maxIndexCount }. Cannot shrink further.` );
 
 			}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -398,11 +398,11 @@ class WebGLRenderer {
 
 					if ( getContext( contextName ) ) {
 
-						throw new Error( 'Error creating WebGL context with your selected attributes.' );
+						throw new Error( 'THREE.WebGLRenderer: Error creating WebGL context with your selected attributes.' );
 
 					} else {
 
-						throw new Error( 'Error creating WebGL context.' );
+						throw new Error( 'THREE.WebGLRenderer: Error creating WebGL context.' );
 
 					}
 
@@ -2941,7 +2941,7 @@ class WebGLRenderer {
 							( renderTarget.width !== depthTexture.image.width || renderTarget.height !== depthTexture.image.height )
 						) {
 
-							throw new Error( 'WebGLRenderTarget: Attached DepthTexture is initialized to the incorrect size.' );
+							throw new Error( 'THREE.WebGLRenderer: Attached DepthTexture is initialized to the incorrect size.' );
 
 						}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1324,7 +1324,7 @@ class Renderer {
 
 		if ( this._initialized === false ) {
 
-			throw new Error( 'Renderer: .render() called before the backend is initialized. Use "await renderer.init();" before rendering.' );
+			throw new Error( 'THREE.Renderer: .render() called before the backend is initialized. Use "await renderer.init();" before rendering.' );
 
 		}
 
@@ -2330,7 +2330,7 @@ class Renderer {
 
 		if ( this._initialized === false ) {
 
-			throw new Error( 'Renderer: .clear() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
+			throw new Error( 'THREE.Renderer: .clear() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
 
 		}
 
@@ -2903,7 +2903,7 @@ class Renderer {
 
 		if ( this._initialized === false ) {
 
-			throw new Error( 'Renderer: .hasFeature() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
+			throw new Error( 'THREE.Renderer: .hasFeature() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
 
 		}
 
@@ -2953,7 +2953,7 @@ class Renderer {
 
 		if ( this._initialized === false ) {
 
-			throw new Error( 'Renderer: .initTexture() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
+			throw new Error( 'THREE.Renderer: .initTexture() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
 
 		}
 
@@ -2970,7 +2970,7 @@ class Renderer {
 
 		if ( this._initialized === false ) {
 
-			throw new Error( 'Renderer: .initRenderTarget() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
+			throw new Error( 'THREE.Renderer: .initRenderTarget() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
 
 		}
 
@@ -3553,7 +3553,7 @@ class Renderer {
 
 		if ( this._initialized === false ) {
 
-			throw new Error( 'Renderer: .hasCompatibility() called before the backend is initialized. Use "await renderer.init();" before using this method.' );
+			throw new Error( 'THREE.Renderer: .hasCompatibility() called before the backend is initialized. Use "await renderer.init();" before using this method.' );
 
 		}
 

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -146,7 +146,7 @@ class PMREMGenerator {
 
 		if ( this._hasInitialized === false ) {
 
-			throw new Error( 'PMREMGenerator: .fromScene() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
+			throw new Error( 'THREE.PMREMGenerator: .fromScene() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
 
 		}
 
@@ -218,7 +218,7 @@ class PMREMGenerator {
 
 		if ( this._hasInitialized === false ) {
 
-			throw new Error( 'PMREMGenerator: .fromEquirectangular() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
+			throw new Error( 'THREE.PMREMGenerator: .fromEquirectangular() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
 
 		}
 
@@ -262,7 +262,7 @@ class PMREMGenerator {
 
 		if ( this._hasInitialized === false ) {
 
-			throw new Error( 'PMREMGenerator: .fromCubemap() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
+			throw new Error( 'THREE.PMREMGenerator: .fromCubemap() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
 
 		}
 

--- a/src/renderers/common/nodes/NodeLibrary.js
+++ b/src/renderers/common/nodes/NodeLibrary.js
@@ -161,8 +161,8 @@ class NodeLibrary {
 
 		}
 
-		if ( typeof nodeClass !== 'function' ) throw new Error( `Node class ${ nodeClass.name } is not a class.` );
-		if ( typeof type === 'function' || typeof type === 'object' ) throw new Error( `Base class ${ type } is not a class.` );
+		if ( typeof nodeClass !== 'function' ) throw new Error( `THREE.NodeLibrary: Node class ${ nodeClass.name } is not a class.` );
+		if ( typeof type === 'function' || typeof type === 'object' ) throw new Error( `THREE.NodeLibrary: Base class ${ type } is not a class.` );
 
 		library.set( type, nodeClass );
 
@@ -184,8 +184,8 @@ class NodeLibrary {
 
 		}
 
-		if ( typeof nodeClass !== 'function' ) throw new Error( `Node class ${ nodeClass.name } is not a class.` );
-		if ( typeof baseClass !== 'function' ) throw new Error( `Base class ${ baseClass.name } is not a class.` );
+		if ( typeof nodeClass !== 'function' ) throw new Error( `THREE.NodeLibrary: Node class ${ nodeClass.name } is not a class.` );
+		if ( typeof baseClass !== 'function' ) throw new Error( `THREE.NodeLibrary: Base class ${ baseClass.name } is not a class.` );
 
 		library.set( baseClass, nodeClass );
 

--- a/src/renderers/webgl-fallback/utils/WebGLAttributeUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLAttributeUtils.js
@@ -286,7 +286,7 @@ class WebGLAttributeUtils {
 
 			if ( target._mapped === true ) {
 
-				throw new Error( 'WebGPURenderer: ReadbackBuffer must be released before being used again.' );
+				throw new Error( 'THREE.WebGPURenderer: ReadbackBuffer must be released before being used again.' );
 
 			}
 

--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -1253,7 +1253,7 @@ class WebGLTextureUtils {
 		if ( glType === gl.HALF_FLOAT ) return Uint16Array;
 		if ( glType === gl.FLOAT ) return Float32Array;
 
-		throw new Error( `Unsupported WebGL type: ${glType}` );
+		throw new Error( `THREE.WebGLTextureUtils: Unsupported WebGL type: ${glType}` );
 
 	}
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -265,7 +265,7 @@ function includeReplacer( match, include ) {
 
 		} else {
 
-			throw new Error( 'Can not resolve #include <' + include + '>' );
+			throw new Error( 'THREE.WebGLProgram: Can not resolve #include <' + include + '>' );
 
 		}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1747,7 +1747,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( ! ( renderTarget.depthTexture && renderTarget.depthTexture.isDepthTexture ) ) {
 
-			throw new Error( 'renderTarget.depthTexture must be an instance of THREE.DepthTexture' );
+			throw new Error( 'THREE.WebGLTextures: renderTarget.depthTexture must be an instance of THREE.DepthTexture.' );
 
 		}
 
@@ -1845,7 +1845,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		} else {
 
-			throw new Error( 'Unknown depthTexture format' );
+			throw new Error( 'THREE.WebGLTextures: Unknown depthTexture format.' );
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -218,7 +218,7 @@ class WebGPUBackend extends Backend {
 
 			if ( adapter === null ) {
 
-				throw new Error( 'WebGPUBackend: Unable to create WebGPU adapter.' );
+				throw new Error( 'THREE.WebGPUBackend: Unable to create WebGPU adapter.' );
 
 			}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -138,7 +138,7 @@ const parse = ( source ) => {
 
 	} else {
 
-		throw new Error( 'FunctionNode: Function is not a WGSL code.' );
+		throw new Error( 'THREE.WGSLNodeFunction: Function is not a WGSL code.' );
 
 	}
 

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -350,7 +350,7 @@ class WebGPUAttributeUtils {
 
 			if ( target._mapped === true ) {
 
-				throw new Error( 'WebGPURenderer: ReadbackBuffer must be released before being used again.' );
+				throw new Error( 'THREE.WebGPUAttributeUtils: ReadbackBuffer must be released before being used again.' );
 
 			}
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -283,7 +283,7 @@ class WebGPUTextureUtils {
 
 			}
 
-			throw new Error( 'WebGPUTextureUtils: Texture already initialized.' );
+			throw new Error( 'THREE.WebGPUTextureUtils: Texture already initialized.' );
 
 		}
 

--- a/src/renderers/webgpu/utils/WebGPUUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUUtils.js
@@ -260,7 +260,7 @@ class WebGPUUtils {
 
 		} else {
 
-			throw new Error( 'Unsupported output buffer type.' );
+			throw new Error( 'THREE.WebGPUUtils: Unsupported output buffer type.' );
 
 		}
 

--- a/src/textures/DepthTexture.js
+++ b/src/textures/DepthTexture.js
@@ -29,7 +29,7 @@ class DepthTexture extends Texture {
 
 		if ( format !== DepthFormat && format !== DepthStencilFormat ) {
 
-			throw new Error( 'DepthTexture format must be either THREE.DepthFormat or THREE.DepthStencilFormat' );
+			throw new Error( 'THREE.DepthTexture: format must be either THREE.DepthFormat or THREE.DepthStencilFormat' );
 
 		}
 


### PR DESCRIPTION
Related issue: -

**Description**

The PR harmonizes the errors thrown in the code base. They should always start with the `THREE` namespace followed by the module name. After a `:` a descriptive text follows. 
