### PR TITLE
TSL: fix transformDirection matrix multiplication order

### DIFF
--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -197,7 +197,7 @@ class MathNode extends TempNode {
 
 			}
 
-			const mulNode = mul( tA, tB ).xyz;
+			const mulNode = mul( tB, tA ).xyz;
 
 			outputNode = normalize( mulNode );
 


### PR DESCRIPTION
Fixes #33309.

`transformDirection` computes `matrix * direction`, but the multiplication order was reversed (`direction * matrix`). This produces incorrect results because matrix multiplication is not commutative.

Fix by swapping `mul(tA, tB)` to `mul(tB, tA)` so the matrix is always the left operand regardless of which argument is the matrix.