### PR TITLE
Examples: Cleanup webgpu_postprocessing_ssaa

### DIFF
--- a/examples/webgpu_postprocessing_ssaa.html
+++ b/examples/webgpu_postprocessing_ssaa.html
@@ -186,7 +186,7 @@
 
 				}
 
-				let newColor = ssaaRenderPass.clearColor;
+				let newColor;
 
 				switch ( params.clearColor ) {
 


### PR DESCRIPTION
Related issue: #33478

**Description**

`ssaaRenderPass.clearColor` does not exist after https://github.com/mrdoob/three.js/pull/33478