### PR TITLE
Box3: Improve docs.

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -142,6 +142,10 @@ class Box3 {
 	 * (including its children), accounting for the object's, and children's,
 	 * world transforms. The function may result in a larger box than strictly necessary.
 	 *
+	 * Note: To compute the correct bounding box, make sure the given 3D object
+	 * has an up-to-date world matrix that reflects the current transformation of its
+	 * ancestor nodes. Call `updateWorldMatrix( true, false )` beforehand if you're unsure.
+	 *
 	 * @param {Object3D} object - The 3D object to compute the bounding box for.
 	 * @param {boolean} [precise=false] - If set to `true`, the method computes the smallest
 	 * world-axis-aligned bounding box at the expense of more computation.


### PR DESCRIPTION
Fixed #21404.

**Description**

The PR clarifies the usage of `setFromObject()` to make sure world matrices are up-to-date before calling this method.
