### PR TITLE
fix(TSL): swap transformDirection matrix multiplication order

### DIFF
--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -197,7 +197,7 @@ class MathNode extends TempNode {
 
 			}
 
-			const mulNode = mul( tA, tB ).xyz;
+			const mulNode = mul( tB, tA ).xyz;
 
 			outputNode = normalize( mulNode );
 


### PR DESCRIPTION
## Problem
The TSL `transformDirection` operation applies matrix multiplication in the wrong order, producing incorrect direction vectors when the first argument is a matrix.

## Root Cause
The generated TSL code uses `mul(tA, tB)` which produces `direction * matrix` (left multiplication), but direction vectors should be right-multiplied: `matrix * direction` — i.e., `mul(tB, tA)`.

## Changes
Swapped the arguments in the matrix multiplication from `mul(tA, tB)` to `mul(tB, tA)`, ensuring the direction vector is correctly right-multiplied by the matrix.