### PR TITLE
ShadowNode: Fix shadow viewer inspect and introduce `equirectDirection`

### DIFF
--- a/examples/webgpu_shadowmap_pointlight.html
+++ b/examples/webgpu_shadowmap_pointlight.html
@@ -1,24 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>three.js webgpu - PointLight ShadowMap</title>
+		<title>three.js webgpu - point light shadow-map</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<meta property="og:title" content="three.js webgpu - PointLight ShadowMap">
 		<meta property="og:type" content="website">
 		<meta property="og:url" content="https://threejs.org/examples/webgpu_shadowmap_pointlight.html">
 		<meta property="og:image" content="https://threejs.org/examples/screenshots/webgpu_shadowmap_pointlight.jpg">
-		<link type="text/css" rel="stylesheet" href="main.css">
+		<link type="text/css" rel="stylesheet" href="example.css">
 	</head>
 	<body>
+
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - WebGPU - PointLight ShadowMap
+			<a href="https://threejs.org/" target="_blank" rel="noopener" class="logo-link"></a>
+
+			<div class="title-wrapper">
+				<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a><span>PointLight ShadowMap</span>
+			</div>
+
+			<small>Animated point light shadows.</small>
 		</div>
 
 		<script type="importmap">
 			{
 				"imports": {
 					"three": "../build/three.webgpu.js",
+					"three/webgpu": "../build/three.webgpu.js",
+					"three/tsl": "../build/three.tsl.js",
 					"three/addons/": "./jsm/"
 				}
 			}
@@ -28,11 +37,11 @@
 
 			import * as THREE from 'three';
 
-			import Stats from 'three/addons/libs/stats.module.js';
-
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
-			let camera, scene, renderer, stats;
+			import { Inspector } from 'three/addons/inspector/Inspector.js';
+
+			let camera, scene, renderer;
 			let pointLight, pointLight2;
 
 			init();
@@ -114,15 +123,16 @@
 				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				// renderer.shadowMap.type = THREE.BasicShadowMap;
-				await renderer.init();
+				renderer.inspector = new Inspector();
 				document.body.appendChild( renderer.domElement );
+
+				await renderer.init();
 
 				const controls = new OrbitControls( camera, renderer.domElement );
 				controls.target.set( 0, 10, 0 );
 				controls.update();
 
-				stats = new Stats();
-				document.body.appendChild( stats.dom );
+
 
 				//
 
@@ -174,8 +184,6 @@
 				pointLight2.rotation.z = time;
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -177,6 +177,7 @@ export const dynamicBufferAttribute = TSL.dynamicBufferAttribute;
 export const element = TSL.element;
 export const emissive = TSL.emissive;
 export const equal = TSL.equal;
+export const equirectDirection = TSL.equirectDirection;
 export const equirectUV = TSL.equirectUV;
 export const exp = TSL.exp;
 export const exp2 = TSL.exp2;

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -13,7 +13,7 @@ import { Loop } from '../utils/LoopNode.js';
 import { screenCoordinate } from '../display/ScreenNode.js';
 import { Compatibility, GreaterEqualCompare, HalfFloatType, LessEqualCompare, LinearFilter, NearestFilter, PCFShadowMap, PCFSoftShadowMap, RGFormat, VSMShadowMap } from '../../constants.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
-import { viewZToLogarithmicDepth } from '../display/ViewportDepthNode.js';
+import { viewZToLogarithmicDepth, perspectiveDepthToViewZ, orthographicDepthToViewZ, viewZToOrthographicDepth } from '../display/ViewportDepthNode.js';
 import { lightShadowMatrix } from '../accessors/Lights.js';
 import { resetRendererAndSceneState, restoreRendererAndSceneState } from '../../renderers/common/RendererUtils.js';
 import { getDataFromObject } from '../core/NodeUtils.js';
@@ -23,6 +23,7 @@ import { textureSize } from '../accessors/TextureSizeNode.js';
 import { uv } from '../accessors/UV.js';
 import { positionLocal } from '../accessors/Position.js';
 import { uniform } from '../core/UniformNode.js';
+import { equirectDirection } from '../utils/EquirectUV.js';
 
 //
 
