### PR TITLE
WebGPURenderer: Fix unsupported texture sample counts

### DIFF
--- a/examples/webgpu_multisampled_renderbuffers.html
+++ b/examples/webgpu_multisampled_renderbuffers.html
@@ -52,7 +52,7 @@
 
 			const params = {
 				animated: true,
-				samples: 4
+				multisampling: true
 			};
 
 			const mat4 = new THREE.Matrix4();
@@ -81,7 +81,7 @@
 			function initGUI() {
 
 				const gui = renderer.inspector.createParameters( 'Settings' );
-				gui.add( params, 'samples', 0, 4, 1 );
+				gui.add( params, 'multisampling' );
 				gui.add( params, 'animated' );
 
 			}
@@ -126,7 +126,7 @@
 				document.body.appendChild( renderer.domElement );
 
 				renderTarget = new THREE.RenderTarget( window.innerWidth * dpr, window.innerHeight * dpr, {
-					samples: params.samples,
+					samples: params.multisampling ? 4 : 1,
 					depthBuffer: true,
 				} );
 
@@ -172,7 +172,7 @@
 
 				}
 
-				renderTarget.samples = params.samples;
+				renderTarget.samples = params.multisampling ? 4 : 1;
 
 				renderer.setRenderTarget( renderTarget );
 				renderer.render( scene, camera );

--- a/src/renderers/webgpu/utils/WebGPUUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUUtils.js
@@ -113,7 +113,7 @@ class WebGPUUtils {
 
 		}
 
-		samples = samples || 1;
+		samples = this.getSampleCount( samples || 1 );
 
 		const isMSAA = samples > 1 && texture.renderTarget !== null && ( texture.isDepthTexture !== true && texture.isFramebufferTexture !== true );
 		const primarySamples = isMSAA ? 1 : samples;


### PR DESCRIPTION
Related issue: --

**Description**

This PR fixes a `GPUValidationError` in `WebGPURenderer` when setting a texture or render target's sample count to unsupported values (e.g. `3` or any value other than `1` or `4`).

Additionally, the `webgpu_multisampled_renderbuffers` example has been updated to use a simpler `boolean` switch (`multisampling`) in the GUI instead of a slider with numbers, as intermediate sample numbers are not natively supported by WebGPU.