### PR TITLE
USDZExporter: Improve usability.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -247,7 +247,15 @@ class USDZExporter {
 		const materials = {};
 		const textures = {};
 
-		buildHierarchy( scene, sceneNode, materials, usedNames, files, options );
+		if ( scene.isScene ) {
+
+			buildHierarchy( scene, sceneNode, materials, usedNames, files, options );
+
+		} else {
+
+			buildNode( scene, sceneNode, materials, usedNames, files, options );
+
+		}
 
 		const materialsNode = buildMaterials(
 			materials,
@@ -544,64 +552,68 @@ function buildHierarchy( object, parentNode, materials, usedNames, files, option
 
 	for ( let i = 0, l = object.children.length; i < l; i ++ ) {
 
-		const child = object.children[ i ];
+		buildNode( object.children[ i ], parentNode, materials, usedNames, files, options );
 
-		if ( child.visible === false && options.onlyVisible === true ) continue;
+	}
 
-		let childNode;
+}
 
-		if ( child.isMesh ) {
+function buildNode( object, parentNode, materials, usedNames, files, options ) {
 
-			const geometry = child.geometry;
-			const material = child.material;
+	if ( object.visible === false && options.onlyVisible === true ) return;
 
-			if ( ! material.isMeshStandardMaterial ) {
+	let childNode;
 
-				console.warn( 'THREE.USDZExporter: Use MeshStandardMaterial for best results.' );
+	if ( object.isMesh ) {
 
-			}
+		const geometry = object.geometry;
+		const material = object.material;
 
-			const geometryFileName = 'geometries/Geometry_' + geometry.id + '.usda';
+		if ( ! material.isMeshStandardMaterial ) {
 
-			if ( ! ( geometryFileName in files ) ) {
+			console.warn( 'THREE.USDZExporter: Use MeshStandardMaterial for best results.' );
 
-				const meshObject = buildMeshObject( geometry );
-				files[ geometryFileName ] = strToU8(
-					buildHeader() + '\n' + meshObject.toString()
-				);
+		}
 
-			}
+		const geometryFileName = 'geometries/Geometry_' + geometry.id + '.usda';
 
-			if ( ! ( material.uuid in materials ) ) {
+		if ( ! ( geometryFileName in files ) ) {
 
-				materials[ material.uuid ] = material;
-
-			}
-
-			childNode = buildMesh(
-				child,
-				geometry,
-				materials[ material.uuid ],
-				usedNames,
-				options
+			const meshObject = buildMeshObject( geometry );
+			files[ geometryFileName ] = strToU8(
+				buildHeader() + '\n' + meshObject.toString()
 			);
 
-		} else if ( child.isCamera ) {
+		}
 
-			childNode = buildCamera( child, usedNames, options );
+		if ( ! ( material.uuid in materials ) ) {
 
-		} else {
-
-			childNode = buildXform( child, usedNames, options );
+			materials[ material.uuid ] = material;
 
 		}
 
-		if ( childNode ) {
+		childNode = buildMesh(
+			object,
+			geometry,
+			materials[ material.uuid ],
+			usedNames,
+			options
+		);
 
-			parentNode.addChild( childNode );
-			buildHierarchy( child, childNode, materials, usedNames, files, options );
+	} else if ( object.isCamera ) {
 
-		}
+		childNode = buildCamera( object, usedNames, options );
+
+	} else {
+
+		childNode = buildXform( object, usedNames, options );
+
+	}
+
+	if ( childNode ) {
+
+		parentNode.addChild( childNode );
+		buildHierarchy( object, childNode, materials, usedNames, files, options );
 
 	}
 

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -555,41 +555,36 @@ function buildHierarchy( object, parentNode, materials, usedNames, files, option
 			const geometry = child.geometry;
 			const material = child.material;
 
-			if ( material.isMeshStandardMaterial ) {
+			if ( ! material.isMeshStandardMaterial ) {
 
-				const geometryFileName = 'geometries/Geometry_' + geometry.id + '.usda';
+				console.warn( 'THREE.USDZExporter: Use MeshStandardMaterial for best results.' );
 
-				if ( ! ( geometryFileName in files ) ) {
+			}
 
-					const meshObject = buildMeshObject( geometry );
-					files[ geometryFileName ] = strToU8(
-						buildHeader() + '\n' + meshObject.toString()
-					);
+			const geometryFileName = 'geometries/Geometry_' + geometry.id + '.usda';
 
-				}
+			if ( ! ( geometryFileName in files ) ) {
 
-				if ( ! ( material.uuid in materials ) ) {
-
-					materials[ material.uuid ] = material;
-
-				}
-
-				childNode = buildMesh(
-					child,
-					geometry,
-					materials[ material.uuid ],
-					usedNames,
-					options
-				);
-
-			} else {
-
-				console.warn(
-					'THREE.USDZExporter: Unsupported material type (USDZ only supports MeshStandardMaterial)',
-					child
+				const meshObject = buildMeshObject( geometry );
+				files[ geometryFileName ] = strToU8(
+					buildHeader() + '\n' + meshObject.toString()
 				);
 
 			}
+
+			if ( ! ( material.uuid in materials ) ) {
+
+				materials[ material.uuid ] = material;
+
+			}
+
+			childNode = buildMesh(
+				child,
+				geometry,
+				materials[ material.uuid ],
+				usedNames,
+				options
+			);
 
 		} else if ( child.isCamera ) {
 
@@ -1097,33 +1092,39 @@ function buildMaterial( material, textures, quickLookCompatible = false ) {
 
 	}
 
-	if ( material.emissiveMap !== null ) {
+	if ( material.emissive ) {
 
-		previewSurfaceNode.addProperty(
-			`color3f inputs:emissiveColor.connect = </Materials/Material_${material.id}/Texture_${material.emissiveMap.id}_emissive.outputs:rgb>`
-		);
+		const emissiveIntensity = material.emissiveIntensity ?? 1;
 
-		const emissiveColor = new Color(
-			material.emissive.r * material.emissiveIntensity,
-			material.emissive.g * material.emissiveIntensity,
-			material.emissive.b * material.emissiveIntensity
-		);
-		const textureNodes = buildTextureNodes(
-			material.emissiveMap,
-			'emissive',
-			emissiveColor
-		);
-		textureNodes.forEach( ( node ) => materialNode.addChild( node ) );
+		if ( material.emissiveMap ) {
 
-	} else if ( material.emissive.getHex() > 0 ) {
+			previewSurfaceNode.addProperty(
+				`color3f inputs:emissiveColor.connect = </Materials/Material_${material.id}/Texture_${material.emissiveMap.id}_emissive.outputs:rgb>`
+			);
 
-		previewSurfaceNode.addProperty(
-			`color3f inputs:emissiveColor = ${buildColor( material.emissive )}`
-		);
+			const emissiveColor = new Color(
+				material.emissive.r * emissiveIntensity,
+				material.emissive.g * emissiveIntensity,
+				material.emissive.b * emissiveIntensity
+			);
+			const textureNodes = buildTextureNodes(
+				material.emissiveMap,
+				'emissive',
+				emissiveColor
+			);
+			textureNodes.forEach( ( node ) => materialNode.addChild( node ) );
+
+		} else if ( material.emissive.getHex() > 0 ) {
+
+			previewSurfaceNode.addProperty(
+				`color3f inputs:emissiveColor = ${buildColor( material.emissive )}`
+			);
+
+		}
 
 	}
 
-	if ( material.normalMap !== null ) {
+	if ( material.normalMap ) {
 
 		previewSurfaceNode.addProperty(
 			`normal3f inputs:normal.connect = </Materials/Material_${material.id}/Texture_${material.normalMap.id}_normal.outputs:rgb>`
@@ -1134,16 +1135,17 @@ function buildMaterial( material, textures, quickLookCompatible = false ) {
 
 	}
 
-	if ( material.aoMap !== null ) {
+	if ( material.aoMap ) {
 
 		previewSurfaceNode.addProperty(
 			`float inputs:occlusion.connect = </Materials/Material_${material.id}/Texture_${material.aoMap.id}_occlusion.outputs:r>`
 		);
 
+		const aoMapIntensity = material.aoMapIntensity ?? 1;
 		const aoColor = new Color(
-			material.aoMapIntensity,
-			material.aoMapIntensity,
-			material.aoMapIntensity
+			aoMapIntensity,
+			aoMapIntensity,
+			aoMapIntensity
 		);
 		const textureNodes = buildTextureNodes(
 			material.aoMap,
@@ -1154,7 +1156,7 @@ function buildMaterial( material, textures, quickLookCompatible = false ) {
 
 	}
 
-	if ( material.roughnessMap !== null ) {
+	if ( material.roughnessMap ) {
 
 		previewSurfaceNode.addProperty(
 			`float inputs:roughness.connect = </Materials/Material_${material.id}/Texture_${material.roughnessMap.id}_roughness.outputs:g>`
@@ -1175,12 +1177,12 @@ function buildMaterial( material, textures, quickLookCompatible = false ) {
 	} else {
 
 		previewSurfaceNode.addProperty(
-			`float inputs:roughness = ${material.roughness}`
+			`float inputs:roughness = ${material.roughness ?? 1}`
 		);
 
 	}
 
-	if ( material.metalnessMap !== null ) {
+	if ( material.metalnessMap ) {
 
 		previewSurfaceNode.addProperty(
 			`float inputs:metallic.connect = </Materials/Material_${material.id}/Texture_${material.metalnessMap.id}_metallic.outputs:b>`
@@ -1201,12 +1203,12 @@ function buildMaterial( material, textures, quickLookCompatible = false ) {
 	} else {
 
 		previewSurfaceNode.addProperty(
-			`float inputs:metallic = ${material.metalness}`
+			`float inputs:metallic = ${material.metalness ?? 0}`
 		);
 
 	}
 
-	if ( material.alphaMap !== null ) {
+	if ( material.alphaMap ) {
 
 		previewSurfaceNode.addProperty(
 			`float inputs:opacity.connect = </Materials/Material_${material.id}/Texture_${material.alphaMap.id}_opacity.outputs:r>`

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -610,12 +610,8 @@ function buildNode( object, parentNode, materials, usedNames, files, options ) {
 
 	}
 
-	if ( childNode ) {
-
-		parentNode.addChild( childNode );
-		buildHierarchy( object, childNode, materials, usedNames, files, options );
-
-	}
+	parentNode.addChild( childNode );
+	buildHierarchy( object, childNode, materials, usedNames, files, options );
 
 }
 


### PR DESCRIPTION
Related issue :#31652

**Description**

The PR improves the usability of `USDZExporter` by applying two best practices from `GLTFExporter`.

- Support other material types than `MeshStandardMaterial` but report a warning about compatibility.
- Allow passing meshes directly to `parseAsync()`.

Both changes should not affect the export of existing setups.