### PR TITLE
TSL: Rename `directionToFaceDirection` -> `negateOnBackSide`

### DIFF
--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -377,6 +377,7 @@ export const mx_worley_noise_float = TSL.mx_worley_noise_float;
 export const mx_worley_noise_vec2 = TSL.mx_worley_noise_vec2;
 export const mx_worley_noise_vec3 = TSL.mx_worley_noise_vec3;
 export const negate = TSL.negate;
+export const negateOnBackSide = TSL.negateOnBackSide;
 export const neutralToneMapping = TSL.neutralToneMapping;
 export const nodeArray = TSL.nodeArray;
 export const nodeImmutable = TSL.nodeImmutable;

--- a/src/materials/nodes/MeshBasicNodeMaterial.js
+++ b/src/materials/nodes/MeshBasicNodeMaterial.js
@@ -5,7 +5,7 @@ import BasicLightMapNode from '../../nodes/lighting/BasicLightMapNode.js';
 import BasicLightingModel from '../../nodes/functions/BasicLightingModel.js';
 import { normalViewGeometry } from '../../nodes/accessors/Normal.js';
 import { diffuseColor } from '../../nodes/core/PropertyNode.js';
-import { directionToFaceDirection } from '../../nodes/display/FrontFacingNode.js';
+import { negateOnBackSide } from '../../nodes/display/FrontFacingNode.js';
 
 import { MeshBasicMaterial } from '../MeshBasicMaterial.js';
 
