### PR TITLE
NodeMaterialObserver: Fix environment rotation and intensity checks.

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -610,13 +610,17 @@ class NodeMaterialObserver {
 
 		const scene = renderObject.scene;
 
-		if ( renderObjectData.environmentIntensity !== scene.environmentIntensity ||
-				renderObjectData.environmentRotation.equals( scene.environmentRotation ) === false ) {
+		if ( scene.environment !== null && material.envMap === null ) {
 
-			renderObjectData.environmentIntensity = scene.environmentIntensity;
-			renderObjectData.environmentRotation.copy( scene.environmentRotation );
+			if ( renderObjectData.environmentIntensity !== scene.environmentIntensity ||
+					renderObjectData.environmentRotation.equals( scene.environmentRotation ) === false ) {
 
-			return false;
+				renderObjectData.environmentIntensity = scene.environmentIntensity;
+				renderObjectData.environmentRotation.copy( scene.environmentRotation );
+
+				return false;
+
+			}
 
 		}
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -217,6 +217,11 @@ class NodeMaterialObserver {
 
 			}
 
+			const { environmentIntensity, environmentRotation } = renderObject.scene;
+
+			data.environmentIntensity = environmentIntensity;
+			data.environmentRotation = environmentRotation.clone();
+
 			data.lights = this.getLightsData( renderObject.lightsNode.getLights(), [] );
 
 			this.renderObjects.set( renderObject, data );
@@ -598,6 +603,20 @@ class NodeMaterialObserver {
 				}
 
 			}
+
+		}
+
+		// scene
+
+		const scene = renderObject.scene;
+
+		if ( renderObjectData.environmentIntensity !== scene.environmentIntensity ||
+				renderObjectData.environmentRotation.equals( scene.environmentRotation ) === false ) {
+
+			renderObjectData.environmentIntensity = scene.environmentIntensity;
+			renderObjectData.environmentRotation.copy( scene.environmentRotation );
+
+			return false;
 
 		}
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -369,7 +369,7 @@ class NodeMaterialObserver {
 	 * @param {RenderObject} renderObject - The render object.
 	 * @param {Array<Light>} lightsData - The current material lights.
 	 * @param {number} renderId - The current render ID.
-	 * @return {boolean} Whether the given render object has changed its state or not.
+	 * @return {boolean} Whether the given render object is equal to its cached state or not.
 	 */
 	equals( renderObject, lightsData, renderId ) {
 
@@ -632,7 +632,7 @@ class NodeMaterialObserver {
 
 				renderObjectData.center.copy( object.center );
 
-				return true;
+				return false;
 
 			}
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -22,6 +22,7 @@ const refreshUniforms = [
 	'emissiveMap',
 	'envMap',
 	'envMapIntensity',
+	'envMapRotation',
 	'gradientMap',
 	'ior',
 	'iridescence',


### PR DESCRIPTION
Fixed #33763.

**Description**

`NodeMaterialObserver` now correctly honors `envMapRotation` as well as `environmentIntensity` and `environmentRotation` on scene level. All are are part of the per-object uniforms and must be refreshed if their state changes.
