### PR TITLE
test/e2e: fix Buffer handling for Node.js 23+

### DIFF
--- a/test/e2e/image.js
+++ b/test/e2e/image.js
@@ -171,7 +171,7 @@ class Image {
 
 		} else {
 
-			buffer = input;
+			buffer = Buffer.isBuffer( input ) ? input : Buffer.from( input );
 
 		}
 


### PR DESCRIPTION
When running "npm run test-e2e" I get the error "TypeError: data.readUInt32BE is not a function".

I have installed node and npm via homebrew. This PR appears to fix it.