### PR TITLE
BufferGeometry: serialize mutated generators as raw data

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -195,6 +195,15 @@ class BufferGeometry extends EventDispatcher {
 		 */
 		this.userData = {};
 
+		/**
+		 * Whether this geometry's buffer data has changed after construction.
+		 *
+		 * @private
+		 * @type {boolean}
+		 * @default false
+		 */
+		this._mutated = false;
+
 	}
 
 	/**
@@ -366,6 +375,8 @@ class BufferGeometry extends EventDispatcher {
 
 		if ( position !== undefined ) {
 
+			this._mutated = true;
+
 			position.applyMatrix4( matrix );
 
 			position.needsUpdate = true;
@@ -375,6 +386,8 @@ class BufferGeometry extends EventDispatcher {
 		const normal = this.attributes.normal;
 
 		if ( normal !== undefined ) {
+
+			this._mutated = true;
 
 			const normalMatrix = new Matrix3().getNormalMatrix( matrix );
 
@@ -387,6 +400,8 @@ class BufferGeometry extends EventDispatcher {
 		const tangent = this.attributes.tangent;
 
 		if ( tangent !== undefined ) {
+
+			this._mutated = true;
 
 			tangent.transformDirection( matrix );
 
@@ -837,6 +852,8 @@ class BufferGeometry extends EventDispatcher {
 
 		}
 
+		this._mutated = true;
+
 		const positionAttribute = attributes.position;
 		const normalAttribute = attributes.normal;
 		const uvAttribute = attributes.uv;
@@ -992,6 +1009,8 @@ class BufferGeometry extends EventDispatcher {
 
 		if ( positionAttribute !== undefined ) {
 
+			this._mutated = true;
+
 			let normalAttribute = this.getAttribute( 'normal' );
 
 			if ( normalAttribute === undefined || normalAttribute.count !== positionAttribute.count ) {
@@ -1082,6 +1101,8 @@ class BufferGeometry extends EventDispatcher {
 	 * correct lighting on the geometry surfaces.
 	 */
 	normalizeNormals() {
+
+		this._mutated = true;
 
 		const normals = this.attributes.normal;
 
@@ -1223,11 +1244,11 @@ class BufferGeometry extends EventDispatcher {
 		// standard BufferGeometry serialization
 
 		data.uuid = this.uuid;
-		data.type = this.type;
+		data.type = this.parameters !== undefined && this._mutated === true ? 'BufferGeometry' : this.type;
 		if ( this.name !== '' ) data.name = this.name;
 		if ( Object.keys( this.userData ).length > 0 ) data.userData = this.userData;
 
-		if ( this.parameters !== undefined ) {
+		if ( this.parameters !== undefined && this._mutated === false ) {
 
 			const parameters = this.parameters;
 
@@ -1437,6 +1458,7 @@ class BufferGeometry extends EventDispatcher {
 		// user data
 
 		this.userData = source.userData;
+		this._mutated = source._mutated;
 
 		return this;
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -76,6 +76,8 @@ class ExtrudeGeometry extends BufferGeometry {
 
 		this.computeVertexNormals();
 
+		this._mutated = false;
+
 		// functions
 
 		function addShape( shape ) {
@@ -763,6 +765,8 @@ class ExtrudeGeometry extends BufferGeometry {
 	toJSON() {
 
 		const data = super.toJSON();
+
+		if ( data.type === 'BufferGeometry' ) return data;
 
 		const shapes = this.parameters.shapes;
 		const options = this.parameters.options;

--- a/src/geometries/PolyhedronGeometry.js
+++ b/src/geometries/PolyhedronGeometry.js
@@ -73,6 +73,8 @@ class PolyhedronGeometry extends BufferGeometry {
 
 		}
 
+		this._mutated = false;
+
 		// helper functions
 
 		function subdivide( detail ) {

--- a/src/geometries/ShapeGeometry.js
+++ b/src/geometries/ShapeGeometry.js
@@ -174,6 +174,8 @@ class ShapeGeometry extends BufferGeometry {
 
 		const data = super.toJSON();
 
+		if ( data.type === 'BufferGeometry' ) return data;
+
 		const shapes = this.parameters.shapes;
 
 		return toJSON( shapes, data );

--- a/src/geometries/TubeGeometry.js
+++ b/src/geometries/TubeGeometry.js
@@ -220,6 +220,8 @@ class TubeGeometry extends BufferGeometry {
 
 		const data = super.toJSON();
 
+		if ( data.type === 'BufferGeometry' ) return data;
+
 		data.path = this.parameters.path.toJSON();
 
 		return data;

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -1,4 +1,5 @@
 import { BufferGeometry } from '../../../../src/core/BufferGeometry.js';
+import { BoxGeometry } from '../../../../src/geometries/BoxGeometry.js';
 
 import {
 	BufferAttribute,
@@ -605,6 +606,29 @@ export default QUnit.module( 'Core', () => {
 			gold.data.morphTargetsRelative = false;
 
 			assert.deepEqual( j, gold, 'Generated JSON with morphAttributes is as expected' );
+
+		} );
+
+		QUnit.test( 'toJSON with mutated geometry generator', ( assert ) => {
+
+			const geometry = new BoxGeometry( 5, 5, 5 );
+
+			const parametersJSON = geometry.toJSON();
+
+			assert.strictEqual( parametersJSON.type, 'BoxGeometry', 'Geometry generator type is serialized before mutation' );
+			assert.strictEqual( parametersJSON.width, 5, 'Constructor parameters are serialized before mutation' );
+			assert.strictEqual( parametersJSON.data, undefined, 'Raw geometry data is omitted before mutation' );
+
+			geometry.translate( 10, 20, 10 );
+
+			const dataJSON = geometry.toJSON();
+			const position = dataJSON.data.attributes.position.array;
+
+			assert.strictEqual( dataJSON.type, 'BufferGeometry', 'Mutated geometry generator serializes as raw buffer data' );
+			assert.strictEqual( dataJSON.width, undefined, 'Constructor parameters are omitted after mutation' );
+			assert.strictEqual( position[ 0 ], 12.5, 'Serialized x coordinate includes translation' );
+			assert.strictEqual( position[ 1 ], 22.5, 'Serialized y coordinate includes translation' );
+			assert.strictEqual( position[ 2 ], 12.5, 'Serialized z coordinate includes translation' );
 
 		} );
 


### PR DESCRIPTION
Related issue: #22586

**Description**

When a generated geometry such as `BoxGeometry` is mutated after construction, `toJSON()` still serialized only the original constructor parameters. That dropped buffer mutations like `translate()` from the JSON output.

This adds an internal mutation flag for buffer-changing operations and falls back to raw `BufferGeometry` serialization for mutated generated geometries, while preserving parameter serialization for untouched generators. Constructor-time normal generation in generated geometries remains clean.

Validation:
- `npm run lint-core`
- `npx eslint test/unit/src/core/BufferGeometry.tests.js`
- `PUPPETEER_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" npm run test-unit`
- `git diff --check`

Note: `npm run lint-test` currently reports an existing trailing-space error in `test/unit/src/extras/curves/CatmullRomCurve3.tests.js`, which this PR does not touch.