### PR TITLE
TSL: Fix transformDirection matrix multiply order

### DIFF
--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -187,7 +187,9 @@ class MathNode extends TempNode {
 			let tA = aNode;
 			let tB = bNode;
 
-			if ( builder.isMatrix( tA.getNodeType( builder ) ) ) {
+			const isMatrixInput = builder.isMatrix( tA.getNodeType( builder ) );
+
+			if ( isMatrixInput ) {
 
 				tB = vec4( vec3( tB ), 0.0 );
 
@@ -197,7 +199,7 @@ class MathNode extends TempNode {
 
 			}
 
-			const mulNode = mul( tA, tB ).xyz;
+			const mulNode = isMatrixInput ? mul( tA, tB ).xyz : mul( tB, tA ).xyz;
 
 			outputNode = normalize( mulNode );
 

--- a/test/unit/src/nodes/math/MathNode.tests.js
+++ b/test/unit/src/nodes/math/MathNode.tests.js
@@ -1,0 +1,91 @@
+import Node from '../../../../../src/nodes/core/Node.js';
+import MathNode from '../../../../../src/nodes/math/MathNode.js';
+
+function createBuilder() {
+
+	const nodeData = new WeakMap();
+	const nodeProperties = new WeakMap();
+
+	return {
+
+		getDataFromNode( node ) {
+
+			if ( nodeData.has( node ) === false ) {
+
+				nodeData.set( node, {} );
+
+			}
+
+			return nodeData.get( node );
+
+		},
+
+		getNodeProperties( node ) {
+
+			if ( nodeProperties.has( node ) === false ) {
+
+				nodeProperties.set( node, {} );
+
+			}
+
+			return nodeProperties.get( node );
+
+		},
+
+		isMatrix( type ) {
+
+			return /^mat[234]$/.test( type );
+
+		}
+
+	};
+
+}
+
+function unwrapNode( node ) {
+
+	while ( node.isStackNode || node.isVarNode ) {
+
+		node = node.outputNode || node.node;
+
+	}
+
+	return node;
+
+}
+
+function getTransformDirectionOperator( transformDirectionNode ) {
+
+	const outputNode = unwrapNode( transformDirectionNode.setup( createBuilder() ) );
+	const splitNode = unwrapNode( outputNode.aNode );
+
+	return unwrapNode( splitNode.node );
+
+}
+
+export default QUnit.module( 'Nodes', () => {
+
+	QUnit.module( 'Math', () => {
+
+		QUnit.module( 'MathNode', () => {
+
+			QUnit.test( 'transformDirection multiplies the matrix before the direction', ( assert ) => {
+
+				const directionNode = new Node( 'vec3' );
+				const matrixNode = new Node( 'mat4' );
+
+				let operatorNode = getTransformDirectionOperator( new MathNode( MathNode.TRANSFORM_DIRECTION, directionNode, matrixNode ) );
+
+				assert.strictEqual( operatorNode.aNode, matrixNode, 'direction, matrix order multiplies the matrix first' );
+
+				operatorNode = getTransformDirectionOperator( new MathNode( MathNode.TRANSFORM_DIRECTION, matrixNode, directionNode ) );
+
+				assert.strictEqual( operatorNode.aNode, matrixNode, 'matrix, direction order keeps multiplying the matrix first' );
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -291,3 +291,6 @@ import './src/textures/VideoTexture.tests.js';
 //src/nodes/display
 import './src/nodes/display/ViewportTextureNode.tests.js';
 import './src/nodes/display/ViewportDepthTextureNode.tests.js';
+
+//src/nodes/math
+import './src/nodes/math/MathNode.tests.js';


### PR DESCRIPTION
Related issue: #33309

**Description**

`transformDirection( direction, matrix )` now keeps the transform matrix on the left side of the multiplication, matching the expected `matrix * direction` operation. The existing matrix-first method-chaining path is preserved, and a unit test covers both operand orders.

Tests:

- `node --input-type=module` focused MathNode regression check with VarIntent wrappers
- `npm_config_cache=/tmp/three-33309-npm-cache npx eslint src/nodes/math/MathNode.js test/unit/src/nodes/math/MathNode.tests.js test/unit/three.source.unit.js && git diff --check`
- `npm_config_cache=/tmp/three-33309-npm-cache PUPPETEER_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' npm test`
