### PR TITLE
E2E: Print elapsed seconds

### DIFF
--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -504,7 +504,7 @@ async function checkFile( ctx, failedScreenshots, cleanPage, isMakeScreenshot, f
 
 		}
 
-		const pageElapsed = + ( ( performance.now() - pageStart ) / 1000 ).toFixed( 1 );
+		const pageElapsed = ( performance.now() - pageStart ) / 1000;
 
 		const screenshot = ( await Image.read( await page.screenshot() ) ).scale( 1 / viewScale );
 
@@ -558,14 +558,14 @@ async function checkFile( ctx, failedScreenshots, cleanPage, isMakeScreenshot, f
 
 			if ( differentPixels < maxDifferentPixels ) {
 
-				console.green( `Diff ${ differentPixels.toFixed( 1 ) }% in file: ${ file } (${ pageElapsed }s)` );
+				console.green( `Diff ${ differentPixels.toFixed( 1 ) }% in file: ${ file } (${ pageElapsed.toFixed( 1 ) }s)` );
 
 			} else {
 
 				await screenshot.write( `test/e2e/output-screenshots/${ file }-actual.jpg`, jpgQuality );
 				await expected.write( `test/e2e/output-screenshots/${ file }-expected.jpg`, jpgQuality );
 				await diff.write( `test/e2e/output-screenshots/${ file }-diff.jpg`, jpgQuality );
-				throw new Error( `Diff wrong in ${ differentPixels.toFixed( 1 ) }% of pixels in file: ${ file } (${ pageElapsed }s)` );
+				throw new Error( `Diff wrong in ${ differentPixels.toFixed( 1 ) }% of pixels in file: ${ file } (${ pageElapsed.toFixed( 1 ) }s)` );
 
 			}
 

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -422,6 +422,7 @@ async function preparePage( page, injection, builds, errorMessages ) {
 async function checkFile( ctx, failedScreenshots, cleanPage, isMakeScreenshot, file ) {
 
 	const page = ctx.page;
+	const pageStart = performance.now();
 
 	try {
 
@@ -503,6 +504,8 @@ async function checkFile( ctx, failedScreenshots, cleanPage, isMakeScreenshot, f
 
 		}
 
+		const pageElapsed = + ( ( performance.now() - pageStart ) / 1000 ).toFixed( 1 );
+
 		const screenshot = ( await Image.read( await page.screenshot() ) ).scale( 1 / viewScale );
 
 		if ( page.error !== undefined ) throw new Error( page.error );
@@ -555,14 +558,14 @@ async function checkFile( ctx, failedScreenshots, cleanPage, isMakeScreenshot, f
 
 			if ( differentPixels < maxDifferentPixels ) {
 
-				console.green( `Diff ${ differentPixels.toFixed( 1 ) }% in file: ${ file }` );
+				console.green( `Diff ${ differentPixels.toFixed( 1 ) }% in file: ${ file } (${ pageElapsed }s)` );
 
 			} else {
 
 				await screenshot.write( `test/e2e/output-screenshots/${ file }-actual.jpg`, jpgQuality );
 				await expected.write( `test/e2e/output-screenshots/${ file }-expected.jpg`, jpgQuality );
 				await diff.write( `test/e2e/output-screenshots/${ file }-diff.jpg`, jpgQuality );
-				throw new Error( `Diff wrong in ${ differentPixels.toFixed( 1 ) }% of pixels in file: ${ file }` );
+				throw new Error( `Diff wrong in ${ differentPixels.toFixed( 1 ) }% of pixels in file: ${ file } (${ pageElapsed }s)` );
 
 			}
 


### PR DESCRIPTION
Related issue: #33559

**Description**

This PR prints elapsed seconds for each page in E2E when they are finished or errored.

I have a strong suspicion that the false errors in `webgpu_pmrem_*` examples which output a black screen are due to timeouts, but I cannot confirm it because the `Render timeout exceeded in file` message is suppressed and is hard to uncomment. This addition will help us decide whether we should increase `renderTimeout`, and should be useful outside this particular issue as well.