### PR TITLE
KTX2Loader: Use relative file urls by default.

### DIFF
--- a/examples/jsm/libs/basis/README.md
+++ b/examples/jsm/libs/basis/README.md
@@ -24,7 +24,6 @@ Both are dependencies of `KTX2Loader`:
 
 ```js
 const ktx2Loader = new KTX2Loader();
-ktx2Loader.setTranscoderPath( 'examples/jsm/libs/basis/' );
 ktx2Loader.detectSupport( renderer );
 ktx2Loader.load( 'diffuse.ktx2', function ( texture ) {
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -103,7 +103,6 @@ import {
 import { ZSTDDecoder } from '../libs/zstddec.module.js';
 import { DisplayP3ColorSpace, LinearDisplayP3ColorSpace } from '../math/ColorSpaces.js';
 
-
 const WASM_BIN_URL = new URL( '../libs/basis/basis_transcoder.wasm', import.meta.url ).toString();
 const WASM_JS_URL = new URL( '../libs/basis/basis_transcoder.js', import.meta.url ).toString();
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -103,6 +103,10 @@ import {
 import { ZSTDDecoder } from '../libs/zstddec.module.js';
 import { DisplayP3ColorSpace, LinearDisplayP3ColorSpace } from '../math/ColorSpaces.js';
 
+
+const WASM_BIN_URL = new URL( '../libs/basis/basis_transcoder.wasm', import.meta.url ).toString();
+const WASM_JS_URL = new URL( '../libs/basis/basis_transcoder.js', import.meta.url ).toString();
+
 const _taskCache = new WeakMap();
 
 let _activeLoaders = 0;
@@ -169,9 +173,9 @@ class KTX2Loader extends Loader {
 	}
 
 	/**
-	 * Sets the transcoder path.
+	 * Sets the transcoder path to optionally set the decoder load path from a CDN.
 	 *
-	 * The WASM transcoder and JS wrapper are available from the `examples/jsm/libs/basis` directory.
+	 * By default The WASM transcoder and JS wrapper are loaded from the `examples/jsm/libs/basis` directory.
 	 *
 	 * @param {string} path - The transcoder path to set.
 	 * @return {KTX2Loader} A reference to this loader.
@@ -280,18 +284,30 @@ class KTX2Loader extends Loader {
 
 		if ( ! this.transcoderPending ) {
 
-			// Load transcoder wrapper.
 			const jsLoader = new FileLoader( this.manager );
-			jsLoader.setPath( this.transcoderPath );
 			jsLoader.setWithCredentials( this.withCredentials );
-			const jsContent = jsLoader.loadAsync( 'basis_transcoder.js' );
 
-			// Load transcoder WASM binary.
 			const binaryLoader = new FileLoader( this.manager );
-			binaryLoader.setPath( this.transcoderPath );
-			binaryLoader.setResponseType( 'arraybuffer' );
 			binaryLoader.setWithCredentials( this.withCredentials );
-			const binaryContent = binaryLoader.loadAsync( 'basis_transcoder.wasm' );
+			binaryLoader.setResponseType( 'arraybuffer' );
+
+			let jsContent, binaryContent;
+			if ( this.transcoderPath === '' ) {
+
+				jsContent = jsLoader.loadAsync( WASM_JS_URL );
+				binaryContent = binaryLoader.loadAsync( WASM_BIN_URL );
+
+			} else {
+
+				// Load transcoder wrapper.
+				jsLoader.setPath( this.transcoderPath );
+				jsContent = jsLoader.loadAsync( 'basis_transcoder.js' );
+
+				// Load transcoder WASM binary.
+				binaryLoader.setPath( this.transcoderPath );
+				binaryContent = binaryLoader.loadAsync( 'basis_transcoder.wasm' );
+
+			}
 
 			this.transcoderPending = Promise.all( [ jsContent, binaryContent ] )
 				.then( ( [ jsContent, binaryContent ] ) => {

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -489,7 +489,6 @@
 				// Exporting compressed textures and meshes (KTX2 / Draco / Meshopt)
 				// ---------------------------------------------------------------------
 				const ktx2Loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 
 				const gltfLoader = new GLTFLoader().setPath( 'models/gltf/' );

--- a/examples/misc_exporter_usdz.html
+++ b/examples/misc_exporter_usdz.html
@@ -90,7 +90,7 @@
 				scene.background = new THREE.Color( 0xf0f0f0 );
 				scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
 
-				const ktx2loader = new KTX2Loader().setTranscoderPath( 'jsm/libs/basis/' ).detectSupport( renderer );
+				const ktx2loader = new KTX2Loader().detectSupport( renderer );
 				const dracoLoader = new DRACOLoader().setDecoderPath( 'jsm/libs/draco/' );
 				const gltfLoader = new GLTFLoader();
 			

--- a/examples/webgl_loader_gltf_animation_pointer.html
+++ b/examples/webgl_loader_gltf_animation_pointer.html
@@ -88,7 +88,6 @@
 			
 
 			const ktx2Loader = new KTX2Loader()
-				.setTranscoderPath( 'jsm/libs/basis/' )
 				.detectSupport( renderer );
 
 			const loader = new GLTFLoader();

--- a/examples/webgl_loader_gltf_compressed.html
+++ b/examples/webgl_loader_gltf_compressed.html
@@ -73,7 +73,6 @@
 				scene.add( grid );
 
 				const ktx2Loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 
 				const loader = new GLTFLoader().setPath( 'models/gltf/' );

--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -150,7 +150,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 
 				const loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
 					.setPath( 'textures/ktx2/' )
 					.detectSupport( renderer );
 

--- a/examples/webgl_materials_envmaps_fasthdr.html
+++ b/examples/webgl_materials_envmaps_fasthdr.html
@@ -109,7 +109,6 @@
 				scene.add( sphere05 );
 
 				const loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 
 				function loadTexture( url ) {

--- a/examples/webgl_morphtargets_face.html
+++ b/examples/webgl_morphtargets_face.html
@@ -73,7 +73,6 @@
 				container.appendChild( renderer.domElement );
 
 				const ktx2Loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 
 				new GLTFLoader()

--- a/examples/webgl_morphtargets_webcam.html
+++ b/examples/webgl_morphtargets_webcam.html
@@ -130,7 +130,6 @@
 			const eyeRotationLimit = THREE.MathUtils.degToRad( 30 );
 
 			const ktx2Loader = new KTX2Loader()
-				.setTranscoderPath( 'jsm/libs/basis/' )
 				.detectSupport( renderer );
 
 			new GLTFLoader()

--- a/examples/webgl_texture2darray_compressed.html
+++ b/examples/webgl_texture2darray_compressed.html
@@ -101,7 +101,6 @@
 				//
 
 				const ktx2Loader = new KTX2Loader();
-				ktx2Loader.setTranscoderPath( 'jsm/libs/basis/' );
 				ktx2Loader.detectSupport( renderer );
 
 				ktx2Loader.load( 'textures/spiritedaway.ktx2', function ( texturearray ) {

--- a/examples/webgl_texture2darray_layerupdate.html
+++ b/examples/webgl_texture2darray_layerupdate.html
@@ -98,7 +98,6 @@
 				// Configure the KTX2 loader.
 
 				const ktx2Loader = new KTX2Loader();
-				ktx2Loader.setTranscoderPath( 'jsm/libs/basis/' );
 				ktx2Loader.detectSupport( renderer );
 
 				// Load several KTX2 textures which will later be used to modify

--- a/examples/webgpu_loader_gltf_compressed.html
+++ b/examples/webgpu_loader_gltf_compressed.html
@@ -82,7 +82,6 @@
 				controls.update();
 
 				const ktx2Loader = await new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 
 				const loader = new GLTFLoader();

--- a/examples/webgpu_loader_texture_ktx2.html
+++ b/examples/webgpu_loader_texture_ktx2.html
@@ -152,7 +152,6 @@
 				await renderer.init();
 
 				const loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
 					.setPath( 'textures/ktx2/' )
 					.detectSupport( renderer );
 

--- a/examples/webgpu_morphtargets_face.html
+++ b/examples/webgpu_morphtargets_face.html
@@ -77,7 +77,6 @@
 				scene.environment = pmremGenerator.fromScene( environment, 0.04 ).texture;
 
 				const ktx2Loader = await new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 
 				new GLTFLoader()

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -79,7 +79,6 @@
 				textureDisplace.wrapT = THREE.RepeatWrapping;
 
 				const ktxLoader = await new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 
 				const ktxTexture = await ktxLoader.loadAsync( './textures/ktx2/2d_uastc.ktx2' );

--- a/examples/webgpu_textures_2d-array_compressed.html
+++ b/examples/webgpu_textures_2d-array_compressed.html
@@ -83,7 +83,6 @@
 				//
 
 				const ktx2Loader = new KTX2Loader();
-				ktx2Loader.setTranscoderPath( 'jsm/libs/basis/' );
 				ktx2Loader.detectSupport( renderer );
 
 				ktx2Loader.load( 'textures/spiritedaway.ktx2', function ( texturearray ) {


### PR DESCRIPTION
Related issue: #33564

**Description**

- Adjust KTX2Loader to use the `new URL( path, import.meta.url )` path by default.
-  Remove call to "setTranscoderPath" from examples.
- Update setTranscoderPath docs