### PR TITLE
DRACOLoader: Deprecate "setDecoderConfig" function

### DIFF
--- a/examples/jsm/libs/draco/README.md
+++ b/examples/jsm/libs/draco/README.md
@@ -22,7 +22,6 @@ Either variation may be used with `DRACOLoader`:
 ```js
 var dracoLoader = new DRACOLoader();
 dracoLoader.setDecoderPath('path/to/decoders/');
-dracoLoader.setDecoderConfig({type: 'js'}); // (Optional) Override detection of WASM support.
 ```
 
 Further [documentation on GitHub](https://github.com/google/draco/tree/master/javascript/example#static-loading-javascript-decoder).

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -102,6 +102,7 @@ class DRACOLoader extends Loader {
 	/**
 	 * Provides configuration for the decoder libraries. Configuration cannot be changed after decoding begins.
 	 *
+	 * @deprecated
 	 * @param {{type:('js'|'wasm')}} config - The decoder config.
 	 * @return {DRACOLoader} A reference to this loader.
 	 */

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -107,6 +107,7 @@ class DRACOLoader extends Loader {
 	 */
 	setDecoderConfig( config ) {
 
+		console.warn( 'THREE.DRACOLoader: setDecoderConfig to has been deprecated and will be removed in r194.' );
 		this.decoderConfig = config;
 
 		return this;

--- a/examples/webgl_loader_3dtiles.html
+++ b/examples/webgl_loader_3dtiles.html
@@ -123,7 +123,6 @@
 				// loader
 				const dracoLoader = new DRACOLoader();
 				dracoLoader.setDecoderPath( 'jsm/libs/draco/gltf/' );
-				dracoLoader.setDecoderConfig( { type: 'js' } );
 
 				const DEG2RAD = Math.PI / 180;
 

--- a/examples/webgl_loader_draco.html
+++ b/examples/webgl_loader_draco.html
@@ -39,7 +39,6 @@
 		// Configure and create Draco decoder.
 		const dracoLoader = new DRACOLoader();
 		dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
-		dracoLoader.setDecoderConfig( { type: 'js' } );
 
 		init();
 

--- a/examples/webgl_postprocessing_gtao.html
+++ b/examples/webgl_postprocessing_gtao.html
@@ -55,7 +55,6 @@
 
 				const dracoLoader = new DRACOLoader();
 				dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
-				dracoLoader.setDecoderConfig( { type: 'js' } );
 				const loader = new GLTFLoader();
 				loader.setDRACOLoader( dracoLoader );
 				loader.setPath( 'models/gltf/' );

--- a/examples/webgl_postprocessing_ssr.html
+++ b/examples/webgl_postprocessing_ssr.html
@@ -66,7 +66,6 @@
 		// Configure and create Draco decoder.
 		const dracoLoader = new DRACOLoader();
 		dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
-		dracoLoader.setDecoderConfig( { type: 'js' } );
 
 		init();
 

--- a/examples/webgpu_caustics.html
+++ b/examples/webgpu_caustics.html
@@ -78,7 +78,6 @@
 
 				const dracoLoader = new DRACOLoader();
 				dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
-				dracoLoader.setDecoderConfig( { type: 'js' } );
 
 				gltf = ( await new GLTFLoader().setDRACOLoader( dracoLoader ).loadAsync( './models/gltf/duck.glb' ) ).scene;
 				gltf.scale.setScalar( .5 );

--- a/examples/webgpu_postprocessing_ao.html
+++ b/examples/webgpu_postprocessing_ao.html
@@ -160,7 +160,6 @@
 
 				const dracoLoader = new DRACOLoader();
 				dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
-				dracoLoader.setDecoderConfig( { type: 'js' } );
 				const loader = new GLTFLoader();
 				loader.setDRACOLoader( dracoLoader );
 				loader.setPath( 'models/gltf/' );

--- a/examples/webgpu_postprocessing_ssr.html
+++ b/examples/webgpu_postprocessing_ssr.html
@@ -79,7 +79,6 @@
 
 			const dracoLoader = new DRACOLoader();
 			dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
-			dracoLoader.setDecoderConfig( { type: 'js' } );
 
 			const loader = new GLTFLoader();
 			loader.setDRACOLoader( dracoLoader );

--- a/examples/webgpu_upscaling_fsr1.html
+++ b/examples/webgpu_upscaling_fsr1.html
@@ -71,7 +71,6 @@
 
 				const dracoLoader = new DRACOLoader();
 				dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
-				dracoLoader.setDecoderConfig( { type: 'js' } );
 				const loader = new GLTFLoader();
 				loader.setDRACOLoader( dracoLoader );
 

--- a/examples/webgpu_upscaling_taau.html
+++ b/examples/webgpu_upscaling_taau.html
@@ -74,7 +74,6 @@
 
 				const dracoLoader = new DRACOLoader();
 				dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
-				dracoLoader.setDecoderConfig( { type: 'js' } );
 				const loader = new GLTFLoader();
 				loader.setDRACOLoader( dracoLoader );
 

--- a/examples/webgpu_volume_caustics.html
+++ b/examples/webgpu_volume_caustics.html
@@ -86,7 +86,6 @@
 
 				const dracoLoader = new DRACOLoader();
 				dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
-				dracoLoader.setDecoderConfig( { type: 'js' } );
 
 				gltf = ( await new GLTFLoader().setDRACOLoader( dracoLoader ).loadAsync( './models/gltf/duck.glb' ) ).scene;
 				gltf.scale.setScalar( .5 );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33564#issuecomment-4432225862

**Description**

Deprecate the "DRACOLoader.setDecoderConfig" function, used to indicate whether "wasm" or "js" decoders should be used, which we'd discussed removing in #33564. As far as I can tell there's no other use for this function.