@@ -595,7 +596,7 @@ class ShadowNode extends ShadowBaseNode {
 
 				if ( this.shadowMap.texture.isCubeTexture ) {
 
-					return cubeTexture( this.shadowMap.texture );
+					return cubeTexture( this.shadowMap.texture, equirectDirection() );
 
 				}
 
@@ -607,15 +608,36 @@ class ShadowNode extends ShadowBaseNode {
 
 		return shadowOutput.toInspector( `${ inspectName } / Depth`, () => {
 
-			// TODO: Use linear depth
+			const shadowCameraNear = reference( 'near', 'float', this.shadow.camera );
+			const shadowCameraFar = reference( 'far', 'float', this.shadow.camera );
+
+			let depthNode;
 
 			if ( this.shadowMap.texture.isCubeTexture ) {
 
-				return cubeTexture( this.shadowMap.texture ).r.oneMinus();
+				depthNode = cubeTexture( this.shadowMap.depthTexture, equirectDirection() ).r;
+
+			} else {
+
+				depthNode = textureLoad( this.shadowMap.depthTexture, uv().mul( textureSize( texture( this.shadowMap.depthTexture ) ) ) ).r;
 
 			}
 
-			return textureLoad( this.shadowMap.depthTexture, uv().mul( textureSize( texture( this.shadowMap.depthTexture ) ) ) ).r.oneMinus();
+			let linearDepth;
+
+			if ( this.shadow.camera.isPerspectiveCamera ) {
+
+				linearDepth = perspectiveDepthToViewZ( depthNode, shadowCameraNear, shadowCameraFar );
+
+			} else {
+
+				linearDepth = orthographicDepthToViewZ( depthNode, shadowCameraNear, shadowCameraFar );
+
+			}
+
+			linearDepth = viewZToOrthographicDepth( linearDepth, shadowCameraNear, shadowCameraFar );
+
+			return linearDepth.oneMinus();
 
 		} );
 

--- a/src/nodes/utils/EquirectUV.js
+++ b/src/nodes/utils/EquirectUV.js
@@ -1,5 +1,6 @@
 import { positionWorldDirection } from '../accessors/Position.js';
-import { Fn, vec2 } from '../tsl/TSLBase.js';
+import { uv as UV } from '../accessors/UV.js';
+import { Fn, vec2, vec3 } from '../tsl/TSLCore.js';
 
 /**
  * TSL function for creating an equirect uv node.
@@ -14,14 +15,38 @@ import { Fn, vec2 } from '../tsl/TSLBase.js';
  *
  * @tsl
  * @function
- * @param {?Node<vec3>} [dirNode=positionWorldDirection] - A direction vector for sampling which is by default `positionWorldDirection`.
+ * @param {?Node<vec3>} [direction=positionWorldDirection] - A direction vector for sampling which is by default `positionWorldDirection`.
  * @returns {Node<vec2>}
  */
-export const equirectUV = /*@__PURE__*/ Fn( ( [ dir = positionWorldDirection ] ) => {
+export const equirectUV = /*@__PURE__*/ Fn( ( [ direction = positionWorldDirection ] ) => {
 
-	const u = dir.z.atan( dir.x ).mul( 1 / ( Math.PI * 2 ) ).add( 0.5 );
-	const v = dir.y.clamp( - 1.0, 1.0 ).asin().mul( 1 / Math.PI ).add( 0.5 );
+	const u = direction.z.atan( direction.x ).mul( 1 / ( Math.PI * 2 ) ).add( 0.5 );
+	const v = direction.y.clamp( - 1.0, 1.0 ).asin().mul( 1 / Math.PI ).add( 0.5 );
 
 	return vec2( u, v );
+
+} );
+
+/**
+ * TSL function for creating an equirect direction node.
+ *
+ * Can be used to compute a direction vector from the given equirectangular
+ * UV coordinates.
+ *
+ * @tsl
+ * @function
+ * @param {?Node<vec2>} [uv=UV()] - The equirectangular UV coordinates.
+ * @returns {Node<vec3>} The computed direction vector.
+ */
+export const equirectDirection = /*@__PURE__*/ Fn( ( [ uv = UV() ] ) => {
+
+	const theta = uv.x.sub( 0.5 ).mul( Math.PI * 2 );
+	const phi = uv.y.sub( 0.5 ).mul( Math.PI );
+	const cosPhi = phi.cos();
+	const x = cosPhi.mul( theta.cos() );
+	const y = phi.sin();
+	const z = cosPhi.mul( theta.sin() );
+
+	return vec3( x, y, z );
 
 } );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33750

**Description**

Fix shadow viewer inspect using `direction = equirectDirection( uv )`, which is the inverse operation of `uv = equirectUV( direction )`. In the current scenario, it is used to inspect the point light shadow in the viewer.

<img width="912" height="903" alt="image" src="https://github.com/user-attachments/assets/b04e84ab-6633-4ad6-bf7f-850732c7a3ab" />