@@ -66,7 +66,7 @@ class MeshBasicNodeMaterial extends NodeMaterial {
 	 */
 	setupNormal() {
 
-		return directionToFaceDirection( normalViewGeometry ); // see #28839
+		return negateOnBackSide( normalViewGeometry ); // see #28839
 
 	}
 

--- a/src/nodes/accessors/Bitangent.js
+++ b/src/nodes/accessors/Bitangent.js
@@ -2,7 +2,7 @@ import { Fn } from '../tsl/TSLCore.js';
 import { normalGeometry, normalLocal, normalView, normalWorld } from './Normal.js';
 import { tangentGeometry, tangentLocal, tangentView, tangentWorld } from './Tangent.js';
 import { bitangentViewFrame } from './TangentUtils.js';
-import { directionToFaceDirection } from '../display/FrontFacingNode.js';
+import { negateOnBackSide } from '../display/FrontFacingNode.js';
 
 /**
  * Returns the bitangent node and assigns it to a varying if the material is not flat shaded.
@@ -65,7 +65,7 @@ export const bitangentView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	if ( builder.isFlatShading() !== true ) {
 
-		node = directionToFaceDirection( node );
+		node = negateOnBackSide( node );
 
 	}
 

--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -3,7 +3,7 @@ import { cameraViewMatrix } from './Camera.js';
 import { modelNormalMatrix, modelWorldMatrix } from './ModelNode.js';
 import { mat3, vec3, Fn, addMethodChaining } from '../tsl/TSLBase.js';
 import { positionView } from './Position.js';
-import { directionToFaceDirection } from '../display/FrontFacingNode.js';
+import { negateOnBackSide } from '../display/FrontFacingNode.js';
 import { warn } from '../../utils.js';
 
 /**
@@ -102,7 +102,7 @@ export const normalView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 		if ( builder.isFlatShading() !== true ) {
 
-			node = directionToFaceDirection( node );
+			node = negateOnBackSide( node );
 
 		}
 

--- a/src/nodes/accessors/Tangent.js
+++ b/src/nodes/accessors/Tangent.js
@@ -3,7 +3,7 @@ import { cameraWorldMatrix } from './Camera.js';
 import { modelViewMatrix } from './ModelNode.js';
 import { Fn, vec4 } from '../tsl/TSLBase.js';
 import { tangentViewFrame } from './TangentUtils.js';
-import { directionToFaceDirection } from '../display/FrontFacingNode.js';
+import { negateOnBackSide } from '../display/FrontFacingNode.js';
 
 /**
  * TSL object that represents the tangent attribute of the current rendered object.
@@ -43,7 +43,7 @@ export const tangentView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	if ( builder.isFlatShading() !== true ) {
 
-		node = directionToFaceDirection( node );
+		node = negateOnBackSide( node );
 
 	}
 

--- a/src/nodes/display/FrontFacingNode.js
+++ b/src/nodes/display/FrontFacingNode.js
@@ -1,5 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeImmutable, float, Fn } from '../tsl/TSLBase.js';
+import { warnOnce } from '../../utils.js';
 
 import { BackSide, DoubleSide } from '../../constants.js';
 
@@ -83,7 +84,7 @@ export const faceDirection = /*@__PURE__*/ float( frontFacing ).mul( 2.0 ).sub( 
  * @param {Node<vec3>} direction - The direction vector to convert.
  * @returns {Node<vec3>} The converted direction vector.
  */
-export const directionToFaceDirection = /*@__PURE__*/ Fn( ( [ direction ], { material } ) => {
+export const negateOnBackSide = /*@__PURE__*/ Fn( ( [ direction ], { material } ) => {
 
 	const side = material.side;
 
@@ -100,3 +101,24 @@ export const directionToFaceDirection = /*@__PURE__*/ Fn( ( [ direction ], { mat
 	return direction;
 
 } );
+
+/**
+ * Converts a direction vector to a face direction vector based on the material's side.
+ *
+ * If the material is set to `BackSide`, the direction is inverted.
+ * If the material is set to `DoubleSide`, the direction is multiplied by `faceDirection`.
+ *
+ * @tsl
+ * @function
+ * @deprecated since r185. Use {@link negateOnBackSide} instead.
+ * @param {Node<vec3>} direction - The direction vector to convert.
+ * @returns {Node<vec3>} The converted direction vector.
+ */
+export const directionToFaceDirection = ( direction ) => {
+
+	warnOnce( 'TSL: "directionToFaceDirection()" has been renamed to "negateOnBackSide()".' ); // @deprecated r185
+
+	return negateOnBackSide( direction );
+
+};
+

--- a/src/nodes/display/FrontFacingNode.js
+++ b/src/nodes/display/FrontFacingNode.js
@@ -75,57 +75,57 @@ export const frontFacing = /*@__PURE__*/ nodeImmutable( FrontFacingNode );
 export const faceDirection = /*@__PURE__*/ float( frontFacing ).mul( 2.0 ).sub( 1.0 );
 
 /**
- * Negates a direction or normal vector if the rendering occurs on the back side of a face,
+ * Negates a vector if the rendering occurs on the back side of a face,
  * based on the material's side configuration.
  *
- * - If the material's side is `BackSide`, the direction is inverted (negated).
- * - If the material's side is `DoubleSide`, the direction is multiplied by `faceDirection`
+ * - If the material's side is `BackSide`, the vector is inverted (negated).
+ * - If the material's side is `DoubleSide`, the vector is multiplied by `faceDirection`
  *   (negated only for back-facing fragments).
- * - If the material's side is `FrontSide` (default), the direction remains unchanged.
+ * - If the material's side is `FrontSide` (default), the vector remains unchanged.
  *
  * @tsl
  * @function
- * @param {Node<vec3>} direction - The direction vector to process.
- * @returns {Node<vec3>} The processed direction vector.
+ * @param {Node<vec3>} vector - The vector to process.
+ * @returns {Node<vec3>} The processed vector.
  */
-export const negateOnBackSide = /*@__PURE__*/ Fn( ( [ direction ], { material } ) => {
+export const negateOnBackSide = /*@__PURE__*/ Fn( ( [ vector ], { material } ) => {
 
 	const side = material.side;
 
 	if ( side === BackSide ) {
 
-		direction = direction.mul( - 1.0 );
+		vector = vector.mul( - 1.0 );
 
 	} else if ( side === DoubleSide ) {
 
-		direction = direction.mul( faceDirection );
+		vector = vector.mul( faceDirection );
 
 	}
 
-	return direction;
+	return vector;
 
 } );
 
 /**
- * Negates a direction or normal vector if the rendering occurs on the back side of a face,
+ * Negates a vector if the rendering occurs on the back side of a face,
  * based on the material's side configuration.
  *
- * - If the material's side is `BackSide`, the direction is inverted (negated).
- * - If the material's side is `DoubleSide`, the direction is multiplied by `faceDirection`
+ * - If the material's side is `BackSide`, the vector is inverted (negated).
+ * - If the material's side is `DoubleSide`, the vector is multiplied by `faceDirection`
  *   (negated only for back-facing fragments).
- * - If the material's side is `FrontSide` (default), the direction remains unchanged.
+ * - If the material's side is `FrontSide` (default), the vector remains unchanged.
  *
  * @tsl
  * @function
  * @deprecated since r185. Use {@link negateOnBackSide} instead.
- * @param {Node<vec3>} direction - The direction vector to convert.
- * @returns {Node<vec3>} The converted direction vector.
+ * @param {Node<vec3>} vector - The vector to convert.
+ * @returns {Node<vec3>} The converted vector.
  */
-export const directionToFaceDirection = ( direction ) => {
+export const directionToFaceDirection = ( vector ) => {
 
 	warnOnce( 'TSL: "directionToFaceDirection()" has been renamed to "negateOnBackSide()".' ); // @deprecated r185
 
-	return negateOnBackSide( direction );
+	return negateOnBackSide( vector );
 
 };
 

--- a/src/nodes/display/FrontFacingNode.js
+++ b/src/nodes/display/FrontFacingNode.js
@@ -75,14 +75,18 @@ export const frontFacing = /*@__PURE__*/ nodeImmutable( FrontFacingNode );
 export const faceDirection = /*@__PURE__*/ float( frontFacing ).mul( 2.0 ).sub( 1.0 );
 
 /**
- * Converts a direction vector to a face direction vector based on the material's side.
+ * Negates a direction or normal vector if the rendering occurs on the back side of a face,
+ * based on the material's side configuration.
  *
- * If the material is set to `BackSide`, the direction is inverted.
- * If the material is set to `DoubleSide`, the direction is multiplied by `faceDirection`.
+ * - If the material's side is `BackSide`, the direction is inverted (negated).
+ * - If the material's side is `DoubleSide`, the direction is multiplied by `faceDirection`
+ *   (negated only for back-facing fragments).
+ * - If the material's side is `FrontSide` (default), the direction remains unchanged.
  *
  * @tsl
- * @param {Node<vec3>} direction - The direction vector to convert.
- * @returns {Node<vec3>} The converted direction vector.
+ * @function
+ * @param {Node<vec3>} direction - The direction vector to process.
+ * @returns {Node<vec3>} The processed direction vector.
  */
 export const negateOnBackSide = /*@__PURE__*/ Fn( ( [ direction ], { material } ) => {
 
@@ -103,10 +107,13 @@ export const negateOnBackSide = /*@__PURE__*/ Fn( ( [ direction ], { material } 
 } );
 
 /**
- * Converts a direction vector to a face direction vector based on the material's side.
+ * Negates a direction or normal vector if the rendering occurs on the back side of a face,
+ * based on the material's side configuration.
  *
- * If the material is set to `BackSide`, the direction is inverted.
- * If the material is set to `DoubleSide`, the direction is multiplied by `faceDirection`.
+ * - If the material's side is `BackSide`, the direction is inverted (negated).
+ * - If the material's side is `DoubleSide`, the direction is multiplied by `faceDirection`
+ *   (negated only for back-facing fragments).
+ * - If the material's side is `FrontSide` (default), the direction remains unchanged.
  *
  * @tsl
  * @function

--- a/src/nodes/display/NormalMapNode.js
+++ b/src/nodes/display/NormalMapNode.js
@@ -5,7 +5,7 @@ import { TBNViewMatrix } from '../accessors/AccessorsUtils.js';
 import { nodeProxy, vec3 } from '../tsl/TSLBase.js';
 
 import { TangentSpaceNormalMap, ObjectSpaceNormalMap, NoNormalPacking, NormalRGPacking, NormalGAPacking } from '../../constants.js';
-import { directionToFaceDirection } from './FrontFacingNode.js';
+import { negateOnBackSide } from './FrontFacingNode.js';
 import { unpackNormal } from '../utils/Packing.js';
 import { error } from '../../utils.js';
 
@@ -107,7 +107,7 @@ class NormalMapNode extends TempNode {
 
 			if ( builder.isFlatShading() === true ) {
 
-				scale = directionToFaceDirection( scale );
+				scale = negateOnBackSide( scale );
 
 			}
 


### PR DESCRIPTION
Related issue: N/A

**Description**

This PR renames `directionToFaceDirection` to `negateOnBackSide` in TSL to improve naming clarity and consistency as suggested by @WestLangley.