### PR TITLE
Matrix3: Remove remaining usage of `translate()` and `scale()`.

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -1657,7 +1657,7 @@ class SVGLoader extends Loader {
 				const tx = parseFloatWithUnits( node.getAttribute( 'x' ) || 0 );
 				const ty = parseFloatWithUnits( node.getAttribute( 'y' ) || 0 );
 
-				transform.translate( tx, ty );
+				transform.makeTranslation( tx, ty );
 
 			}
 
@@ -1709,7 +1709,7 @@ class SVGLoader extends Loader {
 
 								}
 
-								currentTransform.translate( tx, ty );
+								currentTransform.makeTranslation( tx, ty );
 
 							}
 
@@ -1758,7 +1758,7 @@ class SVGLoader extends Loader {
 
 								}
 
-								currentTransform.scale( scaleX, scaleY );
+								currentTransform.makeScale( scaleX, scaleY );
 
 							}
 

--- a/examples/jsm/utils/GeometryCompressionUtils.js
+++ b/examples/jsm/utils/GeometryCompressionUtils.js
@@ -509,7 +509,7 @@ function quantizedEncodeUV( array, bytes ) {
 
 	}
 
-	decodeMat.scale(
+	decodeMat.makeScale(
 		( max[ 0 ] - min[ 0 ] ) / segments,
 		( max[ 1 ] - min[ 1 ] ) / segments
 	);


### PR DESCRIPTION
Related issue: #24733

**Description**

This removes the remaining usage of `translate()` and `scale()`.

@WestLangley How should we proceed with #24733? I would like to get #24731 closed so if you want to deprecated `translate()`, `rotate()` and `scale()`, we should do so. Otherwise let's keep them for backwards compatibility reasons. But we should make a decision.
