### PR TITLE
DRACOLoader: Add exported urls for GLTF decoder

### DIFF
--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -8,7 +8,8 @@ import {
 	LinearSRGBColorSpace,
 	SRGBColorSpace,
 	InterleavedBuffer,
-	InterleavedBufferAttribute
+	InterleavedBufferAttribute,
+	LoaderUtils
 } from 'three';
 
 const _taskCache = new WeakMap();
@@ -16,6 +17,11 @@ const _taskCache = new WeakMap();
 const WASM_BIN_URL = new URL( '../libs/draco/draco_decoder.wasm', import.meta.url ).toString();
 const WASM_JS_URL = new URL( '../libs/draco/draco_wasm_wrapper.js', import.meta.url ).toString();
 const JS_URL = new URL( '../libs/draco/draco_decoder.js', import.meta.url ).toString();
+
+const DRACO_GLTF_CONFIG = {
+	js: new URL( '../libs/draco/draco_wasm_wrapper_gltf.js', import.meta.url ).toString(),
+	wasm: new URL( '../libs/draco/draco_decoder_gltf.wasm', import.meta.url ).toString(),
+};
 
 /**
  * A loader for the Draco format.
@@ -58,7 +64,11 @@ class DRACOLoader extends Loader {
 
 		super( manager );
 
-		this.decoderPath = '';
+		this.decoderPaths = {
+			js: WASM_JS_URL,
+			wasm: WASM_BIN_URL,
+			dep_js: JS_URL,
+		};
 		this.decoderConfig = {};
 		this.decoderBinary = null;
 		this.decoderPending = null;
@@ -86,12 +96,25 @@ class DRACOLoader extends Loader {
 	/**
 	 * Provides configuration for the decoder libraries. Configuration cannot be changed after decoding begins.
 	 *
-	 * @param {string} path - The decoder path.
+	 * @param {string|{js:string, wasm:string}} path - The decoder path, or a config object with explicit URLs for each decoder file.
 	 * @return {DRACOLoader} A reference to this loader.
 	 */
 	setDecoderPath( path ) {
 
-		this.decoderPath = path;
+		const { decoderPaths } = this;
+		if ( typeof path === 'object' ) {
+
+			decoderPaths.js = path.js;
+			decoderPaths.wasm = path.wasm;
+			decoderPaths.dep_js = null;
+
+		} else {
+
+			decoderPaths.js = LoaderUtils.resolveURL( 'draco_wasm_wrapper.js', path );
+			decoderPaths.wasm = LoaderUtils.resolveURL( 'draco_decoder.wasm', path );
+			decoderPaths.dep_js = LoaderUtils.resolveURL( 'draco_decoder.js', path );
+
+		}
 
 		return this;
 
@@ -335,7 +358,6 @@ class DRACOLoader extends Loader {
 	_loadLibrary( url, responseType ) {
 
 		const loader = new FileLoader( this.manager );
-		loader.setPath( this.decoderPath );
 		loader.setResponseType( responseType );
 		loader.setWithCredentials( this.withCredentials );
 
@@ -362,31 +384,21 @@ class DRACOLoader extends Loader {
 		const useJS = typeof WebAssembly !== 'object' || this.decoderConfig.type === 'js';
 		const librariesPending = [];
 
-		if ( this.decoderPath === '' ) {
+		const { decoderPaths } = this;
+		if ( useJS ) {
 
-			if ( useJS ) {
+			if ( decoderPaths.dep_js === null ) {
 
-				librariesPending.push( this._loadLibrary( JS_URL, 'text' ) );
-
-			} else {
-
-				librariesPending.push( this._loadLibrary( WASM_JS_URL, 'text' ) );
-				librariesPending.push( this._loadLibrary( WASM_BIN_URL, 'arraybuffer' ) );
+				throw new Error( 'THREE.DRACOLoader: WebAssembly is required when using a custom decoder paths.' );
 
 			}
+
+			librariesPending.push( this._loadLibrary( decoderPaths.dep_js, 'text' ) );
 
 		} else {
 
-			if ( useJS ) {
-
-				librariesPending.push( this._loadLibrary( 'draco_decoder.js', 'text' ) );
-
-			} else {
-
-				librariesPending.push( this._loadLibrary( 'draco_wasm_wrapper.js', 'text' ) );
-				librariesPending.push( this._loadLibrary( 'draco_decoder.wasm', 'arraybuffer' ) );
-
-			}
+			librariesPending.push( this._loadLibrary( decoderPaths.js, 'text' ) );
+			librariesPending.push( this._loadLibrary( decoderPaths.wasm, 'arraybuffer' ) );
 
 		}
 
@@ -757,4 +769,4 @@ function DRACOWorker() {
 
 }
 
-export { DRACOLoader };
+export { DRACOLoader, DRACO_GLTF_CONFIG };

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -38,12 +38,10 @@ const JS_URL = new URL( '../libs/draco/draco_decoder.js', import.meta.url ).toSt
  *
  * ```js
  * const loader = new DRACOLoader();
- * loader.setDecoderPath( '/examples/jsm/libs/draco/' );
- *
- * const geometry = await dracoLoader.loadAsync( 'models/draco/bunny.drc' );
+ * const geometry = await loader.loadAsync( 'models/draco/bunny.drc' );
  * geometry.computeVertexNormals(); // optional
  *
- * dracoLoader.dispose();
+ * loader.dispose();
  * ```
  *
  * @augments Loader

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -19,8 +19,8 @@ const WASM_JS_URL = new URL( '../libs/draco/draco_wasm_wrapper.js', import.meta.
 const JS_URL = new URL( '../libs/draco/draco_decoder.js', import.meta.url ).toString();
 
 const DRACO_GLTF_CONFIG = {
-	js: new URL( '../libs/draco/draco_wasm_wrapper_gltf.js', import.meta.url ).toString(),
-	wasm: new URL( '../libs/draco/draco_decoder_gltf.wasm', import.meta.url ).toString(),
+	js: new URL( '../libs/draco/gltf/draco_wasm_wrapper.js', import.meta.url ).toString(),
+	wasm: new URL( '../libs/draco/gltf/draco_decoder.wasm', import.meta.url ).toString(),
 };
 
 /**

--- a/examples/webgl_animation_keyframes.html
+++ b/examples/webgl_animation_keyframes.html
@@ -50,7 +50,7 @@
 			import { Sky } from 'three/addons/objects/Sky.js';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-			import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
+			import { DRACOLoader, DRACO_GLTF_CONFIG } from 'three/addons/loaders/DRACOLoader.js';
 
 			let mixer;
 
@@ -95,7 +95,7 @@
 			controls.update();
 
 			const dracoLoader = new DRACOLoader();
-			dracoLoader.setDecoderPath( 'jsm/libs/draco/gltf/' );
+			dracoLoader.setDecoderPath( DRACO_GLTF_CONFIG );
 
 			const loader = new GLTFLoader();
 			loader.setDRACOLoader( dracoLoader );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33564#discussion_r3314527716, #33602

**Description**

This PR updates DRACOLoader to support passing an object into "setDecoderPath" that specifies both the "js" and "wasm" file paths, and additionally provides an export of a pre-formed paths object for pointing to the in-project gltf decoder files:

```js
import { DRACOLoader, DRACO_GLTF_CONFIG } from 'three/addons/loaders/DRACOLoader.js;

// takes a string OR an object
const loader = new DRACOLoader().setDecoderPath( {
  js: './path/to/decoder.js',
  wasm: './path/to/decoder.wasm',
} );

// or use the provided config
const loader = new DRACOLoader().setDecoderPath( DRACO_GLTF_CONFIG );
```

- Exporting the urls like this allows the bundlers to resolve the urls correctly so they can be used by users.
- This will enable these urls to be tree-shaken by bundlers.
- Using "setDecoderPath" rather than something like a "useGltfVariant" flag avoids conceptual conflicts between the two (eg what does it mean if a user has explicitly set the decoder paths but also set "useGltfVariant" to true?)
- It might be worth considering a different function name for this? Or a separate function entirely?
- Updates 1 example to demonstrate functionality. I will submit a subsequent PR updating the remaining examples if this is accepted.