### PR TITLE
WebGPU: Support ExternalTexture as a render-target attachment

### DIFF
--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -126,13 +126,7 @@ class RenderTarget extends EventDispatcher {
 		 */
 		this.viewport = new Vector4( 0, 0, width, height );
 
-		/**
-		 * An array of textures. Each color attachment is represented as a separate texture.
-		 * Has at least a single entry for the default color attachment.
-		 *
-		 * @type {Array<Texture>}
-		 */
-		this.textures = [];
+		this._textures = [];
 
 		const image = { width: width, height: height, depth: options.depth };
 		const texture = new Texture( image );
@@ -258,7 +252,48 @@ class RenderTarget extends EventDispatcher {
 
 	set texture( value ) {
 
+		// A texture assigned as the color attachment becomes a render-target texture, as in the constructor.
+		if ( value !== null ) {
+
+			value.isRenderTargetTexture = true;
+			value.renderTarget = this;
+
+		}
+
 		this.textures[ 0 ] = value;
+
+	}
+
+	/**
+	 * An array of textures. Each color attachment is represented as a separate texture.
+	 * Has at least a single entry for the default color attachment.
+	 *
+	 * Assigning an array flags each entry as a render-target texture, as the constructor does.
+	 *
+	 * @type {Array<Texture>}
+	 */
+	get textures() {
+
+		return this._textures;
+
+	}
+
+	set textures( value ) {
+
+		for ( let i = 0; i < value.length; i ++ ) {
+
+			const texture = value[ i ];
+
+			if ( texture !== null ) {
+
+				texture.isRenderTargetTexture = true;
+				texture.renderTarget = this;
+
+			}
+
+		}
+
+		this._textures = value;
 
 	}
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -283,13 +283,49 @@ class WebGPUTextureUtils {
 
 			}
 
+			// An ExternalTexture wraps a caller-owned GPU texture. On reinitialization (e.g. a render target
+			// resize that bumps the texture version) rebind the source instead of erroring.
+			if ( texture.isExternalTexture === true ) {
+
+				textureData.texture = texture.sourceTexture;
+				textureData.format = texture.sourceTexture.format;
+
+				return;
+
+			}
+
 			throw new Error( 'THREE.WebGPUTextureUtils: Texture already initialized.' );
 
 		}
 
 		if ( texture.isExternalTexture ) {
 
-			textureData.texture = texture.sourceTexture;
+			const sourceTexture = texture.sourceTexture;
+
+			textureData.texture = sourceTexture;
+			textureData.format = sourceTexture.format;
+
+			// When used as a multisampled render target, the external texture is the single-sample resolve
+			// target; three allocates and owns the multisampled attachment that is rendered into and resolved
+			// from (see the resolve handling in WebGPUBackend._getRenderPassDescriptor).
+			const { samples, isMSAA } = backend.utils.getTextureSampleData( texture );
+
+			if ( isMSAA ) {
+
+				const msaaTextureDescriptorGPU = new GPUTextureDescriptor();
+				msaaTextureDescriptorGPU.label = texture.name + '-msaa';
+				msaaTextureDescriptorGPU.size.width = sourceTexture.width;
+				msaaTextureDescriptorGPU.size.height = sourceTexture.height;
+				msaaTextureDescriptorGPU.size.depthOrArrayLayers = sourceTexture.depthOrArrayLayers;
+				msaaTextureDescriptorGPU.sampleCount = samples;
+				msaaTextureDescriptorGPU.dimension = this._getDimension( texture );
+				msaaTextureDescriptorGPU.format = sourceTexture.format;
+				msaaTextureDescriptorGPU.usage = GPUTextureUsage.RENDER_ATTACHMENT;
+
+				textureData.msaaTexture = backend.device.createTexture( msaaTextureDescriptorGPU );
+
+			}
+
 			textureData.initialized = true;
 
 			return;
@@ -406,7 +442,9 @@ class WebGPUTextureUtils {
 		const backend = this.backend;
 		const textureData = backend.get( texture );
 
-		if ( textureData.texture !== undefined && isDefaultTexture === false ) textureData.texture.destroy();
+		// Never destroy an external texture's GPU resource. It is owned by the caller, not by three. The MSAA
+		// resolve attachment below is three-owned even for an external target, so it is still destroyed.
+		if ( textureData.texture !== undefined && isDefaultTexture === false && texture.isExternalTexture !== true ) textureData.texture.destroy();
 
 		if ( textureData.msaaTexture !== undefined ) textureData.msaaTexture.destroy();
 

--- a/src/textures/ExternalTexture.js
+++ b/src/textures/ExternalTexture.js
@@ -23,14 +23,6 @@ class ExternalTexture extends Texture {
 		super();
 
 		/**
-		 * The external source texture.
-		 *
-		 * @type {?(WebGLTexture|GPUTexture)}
-		 * @default null
-		 */
-		this.sourceTexture = sourceTexture;
-
-		/**
 		 * This flag can be used for type testing.
 		 *
 		 * @type {boolean}
@@ -38,6 +30,36 @@ class ExternalTexture extends Texture {
 		 * @default true
 		 */
 		this.isExternalTexture = true;
+
+		this.sourceTexture = sourceTexture;
+
+	}
+
+	/**
+	 * The external source texture.
+	 *
+	 * Assigning it also derives {@link Texture#image} from the source's
+	 * dimensions (when available), so the texture reports a valid size to the renderer.
+	 *
+	 * @type {?(WebGLTexture|GPUTexture)}
+	 * @default null
+	 */
+	get sourceTexture() {
+
+		return this._sourceTexture;
+
+	}
+
+	set sourceTexture( value ) {
+
+		this._sourceTexture = value;
+
+		// A GPUTexture exposes its dimensions; a WebGLTexture is an opaque handle that does not.
+		if ( value !== null && typeof value.width === 'number' ) {
+
+			this.image = { width: value.width, height: value.height, depth: value.depthOrArrayLayers || 1 };
+
+		}
 
 	}
 


### PR DESCRIPTION
**Description**

`ExternalTexture` only works as a sampled input today. This PR also lets it be a render-target color attachment, so the renderer can draw directly into a caller-owned/imported `GPUTexture` - zero-copy interop with e.g. a native compositor, video pipeline, or XR renderer.

WebGPU-backend changes:
- `ExternalTexture` - derives `Texture.image` from `sourceTexture` so the texture reports a size (the render path null-derefs `image.depth` without it).
- `createTexture` - external branch sets the format from `sourceTexture.format`, allocates a three-owned MSAA attachment that resolves into the external texture, and rebinds on reinit instead of throwing.
- `destroyTexture` - skips `.destroy()` for external textures (three doesn't own them); the MSAA attachment is still freed.
- `RenderTarget.texture` setter - wires `isRenderTargetTexture`/`renderTarget` like the constructor, so the assigned attachment is treated as one.
