### PR TITLE
SphereGeometry: Make pole vertices more robust.

### DIFF
--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -101,6 +101,15 @@ class SphereGeometry extends BufferGeometry {
 				vertex.y = radius * Math.cos( thetaStart + v * thetaLength );
 				vertex.z = radius * Math.sin( phiStart + u * phiLength ) * Math.sin( thetaStart + v * thetaLength );
 
+				// snap south-pole vertices to the axis to avoid floating point inaccuracies
+
+				if ( iy === heightSegments && ( thetaStart + thetaLength ) === Math.PI ) {
+
+					vertex.x = 0;
+					vertex.z = 0;
+
+				}
+
 				vertices.push( vertex.x, vertex.y, vertex.z );
 
 				// normal

--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -76,6 +76,10 @@ class SphereGeometry extends BufferGeometry {
 			const verticesRow = [];
 
 			const v = iy / heightSegments;
+			const theta = thetaStart + v * thetaLength;
+
+			const y = radius * Math.cos( theta );
+			const ringRadius = Math.sqrt( radius * radius - y * y );
 
 			// special case for the poles
 
@@ -94,21 +98,13 @@ class SphereGeometry extends BufferGeometry {
 			for ( let ix = 0; ix <= widthSegments; ix ++ ) {
 
 				const u = ix / widthSegments;
+				const phi = phiStart + u * phiLength;
 
 				// vertex
 
-				vertex.x = - radius * Math.cos( phiStart + u * phiLength ) * Math.sin( thetaStart + v * thetaLength );
-				vertex.y = radius * Math.cos( thetaStart + v * thetaLength );
-				vertex.z = radius * Math.sin( phiStart + u * phiLength ) * Math.sin( thetaStart + v * thetaLength );
-
-				// snap south-pole vertices to the axis to avoid floating point inaccuracies
-
-				if ( iy === heightSegments && ( thetaStart + thetaLength ) === Math.PI ) {
-
-					vertex.x = 0;
-					vertex.z = 0;
-
-				}
+				vertex.x = - ringRadius * Math.cos( phi );
+				vertex.y = y;
+				vertex.z = ringRadius * Math.sin( phi );
 
 				vertices.push( vertex.x, vertex.y, vertex.z );
 


### PR DESCRIPTION
Related issue: #11449

**Description**

While revisiting #11449, I have noticed that even alternative ray casting approaches struggle with `SphereGeometry` because of how the pole vertices are computed. `Math.sin( Math.PI )` produces no exact zero but something like `1.2246467991473532e-16` which means the vertices never lie exactly on the local y-axis. By snapping the south-pole vertices exactly to the y-axis, the broken ray/triangle intersection test from #11449 (see https://jsfiddle.net/zraqkg2f/3/) starts to work with our present algorithm.

Even outside of ray casting, this simple fix makes the vertex data a bit more robust and exact.
