### PR TITLE
npm: Exclude `examples/fonts` from the published package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "files": [
     "build",
     "examples/jsm",
-    "examples/fonts",
     "LICENSE",
     "package.json",
     "README.md",


### PR DESCRIPTION
**Description**

The font assets (~7.7 MB) are example data not required by the shipped library. They remain in the repository for the website and examples, but are no longer included in the npm tarball.

This will save 77 terabytes from npm dowloads per week.