### PR TITLE
Update Sketchfab link for Battle Damaged Helmet

### DIFF
--- a/examples/misc_exporter_usdz.html
+++ b/examples/misc_exporter_usdz.html
@@ -28,7 +28,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - USDZ exporter<br />
 			Battle Damaged Sci-fi Helmet by
-			<a href="https://sketchfab.com/theblueturtle_" target="_blank" rel="noopener">theblueturtle_</a>
+			<a href="https://sketchfab.com/3d-models/battle-damaged-sci-fi-helmet-pbr-b81008d513954189a063ff901f7abfe4" target="_blank" rel="noopener">theblueturtle_</a>
 		</div>
 
 		<a id="link" rel="ar" href="" download="asset.usdz">


### PR DESCRIPTION
Link in page goes to a 404 link. Correct link is: https://sketchfab.com/3d-models/battle-damaged-sci-fi-helmet-pbr-b81008d513954189a063ff901f7abfe4

Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
