### PR TITLE
Object3D: Rewrite updateMatrixWorld() as a wrapper

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1164,41 +1164,7 @@ class Object3D extends EventDispatcher {
 	 */
 	updateMatrixWorld( force ) {
 
-		if ( this.matrixAutoUpdate ) this.updateMatrix();
-
-		if ( this.matrixWorldNeedsUpdate || force ) {
-
-			if ( this.matrixWorldAutoUpdate === true ) {
-
-				if ( this.parent === null ) {
-
-					this.matrixWorld.copy( this.matrix );
-
-				} else {
-
-					this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
-
-				}
-
-			}
-
-			this.matrixWorldNeedsUpdate = false;
-
-			force = true;
-
-		}
-
-		// make sure descendants are updated if required
-
-		const children = this.children;
-
-		for ( let i = 0, l = children.length; i < l; i ++ ) {
-
-			const child = children[ i ];
-
-			child.updateMatrixWorld( force );
-
-		}
+	    this.updateWorldMatrix( false, true, force );
 
 	}
 


### PR DESCRIPTION
Finally, there has been convergence between `updateMatrixWorld()` and `updateWorldMatrix()`.

I think it is unwise to retain both, but this is a quiet PR for now.