### PR TITLE
TiledLightsNode: Compute point light radius in screen space

### DIFF
--- a/examples/jsm/tsl/lighting/TiledLightsNode.js
+++ b/examples/jsm/tsl/lighting/TiledLightsNode.js
@@ -391,8 +391,11 @@ class TiledLightsNode extends LightsNode {
 				const ndc = projectedPosition.div( projectedPosition.w );
 				const screenPosition = ndc.xy.mul( 0.5 ).add( 0.5 ).flipY();
 
-				const distanceFromCamera = viewPosition.z;
-				const pointRadius = distance.div( distanceFromCamera );
+				const viewDepth = viewPosition.z.negate();
+				const projectionScaleX = cameraProjectionMatrix.element( 0 ).element( 0 );
+				const projectionScaleY = cameraProjectionMatrix.element( 1 ).element( 1 );
+				const projectionScale = projectionScaleX.max( projectionScaleY );
+				const pointRadius = distance.mul( projectionScale ).mul( 0.5 ).div( viewDepth );
 
 				If( circleIntersectsAABB( screenPosition, pointRadius, minBounds, maxBounds ), () => {
 


### PR DESCRIPTION
Related issue: -

**Description**

`TiledLightsNode` compares point light bounds against tiles in screen UV space, but the previous radius used `distance / viewPosition.z`. That omits the camera projection scale and the `0.5` conversion from NDC to UV, so the binning radius is not in the same coordinate space as `circleIntersectsAABB()`.

This computes the radius from positive view depth, the larger projection-matrix scale, and the NDC-to-UV factor. Using the larger axis keeps the existing circular tile test conservative when the projected light footprint is wider on one screen axis than the other.

Note - I used Codex to create this PR, but was able to validate that it fixed some visual artifacts in my own usage of tiled lighting. 