### PR TITLE
fix(TSL): correct transformDirection matrix multiplication order

### DIFF
--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -197,7 +197,7 @@ class MathNode extends TempNode {
 
 			}
 
-			const mulNode = mul( tA, tB ).xyz;
+			const mulNode = mul( tB, tA ).xyz;
 
 			outputNode = normalize( mulNode );
 


### PR DESCRIPTION
Fixes #33309

In the  operation, the matrix-vector multiplication order was incorrect.

**Current code generates:**


**Should be:**


In the else branch (normal case where direction is the first argument):
-  (the direction as vec4)
- 
-  = direction * matrix (row vector convention) — **incorrect**

Changing to  = matrix * direction (column vector convention) — **correct**

Matrix multiplication is not commutative; for column-vector convention (used by Three.js/GLSL/WGSL), the matrix must come first.