### PR TITLE
Object3D: Honor `matrixWorldNeedsUpdate` in `updateWorldMatrix()`.

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -129,9 +129,9 @@ class Camera extends Object3D {
 
 	}
 
-	updateWorldMatrix( updateParents, updateChildren ) {
+	updateWorldMatrix( updateParents, updateChildren, force = false ) {
 
-		super.updateWorldMatrix( updateParents, updateChildren );
+		super.updateWorldMatrix( updateParents, updateChildren, force );
 
 		// exclude scale from view matrix to be glTF conform
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1208,8 +1208,10 @@ class Object3D extends EventDispatcher {
 	 *
 	 * @param {boolean} [updateParents=false] Whether ancestor nodes should be updated or not.
 	 * @param {boolean} [updateChildren=false] Whether descendant nodes should be updated or not.
+	 * @param {boolean} [force=false] - When set to `true`, a recomputation of world matrices is forced even
+	 * when {@link Object3D#matrixWorldNeedsUpdate} is `false`.
 	 */
-	updateWorldMatrix( updateParents, updateChildren ) {
+	updateWorldMatrix( updateParents, updateChildren, force = false ) {
 
 		const parent = this.parent;
 
@@ -1221,17 +1223,25 @@ class Object3D extends EventDispatcher {
 
 		if ( this.matrixAutoUpdate ) this.updateMatrix();
 
-		if ( this.matrixWorldAutoUpdate === true ) {
+		if ( this.matrixWorldNeedsUpdate || force ) {
 
-			if ( this.parent === null ) {
+			if ( this.matrixWorldAutoUpdate === true ) {
 
-				this.matrixWorld.copy( this.matrix );
+				if ( this.parent === null ) {
 
-			} else {
+					this.matrixWorld.copy( this.matrix );
 
-				this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
+				} else {
+
+					this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
+
+				}
 
 			}
+
+			this.matrixWorldNeedsUpdate = false;
+
+			force = true;
 
 		}
 
@@ -1245,7 +1255,7 @@ class Object3D extends EventDispatcher {
 
 				const child = children[ i ];
 
-				child.updateWorldMatrix( false, true );
+				child.updateWorldMatrix( false, true, force );
 
 			}
 

--- a/src/helpers/DirectionalLightHelper.js
+++ b/src/helpers/DirectionalLightHelper.js
@@ -116,6 +116,8 @@ class DirectionalLightHelper extends Object3D {
 	 */
 	update() {
 
+		this.matrixWorldNeedsUpdate = true;
+
 		this.light.updateWorldMatrix( true, false );
 		this.light.target.updateWorldMatrix( true, false );
 

--- a/src/helpers/HemisphereLightHelper.js
+++ b/src/helpers/HemisphereLightHelper.js
@@ -118,6 +118,8 @@ class HemisphereLightHelper extends Object3D {
 
 		}
 
+		this.matrixWorldNeedsUpdate = true;
+
 		this.light.updateWorldMatrix( true, false );
 
 		mesh.lookAt( _vector.setFromMatrixPosition( this.light.matrixWorld ).negate() );

--- a/src/helpers/PointLightHelper.js
+++ b/src/helpers/PointLightHelper.js
@@ -76,6 +76,8 @@ class PointLightHelper extends Mesh {
 	 */
 	update() {
 
+		this.matrixWorldNeedsUpdate = true;
+
 		this.light.updateWorldMatrix( true, false );
 
 		if ( this.color !== undefined ) {

--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -125,7 +125,7 @@ class SpotLightHelper extends Object3D {
 
 		}
 
-		this.matrixWorld.copy( this.light.matrixWorld );
+		this.matrixWorldNeedsUpdate = true;
 
 		const coneLength = this.light.distance ? this.light.distance : 1000;
 		const coneWidth = coneLength * Math.tan( this.light.angle );

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -1033,6 +1033,7 @@ export default QUnit.module( 'Core', () => {
 			object.matrixWorld.identity();
 
 			object.matrixAutoUpdate = false;
+			object.matrixWorldNeedsUpdate = true;
 			object.updateWorldMatrix( true, false );
 
 			assert.deepEqual( object.matrix.elements,


### PR DESCRIPTION
Related issue: -

**Description**

Right now, `updateWorldMatrix()` recomputes the world matrix unconditionally. That is not correct since unlike `updateMatrixWorld()`, the flag `matrixWorldNeedsUpdate` is currently ignored. 

When `matrixAutoUpdate` is set to `false`, the applications _owns_ `Object3D.matrix`. That means it decides when to call `updateMatrix()` or it writes directly into `Object3D.matrix`. In any case, `matrixWorldNeedsUpdate` indicates when a world matrix update is required and when not. It is auto-set by `updateMatrix()` _or_ by the application/component itself.

`updateWorldMatrix()` must honor this flag otherwise it performs unneeded computations.

The PR also updates some helpers which currently ignore this policy.

Since this is a behavior change (correction) for `updateWorldMatrix()` user, it must be noted in the migration guide.
