### PR TITLE
TSL: Fix varying code sequence in vertex stage

### DIFF
--- a/src/nodes/core/VaryingNode.js
+++ b/src/nodes/core/VaryingNode.js
@@ -170,8 +170,18 @@ class VaryingNode extends Node {
 			const type = this.getNodeType( builder );
 			const propertyName = builder.getPropertyName( varying, NodeShaderStage.VERTEX );
 
-			// force node run in vertex stage
-			builder.flowNodeFromShaderStage( NodeShaderStage.VERTEX, properties.node, type, propertyName );
+			if ( builder.shaderStage === NodeShaderStage.VERTEX ) {
+
+				const snippet = properties.node.build( builder, type );
+
+				builder.addLineFlowCode( `${ propertyName } = ${ snippet }`, this );
+
+			} else {
+
+				// force node run in vertex stage
+				builder.flowNodeFromShaderStage( NodeShaderStage.VERTEX, properties.node, type, propertyName );
+
+			}
 
 			properties[ propertyKey ] = propertyName;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32873

**Description**

Ensure that `VaryingNode` generated during the vertex stage are compiled inline into the current flow code instead of prepending them to the global stage flow. This fixes sequence issues where vertex stage modifications (like `skinning` or `positionLocal` adjustments) were incorrectly evaluated after varying assignments.

| Previous using `positionNode` (wrong) | PR using `positionNode` | Using `vertexNode` |
|---|---|---|
| <img width="768" height="853" alt="image" src="https://github.com/user-attachments/assets/6fc405bc-927b-4843-95b7-bfaec30034be" /> | <img width="775" height="855" alt="image" src="https://github.com/user-attachments/assets/146cf39c-4bbc-4d3c-9064-23ab50b57faa" /> | <img width="766" height="830" alt="image" src="https://github.com/user-attachments/assets/83722949-5d2b-429f-b04a-77677258dca0" /> |

```js
// code used to create vertical waves
material.positionNode = Fn( () => {

	const newPosition = positionLocal;

	newPosition.x.addAssign( positionWorld.y.mul( 10 ).sin().mul( 10 ) );

	return newPosition;

} )();
```

<details>
  <summary>Full example</summary>

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>XX - Stylized Nature Scene</title>
    <style>
        *
        {
            margin: 0;
            padding: 0;
        }

        html,
        body
        {
            overflow: hidden;
        }

        .threejs
        {
            position: fixed;
            top: 0;
            left: 0;
            outline: none;
        }
    </style>
</head>
<body>
    <canvas class="threejs"></canvas>

    <script type="importmap">
        {
            "imports": {
                "three": "../src/three.webgpu.js",
                "three/webgpu": "../src/three.webgpu.js",
                "three/tsl": "../src/three.tsl.js",
                "three/addons/": "./jsm/"
            }
        }
    </script>

    <script type="module">

		import * as THREE from 'three/webgpu';
		import { Fn, positionWorld, positionLocal, modelWorldMatrix, cameraViewMatrix, cameraProjectionMatrix } from 'three/tsl';

		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

		/**
		 * Base
		 */
		// Canvas
		const canvas = document.querySelector( 'canvas.threejs' );

		// Scene
		const scene = new THREE.Scene();

		// Loaders
		const gltfLoader = new GLTFLoader();

		/**
		 * Sizes
		 */
		const sizes = {
			width: window.innerWidth,
			height: window.innerHeight
		};

		window.addEventListener( 'resize', () => {

			// Update sizes
			sizes.width = window.innerWidth;
			sizes.height = window.innerHeight;

			// Update camera
			camera.aspect = sizes.width / sizes.height;
			camera.updateProjectionMatrix();

			// Update renderer
			renderer.setSize( sizes.width, sizes.height );
			renderer.setPixelRatio( Math.min( window.devicePixelRatio, 2 ) );

		} );

		/**
		 * Camera
		 */
		// Base camera
		const camera = new THREE.PerspectiveCamera( 35, sizes.width / sizes.height, 0.1, 100 );
		camera.position.x = 8;
		camera.position.y = 4.5;
		camera.position.z = 6;
		scene.add( camera );

		// Controls
		const controls = new OrbitControls( camera, canvas );
		controls.target.set( 0, 0, 0 );
		controls.enableDamping = true;

		/**
		 * Renderer
		 */
		const renderer = new THREE.WebGPURenderer( {
			canvas: canvas,
			antialias: true
		} );
		renderer.setSize( sizes.width, sizes.height );
		renderer.setPixelRatio( Math.min( window.devicePixelRatio, 2 ) );
		renderer.setClearColor( 0x000000 );
		renderer.outputColorSpace = THREE.LinearSRGBColorSpace;

		/**
		 * Model
		 */
		const model = await gltfLoader.loadAsync( './models/gltf/Michelle.glb' );
		scene.add( model.scene );
		model.scene.scale.setScalar( 3 );
		model.scene.position.y = - 2;

		model.scene.traverse( ( child ) => {

			if ( child instanceof THREE.Mesh ) {

				child.material = new THREE.MeshBasicNodeMaterial();

				child.material.positionNode = Fn( () => {

					const newPosition = positionLocal;

					newPosition.x.addAssign( positionWorld.y.mul( 10 ).sin().mul( 10 ) );

					return newPosition;

				} )();

				/*child.material.vertexNode = Fn( () => {

					const worldPosition = modelWorldMatrix.mul( positionLocal ).toVar();

					worldPosition.x.addAssign( worldPosition.y.mul( 10 ).sin().mul( 0.2 ) );

					return cameraProjectionMatrix.mul( cameraViewMatrix ).mul( worldPosition );

				} )();*/


				child.material.colorNode = Fn( () => {

					return positionWorld;

				} )();

			}

		} );

		const mixer = new THREE.AnimationMixer( model.scene );
		const action = mixer.clipAction( model.animations[ 0 ] );
		action.play();

		/**
		 * Lights
		 */
		const directionalLight = new THREE.DirectionalLight( 0xffffff, 3 );
		directionalLight.castShadow = true;
		directionalLight.position.set( 4, 2, 1 ).normalize().multiplyScalar( 10 );
		directionalLight.shadow.radius = 5;
		directionalLight.shadow.normalBias = 0.1;
		scene.add( directionalLight );

		const ambientLight = new THREE.AmbientLight( 0x859dff, 0.5 );
		scene.add( ambientLight );

		/**
		 * Animate
		 */
		const timer = new THREE.Timer();

		const tick = () => {

			timer.update();

			// Animation
			mixer.update( timer.getDelta() * 0.2 );

			// Update controls
			controls.update();

			// Render
			renderer.render( scene, camera );

		};

		renderer.setAnimationLoop( tick );

    </script>
</body>
</html>
```

</details>

/cc @brunosimon 