### PR TITLE
Editor: Fix `ListboxItem` text content.

### DIFF
--- a/editor/js/Sidebar.Project.Resources.js
+++ b/editor/js/Sidebar.Project.Resources.js
@@ -128,6 +128,7 @@ function SidebarProjectResources( editor ) {
 	function refreshTexturesUI() {
 
 		const textures = [];
+		const types = [];
 		const texturesUsed = new Set();
 
 		const materials = Object.values( editor.materials );
@@ -143,6 +144,7 @@ function SidebarProjectResources( editor ) {
 					if ( texturesUsed.has( value.uuid ) === false ) {
 
 						textures.push( value );
+						types.push( getTextureType( value ) );
 						texturesUsed.add( value.uuid );
 
 					}
@@ -153,8 +155,27 @@ function SidebarProjectResources( editor ) {
 
 		}
 
-		texturesListbox.setItems( textures );
+		texturesListbox.setItems( textures, types );
 		texturesInfo.setValue( textures.length + ' ' + strings.getKey( 'sidebar/project/textures' ).toLowerCase() );
+
+	}
+
+	function getTextureType( texture ) {
+
+		if ( texture.isCanvasTexture ) return 'CanvasTexture';
+		if ( texture.isVideoTexture ) return 'VideoTexture';
+		if ( texture.isCubeDepthTexture ) return 'CubeDepthTexture';
+		if ( texture.isDepthTexture ) return 'DepthTexture';
+		if ( texture.isCompressedArrayTexture ) return 'CompressedArrayTexture';
+		if ( texture.isCompressedCubeTexture ) return 'CompressedCubeTexture';
+		if ( texture.isCompressedTexture ) return 'CompressedTexture';
+		if ( texture.isCubeTexture ) return 'CubeTexture';
+		if ( texture.isData3DTexture ) return 'Data3DTexture';
+		if ( texture.isDataArrayTexture ) return 'DataArrayTexture';
+		if ( texture.isDataTexture ) return 'DataTexture';
+		if ( texture.isFramebufferTexture ) return 'FramebufferTexture';
+
+		return 'Texture';
 
 	}
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -1205,7 +1205,7 @@ class UIListbox extends UIDiv {
 
 			const listitem = new ListboxItem( this );
 			listitem.setId( item.id || `Listbox-${i}` );
-			listitem.setTextContent( item.name || item.type );
+			listitem.setTextContent( item.name || item.constructor.name );
 			this.add( listitem );
 
 		}

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -1184,7 +1184,11 @@ class UIListbox extends UIDiv {
 
 		}
 
-		this.types = types;
+		if ( Array.isArray( types ) ) {
+
+			this.types = types;
+
+		}
 
 		this.render();
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -1169,19 +1169,22 @@ class UIListbox extends UIDiv {
 		this.dom.tabIndex = 0;
 
 		this.items = [];
+		this.types = [];
 		this.listitems = [];
 		this.selectedIndex = 0;
 		this.selectedValue = null;
 
 	}
 
-	setItems( items ) {
+	setItems( items, types = [] ) {
 
 		if ( Array.isArray( items ) ) {
 
 			this.items = items;
 
 		}
+
+		this.types = types;
 
 		this.render();
 
@@ -1205,7 +1208,7 @@ class UIListbox extends UIDiv {
 
 			const listitem = new ListboxItem( this );
 			listitem.setId( item.id || `Listbox-${i}` );
-			listitem.setTextContent( item.name || item.constructor.name );
+			listitem.setTextContent( item.name || this.types[ i ] || item.type );
 			this.add( listitem );
 
 		}


### PR DESCRIPTION
Related issue: #32729

**Description**

The resource panel in the editor does not properly list textures because the listbox shows the `type` property of its items which has a different semantics in three.js classes though. `Object3D`, `BufferGeometry` or `Material` hold the object type but `Texture.type` describes the texture's _data_ type so it holds values like `THREE.UnsignedByteType`. Hence, the texture panel lists now meaningless numbers:

<img width="332" height="78" alt="image" src="https://github.com/user-attachments/assets/e374c9d0-fadd-4aef-beff-31859ccb8ff7" />

With this PR, `UIListbox` uses `item.constructor.name` which works for all objects. 

FYI: Using `item.constructor.name` would break if the editor uses the minified builds or is bundled but I'm not aware of another solution at the moment. Alternatively, we just remove the texture resource tab. You can't assign textures anyway so it's a plain list at the moment with no further functionality.

Edit: I've found another solution without relying on `item.constructor.name`. It's a bit more code but less error prone. The list box now accepts an optional `types` array. When set, the `.type` property is not evaluated. The `types` array for the textures is derived from the `is*` flags. 