### PR TITLE
StereoCamera: Fix matrix computation.

### DIFF
--- a/src/cameras/StereoCamera.js
+++ b/src/cameras/StereoCamera.js
@@ -136,8 +136,11 @@ class StereoCamera {
 
 		}
 
-		this.cameraL.matrixWorld.copy( camera.matrixWorld ).multiply( _eyeLeft );
-		this.cameraR.matrixWorld.copy( camera.matrixWorld ).multiply( _eyeRight );
+		this.cameraL.matrix.copy( camera.matrixWorld ).multiply( _eyeLeft );
+		this.cameraL.matrixWorldNeedsUpdate = true;
+
+		this.cameraR.matrix.copy( camera.matrixWorld ).multiply( _eyeRight );
+		this.cameraR.matrixWorldNeedsUpdate = true;
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

The PR makes sure `StereoCamera` updates its matrices in a more consistent way.

`StereoCamera` sets `matrixAutoUpdate` to `false` for its both internal cameras (left and right eye). Setting this flag to `false` means the component _owns_ the local matrix so no auto-compute happens from the position, rotation and scale properties. 

However, `StereoCamera` overwrites the world matrix which only worked by accident since `matrixWorldNeedsUpdate` was never set to `true`. It's more clean when the component writes into the local matrix and uses `matrixWorldNeedsUpdate` to indicate the need for a world matrix update. That's the intended API usage if  `matrixAutoUpdate` is set to `false`.