### PR TITLE
Manual: Improve Installation guide.

### DIFF
--- a/manual/en/installation.html
+++ b/manual/en/installation.html
@@ -109,21 +109,10 @@ npm install --save-dev vite
                   </p>
                 </details>
                 <details>
-                  <summary>Improve your editor auto-completion with <i>jsconfig</i> or <i>tsconfig</i></summary>
+                  <summary>Using three.js with TypeScript</summary>
                   <p>
-                    Place a <i>jsconfig.json</i> (or <i>tsconfig.json</i> for TypeScript projects) in your project's root. Adding the configuration below helps your editor locate three.js files for enhanced auto-completion.
+                    Community-maintained TypeScript type definitions for three.js are available at [link:https://github.com/three-types/three-ts-types three-types/three-ts-types].
                   </p>
-<pre class="prettyprint notranslate lang-js" translate="no">
-{
-  "compilerOptions": {
-    // other options...
-    "paths": {
-      "three/webgpu": ["node_modules/three/build/three.webgpu.js"],
-      "three/tsl": ["node_modules/three/build/three.tsl.js"],
-    },
-  }
-}
-</pre>
                 </details>
               </aside>
             </li>

--- a/manual/fr/installation.html
+++ b/manual/fr/installation.html
@@ -109,21 +109,10 @@ npm install --save-dev vite
                   </p>
                 </details>
                 <details>
-                  <summary>Améliorez l'auto-complétion de votre éditeur avec <i>jsconfig</i> ou <i>tsconfig</i></summary>
+                  <summary>Using three.js with TypeScript</summary>
                   <p>
-                    Placez un fichier <i>jsconfig.json</i> (ou <i>tsconfig.json</i> pour les projets TypeScript) à la racine de votre projet. L'ajout de la configuration ci-dessous aide votre éditeur à localiser les fichiers three.js pour une auto-complétion améliorée.
+                    Community-maintained TypeScript type definitions for three.js are available at [link:https://github.com/three-types/three-ts-types three-types/three-ts-types].
                   </p>
-<pre class="prettyprint notranslate lang-js" translate="no">
-{
-  "compilerOptions": {
-    // other options...
-    "paths": {
-      "three/webgpu": ["node_modules/three/build/three.webgpu.js"],
-      "three/tsl": ["node_modules/three/build/three.tsl.js"],
-    },
-  }
-}
-</pre>
                 </details>
               </aside>
             </li>

--- a/manual/zh/installation.html
+++ b/manual/zh/installation.html
@@ -109,21 +109,10 @@ npm install --save-dev vite
                   </p>
                 </details>
                 <details>
-                  <summary>使用 <i>jsconfig</i> 或 <i>tsconfig</i> 改善编辑器自动补全</summary>
+                  <summary>Using three.js with TypeScript</summary>
                   <p>
-                    在项目根目录放置一个 <i>jsconfig.json</i>（TypeScript 项目则使用 <i>tsconfig.json</i>）。添加以下配置可以帮助编辑器定位 three.js 文件，从而增强自动补全功能。
+                    Community-maintained TypeScript type definitions for three.js are available at [link:https://github.com/three-types/three-ts-types three-types/three-ts-types].
                   </p>
-<pre class="prettyprint notranslate lang-js" translate="no">
-{
-  "compilerOptions": {
-    // other options...
-    "paths": {
-      "three/webgpu": ["node_modules/three/build/three.webgpu.js"],
-      "three/tsl": ["node_modules/three/build/three.tsl.js"],
-    },
-  }
-}
-</pre>
                 </details>
               </aside>
             </li>


### PR DESCRIPTION
Fixed #33551.

**Description**

The PR removes outdated Installation notes and refers TypeScript users to https://github.com/three-types/three-ts-types for type definition files.