### PR TITLE
GTAONode: Hemisphere clamping of horizon angles

### DIFF
--- a/docs/pages/GTAONode.html.md
+++ b/docs/pages/GTAONode.html.md
@@ -4,7 +4,7 @@
 
 Post processing node for applying Ground Truth Ambient Occlusion (GTAO) to a scene.
 
-Reference: [Practical Real-Time Strategies for Accurate Indirect Occlusion](https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf).
+Reference: [Practical Real-Time Strategies for Accurate Indirect Occlusion](https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf) and its relative [Slides Deck](https://blog.selfshadow.com/publications/s2016-shading-course/activision/s2016_pbs_activision_occlusion.pdf).
 
 ## Code Example
 

--- a/docs/pages/GTAONode.html.md
+++ b/docs/pages/GTAONode.html.md
@@ -4,7 +4,7 @@
 
 Post processing node for applying Ground Truth Ambient Occlusion (GTAO) to a scene.
 
-Reference: [Practical Real-Time Strategies for Accurate Indirect Occlusion](https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf) and its relative [Slides Deck](https://blog.selfshadow.com/publications/s2016-shading-course/activision/s2016_pbs_activision_occlusion.pdf).
+Reference: [Practical Real-Time Strategies for Accurate Indirect Occlusion](https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf).
 
 ## Code Example
 

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -31,6 +31,7 @@ let _rendererState;
  * ```
  *
  * Reference: [Practical Real-Time Strategies for Accurate Indirect Occlusion](https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf).
+ * Reference: [Slides Deck for Practical Real-Time Strategies for Accurate Indirect Occlusion](https://blog.selfshadow.com/publications/s2016-shading-course/activision/s2016_pbs_activision_occlusion.pdf).
  *
  * @augments TempNode
  * @three_import import { ao } from 'three/addons/tsl/display/GTAONode.js';

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -365,6 +365,12 @@ class GTAONode extends TempNode {
 
 			const ao = float( 0 ).toVar();
 
+			// Hemisphere clamp: ±( π/2 − ε ) around the projected normal angle. The 0.05 rad bias
+			// reduces self-shadowing artifacts at grazing angles. (Activision GTAO slides, Slide 58
+			// "Integration Domain": h₁' = n + max(h₁ − n, −π/2), h₂' = n + min(h₂ − n, π/2); paper
+			// Section 4.1, Eq. 5 — the max(cos(θ − γ), 0)⁺ clipping in the visibility integrand.)
+			const HEMISPHERE_MAX_ANGLE = float( Math.PI * 0.5 - 0.05 );
+
 			// Each iteration analyzes one vertical "slice" of the 3D space around the fragment.
 
 			Loop( { start: int( 0 ), end: DIRECTIONS, type: 'int', condition: '<' }, ( { i } ) => {
@@ -442,6 +448,13 @@ class GTAONode extends TempNode {
 
 				const hPos = acos( cosHorizons.y ).toVar();
 				const hNeg = acos( cosHorizons.x ).negate().toVar();
+
+				// Clamp horizons to the hemisphere around the (projected) shading normal.
+				const hPosLimit = angleN.add( HEMISPHERE_MAX_ANGLE );
+				hPos.assign( hPos.lessThan( hPosLimit ).select( hPos, hPosLimit ) );
+
+				const hNegLimit = angleN.sub( HEMISPHERE_MAX_ANGLE );
+				hNeg.assign( hNeg.greaterThan( hNegLimit ).select( hNeg, hNegLimit ) );
 
 				const termPos = cos( hPos.mul( 2 ).sub( angleN ) ).negate().add( nCos ).add( hPos.mul( 2 ).mul( nSin ) );
 				const termNeg = cos( hNeg.mul( 2 ).sub( angleN ) ).negate().add( nCos ).add( hNeg.mul( 2 ).mul( nSin ) );


### PR DESCRIPTION
Related issue: #33632

**Description**

This is more of a correctness change as well, it doesn't have visible change in normal conditions. It implements the Slide 58 of the [slides deck](https://blog.selfshadow.com/publications/s2016-shading-course/activision/s2016_pbs_activision_occlusion.pdf) (also the integral in Equation 5 of [the paper](https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf)), plus a small bias to correct for self-shadowing.

This is needed since cosine-weighted integrand already uses `cos(θ − γ)⁺ = max(cos(θ − γ), 0)` (Equation 5 of the paper) to drop contributions from below the tangent plane. Concretely, horizons need to be clamped to `±(π/2 − 0.05)` around the projected-normal angle.

DEV: https://raw.githack.com/mrdoob/three.js/refs/heads/dev/examples/webgpu_postprocessing_ao.html
PR: https://raw.githack.com/marcofugaro/three.js/refs/heads/gtao-hemisphere-clamp/examples/webgpu_postprocessing_ao.html
