### PR TITLE
VRMLLoader: Allow multi-line strings.

### DIFF
--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -220,7 +220,7 @@ class VRMLLoader extends Loader {
 
 			//
 
-			const StringLiteral = createToken( { name: 'StringLiteral', pattern: /"(?:[^\\"\n\r]|\\[bfnrtv"\\/]|\\u[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])*"/ } );
+			const StringLiteral = createToken( { name: 'StringLiteral', pattern: /"(?:[^\\"]|\\[bfnrtv"\\/]|\\u[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])*"/ } );
 			const HexLiteral = createToken( { name: 'HexLiteral', pattern: /0[xX][0-9a-fA-F]+/ } );
 			const NumberLiteral = createToken( { name: 'NumberLiteral', pattern: /[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?/ } );
 			const TrueLiteral = createToken( { name: 'TrueLiteral', pattern: /TRUE/ } );

--- a/examples/models/vrml/multilineString.wrl
+++ b/examples/models/vrml/multilineString.wrl
@@ -1,0 +1,24 @@
+#VRML V2.0 utf8
+WorldInfo { title "Multi-line string literal test" }
+NavigationInfo { type "EXAMINE" }
+Background { skyColor [ 0.2 0.2 0.3 ] }
+
+Transform {
+	translation 0 0 0
+	children [
+		Shape {
+			appearance Appearance {
+				material Material { diffuseColor 0.2 0.8 0.4 }
+			}
+			geometry Box { size 1 1 1 }
+		}
+	]
+}
+
+DEF S Script {
+	url "javascript:
+function touched(value) {
+	console.log('Box was touched at ' + value);
+}
+"
+}

--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -56,7 +56,8 @@
 				'meshWithTexture',
 				'pixelTexture',
 				'points',
-				'camera'
+				'camera',
+				'multilineString'
 			];
 
 			let vrmlScene;


### PR DESCRIPTION
Related issue: #28959

**Description**

With this change, `VRMLLoader` supports newlines inside string literals which makes it more VRML97 spec conform. Added a new test asset to verify the fix. 

The whole idea behind this PR is to improve support for assets if they contain `Script` sections. The scripts are ignored but the lexer is now able to process them without errors.