### PR TITLE
WebGPURenderer: Fix stale texture references in bindings.

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -265,6 +265,10 @@ class Bindings extends DataMap {
 
 						binding.release();
 
+					} else if ( binding.isSampler ) {
+
+						binding.release();
+
 					}
 
 				}

--- a/src/renderers/common/Sampler.js
+++ b/src/renderers/common/Sampler.js
@@ -119,6 +119,15 @@ class Sampler extends Binding {
 
 	}
 
+	/**
+	 * Releases the texture reference.
+	 */
+	release() {
+
+		this._texture = null;
+
+	}
+
 }
 
 export default Sampler;

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -626,6 +626,7 @@ class Textures extends DataMap {
 						if ( binding.isSampler && binding.texture === texture ) {
 
 							binding.reset();
+							binding.release();
 
 						}
 


### PR DESCRIPTION
Fixed #33675.

**Description**

The PR makes sure `Sampler` releases its texture references when:

- Its texture gets disposed of.
- Its bind group gets deleted. 

The latter one is more of a consistency change. The memeory leak mentioned in #33675 should be fixed with the change in `Textures`.

@yisky Can you please verify if the PR fixes your issue?