### PR TITLE
TSL: Support layout functions with uniforms shared across materials

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2434,14 +2434,15 @@ class NodeBuilder {
 	 */
 	buildFunctionNode( shaderNode ) {
 
-		const backend = this.renderer.backend;
+		const shared = shaderNode.layout ? shaderNode.layout.shared !== false : true;
+		const cacheKey = shared ? this.renderer.backend : this;
 
-		let cache = _functionNodeCache.get( backend );
+		let cache = _functionNodeCache.get( cacheKey );
 
 		if ( cache === undefined ) {
 
 			cache = new WeakMap();
-			_functionNodeCache.set( backend, cache );
+			_functionNodeCache.set( cacheKey, cache );
 
 		}
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2438,7 +2438,12 @@ class NodeBuilder {
 
 		let backendCache = _functionNodeCache.get( backend );
 
-		if ( backendCache !== undefined ) {
+		if ( backendCache === undefined ) {
+
+			backendCache = new WeakMap();
+			_functionNodeCache.set( backend, backendCache );
+
+		} else {
 
 			const fn = backendCache.get( shaderNode );
 
@@ -2452,7 +2457,12 @@ class NodeBuilder {
 
 		let builderCache = _functionNodeCache.get( this );
 
-		if ( builderCache !== undefined ) {
+		if ( builderCache === undefined ) {
+
+			builderCache = new WeakMap();
+			_functionNodeCache.set( this, builderCache );
+
+		} else {
 
 			const fn = builderCache.get( shaderNode );
 
@@ -2479,23 +2489,9 @@ class NodeBuilder {
 
 		if ( hasUniform ) {
 
-			if ( builderCache === undefined ) {
-
-				builderCache = new WeakMap();
-				_functionNodeCache.set( this, builderCache );
-
-			}
-
 			builderCache.set( shaderNode, fn );
 
 		} else {
-
-			if ( backendCache === undefined ) {
-
-				backendCache = new WeakMap();
-				_functionNodeCache.set( this.renderer.backend, backendCache );
-
-			}
 
 			backendCache.set( shaderNode, fn );
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2468,6 +2468,17 @@ class NodeBuilder {
 
 			if ( fn !== undefined ) {
 
+				const nodeData = this.getDataFromNode( fn );
+				const hasUniform = nodeData.hasUniform;
+
+				if ( hasUniform && this.currentFunctionNode !== null ) {
+
+					// Propagate the flag to the current function even when a cache hit.
+					const nodeData = this.getDataFromNode( this.currentFunctionNode );
+					nodeData.hasUniform = true;
+
+				}
+
 				return fn;
 
 			}
@@ -2488,6 +2499,14 @@ class NodeBuilder {
 		const hasUniform = nodeData.hasUniform;
 
 		if ( hasUniform ) {
+
+			if ( previous !== null ) {
+
+				// Propagate the flag to the current function.
+				const nodeData = this.getDataFromNode( previous );
+				nodeData.hasUniform = true;
+
+			}
 
 			builderCache.set( shaderNode, fn );
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2468,14 +2468,12 @@ class NodeBuilder {
 
 			if ( fn !== undefined ) {
 
-				const nodeData = this.getDataFromNode( fn );
-				const hasUniform = nodeData.hasUniform;
+				const cachePerMaterial = this.getDataFromNode( fn ).cachePerMaterial;
 
-				if ( hasUniform && this.currentFunctionNode !== null ) {
+				if ( cachePerMaterial && this.currentFunctionNode !== null ) {
 
 					// Propagate the flag to the current function even when a cache hit.
-					const nodeData = this.getDataFromNode( this.currentFunctionNode );
-					nodeData.hasUniform = true;
+					this.getDataFromNode( this.currentFunctionNode ).cachePerMaterial = true;
 
 				}
 
@@ -2495,16 +2493,14 @@ class NodeBuilder {
 
 		this.currentFunctionNode = previous;
 
-		const nodeData = this.getDataFromNode( fn );
-		const hasUniform = nodeData.hasUniform;
+		const cachePerMaterial = this.getDataFromNode( fn ).cachePerMaterial;
 
-		if ( hasUniform ) {
+		if ( cachePerMaterial ) {
 
 			if ( previous !== null ) {
 
 				// Propagate the flag to the current function.
-				const nodeData = this.getDataFromNode( previous );
-				nodeData.hasUniform = true;
+				this.getDataFromNode( previous ).cachePerMaterial = true;
 
 			}
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2434,33 +2434,70 @@ class NodeBuilder {
 	 */
 	buildFunctionNode( shaderNode ) {
 
-		const shared = shaderNode.layout ? shaderNode.layout.shared !== false : true;
-		const cacheKey = shared ? this.renderer.backend : this;
+		const backend = this.renderer.backend;
 
-		let cache = _functionNodeCache.get( cacheKey );
+		let backendCache = _functionNodeCache.get( backend );
 
-		if ( cache === undefined ) {
+		if ( backendCache !== undefined ) {
 
-			cache = new WeakMap();
-			_functionNodeCache.set( cacheKey, cache );
+			const fn = backendCache.get( shaderNode );
+
+			if ( fn !== undefined ) {
+
+				return fn;
+
+			}
 
 		}
 
-		let fn = cache.get( shaderNode );
+		let builderCache = _functionNodeCache.get( this );
 
-		if ( fn === undefined ) {
+		if ( builderCache !== undefined ) {
 
-			fn = new FunctionNode();
+			const fn = builderCache.get( shaderNode );
 
-			const previous = this.currentFunctionNode;
+			if ( fn !== undefined ) {
 
-			this.currentFunctionNode = fn;
+				return fn;
 
-			fn.code = this.buildFunctionCode( shaderNode );
+			}
 
-			this.currentFunctionNode = previous;
+		}
 
-			cache.set( shaderNode, fn );
+		const fn = new FunctionNode();
+
+		const previous = this.currentFunctionNode;
+
+		this.currentFunctionNode = fn;
+
+		fn.code = this.buildFunctionCode( shaderNode );
+
+		this.currentFunctionNode = previous;
+
+		const nodeData = this.getDataFromNode( fn );
+		const hasUniform = nodeData.hasUniform;
+
+		if ( hasUniform ) {
+
+			if ( builderCache === undefined ) {
+
+				builderCache = new WeakMap();
+				_functionNodeCache.set( this, builderCache );
+
+			}
+
+			builderCache.set( shaderNode, fn );
+
+		} else {
+
+			if ( backendCache === undefined ) {
+
+				backendCache = new WeakMap();
+				_functionNodeCache.set( this.renderer.backend, backendCache );
+
+			}
+
+			backendCache.set( shaderNode, fn );
 
 		}
 

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -178,6 +178,13 @@ class UniformNode extends InputNode {
 
 		if ( builder.context.nodeName !== undefined ) delete builder.context.nodeName;
 
+		if ( builder.currentFunctionNode !== null ) {
+
+			const nodeData = builder.getDataFromNode( builder.currentFunctionNode );
+			nodeData.hasUniform = true;
+
+		}
+
 		//
 
 		let snippet = uniformName;

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -181,7 +181,7 @@ class UniformNode extends InputNode {
 		if ( builder.currentFunctionNode !== null ) {
 
 			const nodeData = builder.getDataFromNode( builder.currentFunctionNode );
-			nodeData.hasUniform = true;
+			nodeData.cachePerMaterial = true;
 
 		}
 


### PR DESCRIPTION
Related issue: #31325

**Description**

This PR adds support for using layout functions with uniforms shared across different materials, by caching them per material when they contain uniform nodes.

Layout functions are built and cached per backend for the first material, and associated uniforms become invalid for other materials. This causes the following situation to fail.

```ts
const x = uniform(1)

const f = Fn(() => x).setLayout({ type: 'float', name: 'f', inputs: [] })

const material1 = new NodeMaterial()
material1.fragmentNode = f()

const material2 = new NodeMaterial()
material2.fragmentNode = f()
```

With this PR, the example above works. Nested layout functions that includes uniforms are also supported.

```js
const x = uniform(1)

const f = Fn(() => x).setLayout({ type: 'float', name: 'f', inputs: [] })
const g = Fn(() => f()).setLayout({ type: 'float', name: 'g', inputs: [] })
const h = Fn(() => f()).setLayout({ type: 'float', name: 'h', inputs: [] })

const material1 = new NodeMaterial()
material1.fragmentNode = h().add(g())

const material2 = new NodeMaterial()
material2.fragmentNode = f().add(g())
```