### PR TITLE
Fix typo in ARButton docstring

### DIFF
--- a/examples/jsm/webxr/ARButton.js
+++ b/examples/jsm/webxr/ARButton.js
@@ -1,7 +1,7 @@
 /**
  * A utility class for creating a button that allows to initiate
  * immersive AR sessions based on WebXR. The button can be created
- * with a factory method and then appended ot the website's DOM.
+ * with a factory method and then appended to the website's DOM.
  *
  * ```js
  * document.body.appendChild( ARButton.createButton( renderer ) );


### PR DESCRIPTION
I noticed a small typo while reading the documentation for `ARButton`, so this PR fixes it.
