### PR TITLE
KTX2Loader: Fix regression in rgba16 unorm support

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -971,6 +971,8 @@ KTX2Loader.BasisWorker = function () {
 
 const UNCOMPRESSED_FORMATS = new Set( [ RGBAFormat, RGBFormat, RGFormat, RedFormat ] );
 
+const NORMALIZED_VK_FORMATS = new Set( [ VK_FORMAT_R16G16B16A16_UNORM ] );
+
 const FORMAT_MAP = {
 
 	[ VK_FORMAT_R32G32B32A32_SFLOAT ]: RGBAFormat,
@@ -1220,6 +1222,7 @@ async function createRawTexture( container ) {
 		texture.minFilter = useMipmaps ? NearestMipmapNearestFilter : NearestFilter;
 		texture.magFilter = NearestFilter;
 		texture.generateMipmaps = container.levelCount === 0;
+		texture.normalized = NORMALIZED_VK_FORMATS.has( vkFormat );
 
 	} else {
 


### PR DESCRIPTION
Related:

- #33245
- #33193

| before | after |
|---|---|
| <img width="1550" height="1508" alt="before" src="https://github.com/user-attachments/assets/c45119f2-4617-41cb-9595-6dec520269aa" /> | <img width="1562" height="1514" alt="after" src="https://github.com/user-attachments/assets/a303d72e-a972-4f9f-b734-928d785e7c77" /> |

Tested on macOS 26.5, M1 Pro. 