### PR TITLE
Matrix3: deprecate `.scale()`, `.rotate()`, and `.translate()`

### DIFF
--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -1,3 +1,5 @@
+import { warnOnce } from '../utils.js';
+
 /**
  * Represents a 3x3 matrix.
  *
@@ -407,11 +409,14 @@ class Matrix3 {
 	/**
 	 * Scales this matrix with the given scalar values.
 	 *
+	 * @deprecated
 	 * @param {number} sx - The amount to scale in the X axis.
 	 * @param {number} sy - The amount to scale in the Y axis.
 	 * @return {Matrix3} A reference to this matrix.
 	 */
 	scale( sx, sy ) {
+
+		warnOnce( 'Matrix3: .scale() is deprecated. Use .makeScale() instead.' ); // @deprecated r185
 
 		this.premultiply( _m3.makeScale( sx, sy ) );
 
@@ -422,10 +427,13 @@ class Matrix3 {
 	/**
 	 * Rotates this matrix by the given angle.
 	 *
+	 * @deprecated
 	 * @param {number} theta - The rotation in radians.
 	 * @return {Matrix3} A reference to this matrix.
 	 */
 	rotate( theta ) {
+
+		warnOnce( 'Matrix3: .rotate() is deprecated. Use .makeRotation() instead.' ); // @deprecated r185
 
 		this.premultiply( _m3.makeRotation( - theta ) );
 
@@ -436,11 +444,14 @@ class Matrix3 {
 	/**
 	 * Translates this matrix by the given scalar values.
 	 *
+	 * @deprecated
 	 * @param {number} tx - The amount to translate in the X axis.
 	 * @param {number} ty - The amount to translate in the Y axis.
 	 * @return {Matrix3} A reference to this matrix.
 	 */
 	translate( tx, ty ) {
+
+		warnOnce( 'Matrix3: .translate() is deprecated. Use .makeTranslation() instead.' ); // @deprecated r185
 
 		this.premultiply( _m3.makeTranslation( tx, ty ) );
 

--- a/test/unit/src/math/Matrix3.tests.js
+++ b/test/unit/src/math/Matrix3.tests.js
@@ -366,7 +366,6 @@ export default QUnit.module( 'Maths', () => {
 				- 0.17677669529663687, 0.1767766952966369, 0.5,
 				0, 0, 1
 			);
-			const b = new Matrix3();
 			const params = {
 				centerX: 0.5,
 				centerY: 0.5,
@@ -389,53 +388,7 @@ export default QUnit.module( 'Maths', () => {
 				params.centerX, params.centerY
 			);
 
-			b.identity()
-			 .translate( - params.centerX, - params.centerY )
-			 .rotate( params.rotation )
-			 .scale( params.repeatX, params.repeatY )
-			 .translate( params.centerX, params.centerY )
-			 .translate( params.offsetX, params.offsetY );
-
 			assert.ok( matrixEquals3( a, expected ), 'Check direct method' );
-			assert.ok( matrixEquals3( b, expected ), 'Check indirect method' );
-
-		} );
-
-		QUnit.test( 'scale', ( assert ) => {
-
-			const a = new Matrix3().set( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
-			const expected = new Matrix3().set(
-				0.25, 0.5, 0.75,
-				1, 1.25, 1.5,
-				7, 8, 9
-			);
-
-			a.scale( 0.25, 0.25 );
-			assert.ok( matrixEquals3( a, expected ), 'Check scaling result' );
-
-		} );
-
-		QUnit.test( 'rotate', ( assert ) => {
-
-			const a = new Matrix3().set( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
-			const expected = new Matrix3().set(
-				3.5355339059327373, 4.949747468305833, 6.363961030678928,
-				2.121320343559643, 2.121320343559643, 2.1213203435596433,
-				7, 8, 9
-			);
-
-			a.rotate( Math.PI / 4 );
-			assert.ok( matrixEquals3( a, expected ), 'Check rotated result' );
-
-		} );
-
-		QUnit.test( 'translate', ( assert ) => {
-
-			const a = new Matrix3().set( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
-			const expected = new Matrix3().set( 22, 26, 30, 53, 61, 69, 7, 8, 9 );
-
-			a.translate( 3, 7 );
-			assert.ok( matrixEquals3( a, expected ), 'Check translation result' );
 
 		} );
 


### PR DESCRIPTION
Follow-on to #33754.

Replaces #24733.

Fixes #24731.

We rotate objects in three.js -- not matrices.

