### PR TITLE
WebGPURenderer: Fix dispose of override material render objects.

### DIFF
--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -282,6 +282,16 @@ class RenderObject {
 		this._monitor = null;
 
 		/**
+		 * The object's original material when this render object is drawn with an
+		 * override material.
+		 *
+		 * @type {?Material}
+		 * @private
+		 * @default null
+		 */
+		this._sourceMaterial = renderer._currentSourceMaterial;
+
+		/**
 		 * An event listener which is defined by `RenderObjects`. It performs
 		 * clean up tasks when `dispose()` on this render object.
 		 *
@@ -327,6 +337,12 @@ class RenderObject {
 
 		this.material.addEventListener( 'dispose', this.onMaterialDispose );
 		this.geometry.addEventListener( 'dispose', this.onGeometryDispose );
+
+		if ( this._sourceMaterial !== null ) {
+
+			this._sourceMaterial.addEventListener( 'dispose', this.onMaterialDispose );
+
+		}
 
 	}
 
@@ -922,6 +938,12 @@ class RenderObject {
 
 		this.material.removeEventListener( 'dispose', this.onMaterialDispose );
 		this.geometry.removeEventListener( 'dispose', this.onGeometryDispose );
+
+		if ( this._sourceMaterial !== null ) {
+
+			this._sourceMaterial.removeEventListener( 'dispose', this.onMaterialDispose );
+
+		}
 
 		this.onDispose();
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -662,6 +662,16 @@ class Renderer {
 		this._compilationPromises = null;
 
 		/**
+		 * When an override material is in use, this property points to the current
+		 * source material during the rendering of a render object.
+		 *
+		 * @private
+		 * @type {?Material}
+		 * @default null
+		 */
+		this._currentSourceMaterial = null;
+
+		/**
 		 * Whether the renderer should render transparent render objects or not.
 		 *
 		 * @type {boolean}
@@ -3491,6 +3501,8 @@ class Renderer {
 
 		if ( material.allowOverride === true && scene.overrideMaterial !== null ) {
 
+			this._currentSourceMaterial = material;
+
 			const overrideMaterial = scene.overrideMaterial;
 
 			materialOverride = true;
@@ -3563,6 +3575,8 @@ class Renderer {
 			scene.overrideMaterial.depthNode = materialDepthNode;
 			scene.overrideMaterial.positionNode = materialPositionNode;
 			scene.overrideMaterial.side = materialSide;
+
+			this._currentSourceMaterial = null;
 
 		}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -3493,6 +3493,8 @@ class Renderer {
 		let materialPositionNode;
 		let materialSide;
 
+		const previousSourceMaterial = this._currentSourceMaterial;
+
 		//
 
 		object.onBeforeRender( this, scene, camera, geometry, material, group );
@@ -3576,9 +3578,9 @@ class Renderer {
 			scene.overrideMaterial.positionNode = materialPositionNode;
 			scene.overrideMaterial.side = materialSide;
 
-			this._currentSourceMaterial = null;
-
 		}
+
+		this._currentSourceMaterial = previousSourceMaterial;
 
 		//
 


### PR DESCRIPTION
Fixed #32409.

**Description**

The PR fixes a substantial memory leak in `WebGPURenderer`.

Every time an 3D object is processed with an override material, internal render objects are created for the override render pass. This render pass might generate shadow maps or render scenes with special materials for post processing.

The disposal of these additional render objects is currently buggy. It only works if the override material is disposed of which is often not the case. When a 3D object is removed from the scene and its material disposed of, the additional render objects of the override render passes survive the disposal.

The PR fixes that by maintaining a reference to the current source material (the material that is replaced with the override material) for the currently processed render item. If an instance of `RenderObject` is created, an additional dispose event listener links the real `material.dispose()` on app level to the override render objects.

That means when the source material is disposed, the own render object but also all "override render objects" are released now.

@yisky Can you please verify if this PR fixes the memory leak in your app?