### PR TITLE
ShaderLib: Fix formatting of main function declaration.

### DIFF
--- a/src/renderers/shaders/ShaderLib/distance.glsl.js
+++ b/src/renderers/shaders/ShaderLib/distance.glsl.js
@@ -57,7 +57,7 @@ varying vec3 vWorldPosition;
 #include <alphahash_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
-void main () {
+void main() {
 
 	vec4 diffuseColor = vec4( 1.0 );
 	#include <clipping_planes_fragment>


### PR DESCRIPTION
**Description**

Shader patching techniques often rely on replacing `void main() {` with a custom string. The string in this shader has an additional space character `void main () {` which breaks this mechanism. This PR just removes the redundant space character.

On a tangent, how about adding dedicated hooks into all shaders (e.g. `// BEFORE_MAIN`, `// MAIN_START`, `// MAIN_END`, ...) which could be used as a more robust way to add shader code instead of relying on replacing `void main() {`?
