### PR TITLE
Support readback targets in async render target pixel reads

### DIFF
--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -345,9 +345,10 @@ class Backend {
 	 * @param {number} width - The width of the copy.
 	 * @param {number} height - The height of the copy.
 	 * @param {number} faceIndex - The face index.
-	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
+	 * @param {?(TypedArray|ReadbackBuffer)} [target=null] - The target buffer.
+	 * @return {Promise<TypedArray|ReadbackBuffer>} A Promise that resolves with the target or a typed array when the copy operation has finished.
 	 */
-	async copyTextureToBuffer( /*texture, x, y, width, height, faceIndex*/ ) {}
+	async copyTextureToBuffer( /*texture, x, y, width, height, faceIndex, target*/ ) {}
 
 	/**
 	 * Copies data of the given source texture to the given destination texture.

--- a/src/renderers/common/Info.js
+++ b/src/renderers/common/Info.js
@@ -360,7 +360,11 @@ class Info {
 	 */
 	destroyReadbackBuffer( readbackBuffer ) {
 
-		const { size } = this.memoryMap.get( readbackBuffer );
+		const data = this.memoryMap.get( readbackBuffer );
+
+		if ( data === undefined ) return;
+
+		const { size } = data;
 		this.memoryMap.delete( readbackBuffer );
 
 		this.memory.readbackBuffers --;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1928,26 +1928,7 @@ class Renderer {
 	 */
 	async getArrayBufferAsync( attribute, target = null, offset = 0, count = - 1 ) {
 
-		// tally the memory for this readback buffer
-		if ( target !== null && target.isReadbackBuffer ) {
-
-			if ( this.info.memoryMap.has( target ) === false ) {
-
-				this.info.createReadbackBuffer( target );
-
-				const disposeInfo = () => {
-
-					target.removeEventListener( 'dispose', disposeInfo );
-
-					this.info.destroyReadbackBuffer( target );
-
-				};
-
-				target.addEventListener( 'dispose', disposeInfo );
-
-			}
-
-		}
+		this._trackReadbackBuffer( target );
 
 		if ( offset % 4 !== 0 || ( count > 0 && count % 4 !== 0 ) ) {
 
@@ -3034,13 +3015,53 @@ class Renderer {
 	 * @param {number} y - The `y` coordinate of the copy region's origin.
 	 * @param {number} width - The width of the copy region.
 	 * @param {number} height - The height of the copy region.
-	 * @param {number} [textureIndex=0] - The texture index of a MRT render target.
+	 * @param {?(TypedArray|ReadbackBuffer|number)} [target=null] - The target buffer. When a number is passed, it is treated as the texture index.
 	 * @param {number} [faceIndex=0] - The active cube face index.
-	 * @return {Promise<TypedArray>} A Promise that resolves when the read has been finished. The resolve provides the read data as a typed array.
+	 * @param {number} [textureIndex=0] - The texture index of a MRT render target.
+	 * @return {Promise<TypedArray|ReadbackBuffer>} A Promise that resolves when the read has been finished. The resolve provides the read data as a typed array or readback buffer.
 	 */
-	async readRenderTargetPixelsAsync( renderTarget, x, y, width, height, textureIndex = 0, faceIndex = 0 ) {
+	async readRenderTargetPixelsAsync( renderTarget, x, y, width, height, target = null, faceIndex = 0, textureIndex = 0 ) {
 
-		return this.backend.copyTextureToBuffer( renderTarget.textures[ textureIndex ], x, y, width, height, faceIndex );
+		if ( typeof target === 'number' ) {
+
+			textureIndex = target;
+			target = null;
+
+		}
+
+		this._trackReadbackBuffer( target );
+
+		return this.backend.copyTextureToBuffer( renderTarget.textures[ textureIndex ], x, y, width, height, faceIndex, target );
+
+	}
+
+	/**
+	 * Tracks readback buffer memory.
+	 *
+	 * @private
+	 * @param {?ReadbackBuffer} target - The readback buffer to track.
+	 */
+	_trackReadbackBuffer( target ) {
+
+		if ( target !== null && target.isReadbackBuffer ) {
+
+			if ( this.info.memoryMap.has( target ) === false ) {
+
+				this.info.createReadbackBuffer( target );
+
+				const disposeInfo = () => {
+
+					target.removeEventListener( 'dispose', disposeInfo );
+
+					this.info.destroyReadbackBuffer( target );
+
+				};
+
+				target.addEventListener( 'dispose', disposeInfo );
+
+			}
+
+		}
 
 	}
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1406,11 +1406,12 @@ class WebGLBackend extends Backend {
 	 * @param {number} width - The width of the copy.
 	 * @param {number} height - The height of the copy.
 	 * @param {number} faceIndex - The face index.
-	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
+	 * @param {?(TypedArray|ReadbackBuffer)} [target=null] - The target buffer.
+	 * @return {Promise<TypedArray|ReadbackBuffer>} A Promise that resolves with the target or a typed array when the copy operation has finished.
 	 */
-	async copyTextureToBuffer( texture, x, y, width, height, faceIndex ) {
+	async copyTextureToBuffer( texture, x, y, width, height, faceIndex, target = null ) {
 
-		return this.textureUtils.copyTextureToBuffer( texture, x, y, width, height, faceIndex );
+		return this.textureUtils.copyTextureToBuffer( texture, x, y, width, height, faceIndex, target );
 
 	}
 

--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -1186,9 +1186,10 @@ class WebGLTextureUtils {
 	 * @param {number} width - The width of the copy.
 	 * @param {number} height - The height of the copy.
 	 * @param {number} faceIndex - The face index.
-	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
+	 * @param {?(TypedArray|ReadbackBuffer)} [target=null] - The target buffer.
+	 * @return {Promise<TypedArray|ReadbackBuffer>} A Promise that resolves with the target or a typed array when the copy operation has finished.
 	 */
-	async copyTextureToBuffer( texture, x, y, width, height, faceIndex ) {
+	async copyTextureToBuffer( texture, x, y, width, height, faceIndex, target = null ) {
 
 		const { backend, gl } = this;
 
@@ -1198,15 +1199,62 @@ class WebGLTextureUtils {
 
 		backend.state.bindFramebuffer( gl.READ_FRAMEBUFFER, fb );
 
-		const target = texture.isCubeTexture ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + faceIndex : gl.TEXTURE_2D;
+		const glTarget = texture.isCubeTexture ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + faceIndex : gl.TEXTURE_2D;
 
-		gl.framebufferTexture2D( gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, target, textureGPU, 0 );
+		gl.framebufferTexture2D( gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, glTarget, textureGPU, 0 );
 
 		const typedArrayType = this._getTypedArrayType( glType );
 		const bytesPerTexel = this._getBytesPerTexel( glType, glFormat );
 
 		const elementCount = width * height;
 		const byteLength = elementCount * bytesPerTexel;
+
+		let dstBuffer;
+		if ( target === null ) {
+
+			dstBuffer = new typedArrayType( byteLength / typedArrayType.BYTES_PER_ELEMENT );
+
+		} else if ( target.isReadbackBuffer ) {
+
+			if ( target._mapped === true ) {
+
+				throw new Error( 'THREE.WebGLTextureUtils: ReadbackBuffer must be released before being used again.' );
+
+			}
+
+			if ( target.maxByteLength < byteLength ) {
+
+				throw new Error( 'THREE.WebGLTextureUtils: ReadbackBuffer maxByteLength is smaller than the required readback size.' );
+
+			}
+
+			target._mapped = true;
+
+			const releaseCallback = () => {
+
+				target.buffer = null;
+				target._mapped = false;
+				target.removeEventListener( 'release', releaseCallback );
+				target.removeEventListener( 'dispose', releaseCallback );
+
+			};
+
+			target.addEventListener( 'release', releaseCallback );
+			target.addEventListener( 'dispose', releaseCallback );
+
+			dstBuffer = new typedArrayType( byteLength / typedArrayType.BYTES_PER_ELEMENT );
+
+		} else {
+
+			if ( target.byteLength < byteLength ) {
+
+				throw new Error( 'THREE.WebGLTextureUtils: Target buffer is smaller than the required readback size.' );
+
+			}
+
+			dstBuffer = ArrayBuffer.isView( target ) ? new Uint8Array( target.buffer, target.byteOffset, byteLength ) : new Uint8Array( target, 0, byteLength );
+
+		}
 
 		const buffer = gl.createBuffer();
 
@@ -1217,17 +1265,17 @@ class WebGLTextureUtils {
 
 		await backend.utils._clientWaitAsync();
 
-		const dstBuffer = new typedArrayType( byteLength / typedArrayType.BYTES_PER_ELEMENT );
-
 		gl.bindBuffer( gl.PIXEL_PACK_BUFFER, buffer );
 		gl.getBufferSubData( gl.PIXEL_PACK_BUFFER, 0, dstBuffer );
 		gl.bindBuffer( gl.PIXEL_PACK_BUFFER, null );
+
+		if ( target && target.isReadbackBuffer ) target.buffer = dstBuffer.buffer;
 
 		backend.state.bindFramebuffer( gl.READ_FRAMEBUFFER, null );
 
 		gl.deleteFramebuffer( fb );
 
-		return dstBuffer;
+		return target !== null ? target : dstBuffer;
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2196,11 +2196,12 @@ class WebGPUBackend extends Backend {
 	 * @param {number} width - The width of the copy.
 	 * @param {number} height - The height of the copy.
 	 * @param {number} faceIndex - The face index.
-	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
+	 * @param {?(TypedArray|ReadbackBuffer)} [target=null] - The target buffer.
+	 * @return {Promise<TypedArray|ReadbackBuffer>} A Promise that resolves with the target or a typed array when the copy operation has finished.
 	 */
-	async copyTextureToBuffer( texture, x, y, width, height, faceIndex ) {
+	async copyTextureToBuffer( texture, x, y, width, height, faceIndex, target = null ) {
 
-		return this.textureUtils.copyTextureToBuffer( texture, x, y, width, height, faceIndex );
+		return this.textureUtils.copyTextureToBuffer( texture, x, y, width, height, faceIndex, target );
 
 	}
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -696,9 +696,10 @@ class WebGPUTextureUtils {
 	 * @param {number} width - The width of the copy.
 	 * @param {number} height - The height of the copy.
 	 * @param {number} faceIndex - The face index.
-	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
+	 * @param {?(TypedArray|ReadbackBuffer)} [target=null] - The target buffer.
+	 * @return {Promise<TypedArray|ReadbackBuffer>} A Promise that resolves with the target or a typed array when the copy operation has finished.
 	 */
-	async copyTextureToBuffer( texture, x, y, width, height, faceIndex ) {
+	async copyTextureToBuffer( texture, x, y, width, height, faceIndex, target = null ) {
 
 		const device = this.backend.device;
 
@@ -711,9 +712,91 @@ class WebGPUTextureUtils {
 		bytesPerRow = Math.ceil( bytesPerRow / 256 ) * 256; // Align to 256 bytes
 
 		_bufferDescriptor.size = ( ( height - 1 ) * bytesPerRow ) + ( width * bytesPerTexel ); // see https://github.com/mrdoob/three.js/issues/31658#issuecomment-3229442010
-		_bufferDescriptor.usage = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
+		const byteLength = _bufferDescriptor.size;
 
-		const readBuffer = device.createBuffer( _bufferDescriptor );
+		let targetByteLength = 0;
+		let readBuffer;
+		if ( target !== null && target.isReadbackBuffer ) {
+
+			const readbackInfo = this.backend.get( target );
+
+			if ( target._mapped === true ) {
+
+				throw new Error( 'THREE.WebGPUTextureUtils: ReadbackBuffer must be released before being used again.' );
+
+			}
+
+			if ( target.maxByteLength < byteLength ) {
+
+				throw new Error( 'THREE.WebGPUTextureUtils: ReadbackBuffer maxByteLength is smaller than the required readback size.' );
+
+			}
+
+			target._mapped = true;
+
+			if ( readbackInfo.readBufferGPU === undefined ) {
+
+				_bufferDescriptor.label = `${ target.name }_readback`;
+				_bufferDescriptor.size = target.maxByteLength;
+				_bufferDescriptor.usage = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
+
+				readBuffer = device.createBuffer( _bufferDescriptor );
+
+				const releaseCallback = () => {
+
+					target.buffer = null;
+					target._mapped = false;
+
+					readBuffer.unmap();
+
+				};
+
+				const disposeCallback = () => {
+
+					target.buffer = null;
+					target._mapped = false;
+
+					readBuffer.destroy();
+
+					this.backend.delete( target );
+
+					target.removeEventListener( 'release', releaseCallback );
+					target.removeEventListener( 'dispose', disposeCallback );
+
+				};
+
+				target.addEventListener( 'release', releaseCallback );
+				target.addEventListener( 'dispose', disposeCallback );
+
+				readbackInfo.readBufferGPU = readBuffer;
+
+			} else {
+
+				readBuffer = readbackInfo.readBufferGPU;
+
+			}
+
+		} else if ( target !== null ) {
+
+			targetByteLength = target.byteLength;
+
+			if ( targetByteLength < byteLength ) {
+
+				throw new Error( 'THREE.WebGPUTextureUtils: Target buffer is smaller than the required readback size.' );
+
+			}
+
+			_bufferDescriptor.usage = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
+
+			readBuffer = device.createBuffer( _bufferDescriptor );
+
+		} else {
+
+			_bufferDescriptor.usage = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
+
+			readBuffer = device.createBuffer( _bufferDescriptor );
+
+		}
 
 		_bufferDescriptor.reset();
 
@@ -744,13 +827,34 @@ class WebGPUTextureUtils {
 
 		submit( device, encoder.finish() );
 
-		await readBuffer.mapAsync( GPUMapMode.READ );
+		await readBuffer.mapAsync( GPUMapMode.READ, 0, byteLength );
 
-		const buffer = readBuffer.getMappedRange().slice();
+		if ( target === null ) {
 
-		readBuffer.destroy();
+			const buffer = readBuffer.getMappedRange( 0, byteLength ).slice();
+			readBuffer.destroy();
 
-		return new typedArrayType( buffer );
+			return new typedArrayType( buffer );
+
+		} else if ( target.isReadbackBuffer ) {
+
+			target.buffer = readBuffer.getMappedRange( 0, byteLength );
+
+			return target;
+
+		} else {
+
+			const buffer = readBuffer.getMappedRange( 0, byteLength );
+			const targetBuffer = ArrayBuffer.isView( target ) ? target.buffer : target;
+			const byteOffset = ArrayBuffer.isView( target ) ? target.byteOffset : 0;
+			const targetArray = new Uint8Array( targetBuffer, byteOffset, targetByteLength );
+
+			targetArray.set( new Uint8Array( buffer ) );
+			readBuffer.destroy();
+
+			return target;
+
+		}
 
 	}
 

--- a/test/unit/src/renderers/common/Renderer.tests.js
+++ b/test/unit/src/renderers/common/Renderer.tests.js
@@ -1,0 +1,88 @@
+import Renderer from '../../../../../src/renderers/common/Renderer.js';
+import ReadbackBuffer from '../../../../../src/renderers/common/ReadbackBuffer.js';
+
+function createRenderer() {
+
+	const domElement = {
+		style: {},
+		addEventListener() {},
+		removeEventListener() {}
+	};
+
+	const backend = {
+		getDomElement: () => domElement,
+		copyTextureToBuffer: async ( ...args ) => args,
+		init: async () => {},
+		get: () => ( {} ),
+		has: () => false,
+		updateSize: () => {},
+		getDrawingBufferSize: () => ( { width: 1, height: 1 } ),
+		getPixelRatio: () => 1
+	};
+
+	return new Renderer( backend );
+
+}
+
+export default QUnit.module( 'Renderers', () => {
+
+	QUnit.module( 'Renderer', () => {
+
+		QUnit.test( 'readRenderTargetPixelsAsync', async ( assert ) => {
+
+			const renderer = createRenderer();
+			const texture0 = { name: 'texture0' };
+			const texture1 = { name: 'texture1' };
+			const renderTarget = { textures: [ texture0, texture1 ] };
+
+			let result = await renderer.readRenderTargetPixelsAsync( renderTarget, 1, 2, 3, 4, 1, 5 );
+
+			assert.strictEqual( result[ 0 ], texture1, 'numeric target keeps previous textureIndex argument behavior' );
+			assert.strictEqual( result[ 5 ], 5, 'numeric target keeps previous faceIndex argument behavior' );
+			assert.strictEqual( result[ 6 ], null, 'numeric target does not forward a readback target' );
+
+			const target = new Uint8Array( 16 );
+
+			result = await renderer.readRenderTargetPixelsAsync( renderTarget, 1, 2, 3, 4, target, 5, 1 );
+
+			assert.strictEqual( result[ 0 ], texture1, 'typed array target forwards the selected MRT texture' );
+			assert.strictEqual( result[ 5 ], 5, 'typed array target forwards the face index' );
+			assert.strictEqual( result[ 6 ], target, 'typed array target is forwarded to the backend' );
+
+			result = await renderer.readRenderTargetPixelsAsync( renderTarget, 1, 2, 3, 4, target, 5 );
+
+			assert.strictEqual( result[ 0 ], texture0, 'typed array target without texture index keeps the default texture' );
+			assert.strictEqual( result[ 5 ], 5, 'typed array target without texture index treats the next argument as faceIndex' );
+
+			const readbackBuffer = new ReadbackBuffer( 16 );
+
+			result = await renderer.readRenderTargetPixelsAsync( renderTarget, 1, 2, 3, 4, readbackBuffer, 5, 0 );
+
+			assert.strictEqual( result[ 5 ], 5, 'ReadbackBuffer target forwards the face index' );
+			assert.strictEqual( result[ 6 ], readbackBuffer, 'ReadbackBuffer target is forwarded to the backend' );
+			assert.strictEqual( renderer.info.memory.readbackBuffers, 1, 'ReadbackBuffer target is tracked' );
+			assert.strictEqual( renderer.info.memory.readbackBuffersSize, 16, 'ReadbackBuffer target size is tracked' );
+
+			readbackBuffer.dispose();
+
+			assert.strictEqual( renderer.info.memory.readbackBuffers, 0, 'ReadbackBuffer dispose clears tracking' );
+			assert.strictEqual( renderer.info.memory.readbackBuffersSize, 0, 'ReadbackBuffer dispose clears tracked size' );
+
+			result = await renderer.readRenderTargetPixelsAsync( renderTarget, 1, 2, 3, 4, readbackBuffer );
+
+			assert.strictEqual( result[ 6 ], readbackBuffer, 'ReadbackBuffer target can be tracked again after dispose' );
+
+			renderer.info.dispose();
+
+			assert.strictEqual( renderer.info.memory.readbackBuffers, 0, 'renderer info dispose clears tracked readback buffers' );
+			assert.strictEqual( renderer.info.memory.readbackBuffersSize, 0, 'renderer info dispose clears tracked readback buffer size' );
+			assert.strictEqual( renderer.info.memory.total, 0, 'renderer info dispose clears total memory' );
+			assert.strictEqual( readbackBuffer.dispose(), undefined, 'ReadbackBuffer dispose after renderer info dispose does not throw' );
+			assert.strictEqual( renderer.info.memory.readbackBuffers, 0, 'late ReadbackBuffer dispose keeps tracking at zero' );
+			assert.strictEqual( renderer.info.memory.readbackBuffersSize, 0, 'late ReadbackBuffer dispose keeps tracked size at zero' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -231,6 +231,7 @@ import './src/objects/Sprite.tests.js';
 
 
 //src/renderers
+import './src/renderers/common/Renderer.tests.js';
 import './src/renderers/WebGL3DRenderTarget.tests.js';
 import './src/renderers/WebGLArrayRenderTarget.tests.js';
 import './src/renderers/WebGLCubeRenderTarget.tests.js';


### PR DESCRIPTION
## Summary

Fixes #33555.

Adds optional output-target support to
`Renderer.readRenderTargetPixelsAsync()`. Callers can now pass a typed array or
`ReadbackBuffer` target and the promise resolves with that same target when the
async read has completed.

For WebGPU, `ReadbackBuffer` targets reuse the backend GPU readback buffer until
the target is released or disposed. Typed-array targets use a temporary staging
buffer and copy the mapped result into the supplied array.

The existing numeric sixth-argument call shape is preserved for compatibility:
passing a number in the target slot still treats it as `textureIndex`. When a
typed array or `ReadbackBuffer` is supplied, the argument order is
`target, faceIndex, textureIndex`.

## Notes

WebGPU readbacks keep the existing backend readback layout, including
`copyTextureToBuffer()` row alignment. Supplied targets therefore need capacity
for the backend readback size, which can be larger than
`width * height * bytesPerPixel` for narrow multi-row reads. The renderer JSDoc
now calls out that WebGPU capacity requirement.

## Changes

- Add optional target forwarding through `Renderer`, `Backend`, WebGPU, and
  WebGL fallback render target readback paths.
- Reuse WebGPU readback buffers for `ReadbackBuffer` targets.
- Keep `ReadbackBuffer` memory accounting paired with renderer info disposal and
  target `release()` / `dispose()`.
- Add explicit target-size errors before low-level backend failures.
- Preserve oversized typed-array targets in the WebGL fallback path while only
  reading the required byte range.
- Document the new overload and WebGPU row-padding capacity requirement in
  renderer JSDoc.
- Add renderer unit coverage for overload routing, target forwarding, and
  readback-buffer memory accounting.

## Verification

- `node --check src/renderers/common/Renderer.js`
- `node --check src/renderers/common/Backend.js`
- `node --check src/renderers/webgpu/WebGPUBackend.js`
- `node --check src/renderers/webgl-fallback/WebGLBackend.js`
- `node --check src/renderers/webgpu/utils/WebGPUTextureUtils.js`
- `node --check src/renderers/webgl-fallback/utils/WebGLTextureUtils.js`
- `node --check test/unit/src/renderers/common/Renderer.tests.js`
- `npx eslint src/renderers/common/Backend.js src/renderers/common/Renderer.js src/renderers/webgpu/WebGPUBackend.js src/renderers/webgpu/utils/WebGPUTextureUtils.js src/renderers/webgl-fallback/WebGLBackend.js src/renderers/webgl-fallback/utils/WebGLTextureUtils.js test/unit/src/renderers/common/Renderer.tests.js test/unit/three.source.unit.js`
- `npm run build-module`
- `npm run test-unit -- --testPage=UnitTests.html --mode=headless`
- `git diff --check`

I also ran focused local browser smoke tests for:

- WebGPU `ReadbackBuffer` reuse across two render target reads, including
  too-small-target rejection and `renderer.info.memory.readbackBuffers` cleanup.
- WebGPU typed-array target readback, including too-small-target rejection and a
  successful padded-capacity read.
- WebGL fallback `ReadbackBuffer` timing, verifying `buffer` is assigned only
  after the async read completes.
- WebGL fallback oversized typed-array target readback, verifying the supplied
  target object is returned and unused tail bytes are preserved.
