### PR TITLE
Docs: Fix Safari scrolling to anchors

### DIFF
--- a/utils/docs/template/static/scripts/page.js
+++ b/utils/docs/template/static/scripts/page.js
@@ -30,9 +30,15 @@ if ( typeof hljs !== 'undefined' ) {
 
 	if ( hash ) {
 
-		const element = document.getElementById( hash );
+		window.history.scrollRestoration = 'manual';
 
-		if ( element ) element.scrollIntoView();
+		window.addEventListener( 'pageshow', function () {
+
+			const element = document.getElementById( hash );
+
+			if ( element ) element.scrollIntoView();
+
+		}, { once: true } );
 
 	}
 


### PR DESCRIPTION
Related: https://github.com/mrdoob/three.js/pull/32312#issuecomment-4620754420
Fixed #32302.
Closes #32312.

**Description**

This PR fixes Safari not scrolling to anchors on document load in the docs, as outlined in https://github.com/mrdoob/three.js/pull/32312.

For testing: https://raw.githack.com/shotamatsuda/three.js/fix/docs-safari-scroll/docs/