### PR TITLE
WebGLUniformsGroups: Optimize UBO updates to avoid GC churn.

### DIFF
--- a/src/renderers/webgl/WebGLUniformsGroups.js
+++ b/src/renderers/webgl/WebGLUniformsGroups.js
@@ -98,73 +98,98 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 		for ( let i = 0, il = uniforms.length; i < il; i ++ ) {
 
-			const uniformArray = Array.isArray( uniforms[ i ] ) ? uniforms[ i ] : [ uniforms[ i ] ];
+			const uniformItem = uniforms[ i ];
 
-			for ( let j = 0, jl = uniformArray.length; j < jl; j ++ ) {
+			if ( Array.isArray( uniformItem ) ) {
 
-				const uniform = uniformArray[ j ];
+				for ( let j = 0, jl = uniformItem.length; j < jl; j ++ ) {
 
-				if ( hasUniformChanged( uniform, i, j, cache ) === true ) {
-
-					const offset = uniform.__offset;
-
-					const values = Array.isArray( uniform.value ) ? uniform.value : [ uniform.value ];
-
-					let arrayOffset = 0;
-
-					for ( let k = 0; k < values.length; k ++ ) {
-
-						const value = values[ k ];
-
-						const info = getUniformSize( value );
-
-						// TODO add integer and struct support
-						if ( typeof value === 'number' || typeof value === 'boolean' ) {
-
-							uniform.__data[ 0 ] = value;
-							gl.bufferSubData( gl.UNIFORM_BUFFER, offset + arrayOffset, uniform.__data );
-
-						} else if ( value.isMatrix3 ) {
-
-							// manually converting 3x3 to 3x4
-
-							uniform.__data[ 0 ] = value.elements[ 0 ];
-							uniform.__data[ 1 ] = value.elements[ 1 ];
-							uniform.__data[ 2 ] = value.elements[ 2 ];
-							uniform.__data[ 3 ] = 0;
-							uniform.__data[ 4 ] = value.elements[ 3 ];
-							uniform.__data[ 5 ] = value.elements[ 4 ];
-							uniform.__data[ 6 ] = value.elements[ 5 ];
-							uniform.__data[ 7 ] = 0;
-							uniform.__data[ 8 ] = value.elements[ 6 ];
-							uniform.__data[ 9 ] = value.elements[ 7 ];
-							uniform.__data[ 10 ] = value.elements[ 8 ];
-							uniform.__data[ 11 ] = 0;
-
-						} else if ( ArrayBuffer.isView( value ) ) {
-
-							// copy the buffer data using "set"
-							uniform.__data.set( new value.constructor( value.buffer, value.byteOffset, uniform.__data.length ) );
-
-						} else {
-
-							value.toArray( uniform.__data, arrayOffset );
-
-							arrayOffset += info.storage / Float32Array.BYTES_PER_ELEMENT;
-
-						}
-
-					}
-
-					gl.bufferSubData( gl.UNIFORM_BUFFER, offset, uniform.__data );
+					updateUniform( uniformItem[ j ], i, j, cache );
 
 				}
+
+			} else {
+
+				updateUniform( uniformItem, i, 0, cache );
 
 			}
 
 		}
 
 		gl.bindBuffer( gl.UNIFORM_BUFFER, null );
+
+	}
+
+	function updateUniform( uniform, index, indexArray, cache ) {
+
+		if ( hasUniformChanged( uniform, index, indexArray, cache ) === true ) {
+
+			const offset = uniform.__offset;
+			const value = uniform.value;
+
+			if ( Array.isArray( value ) ) {
+
+				let arrayOffset = 0;
+
+				for ( let k = 0; k < value.length; k ++ ) {
+
+					const val = value[ k ];
+					const info = getUniformSize( val );
+
+					writeUniformValue( val, uniform.__data, arrayOffset );
+
+					// Only non-primitives advance arrayOffset in STD140 layout
+					if ( typeof val !== 'number' && typeof val !== 'boolean' && ! val.isMatrix3 && ! ArrayBuffer.isView( val ) ) {
+
+						arrayOffset += info.storage / Float32Array.BYTES_PER_ELEMENT;
+
+					}
+
+				}
+
+			} else {
+
+				writeUniformValue( value, uniform.__data, 0 );
+
+			}
+
+			gl.bufferSubData( gl.UNIFORM_BUFFER, offset, uniform.__data );
+
+		}
+
+	}
+
+	function writeUniformValue( value, data, offset ) {
+
+		if ( typeof value === 'number' || typeof value === 'boolean' ) {
+
+			data[ 0 ] = value;
+			gl.bufferSubData( gl.UNIFORM_BUFFER, offset, data );
+
+		} else if ( value.isMatrix3 ) {
+
+			data[ 0 ] = value.elements[ 0 ];
+			data[ 1 ] = value.elements[ 1 ];
+			data[ 2 ] = value.elements[ 2 ];
+			data[ 3 ] = 0;
+			data[ 4 ] = value.elements[ 3 ];
+			data[ 5 ] = value.elements[ 4 ];
+			data[ 6 ] = value.elements[ 5 ];
+			data[ 7 ] = 0;
+			data[ 8 ] = value.elements[ 6 ];
+			data[ 9 ] = value.elements[ 7 ];
+			data[ 10 ] = value.elements[ 8 ];
+			data[ 11 ] = 0;
+
+		} else if ( ArrayBuffer.isView( value ) ) {
+
+			data.set( new value.constructor( value.buffer, value.byteOffset, data.length ) );
+
+		} else {
+
+			value.toArray( data, offset );
+
+		}
 
 	}
 

--- a/src/renderers/webgl/WebGLUniformsGroups.js
+++ b/src/renderers/webgl/WebGLUniformsGroups.js
@@ -138,7 +138,7 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 					writeUniformValue( val, uniform.__data, arrayOffset );
 
-					// Only non-primitives advance arrayOffset in STD140 layout
+					// only toArray() values advance arrayOffset
 					if ( typeof val !== 'number' && typeof val !== 'boolean' && ! val.isMatrix3 && ! ArrayBuffer.isView( val ) ) {
 
 						arrayOffset += info.storage / Float32Array.BYTES_PER_ELEMENT;
@@ -161,11 +161,14 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 	function writeUniformValue( value, data, offset ) {
 
+		// TODO add integer and struct support
 		if ( typeof value === 'number' || typeof value === 'boolean' ) {
 
 			data[ 0 ] = value;
 
 		} else if ( value.isMatrix3 ) {
+
+			// manually converting 3x3 to 3x4
 
 			data[ 0 ] = value.elements[ 0 ];
 			data[ 1 ] = value.elements[ 1 ];
@@ -182,6 +185,7 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 		} else if ( ArrayBuffer.isView( value ) ) {
 
+			// copy the buffer data using "set"
 			data.set( new value.constructor( value.buffer, value.byteOffset, data.length ) );
 
 		} else {

--- a/src/renderers/webgl/WebGLUniformsGroups.js
+++ b/src/renderers/webgl/WebGLUniformsGroups.js
@@ -164,7 +164,6 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 		if ( typeof value === 'number' || typeof value === 'boolean' ) {
 
 			data[ 0 ] = value;
-			gl.bufferSubData( gl.UNIFORM_BUFFER, offset, data );
 
 		} else if ( value.isMatrix3 ) {
 


### PR DESCRIPTION
**Description**

This PR optimizes the WebGL 2 Uniform Buffer Objects (UBO) update pipeline to eliminate unnecessary array allocations and GC churn.

* **Problem**: `updateBufferData()` previously wrapped single uniforms and values in temporary single-element arrays (`[uniforms[i]]` and `[uniform.value]`) on every update check. For standard (non-array) properties, this allocated and discarded thousands of array objects per frame, leading to high Garbage Collection overhead.
* **Optimization**: Refactored UBO synchronization to branch natively using `Array.isArray()`—eliminating all temporary wrapper array allocations on hot paths.
* **Refactoring**: Extracted copying and synchronization logic into `updateUniform()` and `writeUniformValue()` helpers to remove code repetition, making the UBO sync codebase clean, modular, and easy to maintain.

(Made with Gemini/Antigravity 2.0)