### PR TITLE
USDLoader: Fix texture paths in standalone USD files.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -780,7 +780,7 @@ function Loader( editor ) {
 					const { USDLoader } = await import( 'three/addons/loaders/USDLoader.js' );
 
 					const loader = new USDLoader( manager );
-					loader.parse( contents, function ( group ) {
+					loader.parse( contents, '', function ( group ) {
 
 						group.name = filename;
 						editor.execute( new AddObjectCommand( editor, group ) );

--- a/examples/jsm/loaders/USDLoader.js
+++ b/examples/jsm/loaders/USDLoader.js
@@ -1,6 +1,7 @@
 import {
 	FileLoader,
-	Loader
+	Loader,
+	LoaderUtils
 } from 'three';
 
 import { unzipSync } from '../libs/fflate.module.js';
@@ -49,6 +50,8 @@ class USDLoader extends Loader {
 
 		const scope = this;
 
+		const path = ( scope.path === '' ) ? LoaderUtils.extractUrlBase( url ) : scope.path;
+
 		const loader = new FileLoader( scope.manager );
 		loader.setPath( scope.path );
 		loader.setResponseType( 'arraybuffer' );
@@ -58,7 +61,7 @@ class USDLoader extends Loader {
 
 			try {
 
-				scope.parse( text, onLoad, onError );
+				scope.parse( text, path, onLoad, onError );
 
 			} catch ( e ) {
 
@@ -88,11 +91,12 @@ class USDLoader extends Loader {
 	 * textures have finished loading.
 	 *
 	 * @param {ArrayBuffer|string} buffer - The raw USDZ data as an array buffer.
+	 * @param {string} [path=''] - Base URL or directory.
 	 * @param {function(Group)} [onLoad] - Executed once the group and all of its textures are ready.
 	 * @param {onErrorCallback} [onError] - Executed when errors occur.
 	 * @return {Group} The parsed asset as a group.
 	 */
-	parse( buffer, onLoad, onError ) {
+	parse( buffer, path = '', onLoad, onError ) {
 
 		const usda = new USDAParser();
 		const usdc = new USDCParser();
@@ -243,7 +247,7 @@ class USDLoader extends Loader {
 
 			const composer = new USDComposer( scope.manager );
 			const data = usda.parseData( buffer );
-			return finalize( composer, composer.compose( data, {} ) );
+			return finalize( composer, composer.compose( data, {}, {}, path ) );
 
 		}
 
@@ -253,7 +257,7 @@ class USDLoader extends Loader {
 
 			const composer = new USDComposer( scope.manager );
 			const data = usdc.parseData( toArrayBuffer( buffer ) );
-			return finalize( composer, composer.compose( data, {} ) );
+			return finalize( composer, composer.compose( data, {}, {}, path ) );
 
 		}
 
@@ -290,7 +294,7 @@ class USDLoader extends Loader {
 		const composer = new USDComposer( scope.manager );
 		const text = textDecoder.decode( bytes );
 		const data = usda.parseData( text );
-		return finalize( composer, composer.compose( data, {} ) );
+		return finalize( composer, composer.compose( data, {}, {}, path ) );
 
 	}
 

--- a/examples/jsm/loaders/USDLoader.js
+++ b/examples/jsm/loaders/USDLoader.js
@@ -91,7 +91,7 @@ class USDLoader extends Loader {
 	 * textures have finished loading.
 	 *
 	 * @param {ArrayBuffer|string} buffer - The raw USDZ data as an array buffer.
-	 * @param {string} [path=''] - Base URL or directory.
+	 * @param {string} [path=''] - The URL base path.
 	 * @param {function(Group)} [onLoad] - Executed once the group and all of its textures are ready.
 	 * @param {onErrorCallback} [onError] - Executed when errors occur.
 	 * @return {Group} The parsed asset as a group.

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -11,6 +11,7 @@ import {
 	DirectionalLight,
 	Euler,
 	Group,
+	LoaderUtils,
 	Matrix4,
 	Mesh,
 	MeshPhysicalMaterial,
@@ -854,14 +855,13 @@ class USDComposer {
 
 		}
 
-		// Combine with base path
-		if ( this.basePath ) {
+		if ( ! this.basePath ) return cleanPath;
 
-			return this.basePath + '/' + cleanPath;
+		// LoaderUtils.resolveURL expects basePath to end with a separator;
+		// the USDZ flow passes the zip-internal directory name without one.
+		const base = this.basePath.endsWith( '/' ) ? this.basePath : this.basePath + '/';
 
-		}
-
-		return cleanPath;
+		return LoaderUtils.resolveURL( cleanPath, base );
 
 	}
 
@@ -3816,6 +3816,16 @@ class USDComposer {
 					return this._createTextureFromData( this.assets[ key ], textureAttrs, transformAttrs );
 
 				}
+
+			}
+
+			// Standalone .usd/.usda/.usdc files don't pre-load assets; treat the
+			// resolved path as a URL relative to basePath so the browser fetches
+			// the texture from disk next to the layer.
+
+			if ( this.basePath ) {
+
+				return this._createTextureFromData( resolvedPath, textureAttrs, transformAttrs );
 
 			}
 


### PR DESCRIPTION
Closes #33609.

**Description**

The PR makes sure `USDLoader` is able to load textures in standalone USD files meaning when textures lives outside the USD archive.

Compared to #33609, the PR makes `USDLoader` more similar to `GLTFLoader` or `FBXLoader` by adding a `path` parameter to its `parse()` method. This is a not a breaking change since up to r184, the method only had one parameter. `onLoad()` and `onError()` were added just a few days ago, see #33582.