### PR TITLE
Allow ObjectLoader to use custom loading managers in sync'd image loads

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -459,6 +459,8 @@ class ObjectLoader extends Loader {
 
 		function loadImage( url ) {
 
+			url = scope.manager.resolveURL( url );
+
 			scope.manager.itemStart( url );
 
 			return loader.load( url, function () {


### PR DESCRIPTION
While this was addressed for asynchronous loads in #22031, sychronous loading was skipped. This gives parseImages the chance to resolve the URL from bespoke loading managers.

Related issue: #13177

**Description**

The problem described in #13177 persisted for synchronized loads. This brings the synchronized image load to parity with the asynchronous (with respect to configured URL managers). For an example, see [this test page](https://github.com/SeanCurtis-TRI/meshcat/blob/PR_embedded_image_resolution/test/embedded_image_url_resolution.html) with particular emphasis on the specification of [`setURLModifier()`](https://github.com/SeanCurtis-TRI/meshcat/blob/PR_embedded_image_resolution/test/embedded_image_url_resolution.html#L63-L69).
