### PR TITLE
Editor: Fix outliner regression.

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -517,9 +517,9 @@ function SidebarScene( editor ) {
 
 				const openerElement = option.querySelector( ':scope > .opener' );
 
-				const openerHTML = openerElement ? openerElement.outerHTML : '';
+				option.innerHTML = buildHTML( object );
 
-				option.innerHTML = openerHTML + buildHTML( object );
+				if ( openerElement !== null ) option.insertBefore( openerElement, option.firstChild );
 
 				return;
 


### PR DESCRIPTION
Fixed #33734.

**Description**

The current way `Sidebar.Scene.js` rebuilds the HTML during on object change event looses the toggle/collapse event listener until a UI redraw happens. The PR preserve and re-insert the original opener element instead of stringifying it.
