### PR TITLE
SSGINode: Use a half float render target.

### DIFF
--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -1,4 +1,4 @@
-import { RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils, MathUtils } from 'three/webgpu';
+import { HalfFloatType, RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils, MathUtils } from 'three/webgpu';
 import { clamp, normalize, reference, Fn, NodeUpdateType, uniform, vec4, passTexture, uv, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getViewPosition, screenCoordinate, float, sub, fract, dot, vec2, rand, vec3, Loop, mul, PI, cos, sin, uint, cross, acos, sign, pow, luminance, If, max, abs, Break, sqrt, HALF_PI, div, ceil, shiftRight, convertToTexture, bool, getNormalFromDepth, countOneBits, interleavedGradientNoise } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
@@ -272,7 +272,7 @@ class SSGINode extends TempNode {
 		 * @private
 		 * @type {RenderTarget}
 		 */
-		this._ssgiRenderTarget = new RenderTarget( 1, 1, { depthBuffer: false } );
+		this._ssgiRenderTarget = new RenderTarget( 1, 1, { depthBuffer: false, type: HalfFloatType } );
 		this._ssgiRenderTarget.texture.name = 'SSGI';
 
 		/**


### PR DESCRIPTION
**Description**

The GI pass produces HDR output — the shader clamps luminance at 7, and since the clamp is on luminance, individual channels can go far above 1. The render target used the default 8-bit type, so values were clipped per channel before compositing, losing bounce light energy and shifting its hue. This also made the in-shader HDR clamp dead code.

Using `HalfFloatType` fixes this and matches `SSRNode`/`TRAANode`.