### PR TITLE
NodeBuilder: Fast-path getDataFromNode when no sub-build is active.

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1852,6 +1852,8 @@ class NodeBuilder {
 
 		let data = nodeData[ shaderStage ];
 
+		if ( this.subBuildLayers.length === 0 ) return data;
+
 		const subBuilds = nodeData.any ? nodeData.any.subBuilds : null;
 		const subBuild = this.getClosestSubBuild( subBuilds );
 


### PR DESCRIPTION
**Description**

@sunag Asked claude to look for opportunities to improve TSL compilation performance...

> `getDataFromNode` is one of the hottest functions in TSL compilation. It unconditionally calls `getClosestSubBuild()` even when no sub-build is active — the common case, where the call cannot return anything but `null`.

This makes `webgpu_loader_materialx` ~8% faster.