### PR TITLE
NodeManager: Fix render object cache key.

### DIFF
--- a/src/renderers/common/nodes/NodeManager.js
+++ b/src/renderers/common/nodes/NodeManager.js
@@ -243,8 +243,7 @@ class NodeManager extends DataMap {
 
 					return buildNodeBuilder().then( ( nodeBuilder ) => {
 
-						nodeBuilderState = this._createNodeBuilderState( nodeBuilder );
-						nodeBuilderCache.set( cacheKey, nodeBuilderState );
+						nodeBuilderState = this._cacheNodeBuilderState( renderObject, nodeBuilder );
 						nodeBuilderState.usedTimes ++;
 						renderObjectData.nodeBuilderState = nodeBuilderState;
 
@@ -280,9 +279,7 @@ class NodeManager extends DataMap {
 
 					}
 
-					nodeBuilderState = this._createNodeBuilderState( nodeBuilder );
-
-					nodeBuilderCache.set( cacheKey, nodeBuilderState );
+					nodeBuilderState = this._cacheNodeBuilderState( renderObject, nodeBuilder );
 
 				}
 
@@ -459,6 +456,31 @@ class NodeManager extends DataMap {
 			computeData.version = computeNode.version;
 
 		}
+
+		return nodeBuilderState;
+
+	}
+
+	/**
+	 * Creates a node builder state for the freshly built node builder and stores it in the
+	 * node builder cache.
+	 *
+	 * @private
+	 * @param {RenderObject} renderObject - The render object.
+	 * @param {NodeBuilder} nodeBuilder - The node builder.
+	 * @return {NodeBuilderState} The node builder state.
+	 */
+	_cacheNodeBuilderState( renderObject, nodeBuilder ) {
+
+		const nodeBuilderState = this._createNodeBuilderState( nodeBuilder );
+
+		// The cache key is recomputed *after* the build because a material's setup() is allowed
+		// to assign cache-key relevant nodes onto the material instance.
+
+		const cacheKey = renderObject.getCacheKey();
+		renderObject.initialCacheKey = cacheKey;
+
+		this.nodeBuilderCache.set( cacheKey, nodeBuilderState );
 
 		return nodeBuilderState;
 


### PR DESCRIPTION
Related issue:  #33673

**Description**

The fiddle in https://github.com/mrdoob/three.js/issues/33673#issuecomment-4575359568 demonstrates the `nodeBuilderCache` is filled with node builder states because the related caching is not reliable. That produces an unexpected memory leak.

The fiddle creates per frame an instance of `LineSegments2` with a _shared material_. Every time an object is removed and a new one added to the scene, `NodeManager.getForRender()` is not able to find the correct node builder state. That happens because the render object's cache key is wrong. 

The render object's cache key honors the node objects of its material. However, the build (and thus setup()) of node materials is executed _after_ the cache key comparison. That means the actual build _mutates_ the object's cache key but never writes it back. In this way, there is never a stable cache key so we get no cache hits at all.

To fix that, the render object's cache key must be updated _after_ the build so subsequent comparison do not fail.