### PR TITLE
WebGPURenderer: Fix `getShaderAsync()` render context retrieval

### DIFF
--- a/examples/webgpu_tsl_editor.html
+++ b/examples/webgpu_tsl_editor.html
@@ -184,6 +184,8 @@ output = vec4( finalColor, opacity );
 
 							compiling = true;
 
+							mesh.visible = false;
+
 							if ( options.output === 'WGSL' ) {
 
 								rawShader = await renderer.debug.getShaderAsync( scene, camera, mesh );
@@ -194,6 +196,8 @@ output = vec4( finalColor, opacity );
 								rawShader = await webGLRenderer.debug.getShaderAsync( scene, camera, mesh );
 
 							}
+
+							mesh.visible = true;
 
 							compiling = false;
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -737,10 +737,13 @@ class Renderer {
 			onShaderError: null,
 			getShaderAsync: async ( scene, camera, object ) => {
 
-				await this.compileAsync( scene, camera );
+				await this.compileAsync( object, camera, scene );
+
+				const useFrameBufferTarget = this.needsFrameBufferTarget && this._renderTarget === null;
+				const renderTarget = useFrameBufferTarget ? this._getFrameBufferTarget() : ( this._renderTarget || this._outputRenderTarget );
 
 				const renderList = this._renderLists.get( scene, camera );
-				const renderContext = this._renderContexts.get( this._renderTarget, this._mrt );
+				const renderContext = this._renderContexts.get( renderTarget, this._mrt );
 
 				const material = scene.overrideMaterial || object.material;
 


### PR DESCRIPTION
Related issue: N/A

**Description**

This PR fixes a bug in `Renderer.debug.getShaderAsync()` where compilation failed or retrieved an incorrect render context, and updates the TSL Editor example to ensure smooth async compilation.