### PR TITLE
AnimationAction: Fix time warping bug.

### DIFF
--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -56,6 +56,7 @@ class AnimationAction {
 		this._byClipCacheIndex = null; // for the memory manager
 
 		this._timeScaleInterpolant = null;
+		this._restoreTimeScale = null;
 		this._weightInterpolant = null;
 
 		/**
@@ -343,6 +344,10 @@ class AnimationAction {
 				startEndRatio = fadeOutDuration / fadeInDuration,
 				endStartRatio = fadeInDuration / fadeOutDuration;
 
+
+			fadeOutAction._restoreTimeScale = fadeOutAction.timeScale;
+			this._restoreTimeScale = this.timeScale;
+
 			fadeOutAction.warp( 1.0, startEndRatio, duration );
 			this.warp( endStartRatio, 1.0, duration );
 
@@ -510,6 +515,8 @@ class AnimationAction {
 			this._mixer._takeBackControlInterpolant( timeScaleInterpolant );
 
 		}
+
+		this._restoreTimeScale = null;
 
 		return this;
 
@@ -683,8 +690,6 @@ class AnimationAction {
 
 				if ( time > interpolant.parameterPositions[ 1 ] ) {
 
-					this.stopWarping();
-
 					if ( timeScale === 0 ) {
 
 						// motion has halted, pause
@@ -692,10 +697,18 @@ class AnimationAction {
 
 					} else {
 
+						if ( this._restoreTimeScale !== null ) {
+
+							timeScale = this._restoreTimeScale;
+
+						}
+
 						// warp done - apply final time scale
 						this.timeScale = timeScale;
 
 					}
+
+					this.stopWarping();
 
 				}
 


### PR DESCRIPTION
Fixed #11147.

**Description**

The PR attempts to fix a long-standing bug in the animation system that appears when using cross fading. It was overshadowed by most apps because a) they don't use warping when crossfading or b) if they use it, they use it in every transition. In these cases, the bug did not appear. However, if you mixing warping usage the bug becomes real.

Fiddle for reproduction: https://jsfiddle.net/k0wyj21r/1/

As you can see, after the second crossfade, the animation is played too slow because of a left-over time scale value (exactly what has been reported in https://github.com/mrdoob/three.js/issues/11147#issue-220408353). The PR makes sure to restore the correct time scale value after a warp.
