### PR TITLE
RTTNode: Introduce `setResolutioScale()` and updates

### DIFF
--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -312,8 +312,8 @@ class BloomNode extends TempNode {
 	 */
 	setSize( width, height ) {
 
-		let resx = Math.round( width * this._resolutionScale );
-		let resy = Math.round( height * this._resolutionScale );
+		let resx = Math.floor( width * this._resolutionScale );
+		let resy = Math.floor( height * this._resolutionScale );
 
 		this._renderTargetBright.setSize( resx, resy );
 
@@ -324,8 +324,8 @@ class BloomNode extends TempNode {
 
 			this._separableBlurMaterials[ i ].invSize.value.set( 1 / resx, 1 / resy );
 
-			resx = Math.round( resx / 2 );
-			resy = Math.round( resy / 2 );
+			resx = Math.floor( resx / 2 );
+			resy = Math.floor( resy / 2 );
 
 		}
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -998,19 +998,6 @@ class PassNode extends TempNode {
 	}
 
 	/**
-	 * Sets the pixel ratio the pass's render target and updates the size.
-	 *
-	 * @param {number} pixelRatio - The pixel ratio to set.
-	 */
-	setPixelRatio( pixelRatio ) {
-
-		this._pixelRatio = pixelRatio;
-
-		this.setSize( this._width, this._height );
-
-	}
-
-	/**
 	 * Frees internal resources. Should be called when the node is no longer in use.
 	 */
 	dispose() {

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -228,15 +228,6 @@ class PassNode extends TempNode {
 		this.options = options;
 
 		/**
-		 * The pass's pixel ratio. Will be kept automatically kept in sync with the renderer's pixel ratio.
-		 *
-		 * @private
-		 * @type {number}
-		 * @default 1
-		 */
-		this._pixelRatio = 1;
-
-		/**
 		 * The pass's pixel width. Will be kept automatically kept in sync with the renderer's width.
 		 * @private
 		 * @type {number}
@@ -252,7 +243,7 @@ class PassNode extends TempNode {
 		 */
 		this._height = 1;
 
-		const renderTarget = new RenderTarget( this._width * this._pixelRatio, this._height * this._pixelRatio, { type: HalfFloatType, ...options, } );
+		const renderTarget = new RenderTarget( this._width, this._height, { type: HalfFloatType, ...options, } );
 		renderTarget.texture.name = 'output';
 
 		let depthTexture = null;
@@ -792,13 +783,11 @@ class PassNode extends TempNode {
 		const { scene } = this;
 
 		let camera;
-		let pixelRatio;
 
 		const outputRenderTarget = renderer.getOutputRenderTarget();
 
 		if ( outputRenderTarget && outputRenderTarget.isXRRenderTarget === true ) {
 
-			pixelRatio = 1;
 			camera = renderer.xr.getCamera();
 
 			renderer.xr.updateCamera( camera );
@@ -808,13 +797,10 @@ class PassNode extends TempNode {
 		} else {
 
 			camera = this.camera;
-			pixelRatio = renderer.getPixelRatio();
 
-			renderer.getSize( _size );
+			renderer.getDrawingBufferSize( _size );
 
 		}
-
-		this._pixelRatio = pixelRatio;
 
 		this.setSize( _size.width, _size.height );
 
@@ -900,8 +886,8 @@ class PassNode extends TempNode {
 		this._width = width;
 		this._height = height;
 
-		const effectiveWidth = Math.floor( this._width * this._pixelRatio * this._resolutionScale );
-		const effectiveHeight = Math.floor( this._height * this._pixelRatio * this._resolutionScale );
+		const effectiveWidth = Math.floor( this._width * this._resolutionScale );
+		const effectiveHeight = Math.floor( this._height * this._resolutionScale );
 
 		this.renderTarget.setSize( effectiveWidth, effectiveHeight );
 
@@ -909,7 +895,7 @@ class PassNode extends TempNode {
 
 		if ( this._scissor !== null ) {
 
-			this.renderTarget.scissor.copy( this._scissor ).multiplyScalar( this._pixelRatio * this._resolutionScale ).floor();
+			this.renderTarget.scissor.copy( this._scissor ).multiplyScalar( this._resolutionScale ).floor();
 			this.renderTarget.scissorTest = true;
 
 		} else {
@@ -922,7 +908,7 @@ class PassNode extends TempNode {
 
 		if ( this._viewport !== null ) {
 
-			this.renderTarget.viewport.copy( this._viewport ).multiplyScalar( this._pixelRatio * this._resolutionScale ).floor();
+			this.renderTarget.viewport.copy( this._viewport ).multiplyScalar( this._resolutionScale ).floor();
 
 		}
 

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -8,6 +8,7 @@ import QuadMesh from '../../renderers/common/QuadMesh.js';
 import { RenderTarget } from '../../core/RenderTarget.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { HalfFloatType } from '../../constants.js';
+import { warnOnce } from '../../utils.js';
 
 const _size = /*@__PURE__*/ new Vector2();
 
@@ -75,14 +76,6 @@ class RTTNode extends TextureNode {
 		this.height = height;
 
 		/**
-		 * The pixel ratio
-		 *
-		 * @type {number}
-		 * @default 1
-		 */
-		this.pixelRatio = 1;
-
-		/**
 		 * The render target
 		 *
 		 * @type {RenderTarget}
@@ -104,6 +97,15 @@ class RTTNode extends TextureNode {
 		 * @default true
 		 */
 		this.autoUpdate = true;
+
+		/**
+		 * The resolution scale
+		 *
+		 * @private
+		 * @type {number}
+		 * @default 1
+		 */
+		this._resolutionScale = 1;
 
 		/**
 		 * The node which is used with the quad mesh for RTT.
@@ -164,11 +166,8 @@ class RTTNode extends TextureNode {
 	 */
 	setSize( width, height ) {
 
-		this.width = width;
-		this.height = height;
-
-		const effectiveWidth = width * this.pixelRatio;
-		const effectiveHeight = height * this.pixelRatio;
+		const effectiveWidth = Math.round( width * this._resolutionScale );
+		const effectiveHeight = Math.round( height * this._resolutionScale );
 
 		this.renderTarget.setSize( effectiveWidth, effectiveHeight );
 
@@ -180,12 +179,43 @@ class RTTNode extends TextureNode {
 	 * Sets the pixel ratio. This will also resize the render target.
 	 *
 	 * @param {number} pixelRatio - The pixel ratio to set.
+	 * @deprecated since r185. Use "RTTNode.setSize( width * pixelRatio, height * pixelRatio )" instead.
 	 */
-	setPixelRatio( pixelRatio ) {
+	setPixelRatio( /*pixelRatio*/ ) {
 
-		this.pixelRatio = pixelRatio;
+		warnOnce( 'RTTNode: ".setPixelRatio()" is deprecated. Use "RTTNode.setSize( width * pixelRatio, height * pixelRatio )" instead.' );
 
-		this.setSize( this.width, this.height );
+	}
+
+	/**
+	 * Sets the resolution scale.
+	 * The resolution scale is a factor that is multiplied with the renderer's width and height.
+	 *
+	 * @param {number} resolutionScale - The resolution scale to set. A value of `1` means full resolution.
+	 * @returns {RTTNode} A reference to this node.
+	 */
+	setResolutionScale( resolutionScale ) {
+
+		this._resolutionScale = resolutionScale;
+
+		if ( this.autoResize === false ) {
+
+			this.setSize( this.width, this.height );
+
+		}
+
+		return this;
+
+	}
+
+	/**
+	 * Gets the resolution scale.
+	 *
+	 * @returns {number} The resolution scale.
+	 */
+	getResolutionScale() {
+
+		return this._resolutionScale;
 
 	}
 
@@ -201,23 +231,10 @@ class RTTNode extends TextureNode {
 
 		if ( this.autoResize === true ) {
 
-			let effectiveWidth;
-			let effectiveHeight;
+			const size = renderer.getDrawingBufferSize( _size );
 
-			if ( currentRenderTarget ) {
-
-				effectiveWidth = currentRenderTarget.width;
-				effectiveHeight = currentRenderTarget.height;
-
-			} else {
-
-				const pixelRatio = renderer.getPixelRatio();
-				const size = renderer.getSize( _size );
-
-				effectiveWidth = Math.floor( size.width * pixelRatio );
-				effectiveHeight = Math.floor( size.height * pixelRatio );
-
-			}
+			const effectiveWidth = Math.round( size.width * this._resolutionScale );
+			const effectiveHeight = Math.round( size.height * this._resolutionScale );
 
 			if ( effectiveWidth !== this.renderTarget.width || effectiveHeight !== this.renderTarget.height ) {
 

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -165,8 +165,8 @@ class RTTNode extends TextureNode {
 	 */
 	setSize( width, height ) {
 
-		const effectiveWidth = Math.round( width * this._resolutionScale );
-		const effectiveHeight = Math.round( height * this._resolutionScale );
+		const effectiveWidth = Math.floor( width * this._resolutionScale );
+		const effectiveHeight = Math.floor( height * this._resolutionScale );
 
 		this.renderTarget.setSize( effectiveWidth, effectiveHeight );
 
@@ -220,8 +220,8 @@ class RTTNode extends TextureNode {
 
 			const size = renderer.getDrawingBufferSize( _size );
 
-			const effectiveWidth = Math.round( size.width * this._resolutionScale );
-			const effectiveHeight = Math.round( size.height * this._resolutionScale );
+			const effectiveWidth = Math.floor( size.width * this._resolutionScale );
+			const effectiveHeight = Math.floor( size.height * this._resolutionScale );
 
 			if ( effectiveWidth !== this.renderTarget.width || effectiveHeight !== this.renderTarget.height ) {
 

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -176,18 +176,6 @@ class RTTNode extends TextureNode {
 	}
 
 	/**
-	 * Sets the pixel ratio. This will also resize the render target.
-	 *
-	 * @param {number} pixelRatio - The pixel ratio to set.
-	 * @deprecated since r185. Use "RTTNode.setSize( width * pixelRatio, height * pixelRatio )" instead.
-	 */
-	setPixelRatio( /*pixelRatio*/ ) {
-
-		warnOnce( 'RTTNode: ".setPixelRatio()" is deprecated. Use ".setSize( width * pixelRatio, height * pixelRatio )" instead.' );
-
-	}
-
-	/**
 	 * Sets the resolution scale.
 	 * The resolution scale is a factor that is multiplied with the renderer's width and height.
 	 *

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -8,7 +8,6 @@ import QuadMesh from '../../renderers/common/QuadMesh.js';
 import { RenderTarget } from '../../core/RenderTarget.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { HalfFloatType } from '../../constants.js';
-import { warnOnce } from '../../utils.js';
 
 const _size = /*@__PURE__*/ new Vector2();
 

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -183,7 +183,7 @@ class RTTNode extends TextureNode {
 	 */
 	setPixelRatio( /*pixelRatio*/ ) {
 
-		warnOnce( 'RTTNode: ".setPixelRatio()" is deprecated. Use "RTTNode.setSize( width * pixelRatio, height * pixelRatio )" instead.' );
+		warnOnce( 'RTTNode: ".setPixelRatio()" is deprecated. Use ".setSize( width * pixelRatio, height * pixelRatio )" instead.' );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33600#discussion_r3264779248

**Description**

Add `setResolutionScale()`, which has become a common interface for controlling renderer pass resolution. Considering that RTT is also one, this allows manual control of the operation and can make the auto-size logic less complex.

- [x] Introduce `RTTNode.setResolutionScale()`
- [x] Removed `RTTNode.setPixelRatio()` and `PassNode.setPixelRatio()`
- [x] Use `Renderer.getDrawingBufferSize()` as default to auto size