### PR TITLE
RenderList: Fix `occlusionQueryCount`.

### DIFF
--- a/src/renderers/common/RenderList.js
+++ b/src/renderers/common/RenderList.js
@@ -192,6 +192,18 @@ class RenderList {
 		 */
 		this.occlusionQueryCount = 0;
 
+		/**
+		 * The last object that was counted for occlusion query testing. Used to
+		 * avoid counting an object more than once when it produces multiple render
+		 * items (e.g. a mesh with multiple material groups), since such an object
+		 * is covered by a single occlusion query.
+		 *
+		 * @private
+		 * @type {?Object3D}
+		 * @default null
+		 */
+		this._lastOcclusionObject = null;
+
 	}
 
 	/**
@@ -213,6 +225,7 @@ class RenderList {
 		this.lightsArray.length = 0;
 
 		this.occlusionQueryCount = 0;
+		this._lastOcclusionObject = null;
 
 		return this;
 
@@ -290,7 +303,12 @@ class RenderList {
 
 		const renderItem = this.getNextRenderItem( object, geometry, material, groupOrder, z, group, clippingContext );
 
-		if ( object.occlusionTest === true ) this.occlusionQueryCount ++;
+		if ( object.occlusionTest === true && this._lastOcclusionObject !== object ) {
+
+			this.occlusionQueryCount ++;
+			this._lastOcclusionObject = object;
+
+		}
 
 		if ( material.transparent === true || material.transmission > 0 ||
 			( material.transmissionNode && material.transmissionNode.isNode ) ||

--- a/src/renderers/common/RenderList.js
+++ b/src/renderers/common/RenderList.js
@@ -225,7 +225,6 @@ class RenderList {
 		this.lightsArray.length = 0;
 
 		this.occlusionQueryCount = 0;
-		this._lastOcclusionObject = null;
 
 		return this;
 
@@ -432,6 +431,8 @@ class RenderList {
 			renderItem.clippingContext = null;
 
 		}
+
+		this._lastOcclusionObject = null;
 
 	}
 


### PR DESCRIPTION
Fixed #33759.

**Description**

The bug reported in  #33759 is real but it can be fixed in a much more simple way than proposed.

 `RenderList` just has to make sure to not count the same 3D object multiple times. So we apply the same "lastObject" tracking from the backends to the render lists to correctly count objects.

Both reproduction test cases from the issue are fixed with this PR.
