### PR TITLE
WebGLRenderer: reset statistics (info.reset) before shadowMap.render

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1699,6 +1699,8 @@ class WebGLRenderer {
 
 			this.info.render.frame ++;
 
+			if ( this.info.autoReset === true ) this.info.reset();
+
 			if ( _clippingEnabled === true ) clipping.beginShadows();
 
 			const shadowsArray = currentRenderState.state.shadowsArray;
@@ -1708,8 +1710,6 @@ class WebGLRenderer {
 			if ( _clippingEnabled === true ) clipping.endShadows();
 
 			//
-
-			if ( this.info.autoReset === true ) this.info.reset();
 
 			// render scene (skip if first effect is a render pass - it will render the scene itself)
 


### PR DESCRIPTION
[Related Discourse](https://discourse.threejs.org/t/webglrenderer-info-and-autoreset/91823)

**Description**

With info.autoReset = true, WebGLRenderer statistics are reset **after** a call to shadowMap.render which excludes those stats. This fix moves the reset call before the shadowMap.render call so that statistics are properly accounted for.

<!-- Remove the line below if is not relevant -->
