### PR TITLE
Add value support to TSL Return

### DIFF
--- a/src/nodes/utils/Discard.js
+++ b/src/nodes/utils/Discard.js
@@ -1,6 +1,7 @@
 import { select } from '../math/ConditionalNode.js';
 import { expression } from '../code/ExpressionNode.js';
 import { addMethodChaining } from '../tsl/TSLCore.js';
+import { returnNode } from './ReturnNode.js';
 
 /**
  * Represents a `discard` shader operation in TSL.
@@ -17,8 +18,10 @@ export const Discard = ( conditional ) => ( conditional ? select( conditional, e
  *
  * @tsl
  * @function
- * @return {ExpressionNode} The `return` expression.
+ * @param {?Node} value - Optional return value.
+ * @return {ReturnNode} The `return` expression.
  */
-export const Return = () => expression( 'return' ).toStack();
+export const Return = ( value = null ) => returnNode( value ).toStack();
 
 addMethodChaining( 'discard', Discard );
+addMethodChaining( 'return', Return );

--- a/src/nodes/utils/ReturnNode.js
+++ b/src/nodes/utils/ReturnNode.js
@@ -1,0 +1,40 @@
+import Node from '../core/Node.js';
+import { nodeObject, nodeProxy } from '../tsl/TSLCore.js';
+
+class ReturnNode extends Node {
+
+	static get type() {
+
+		return 'ReturnNode';
+
+	}
+
+	constructor( valueNode = null ) {
+
+		super( 'void' );
+
+		this.valueNode = valueNode;
+
+	}
+
+	generate( builder ) {
+
+		if ( this.valueNode !== null ) {
+
+			const snippet = this.valueNode.build( builder );
+
+			builder.addLineFlowCode( `return ${ snippet };`, this );
+
+		} else {
+
+			builder.addLineFlowCode( 'return;', this );
+
+		}
+
+	}
+
+}
+
+export default ReturnNode;
+
+export const returnNode = ( value = null ) => nodeProxy( ReturnNode )( value === null ? null : nodeObject( value ) );


### PR DESCRIPTION
Related issue: #33403

## Description

This PR adds value support for `Return()` in TSL by introducing a dedicated `ReturnNode`.

Previously, `Return()` only generated a plain `return` expression and did not support returning node values inside `Fn()` control flow. This made early-return patterns difficult or impossible in some TSL functions.

The new `ReturnNode` builds and emits proper flow code using node-generated snippets, enabling patterns like:

```js
If( x.lessThan( 0 ), () => {

	Return( 0 );

} );
```

This keeps return handling aligned with the node-based architecture used throughout TSL and improves compatibility with shader code generation.


