### PR TITLE
Renderes: Make sure cameras correctly update their world matrix.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1636,7 +1636,7 @@ class WebGLRenderer {
 
 			// update camera matrices and frustum
 
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if ( camera.matrixWorldAutoUpdate === true ) camera.updateWorldMatrix( true, true );
 
 			if ( xr.enabled === true && xr.isPresenting === true && ( output === null || output.isCompositing() === false ) ) {
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -3456,7 +3456,7 @@ class Renderer {
 
 		}
 
-		if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+		if ( camera.matrixWorldAutoUpdate === true ) camera.updateWorldMatrix( true, true );
 
 		// handle XR
 


### PR DESCRIPTION
Fixed #15929.

**Description**

The PR makes sure cameras do not update via `camera.updateMatrixWorld();` anymore but use `camera.updateWorldMatrix( true, true );`. So the update performs a full ancestor chain refreshed before the world matrix is composed. The descendant-update is controlled by the second `true` argument.