### PR TITLE
Ray: New watertight intersectTriangle().

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -185,6 +185,11 @@ class Raycaster {
 	 * be detected. To raycast against both faces of an object, you'll want to set  {@link Material#side}
 	 * to `THREE.DoubleSide`.
 	 *
+	 * Note that a ray hitting a triangle mesh exactly along an edge shared by two faces may be
+	 * reported by both faces, resulting in two coincident intersections (identical point and
+	 * distance) in the returned array. Code that expects a single result per surface crossing
+	 * should account for this.
+	 *
 	 * @param {Object3D} object - The 3D object to check for intersection with the ray.
 	 * @param {boolean} [recursive=true] - If set to `true`, it also checks all descendants.
 	 * Otherwise it only checks intersection with the object.

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -187,8 +187,7 @@ class Raycaster {
 	 *
 	 * Note that a ray hitting a triangle mesh exactly along an edge shared by two faces may be
 	 * reported by both faces, resulting in two coincident intersections (identical point and
-	 * distance) in the returned array. Code that expects a single result per surface crossing
-	 * should account for this.
+	 * distance) in the returned array.
 	 *
 	 * @param {Object3D} object - The 3D object to check for intersection with the ray.
 	 * @param {boolean} [recursive=true] - If set to `true`, it also checks all descendants.

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -5,10 +5,6 @@ const _segCenter = /*@__PURE__*/ new Vector3();
 const _segDir = /*@__PURE__*/ new Vector3();
 const _diff = /*@__PURE__*/ new Vector3();
 
-const _edge1 = /*@__PURE__*/ new Vector3();
-const _edge2 = /*@__PURE__*/ new Vector3();
-const _normal = /*@__PURE__*/ new Vector3();
-
 /**
  * A ray that emits from an origin in a certain direction. The class is used by
  * {@link Raycaster} to assist with raycasting. Raycasting is used for
@@ -539,76 +535,128 @@ class Ray {
 	 */
 	intersectTriangle( a, b, c, backfaceCulling, target ) {
 
-		// Compute the offset origin, edges, and normal.
+		// Watertight ray/triangle intersection. Reference: Woop, Benthin, Wald,
+		// "Watertight Ray/Triangle Intersection", JCGT vol. 2 no. 1 (2013), Appendix A.
+		// https://jcgt.org/published/0002/01/05/
 
-		// from https://github.com/pmjoniak/GeometricTools/blob/master/GTEngine/Include/Mathematics/GteIntrRay3Triangle3.h
+		const origin = this.origin;
+		const direction = this.direction;
 
-		_edge1.subVectors( b, a );
-		_edge2.subVectors( c, a );
-		_normal.crossVectors( _edge1, _edge2 );
+		const dx = direction.x;
+		const dy = direction.y;
+		const dz = direction.z;
 
-		// Solve Q + t*D = b1*E1 + b2*E2 (Q = kDiff, D = ray direction,
-		// E1 = kEdge1, E2 = kEdge2, N = Cross(E1,E2)) by
-		//   |Dot(D,N)|*b1 = sign(Dot(D,N))*Dot(D,Cross(Q,E2))
-		//   |Dot(D,N)|*b2 = sign(Dot(D,N))*Dot(D,Cross(E1,Q))
-		//   |Dot(D,N)|*t = -sign(Dot(D,N))*Dot(Q,N)
-		let DdN = this.direction.dot( _normal );
-		let sign;
+		// triangle vertices relative to the ray origin
 
-		if ( DdN > 0 ) {
+		const aox = a.x - origin.x, aoy = a.y - origin.y, aoz = a.z - origin.z;
+		const box = b.x - origin.x, boy = b.y - origin.y, boz = b.z - origin.z;
+		const cox = c.x - origin.x, coy = c.y - origin.y, coz = c.z - origin.z;
 
-			if ( backfaceCulling ) return null;
-			sign = 1;
+		// Use the dimension where the ray direction is maximal as the projection
+		// axis (kz) and read every component already permuted into (kx, ky, kz).
+		// kx and ky are swapped when the direction's kz component is negative, to
+		// preserve the winding order of triangles.
 
-		} else if ( DdN < 0 ) {
+		const adx = Math.abs( dx ), ady = Math.abs( dy ), adz = Math.abs( dz );
 
-			sign = - 1;
-			DdN = - DdN;
+		let dkx, dky, dkz;
+		let akx, aky, akz, bkx, bky, bkz, ckx, cky, ckz;
+
+		if ( adx >= ady && adx >= adz ) {
+
+			dkz = dx; akz = aox; bkz = box; ckz = cox;
+
+			if ( dx >= 0 ) {
+
+				dkx = dy; dky = dz;
+				akx = aoy; aky = aoz; bkx = boy; bky = boz; ckx = coy; cky = coz;
+
+			} else {
+
+				dkx = dz; dky = dy;
+				akx = aoz; aky = aoy; bkx = boz; bky = boy; ckx = coz; cky = coy;
+
+			}
+
+		} else if ( ady >= adz ) {
+
+			dkz = dy; akz = aoy; bkz = boy; ckz = coy;
+
+			if ( dy >= 0 ) {
+
+				dkx = dz; dky = dx;
+				akx = aoz; aky = aox; bkx = boz; bky = box; ckx = coz; cky = cox;
+
+			} else {
+
+				dkx = dx; dky = dz;
+				akx = aox; aky = aoz; bkx = box; bky = boz; ckx = cox; cky = coz;
+
+			}
 
 		} else {
 
-			return null;
+			dkz = dz; akz = aoz; bkz = boz; ckz = coz;
+
+			if ( dz >= 0 ) {
+
+				dkx = dx; dky = dy;
+				akx = aox; aky = aoy; bkx = box; bky = boy; ckx = cox; cky = coy;
+
+			} else {
+
+				dkx = dy; dky = dx;
+				akx = aoy; aky = aox; bkx = boy; bky = box; ckx = coy; cky = cox;
+
+			}
 
 		}
 
-		_diff.subVectors( this.origin, a );
-		const DdQxE2 = sign * this.direction.dot( _edge2.crossVectors( _diff, _edge2 ) );
+		// a zero direction has no maximal axis and cannot intersect
 
-		// b1 < 0, no intersection
-		if ( DdQxE2 < 0 ) {
+		if ( dkz === 0 ) return null;
 
-			return null;
+		// shear constants that align the ray with the +kz axis
 
-		}
+		const sx = dkx / dkz, sy = dky / dkz, sz = 1 / dkz;
 
-		const DdE1xQ = sign * this.direction.dot( _edge1.cross( _diff ) );
+		// sheared and scaled vertices
 
-		// b2 < 0, no intersection
-		if ( DdE1xQ < 0 ) {
+		const ax = akx - sx * akz, ay = aky - sy * akz;
+		const bx = bkx - sx * bkz, by = bky - sy * bkz;
+		const cx = ckx - sx * ckz, cy = cky - sy * ckz;
 
-			return null;
+		// scaled barycentric coordinates (signed edge functions); the shear makes a
+		// shared edge evaluate identically for both adjacent triangles, so the ray
+		// can never fall between them
 
-		}
+		const u = cx * by - cy * bx;
+		const v = ax * cy - ay * cx;
+		const w = bx * ay - by * ax;
 
-		// b1+b2 > 1, no intersection
-		if ( DdQxE2 + DdE1xQ > DdN ) {
+		if ( backfaceCulling ) {
 
-			return null;
+			if ( u < 0 || v < 0 || w < 0 ) return null;
 
-		}
+		} else {
 
-		// Line intersects triangle, check if ray does.
-		const QdN = - sign * _diff.dot( _normal );
-
-		// t < 0, no intersection
-		if ( QdN < 0 ) {
-
-			return null;
+			if ( ( u < 0 || v < 0 || w < 0 ) && ( u > 0 || v > 0 || w > 0 ) ) return null;
 
 		}
 
-		// Ray intersects triangle.
-		return this.at( QdN / DdN, target );
+		const det = u + v + w;
+
+		// ray is co-planar with the triangle
+
+		if ( det === 0 ) return null;
+
+		// scaled hit distance; t = tScaled / det must lie in front of the origin
+
+		const tScaled = sz * ( u * akz + v * bkz + w * ckz );
+
+		if ( det > 0 ? tScaled < 0 : tScaled > 0 ) return null;
+
+		return this.at( tScaled / det, target );
 
 	}
 

--- a/test/unit/src/math/Ray.tests.js
+++ b/test/unit/src/math/Ray.tests.js
@@ -431,6 +431,38 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( 'intersectTriangle (watertight at shared edges)', ( assert ) => {
+
+			// Two triangles forming a quad and sharing the diagonal edge from
+			// ( -2, -2, -2 ) to ( 2, -2, 2 ). A ray aimed exactly at the midpoint of
+			// that shared edge must be detected: a non-watertight test can let the ray
+			// slip through the seam between the triangles and miss both of them.
+
+			const t1a = new Vector3( - 2, - 2, 2 );
+			const t1b = new Vector3( - 2, - 2, - 2 );
+			const t1c = new Vector3( 2, - 2, 2 );
+
+			const t2a = new Vector3( - 2, - 2, - 2 );
+			const t2b = new Vector3( 2, - 2, - 2 );
+			const t2c = new Vector3( 2, - 2, 2 );
+
+			const seam = new Vector3( 0, - 2, 0 ); // midpoint of the shared edge
+			const origin = new Vector3( - 4, - 9, 0.4 );
+			const direction = new Vector3().subVectors( seam, origin ).normalize();
+			const ray = new Ray( origin, direction );
+
+			const p1 = new Vector3();
+			const p2 = new Vector3();
+			const hit1 = ray.intersectTriangle( t1a, t1b, t1c, false, p1 );
+			const hit2 = ray.intersectTriangle( t2a, t2b, t2c, false, p2 );
+
+			assert.ok( hit1 !== null || hit2 !== null, 'Ray hitting the shared edge is not dropped' );
+
+			const hit = hit1 !== null ? p1 : p2;
+			assert.ok( hit.distanceTo( seam ) <= eps, 'Intersection lies on the shared edge' );
+
+		} );
+
 		QUnit.test( 'applyMatrix4', ( assert ) => {
 
 			let a = new Ray( one3.clone(), new Vector3( 0, 0, 1 ) );


### PR DESCRIPTION
Fixed #11449.

**Description**

The current implemented ray/triangle intersection test based on Möller–Trumbore is not watertight. As demonstrated in https://github.com/mrdoob/three.js/issues/11449#issuecomment-4553309085, the algorithm can miss intersections if the ray travels exactly through an edge or vertex because of minor floating point precision issues.

This PR implements the Woop–Benthin–Wald watertight algorithm (see https://jcgt.org/published/0002/01/05/paper.pdf) which fixes the issue reported in https://github.com/mrdoob/three.js/issues/11449#issuecomment-4553309085. It's a port of the pseudo C++ implementation from Appendix A.

I've created a performance benchmark that compares both approaches in an isolated fashion: https://jsfiddle.net/qtm304pL/

Chrome (macOS):
```
— random ray + random triangle each call —
  cull=false  old(Möller) 41.04 Mops/s  new(watertight) 56.50 Mops/s  → new is 1.38x faster
  cull=true  old(Möller) 43.03 Mops/s  new(watertight) 62.82 Mops/s  → new is 1.46x faster
— one fixed ray vs many triangles (mesh raycast) —
  cull=false  old(Möller) 29.57 Mops/s  new(watertight) 51.52 Mops/s  → new is 1.74x faster
  cull=true  old(Möller) 45.41 Mops/s  new(watertight) 54.11 Mops/s  → new is 1.19x faster
```
Firefox (macOS)
```
— random ray + random triangle each call —
  cull=false  old(Möller) 17.36 Mops/s  new(watertight) 37.58 Mops/s  → new is 2.17x faster
  cull=true  old(Möller) 23.01 Mops/s  new(watertight) 37.24 Mops/s  → new is 1.62x faster
— one fixed ray vs many triangles (mesh raycast) —
  cull=false  old(Möller) 17.89 Mops/s  new(watertight) 36.25 Mops/s  → new is 2.03x faster
  cull=true  old(Möller) 23.81 Mops/s  new(watertight) 38.64 Mops/s  → new is 1.62x faster
```
Safari (macOS)
```
— random ray + random triangle each call —
  cull=false  old(Möller) 40.55 Mops/s  new(watertight) 66.06 Mops/s  → new is 1.63x faster
  cull=true  old(Möller) 55.35 Mops/s  new(watertight) 58.51 Mops/s  → new is 1.06x faster
— one fixed ray vs many triangles (mesh raycast) —
  cull=false  old(Möller) 42.67 Mops/s  new(watertight) 58.51 Mops/s  → new is 1.37x faster
  cull=true  old(Möller) 56.11 Mops/s  new(watertight) 48.76 Mops/s  → new is 0.87x slower
```
These numbers vary slightly when executing the test over and over but that is not unusual when doing benchmarking with JS. It makes sense to test the performance on more device but at the moment the the new algorithm is not only more correct but _in average_ a bit faster.