### PR TITLE
SkeletonHelper: Use `onBeforeRender()`.

### DIFF
--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -87,6 +87,8 @@ class SkeletonHelper extends LineSegments {
 		this.matrix = object.matrixWorld;
 		this.matrixAutoUpdate = false;
 
+		this.frustumCulled = false;
+
 		// colors
 
 		const color1 = new Color( 0x0000ff );

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -96,7 +96,7 @@ class SkeletonHelper extends LineSegments {
 
 	}
 
-	updateMatrixWorld( force ) {
+	onBeforeRender() {
 
 		const bones = this.bones;
 
@@ -125,9 +125,7 @@ class SkeletonHelper extends LineSegments {
 
 		}
 
-		geometry.getAttribute( 'position' ).needsUpdate = true;
-
-		super.updateMatrixWorld( force );
+		position.needsUpdate = true;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33758#issuecomment-4667829426

**Description**

Instead of using `updateMatrixWorld()`, `SkeletonHelper` can rely on `onBeforeRender()`.

The callback is only used for updating its line geometry before the helper gets rendered so there is no need to use a custom `updateMatrixWorld()`.