### PR TITLE
SSGI: Add SVGF denoising, blue noise sampling and resolutionScale.

### DIFF
--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -88,6 +88,8 @@ class SSGINode extends TempNode {
 		 * drives the slice rotation and `y` the initial ray step, both in `[0, 1)`. The
 		 * node is expected to vary over time when temporal filtering is used — an animated
 		 * blue-noise node converges faster and with less visible noise than the default.
+		 * Keep the source static when `useTemporalFiltering` is disabled (e.g. via
+		 * `BlueNoiseNode.animated = false`).
 		 * When `null`, interleaved gradient noise with the GTAO spatial/temporal offset
 		 * tables is used instead.
 		 *

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -1,5 +1,5 @@
 import { HalfFloatType, RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils, MathUtils } from 'three/webgpu';
-import { clamp, normalize, reference, Fn, NodeUpdateType, uniform, vec4, passTexture, uv, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getViewPosition, screenCoordinate, float, sub, fract, dot, vec2, rand, vec3, Loop, mul, PI, cos, sin, uint, cross, acos, sign, pow, luminance, If, max, abs, Break, sqrt, HALF_PI, div, ceil, shiftRight, convertToTexture, bool, getNormalFromDepth, countOneBits, interleavedGradientNoise } from 'three/tsl';
+import { clamp, normalize, reference, Fn, NodeUpdateType, uniform, vec4, passTexture, uv, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getViewPosition, screenCoordinate, float, sub, fract, dot, vec2, rand, vec3, Loop, mul, PI, cos, sin, uint, cross, acos, sign, pow, luminance, If, max, abs, Break, sqrt, HALF_PI, div, ceil, shiftRight, convertToTexture, getNormalFromDepth, countOneBits, interleavedGradientNoise } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -578,8 +578,13 @@ class SSGINode extends TempNode {
 
 				globalOccludedBitfield.assign( 0 );
 
-				color.addAssign( horizonSampling( bool( true ), stepRadius, radiusVS, viewPosition, slideDirTexelSize, initialRayStep, uvNode, viewDir, viewNormal, n ) );
-				color.addAssign( horizonSampling( bool( false ), stepRadius, radiusVS, viewPosition, slideDirTexelSize, initialRayStep, uvNode, viewDir, viewNormal, n ) );
+				Loop( { start: uint( 0 ), end: uint( 2 ), type: 'uint', condition: '<', name: 'side' }, ( { side } ) => {
+
+					const directionIsRight = side.equal( uint( 0 ) );
+
+					color.addAssign( horizonSampling( directionIsRight, stepRadius, radiusVS, viewPosition, slideDirTexelSize, initialRayStep, uvNode, viewDir, viewNormal, n ) );
+
+				} );
 
 				ao.addAssign( float( countOneBits( globalOccludedBitfield ) ).div( float( MAX_RAY ) ) );
 

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -1,5 +1,5 @@
-import { HalfFloatType, RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils, MathUtils } from 'three/webgpu';
-import { clamp, normalize, reference, Fn, NodeUpdateType, uniform, vec4, passTexture, uv, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getViewPosition, screenCoordinate, float, sub, fract, dot, vec2, rand, vec3, Loop, mul, PI, cos, sin, uint, cross, acos, sign, pow, luminance, If, max, abs, Break, sqrt, HALF_PI, div, ceil, shiftRight, convertToTexture, getNormalFromDepth, countOneBits, interleavedGradientNoise } from 'three/tsl';
+import { HalfFloatType, RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils, MathUtils, WebGPUCoordinateSystem } from 'three/webgpu';
+import { clamp, normalize, reference, Fn, NodeUpdateType, uniform, vec4, passTexture, uv, logarithmicDepthToViewZ, viewZToPerspectiveDepth, screenCoordinate, float, sub, fract, dot, vec2, rand, vec3, Loop, mul, PI, cos, sin, uint, cross, acos, sign, pow, luminance, If, max, abs, Break, sqrt, HALF_PI, div, ceil, shiftRight, convertToTexture, getNormalFromDepth, countOneBits, interleavedGradientNoise } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -403,6 +403,37 @@ class SSGINode extends TempNode {
 		const sampleNormal = ( uv ) => ( this.normalNode !== null ) ? this.normalNode.sample( uv ).rgb.normalize() : getNormalFromDepth( uv, this.depthNode.value, this._cameraProjectionMatrixInverse );
 		const sampleBeauty = ( uv ) => this.beautyNode.sample( uv );
 
+		// optimized version of getViewPosition() that exploits the sparsity of the inverse projection matrix
+
+		const getViewPosition = ( screenPosition, depth ) => {
+
+			let ndc;
+
+			if ( builder.renderer.coordinateSystem === WebGPUCoordinateSystem ) {
+
+				ndc = vec3( vec2( screenPosition.x, screenPosition.y.oneMinus() ).mul( 2.0 ).sub( 1.0 ), depth ).toConst();
+
+			} else {
+
+				ndc = vec3( screenPosition.x, screenPosition.y.oneMinus(), depth ).mul( 2.0 ).sub( 1.0 ).toConst();
+
+			}
+
+			const c0 = this._cameraProjectionMatrixInverse.element( 0 );
+			const c1 = this._cameraProjectionMatrixInverse.element( 1 );
+			const c2 = this._cameraProjectionMatrixInverse.element( 2 );
+			const c3 = this._cameraProjectionMatrixInverse.element( 3 );
+
+			const viewSpacePosition = vec3(
+				ndc.x.mul( c0.x ).add( c3.x ),
+				ndc.y.mul( c1.y ).add( c3.y ),
+				ndc.z.mul( c2.z ).add( c3.z )
+			);
+
+			return viewSpacePosition.div( ndc.z.mul( c2.w ).add( c3.w ) );
+
+		};
+
 		// From Activision GTAO paper: https://www.activision.com/cdn/research/s2016_pbs_activision_occlusion.pptx
 
 		const spatialOffsets = Fn( ( [ position ] ) => {
@@ -459,7 +490,7 @@ class SSGINode extends TempNode {
 
 				} );
 
-				const sampleViewPosition = getViewPosition( sampleUV, sampleDepth( sampleUV ), this._cameraProjectionMatrixInverse ).toConst();
+				const sampleViewPosition = getViewPosition( sampleUV, sampleDepth( sampleUV ) ).toConst();
 				const pixelToSample = sampleViewPosition.sub( viewPosition ).normalize().toConst();
 				const linearThicknessMultiplier = this.useLinearThickness.equal( true ).select( sampleViewPosition.z.negate().div( this._cameraFar ).clamp().mul( 100 ), float( 1 ) );
 				const pixelToSampleBackface = normalize( sampleViewPosition.sub( linearThicknessMultiplier.mul( viewDir ).mul( THICKNESS ) ).sub( viewPosition ) );
@@ -525,7 +556,7 @@ class SSGINode extends TempNode {
 
 			depth.greaterThanEqual( 1.0 ).discard();
 
-			const viewPosition = getViewPosition( uvNode, depth, this._cameraProjectionMatrixInverse ).toVar();
+			const viewPosition = getViewPosition( uvNode, depth ).toVar();
 			const viewNormal = sampleNormal( uvNode ).toVar();
 			const viewDir = normalize( viewPosition.xyz.negate() ).toVar();
 

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -84,6 +84,19 @@ class SSGINode extends TempNode {
 		this.normalNode = normalNode;
 
 		/**
+		 * An optional node that supplies the per-pixel sampling jitter as a `vec2`: `x`
+		 * drives the slice rotation and `y` the initial ray step, both in `[0, 1)`. The
+		 * node is expected to vary over time when temporal filtering is used — an animated
+		 * blue-noise node converges faster and with less visible noise than the default.
+		 * When `null`, interleaved gradient noise with the GTAO spatial/temporal offset
+		 * tables is used instead.
+		 *
+		 * @type {?Node}
+		 * @default null
+		 */
+		this.noiseNode = null;
+
+		/**
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
@@ -562,10 +575,26 @@ class SSGINode extends TempNode {
 
 			//
 
-			const noiseOffset = spatialOffsets( screenCoordinate );
-			const noiseDirection = interleavedGradientNoise( screenCoordinate );
-			const noiseJitterIdx = this._temporalDirection.mul( 0.02 ); // Port: Add noiseJitterIdx here for slightly better noise convergence with TRAA (see #31890 for more details)
-			const initialRayStep = fract( noiseOffset.add( this._temporalOffset ) ).add( rand( uvNode.add( noiseJitterIdx ).mul( 2 ).sub( 1 ) ) );
+			// Per-pixel sampling jitter: the slice rotation ( noiseDirection ) and the initial ray step.
+
+			let noiseDirection, initialRayStep;
+
+			if ( this.noiseNode !== null ) {
+
+				const noise = vec2( this.noiseNode );
+
+				noiseDirection = noise.x;
+				initialRayStep = noise.y;
+
+			} else {
+
+				const noiseOffset = spatialOffsets( screenCoordinate );
+				const noiseJitterIdx = this._temporalDirection.mul( 0.02 ); // Port: Add noiseJitterIdx here for slightly better noise convergence with TRAA (see #31890 for more details)
+
+				noiseDirection = interleavedGradientNoise( screenCoordinate ).add( this._temporalDirection );
+				initialRayStep = fract( noiseOffset.add( this._temporalOffset ) ).add( rand( uvNode.add( noiseJitterIdx ).mul( 2 ).sub( 1 ) ) );
+
+			}
 
 			const ao = float( 0 );
 			const color = vec3( 0 );
@@ -595,7 +624,7 @@ class SSGINode extends TempNode {
 
 			Loop( { start: uint( 0 ), end: ROTATION_COUNT, type: 'uint', condition: '<' }, ( { i } ) => {
 
-				const rotationAngle = mul( float( i ).add( noiseDirection ).add( this._temporalDirection ), PI.div( float( ROTATION_COUNT ) ) ).toConst();
+				const rotationAngle = mul( float( i ).add( noiseDirection ), PI.div( float( ROTATION_COUNT ) ) ).toConst();
 				const sliceDir = vec3( vec2( cos( rotationAngle ), sin( rotationAngle ) ), 0 ).toConst();
 				const slideDirTexelSize = sliceDir.xy.mul( float( 1 ).div( this._resolution ) ).toConst();
 

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -164,7 +164,7 @@ class SSGINode extends TempNode {
 		 * Makes the sample distance in screen space instead of world-space (helps having more detail up close).
 		 *
 		 * @type {UniformNode<bool>}
-		 * @default false
+		 * @default true
 		 */
 		this.useScreenSpaceSampling = uniform( true, 'bool' );
 
@@ -205,12 +205,11 @@ class SSGINode extends TempNode {
 
 		/**
 		 * Whether to use temporal filtering or not. Setting this property to
-		 * `true` requires the usage of `TRAANode`. This will help to reduce noise
-		 * although it introduces typical TAA artifacts like ghosting and temporal
-		 * instabilities.
+		 * `true` requires a temporal resolve like `TRAANode` or `SVGFNode` in the
+		 * pipeline, which converges the varying sampling pattern to a stable result.
 		 *
-		 * If setting this property to `false`, a manual denoise via `DenoiseNode`
-		 * is required.
+		 * If setting this property to `false`, the sampling pattern is static and
+		 * a spatial denoise via `DenoiseNode` is required instead.
 		 *
 		 * @type {boolean}
 		 * @default true
@@ -231,7 +230,7 @@ class SSGINode extends TempNode {
 		 * Used to compute the effective step radius when viewSpaceSampling is `false`.
 		 *
 		 * @private
-		 * @type {UniformNode<vec2>}
+		 * @type {UniformNode<float>}
 		 */
 		this._halfProjScale = uniform( 1 );
 
@@ -501,8 +500,8 @@ class SSGINode extends TempNode {
 			const THICKNESS = this.thickness.toConst();
 			const BACKFACE_LIGHTING = this.backfaceLighting.toConst();
 
-			const uvDirection = directionIsRight.equal( true ).select( vec2( 1, - 1 ), vec2( - 1, 1 ) ); // Port note: Because of different uv conventions, uv-y has a different sign
-			const samplingDirection = directionIsRight.equal( true ).select( 1, - 1 );
+			const uvDirection = directionIsRight.select( vec2( 1, - 1 ), vec2( - 1, 1 ) ); // Port note: Because of different uv conventions, uv-y has a different sign
+			const samplingDirection = directionIsRight.select( 1, - 1 );
 
 			const color = vec3( 0 );
 
@@ -520,13 +519,13 @@ class SSGINode extends TempNode {
 
 				const sampleViewPosition = getViewPosition( sampleUV, sampleDepth( sampleUV ) ).toConst();
 				const pixelToSample = sampleViewPosition.sub( viewPosition ).normalize().toConst();
-				const linearThicknessMultiplier = this.useLinearThickness.equal( true ).select( sampleViewPosition.z.negate().div( this._cameraFar ).clamp().mul( 100 ), float( 1 ) );
+				const linearThicknessMultiplier = this.useLinearThickness.select( sampleViewPosition.z.negate().div( this._cameraFar ).clamp().mul( 100 ), float( 1 ) );
 				const pixelToSampleBackface = normalize( sampleViewPosition.sub( linearThicknessMultiplier.mul( viewDir ).mul( THICKNESS ) ).sub( viewPosition ) );
 
 				let frontBackHorizon = vec2( dot( pixelToSample, viewDir ), dot( pixelToSampleBackface, viewDir ) );
 				frontBackHorizon = GTAOFastAcos( clamp( frontBackHorizon, - 1, 1 ) );
 				frontBackHorizon = clamp( div( mul( samplingDirection, frontBackHorizon.negate() ).sub( n.sub( HALF_PI ) ), PI ) ); // Port note: subtract half pi instead of adding it
-				frontBackHorizon = directionIsRight.equal( true ).select( frontBackHorizon.yx, frontBackHorizon.xy ); // Front/Back get inverted depending on angle
+				frontBackHorizon = directionIsRight.select( frontBackHorizon.yx, frontBackHorizon.xy ); // Front/Back get inverted depending on angle
 
 				// inline ComputeOccludedBitfield() for easier debugging
 
@@ -574,7 +573,7 @@ class SSGINode extends TempNode {
 
 			} );
 
-			return vec3( color );
+			return color;
 
 		} );
 
@@ -624,7 +623,7 @@ class SSGINode extends TempNode {
 
 			const stepRadius = float( 0 );
 
-			If( this.useScreenSpaceSampling.equal( true ), () => {
+			If( this.useScreenSpaceSampling, () => {
 
 				stepRadius.assign( RADIUS.mul( this._resolution.x.div( 2 ) ).div( float( 16 ) ) ); // SSRT3 has a bug where stepRadius is divided by STEP_COUNT twice; fix here
 

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -99,6 +99,16 @@ class SSGINode extends TempNode {
 		this.noiseNode = null;
 
 		/**
+		 * The resolution scale. By default the effect is rendered in full resolution
+		 * for best quality but a value of `0.5` is an effective way of improving
+		 * performance, especially when the result is denoised and upsampled anyway.
+		 *
+		 * @type {number}
+		 * @default 1
+		 */
+		this.resolutionScale = 1;
+
+		/**
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
@@ -327,6 +337,9 @@ class SSGINode extends TempNode {
 	 * @param {number} height - The height of the effect.
 	 */
 	setSize( width, height ) {
+
+		width = Math.round( width * this.resolutionScale );
+		height = Math.round( height * this.resolutionScale );
 
 		this._resolution.value.set( width, height );
 		this._ssgiRenderTarget.setSize( width, height );

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -435,27 +435,13 @@ class SSGINode extends TempNode {
 			]
 		} );
 
-		const horizonSampling = Fn( ( [ directionIsRight, RADIUS, viewPosition, slideDirTexelSize, initialRayStep, uvNode, viewDir, viewNormal, n ] ) => {
+		const horizonSampling = Fn( ( [ directionIsRight, stepRadius, radiusVS, viewPosition, slideDirTexelSize, initialRayStep, uvNode, viewDir, viewNormal, n ] ) => {
 
 			const STEP_COUNT = this.stepCount.toConst();
 			const EXP_FACTOR = this.expFactor.toConst();
 			const THICKNESS = this.thickness.toConst();
 			const BACKFACE_LIGHTING = this.backfaceLighting.toConst();
 
-			const stepRadius = float( 0 );
-
-			If( this.useScreenSpaceSampling.equal( true ), () => {
-
-				stepRadius.assign( RADIUS.mul( this._resolution.x.div( 2 ) ).div( float( 16 ) ) ); // SSRT3 has a bug where stepRadius is divided by STEP_COUNT twice; fix here
-
-			} ).Else( () => {
-
-				stepRadius.assign( max( RADIUS.mul( this._halfProjScale ).div( viewPosition.z.negate() ), float( STEP_COUNT ) ) ); // Port note: viewZ is negative so a negate is required
-
-			} );
-
-			stepRadius.divAssign( float( STEP_COUNT ).add( 1 ) );
-			const radiusVS = max( 1, float( STEP_COUNT.sub( 1 ) ) ).mul( stepRadius );
 			const uvDirection = directionIsRight.equal( true ).select( vec2( 1, - 1 ), vec2( - 1, 1 ) ); // Port note: Because of different uv conventions, uv-y has a different sign
 			const samplingDirection = directionIsRight.equal( true ).select( 1, - 1 );
 
@@ -554,9 +540,27 @@ class SSGINode extends TempNode {
 			const color = vec3( 0 );
 
 			const ROTATION_COUNT = this.sliceCount.toConst();
+			const STEP_COUNT = this.stepCount.toConst();
 			const AO_INTENSITY = this.aoIntensity.toConst();
 			const GI_INTENSITY = this.giIntensity.toConst();
 			const RADIUS = this.radius.toConst();
+
+			// the step radius only depends on per-pixel values so it can be computed once for all slice directions
+
+			const stepRadius = float( 0 );
+
+			If( this.useScreenSpaceSampling.equal( true ), () => {
+
+				stepRadius.assign( RADIUS.mul( this._resolution.x.div( 2 ) ).div( float( 16 ) ) ); // SSRT3 has a bug where stepRadius is divided by STEP_COUNT twice; fix here
+
+			} ).Else( () => {
+
+				stepRadius.assign( max( RADIUS.mul( this._halfProjScale ).div( viewPosition.z.negate() ), float( STEP_COUNT ) ) ); // Port note: viewZ is negative so a negate is required
+
+			} );
+
+			stepRadius.divAssign( float( STEP_COUNT ).add( 1 ) );
+			const radiusVS = max( 1, float( STEP_COUNT.sub( 1 ) ) ).mul( stepRadius ).toConst();
 
 			Loop( { start: uint( 0 ), end: ROTATION_COUNT, type: 'uint', condition: '<' }, ( { i } ) => {
 
@@ -574,8 +578,8 @@ class SSGINode extends TempNode {
 
 				globalOccludedBitfield.assign( 0 );
 
-				color.addAssign( horizonSampling( bool( true ), RADIUS, viewPosition, slideDirTexelSize, initialRayStep, uvNode, viewDir, viewNormal, n ) );
-				color.addAssign( horizonSampling( bool( false ), RADIUS, viewPosition, slideDirTexelSize, initialRayStep, uvNode, viewDir, viewNormal, n ) );
+				color.addAssign( horizonSampling( bool( true ), stepRadius, radiusVS, viewPosition, slideDirTexelSize, initialRayStep, uvNode, viewDir, viewNormal, n ) );
+				color.addAssign( horizonSampling( bool( false ), stepRadius, radiusVS, viewPosition, slideDirTexelSize, initialRayStep, uvNode, viewDir, viewNormal, n ) );
 
 				ao.addAssign( float( countOneBits( globalOccludedBitfield ) ).div( float( MAX_RAY ) ) );
 

--- a/examples/jsm/tsl/display/SVGFNode.js
+++ b/examples/jsm/tsl/display/SVGFNode.js
@@ -167,6 +167,17 @@ class SVGFNode extends TempNode {
 		 */
 		this.lumaPhi = uniform( 4 );
 
+		/**
+		 * Clamps the luminance of each incoming sample to this multiple of its local
+		 * neighborhood mean before accumulation. Suppresses isolated bright outliers
+		 * ( fireflies ) that would otherwise blink in dark regions. Lower values suppress
+		 * more aggressively at the cost of dimming small bright details.
+		 *
+		 * @type {UniformNode<float>}
+		 * @default 2
+		 */
+		this.fireflyFactor = uniform( 2 );
+
 		// private uniforms
 
 		/**
@@ -510,6 +521,14 @@ class SVGFNode extends TempNode {
 				}
 
 				blurredLuma.mulAssign( 1 / 9 );
+
+				// suppress fireflies: clamp the sample against its neighborhood mean so isolated
+				// bright outliers cannot blink in and out of the accumulated result
+
+				const currentLuma = luminance( current.rgb ).toVar();
+				const maxLuma = blurredLuma.mul( this.fireflyFactor );
+
+				current.rgb.mulAssign( currentLuma.greaterThan( maxLuma ).select( maxLuma.div( currentLuma ), float( 1.0 ) ) );
 
 				const historyLuma = luminance( history.rgb );
 				const gradient = abs( blurredLuma.sub( historyLuma ) ).div( max( blurredLuma, historyLuma ).add( 0.01 ) );

--- a/examples/jsm/tsl/display/SVGFNode.js
+++ b/examples/jsm/tsl/display/SVGFNode.js
@@ -1,5 +1,5 @@
 import { RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils, HalfFloatType, NearestFilter, DepthTexture, FloatType } from 'three/webgpu';
-import { Fn, float, vec2, vec4, uv, uniform, texture, passTexture, convertToTexture, luminance, dot, max, abs, pow, mix, If, ivec2, getViewPosition, getNormalFromDepth, NodeUpdateType } from 'three/tsl';
+import { Fn, If, float, vec2, vec4, uv, uniform, texture, passTexture, convertToTexture, luminance, dot, min, max, abs, pow, mix, outputStruct, property, sqrt, ivec2, perspectiveDepthToViewZ, getNormalFromDepth, NodeUpdateType } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -10,6 +10,16 @@ let _rendererState;
 // keeps each level cheap, while the increasing per-level step still covers a wide area across levels.
 const _kernel = [ 1 / 4, 1 / 2, 1 / 4 ];
 
+// deadzone of the temporal gradient, in units of the local standard deviation: sampling jitter
+// moves the neighborhood mean by about one deviation per frame ( the jitter is spatially
+// coherent ) while a real lighting change moves it by many
+const _gradientDeadzone = 3;
+
+// fixed accumulation weight of the luminance moments, decoupled from the adaptive alpha: if the
+// moments followed it, a fully rejected history would collapse the variance to zero, which in
+// turn pins the gradient and the alpha at their maximum with no way to recover
+const _momentsAlpha = 0.2;
+
 /**
  * Post processing node that denoises a noisy screen-space signal (such as the raw output of
  * {@link SSGINode}) using a spatiotemporal filter in the spirit of SVGF (Spatiotemporal
@@ -18,19 +28,19 @@ const _kernel = [ 1 / 4, 1 / 2, 1 / 4 ];
  * The pipeline is:
  * - **Temporal accumulation**: the current frame is reprojected against history using the
  *   velocity buffer and blended, with a depth-based disocclusion test that resets history where
- *   the reprojection is invalid. This is an alternative to denoising via {@link TRAANode}.
- * - **Adaptive temporal alpha** (A-SVGF-style): a temporal gradient raises the accumulation weight
- *   towards the current frame where the signal changed, rejecting stale history to limit ghosting
- *   under motion. The gradient is derived here from the current-vs-history difference rather than
- *   from re-shaded forward-projected samples as in the original A-SVGF.
- * - **Edge-avoiding à-trous**: a multi-level wavelet filter (increasing step size per level)
- *   spatially denoises the accumulated signal while preserving edges via depth, normal and
- *   luminance edge-stopping functions.
+ *   the reprojection is invalid. Luminance moments are accumulated alongside the signal, giving
+ *   a per-pixel variance estimate of the incoming noise.
+ * - **Adaptive temporal alpha**: a temporal gradient measured in units of the local standard
+ *   deviation raises the accumulation weight towards the current frame where the signal changed,
+ *   rejecting stale history to limit ghosting. Expressing the gradient in deviation units
+ *   separates sampling jitter (about one deviation by construction) from real lighting change
+ *   (many deviations).
+ * - **Variance-guided à-trous**: a multi-level edge-avoiding wavelet filter (increasing step size
+ *   per level) spatially denoises the accumulated signal. The luminance edge-stop scales with the
+ *   local deviation, so noisy regions are smoothed aggressively while converged regions keep
+ *   their edges; the variance estimate is filtered along with the signal.
  * - **Feedback**: the first à-trous level is fed back as the color history for the next frame,
  *   which keeps the temporal signal denoised without over-blurring (the SVGF feedback trick).
- *
- * It does not include SVGF's variance-guided luminance weighting (per-pixel variance from temporal
- * moments driving the à-trous luminance edge-stop); the luminance weight uses a fixed `lumaPhi`.
  *
  * References:
  * - {@link https://cg.ivd.kit.edu/publications/2017/svgf/svgf_preprint.pdf} (SVGF, Schied et al.)
@@ -124,11 +134,11 @@ class SVGFNode extends TempNode {
 		this.temporalAlpha = uniform( 0.1 );
 
 		/**
-		 * Strength of the adaptive temporal alpha (A-SVGF-style anti-ghosting). The temporal gradient
-		 * (how much the signal changed vs reprojected history) is scaled by this value to raise the
-		 * accumulation weight towards the current frame where change is detected, rejecting stale
-		 * history under motion. `0` disables it (fixed `temporalAlpha`); higher reduces ghosting at
-		 * the cost of more noise on moving regions.
+		 * Strength of the adaptive temporal alpha (anti-ghosting). The temporal gradient — how much
+		 * the signal changed versus the reprojected history, in units of the local standard
+		 * deviation — is scaled by this value to raise the accumulation weight towards the current
+		 * frame, rejecting stale history where the lighting changed. `0` disables it (fixed
+		 * `temporalAlpha`); higher reduces ghosting at the cost of more noise on changing regions.
 		 *
 		 * @type {UniformNode<float>}
 		 * @default 4
@@ -160,7 +170,9 @@ class SVGFNode extends TempNode {
 		this.normalPhi = uniform( 128 );
 
 		/**
-		 * Luminance edge-stopping strength of the à-trous filter.
+		 * Luminance edge-stopping strength of the à-trous filter, in units of the local standard
+		 * deviation. Differences below `lumaPhi` deviations are smoothed; larger differences are
+		 * treated as edges and preserved.
 		 *
 		 * @type {UniformNode<float>}
 		 * @default 4
@@ -204,28 +216,35 @@ class SVGFNode extends TempNode {
 		 */
 		this._cameraProjectionMatrixInverse = uniform( camera.projectionMatrixInverse );
 
-		// render targets
+		/**
+		 * The camera's near and far values.
+		 *
+		 * @private
+		 * @type {UniformNode<vec2>}
+		 */
+		this._cameraNearFar = uniform( new Vector2() );
 
-		const rtOptions = { depthBuffer: false, type: HalfFloatType };
+		// render targets. The signal targets carry two attachments: the filtered signal, and
+		// the luminance moments with the variance derived from them
+
+		const rtOptions = { depthBuffer: false, type: HalfFloatType, count: 2 };
 
 		/**
-		 * Holds the previous frame's filtered result (the color history fed back each frame). Its
-		 * depth texture stores the previous frame's depth for the disocclusion test.
+		 * Holds the previous frame's filtered result and luminance moments (the history fed back
+		 * each frame). Its depth texture stores the previous frame's depth for the disocclusion test.
 		 *
 		 * @private
 		 * @type {RenderTarget}
 		 */
 		this._historyRenderTarget = new RenderTarget( 1, 1, { ...rtOptions, depthTexture: new DepthTexture() } );
-		this._historyRenderTarget.texture.name = 'SVGF.history';
 
 		/**
-		 * Holds the temporally accumulated signal before spatial filtering.
+		 * Holds the temporally accumulated signal and moments before spatial filtering.
 		 *
 		 * @private
 		 * @type {RenderTarget}
 		 */
 		this._temporalRenderTarget = new RenderTarget( 1, 1, rtOptions );
-		this._temporalRenderTarget.texture.name = 'SVGF.temporal';
 
 		/**
 		 * Ping-pong targets for the à-trous iterations.
@@ -234,8 +253,6 @@ class SVGFNode extends TempNode {
 		 * @type {Array<RenderTarget>}
 		 */
 		this._atrousRenderTargets = [ new RenderTarget( 1, 1, rtOptions ), new RenderTarget( 1, 1, rtOptions ) ];
-		this._atrousRenderTargets[ 0 ].texture.name = 'SVGF.atrous0';
-		this._atrousRenderTargets[ 1 ].texture.name = 'SVGF.atrous1';
 
 		/**
 		 * Holds the final filtered result.
@@ -244,7 +261,6 @@ class SVGFNode extends TempNode {
 		 * @type {RenderTarget}
 		 */
 		this._resolveRenderTarget = new RenderTarget( 1, 1, rtOptions );
-		this._resolveRenderTarget.texture.name = 'SVGF.resolve';
 
 		/**
 		 * Holds a packed geometry buffer ( view-space normal in rgb, linear view-space Z in a )
@@ -253,16 +269,31 @@ class SVGFNode extends TempNode {
 		 * @private
 		 * @type {RenderTarget}
 		 */
-		this._geometryRenderTarget = new RenderTarget( 1, 1, rtOptions );
+		this._geometryRenderTarget = new RenderTarget( 1, 1, { depthBuffer: false, type: HalfFloatType } );
 		this._geometryRenderTarget.texture.name = 'SVGF.geometry';
 
-		// the resolve target keeps linear filtering so the result upsamples smoothly when the
+		this._historyRenderTarget.textures[ 0 ].name = 'SVGF.history';
+		this._historyRenderTarget.textures[ 1 ].name = 'SVGF.history.moments';
+		this._temporalRenderTarget.textures[ 0 ].name = 'SVGF.temporal';
+		this._temporalRenderTarget.textures[ 1 ].name = 'SVGF.temporal.moments';
+		this._atrousRenderTargets[ 0 ].textures[ 0 ].name = 'SVGF.atrous0';
+		this._atrousRenderTargets[ 0 ].textures[ 1 ].name = 'SVGF.atrous0.moments';
+		this._atrousRenderTargets[ 1 ].textures[ 0 ].name = 'SVGF.atrous1';
+		this._atrousRenderTargets[ 1 ].textures[ 1 ].name = 'SVGF.atrous1.moments';
+		this._resolveRenderTarget.textures[ 0 ].name = 'SVGF.resolve';
+		this._resolveRenderTarget.textures[ 1 ].name = 'SVGF.resolve.moments';
+
+		// the resolve output keeps linear filtering so the result upsamples smoothly when the
 		// effect runs at a lower resolution than the output
 
 		for ( const rt of [ this._historyRenderTarget, this._temporalRenderTarget, this._geometryRenderTarget, ...this._atrousRenderTargets ] ) {
 
-			rt.texture.minFilter = NearestFilter;
-			rt.texture.magFilter = NearestFilter;
+			for ( const tex of rt.textures ) {
+
+				tex.minFilter = NearestFilter;
+				tex.magFilter = NearestFilter;
+
+			}
 
 		}
 
@@ -303,15 +334,31 @@ class SVGFNode extends TempNode {
 		 * @private
 		 * @type {TextureNode}
 		 */
-		this._historyNode = texture( this._historyRenderTarget.texture );
+		this._historyNode = texture( this._historyRenderTarget.textures[ 0 ] );
 
 		/**
-		 * Texture node holding the current à-trous input (swapped per iteration).
+		 * Texture node holding the history luminance moments.
 		 *
 		 * @private
 		 * @type {TextureNode}
 		 */
-		this._atrousInputNode = texture( this._temporalRenderTarget.texture );
+		this._historyMomentsNode = texture( this._historyRenderTarget.textures[ 1 ] );
+
+		/**
+		 * Texture node holding the current à-trous color input (swapped per iteration).
+		 *
+		 * @private
+		 * @type {TextureNode}
+		 */
+		this._atrousInputNode = texture( this._temporalRenderTarget.textures[ 0 ] );
+
+		/**
+		 * Texture node holding the current à-trous variance input (swapped per iteration).
+		 *
+		 * @private
+		 * @type {TextureNode}
+		 */
+		this._atrousVarianceNode = texture( this._temporalRenderTarget.textures[ 1 ] );
 
 		/**
 		 * Texture node holding the packed geometry buffer ( view normal + linear view Z ).
@@ -327,7 +374,7 @@ class SVGFNode extends TempNode {
 		 * @private
 		 * @type {PassTextureNode}
 		 */
-		this._textureNode = passTexture( this, this._resolveRenderTarget.texture );
+		this._textureNode = passTexture( this, this._resolveRenderTarget.textures[ 0 ] );
 
 	}
 
@@ -371,6 +418,7 @@ class SVGFNode extends TempNode {
 		const { renderer } = frame;
 
 		this._cameraProjectionMatrixInverse.value.copy( this.camera.projectionMatrixInverse );
+		this._cameraNearFar.value.set( this.camera.near, this.camera.far );
 
 		// keep the effect in sync with the dimensions of the beauty texture
 
@@ -390,7 +438,7 @@ class SVGFNode extends TempNode {
 			// not fade in from black
 
 			renderer.initRenderTarget( this._historyRenderTarget );
-			renderer.copyTextureToTexture( beautyTexture, this._historyRenderTarget.texture );
+			renderer.copyTextureToTexture( beautyTexture, this._historyRenderTarget.textures[ 0 ] );
 
 		}
 
@@ -408,10 +456,14 @@ class SVGFNode extends TempNode {
 		_quadMesh.name = 'SVGF.temporal';
 		_quadMesh.render( renderer );
 
+		// the integrated moments become next frame's moments history
+
+		renderer.copyTextureToTexture( this._temporalRenderTarget.textures[ 1 ], this._historyRenderTarget.textures[ 1 ] );
+
 		// edge-avoiding à-trous, ping-pong between targets, last level into the resolve target
 
 		const iterations = this.atrousIterations;
-		let inputTexture = this._temporalRenderTarget.texture;
+		let inputTarget = this._temporalRenderTarget;
 
 		_quadMesh.material = this._atrousMaterial;
 		_quadMesh.name = 'SVGF.atrous';
@@ -421,7 +473,8 @@ class SVGFNode extends TempNode {
 			const target = ( i === iterations - 1 ) ? this._resolveRenderTarget : this._atrousRenderTargets[ i % 2 ];
 
 			this._stepSize.value = 1 << i; // 1, 2, 4, 8, 16, ...
-			this._atrousInputNode.value = inputTexture;
+			this._atrousInputNode.value = inputTarget.textures[ 0 ];
+			this._atrousVarianceNode.value = inputTarget.textures[ 1 ];
 
 			renderer.setRenderTarget( target );
 			_quadMesh.render( renderer );
@@ -430,11 +483,11 @@ class SVGFNode extends TempNode {
 
 			if ( i === 0 ) {
 
-				renderer.copyTextureToTexture( target.texture, this._historyRenderTarget.texture );
+				renderer.copyTextureToTexture( target.textures[ 0 ], this._historyRenderTarget.textures[ 0 ] );
 
 			}
 
-			inputTexture = target.texture;
+			inputTarget = target;
 
 		}
 
@@ -472,7 +525,14 @@ class SVGFNode extends TempNode {
 		const sampleDepth = ( uvNode ) => this.depthNode.sample( uvNode ).r;
 		const sampleNormal = ( uvNode ) => ( this.normalNode !== null ) ? this.normalNode.sample( uvNode ).rgb.normalize() : getNormalFromDepth( uvNode, this.depthNode.value, this._cameraProjectionMatrixInverse );
 
+		const sharedContext = builder.getSharedContext();
+
 		// --- temporal accumulation pass ---
+		// outputs the accumulated signal and the integrated luminance moments
+		// ( μ1, μ2 ) with the variance derived from them
+
+		const temporalColor = property( 'vec4' );
+		const temporalMoments = property( 'vec4' );
 
 		const temporal = Fn( () => {
 
@@ -482,7 +542,8 @@ class SVGFNode extends TempNode {
 			const current = this.beautyNode.sample( uvNode ).toVar();
 			const depth = sampleDepth( uvNode ).toVar();
 
-			const result = vec4( current ).toVar();
+			temporalColor.assign( current );
+			temporalMoments.assign( vec4( 0.0 ) );
 
 			If( depth.lessThan( 1.0 ), () => {
 
@@ -495,76 +556,90 @@ class SVGFNode extends TempNode {
 
 				// depth-based disocclusion test ( compare linear view-space Z )
 
-				const currentZ = getViewPosition( uvNode, depth, this._cameraProjectionMatrixInverse ).z;
-				const previousZ = getViewPosition( historyUV, this._previousDepthNode.sample( historyUV ).r, this._cameraProjectionMatrixInverse ).z;
+				const { x: near, y: far } = this._cameraNearFar;
+				const currentZ = perspectiveDepthToViewZ( depth, near, far );
+				const previousZ = perspectiveDepthToViewZ( this._previousDepthNode.sample( historyUV ).r, near, far );
 				const validDepth = abs( currentZ.sub( previousZ ) ).lessThan( abs( currentZ ).mul( this.depthRejection ) );
 
 				const validHistory = inBounds.and( validDepth );
 
-				const history = this._historyNode.sample( historyUV );
+				const history = this._historyNode.sample( historyUV ).toVar();
+				const historyMoments = this._historyMomentsNode.sample( historyUV ).rg.toVar();
 
-				// A-SVGF-style adaptive temporal alpha. The temporal gradient measures how much the
-				// signal changed versus the reprojected ( denoised ) history. Because the input is
-				// noisy, the current luminance is averaged over a 3×3 neighborhood and a small noise
-				// floor is subtracted, so only real change ( motion, disocclusion, lighting ) raises
-				// alpha towards 1 and rejects stale history. A true A-SVGF gradient would instead
-				// re-shade forward-projected samples with the same random sequence.
+				// 3×3 spatial luminance moments of the incoming frame: used by the firefly clamp, as
+				// the change estimate for the temporal gradient and as variance fallback on disocclusion
 
-				const blurredLuma = float( 0 ).toVar();
+				const currentLuma = luminance( current.rgb ).toVar();
+
+				const blurredLuma = float( currentLuma ).toVar();
+				const blurredLuma2 = currentLuma.mul( currentLuma ).toVar();
 
 				for ( let y = - 1; y <= 1; y ++ ) {
 
 					for ( let x = - 1; x <= 1; x ++ ) {
 
-						blurredLuma.addAssign( luminance( this.beautyNode.sample( uvNode.add( vec2( x, y ).mul( this._invSize ) ) ).rgb ) );
+						if ( x === 0 && y === 0 ) continue; // the center tap is already in currentLuma
+
+						const tapLuma = luminance( this.beautyNode.sample( uvNode.add( vec2( x, y ).mul( this._invSize ) ) ).rgb );
+
+						blurredLuma.addAssign( tapLuma );
+						blurredLuma2.addAssign( tapLuma.mul( tapLuma ) );
 
 					}
 
 				}
 
 				blurredLuma.mulAssign( 1 / 9 );
+				blurredLuma2.mulAssign( 1 / 9 );
 
 				// suppress fireflies: clamp the sample against its neighborhood mean so isolated
 				// bright outliers cannot blink in and out of the accumulated result
 
-				const currentLuma = luminance( current.rgb ).toVar();
 				const maxLuma = blurredLuma.mul( this.fireflyFactor );
 
 				current.rgb.mulAssign( currentLuma.greaterThan( maxLuma ).select( maxLuma.div( currentLuma ), float( 1.0 ) ) );
 
+				// temporal gradient in units of the local standard deviation
+
+				const historyVariance = max( historyMoments.y.sub( historyMoments.x.mul( historyMoments.x ) ), 0.0 );
+				const deviation = sqrt( historyVariance.add( 1e-4 ) );
 				const historyLuma = luminance( history.rgb );
+				const gradient = abs( blurredLuma.sub( historyLuma ) ).div( deviation );
 
-				// the luminance floor in the denominator keeps the relative gradient from amplifying
-				// sub-noise changes in dark regions, where it would otherwise keep rejecting history
-				// and let the raw noise blink through
-
-				const gradient = abs( blurredLuma.sub( historyLuma ) ).div( max( blurredLuma, historyLuma ).add( 0.25 ) );
-
-				// the gradient compares a single jittered frame against the accumulated history, so it
-				// cannot distinguish sampling jitter from real lighting change. The deadzone must stay
-				// above the per-frame deviation the jitter produces, otherwise the accumulation tracks
-				// the jitter cycle instead of averaging it and the result never settles
-
-				const adaptiveAlpha = max( this.temporalAlpha, gradient.sub( 0.35 ).mul( this.antiGhosting ).clamp() );
+				const adaptiveAlpha = max( this.temporalAlpha, gradient.sub( _gradientDeadzone ).mul( this.antiGhosting ).clamp() );
 
 				const alpha = validHistory.select( adaptiveAlpha, float( 1.0 ) );
 
-				result.assign( mix( history, current, alpha ) );
+				temporalColor.assign( mix( history, current, alpha ) );
+
+				// the luminance moments are accumulated with the same reprojection; on disocclusion
+				// the spatial moments take over as an immediate estimate
+
+				const clampedLuma = min( currentLuma, maxLuma ); // the firefly clamp limits the luminance to maxLuma
+				const currentMoments = vec2( clampedLuma, clampedLuma.mul( clampedLuma ) );
+				const integratedMoments = validHistory.select( mix( historyMoments, currentMoments, _momentsAlpha ), vec2( blurredLuma, blurredLuma2 ) ).toVar();
+				const variance = max( integratedMoments.y.sub( integratedMoments.x.mul( integratedMoments.x ) ), 0.0 );
+
+				temporalMoments.assign( vec4( integratedMoments, variance, 0.0 ) );
 
 			} );
 
-			return result;
+			return vec4( 0 ); // temporary solution until TSL does not complain anymore
 
 		} );
+
+		this._temporalMaterial.colorNode = temporal().context( sharedContext );
+		this._temporalMaterial.outputNode = outputStruct( temporalColor, temporalMoments );
+		this._temporalMaterial.needsUpdate = true;
 
 		// --- geometry prepare pass ( view normal + linear view Z, packed once per frame ) ---
 
 		const prepare = Fn( () => {
 
 			const uvNode = uv();
-			const depth = this.depthNode.sample( uvNode ).r;
+			const depth = sampleDepth( uvNode );
 			const normal = sampleNormal( uvNode );
-			const viewZ = getViewPosition( uvNode, depth, this._cameraProjectionMatrixInverse ).z;
+			const viewZ = perspectiveDepthToViewZ( depth, this._cameraNearFar.x, this._cameraNearFar.y );
 
 			// valid view Z is negative; store a positive sentinel for background so the filter skips it
 
@@ -572,27 +647,36 @@ class SVGFNode extends TempNode {
 
 		} );
 
-		// --- edge-avoiding à-trous pass ---
+		this._geometryMaterial.fragmentNode = prepare().context( sharedContext );
+		this._geometryMaterial.needsUpdate = true;
+
+		// --- variance-guided à-trous pass ---
+
+		const atrousColor = property( 'vec4' );
+		const atrousMoments = property( 'vec4' );
 
 		const atrous = Fn( () => {
 
 			const uvNode = uv();
 
 			const centerColor = this._atrousInputNode.sample( uvNode ).toVar();
+			const centerVariance = this._atrousVarianceNode.sample( uvNode ).b.toVar();
 			const centerGeometry = this._geometryNode.sample( uvNode ).toVar();
 			const centerZ = centerGeometry.w.toVar();
 
-			const result = vec4( centerColor ).toVar();
+			atrousColor.assign( centerColor );
+			atrousMoments.assign( vec4( 0.0, 0.0, centerVariance, 0.0 ) );
 
 			If( centerZ.lessThan( 0.0 ), () => { // valid geometry only
 
 				const centerNormal = centerGeometry.xyz.toVar();
 				const centerLuma = luminance( centerColor.rgb ).toVar();
 
-				const sum = vec4( centerColor ).toVar(); // center tap has weight 1
-				const totalWeight = float( 1.0 ).toVar();
-
 				const step = this._invSize.mul( this._stepSize );
+
+				// gather the neighborhood once; the taps drive both the variance prefilter and the filter itself
+
+				const taps = [];
 
 				for ( let y = - 1; y <= 1; y ++ ) {
 
@@ -600,43 +684,66 @@ class SVGFNode extends TempNode {
 
 						if ( x === 0 && y === 0 ) continue;
 
-						const kernelWeight = _kernel[ x + 1 ] * _kernel[ y + 1 ];
-
 						const sampleUV = uvNode.add( vec2( x, y ).mul( step ) ).toVar();
 
-						const sampleColor = this._atrousInputNode.sample( sampleUV );
-						const sampleGeometry = this._geometryNode.sample( sampleUV );
-
-						// edge-stopping weights ( normal, linear depth, luminance )
-
-						const normalWeight = pow( max( dot( centerNormal, sampleGeometry.xyz ), 0.0 ), this.normalPhi );
-						const depthWeight = max( float( 1.0 ).sub( abs( centerZ.sub( sampleGeometry.w ) ).div( this.depthPhi ) ), 0.0 );
-						const lumaWeight = max( float( 1.0 ).sub( abs( luminance( sampleColor.rgb ).sub( centerLuma ) ).div( this.lumaPhi ) ), 0.0 );
-
-						const weight = float( kernelWeight ).mul( normalWeight ).mul( depthWeight ).mul( lumaWeight );
-
-						sum.addAssign( sampleColor.mul( weight ) );
-						totalWeight.addAssign( weight );
+						taps.push( {
+							kernelWeight: _kernel[ x + 1 ] * _kernel[ y + 1 ],
+							color: this._atrousInputNode.sample( sampleUV ).toVar(),
+							geometry: this._geometryNode.sample( sampleUV ).toVar(),
+							variance: this._atrousVarianceNode.sample( sampleUV ).b.toVar()
+						} );
 
 					}
 
 				}
 
-				result.assign( sum.div( totalWeight ) );
+				// the variance estimate is itself noisy: a kernel-prefiltered variance stabilizes the
+				// luminance edge-stop
+
+				const prefilteredVariance = centerVariance.mul( _kernel[ 1 ] * _kernel[ 1 ] ).toVar();
+
+				for ( const tap of taps ) {
+
+					prefilteredVariance.addAssign( tap.variance.mul( tap.kernelWeight ) );
+
+				}
+
+				// luminance differences are weighted in units of the local deviation: noisy regions
+				// get smoothed aggressively while converged regions keep their edges
+
+				const lumaScale = sqrt( prefilteredVariance ).mul( this.lumaPhi ).add( 1e-3 ).toVar();
+
+				const sum = centerColor.toVar(); // center tap has weight 1
+				const totalWeight = float( 1.0 ).toVar();
+				const varianceSum = centerVariance.toVar();
+
+				for ( const tap of taps ) {
+
+					// edge-stopping weights ( normal, linear depth, luminance )
+
+					const normalWeight = pow( max( dot( centerNormal, tap.geometry.xyz ), 0.0 ), this.normalPhi );
+					const depthWeight = max( float( 1.0 ).sub( abs( centerZ.sub( tap.geometry.w ) ).div( this.depthPhi ) ), 0.0 );
+					const lumaWeight = max( float( 1.0 ).sub( abs( luminance( tap.color.rgb ).sub( centerLuma ) ).div( lumaScale ) ), 0.0 );
+
+					const weight = float( tap.kernelWeight ).mul( normalWeight ).mul( depthWeight ).mul( lumaWeight ).toVar();
+
+					sum.addAssign( tap.color.mul( weight ) );
+					totalWeight.addAssign( weight );
+					varianceSum.addAssign( tap.variance.mul( weight.mul( weight ) ) );
+
+				}
+
+				atrousColor.assign( sum.div( totalWeight ) );
+				atrousMoments.assign( vec4( 0.0, 0.0, varianceSum.div( totalWeight.mul( totalWeight ) ), 0.0 ) );
 
 			} );
 
-			return result;
+			return vec4( 0 ); // temporary solution until TSL does not complain anymore
 
 		} );
 
-		this._geometryMaterial.fragmentNode = prepare().context( builder.getSharedContext() );
-		this._geometryMaterial.needsUpdate = true;
-
-		this._temporalMaterial.fragmentNode = temporal().context( builder.getSharedContext() );
-		this._temporalMaterial.needsUpdate = true;
-
-		this._atrousMaterial.fragmentNode = atrous().context( builder.getSharedContext() );
+		this._atrousMaterial.colorNode = atrous().context( sharedContext );
+		this._atrousMaterial.outputNode = outputStruct( atrousColor, atrousMoments );
 		this._atrousMaterial.needsUpdate = true;
 
 		return this._textureNode;

--- a/examples/jsm/tsl/display/SVGFNode.js
+++ b/examples/jsm/tsl/display/SVGFNode.js
@@ -256,7 +256,10 @@ class SVGFNode extends TempNode {
 		this._geometryRenderTarget = new RenderTarget( 1, 1, rtOptions );
 		this._geometryRenderTarget.texture.name = 'SVGF.geometry';
 
-		for ( const rt of [ this._historyRenderTarget, this._temporalRenderTarget, this._resolveRenderTarget, this._geometryRenderTarget, ...this._atrousRenderTargets ] ) {
+		// the resolve target keeps linear filtering so the result upsamples smoothly when the
+		// effect runs at a lower resolution than the output
+
+		for ( const rt of [ this._historyRenderTarget, this._temporalRenderTarget, this._geometryRenderTarget, ...this._atrousRenderTargets ] ) {
 
 			rt.texture.minFilter = NearestFilter;
 			rt.texture.magFilter = NearestFilter;

--- a/examples/jsm/tsl/display/SVGFNode.js
+++ b/examples/jsm/tsl/display/SVGFNode.js
@@ -474,8 +474,7 @@ class SVGFNode extends TempNode {
 		const temporal = Fn( () => {
 
 			const uvNode = uv();
-			const size = this.beautyNode.size();
-			const texel = ivec2( uvNode.mul( size ) );
+			const texel = ivec2( uvNode.mul( this.velocityNode.size() ) ); // texel coordinates of the velocity texture, whose resolution can differ from the input
 
 			const current = this.beautyNode.sample( uvNode ).toVar();
 			const depth = sampleDepth( uvNode ).toVar();

--- a/examples/jsm/tsl/display/SVGFNode.js
+++ b/examples/jsm/tsl/display/SVGFNode.js
@@ -1,0 +1,648 @@
+import { RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils, HalfFloatType, NearestFilter, DepthTexture, FloatType } from 'three/webgpu';
+import { Fn, float, vec2, vec4, uv, uniform, texture, passTexture, convertToTexture, luminance, dot, max, abs, pow, mix, If, ivec2, getViewPosition, getNormalFromDepth, NodeUpdateType } from 'three/tsl';
+
+const _quadMesh = /*@__PURE__*/ new QuadMesh();
+const _size = /*@__PURE__*/ new Vector2();
+
+let _rendererState;
+
+// à-trous kernel ( 1/4, 1/2, 1/4 ) used as a 3×3 separable filter. The small per-level tap footprint
+// keeps each level cheap, while the increasing per-level step still covers a wide area across levels.
+const _kernel = [ 1 / 4, 1 / 2, 1 / 4 ];
+
+/**
+ * Post processing node that denoises a noisy screen-space signal (such as the raw output of
+ * {@link SSGINode}) using a spatiotemporal filter in the spirit of SVGF (Spatiotemporal
+ * Variance-Guided Filtering).
+ *
+ * The pipeline is:
+ * - **Temporal accumulation**: the current frame is reprojected against history using the
+ *   velocity buffer and blended, with a depth-based disocclusion test that resets history where
+ *   the reprojection is invalid. This is an alternative to denoising via {@link TRAANode}.
+ * - **Adaptive temporal alpha** (A-SVGF-style): a temporal gradient raises the accumulation weight
+ *   towards the current frame where the signal changed, rejecting stale history to limit ghosting
+ *   under motion. The gradient is derived here from the current-vs-history difference rather than
+ *   from re-shaded forward-projected samples as in the original A-SVGF.
+ * - **Edge-avoiding à-trous**: a multi-level wavelet filter (increasing step size per level)
+ *   spatially denoises the accumulated signal while preserving edges via depth, normal and
+ *   luminance edge-stopping functions.
+ * - **Feedback**: the first à-trous level is fed back as the color history for the next frame,
+ *   which keeps the temporal signal denoised without over-blurring (the SVGF feedback trick).
+ *
+ * It does not include SVGF's variance-guided luminance weighting (per-pixel variance from temporal
+ * moments driving the à-trous luminance edge-stop); the luminance weight uses a fixed `lumaPhi`.
+ *
+ * References:
+ * - {@link https://cg.ivd.kit.edu/publications/2017/svgf/svgf_preprint.pdf} (SVGF, Schied et al.)
+ * - {@link https://cg.ivd.kit.edu/english/atf.php} (A-SVGF adaptive temporal filtering, Schied et al.)
+ * - {@link https://jo.dreggn.org/home/2010_atrous.pdf} (Edge-Avoiding À-Trous, Dammertz et al.)
+ *
+ * @augments TempNode
+ * @three_import import { svgf } from 'three/addons/tsl/display/SVGFNode.js';
+ */
+class SVGFNode extends TempNode {
+
+	static get type() {
+
+		return 'SVGFNode';
+
+	}
+
+	/**
+	 * Constructs a new SVGF node.
+	 *
+	 * @param {TextureNode} beautyNode - The noisy texture node to denoise (e.g. the SSGI output).
+	 * @param {TextureNode} depthNode - A texture node that represents the scene's depth.
+	 * @param {?TextureNode} normalNode - A texture node that represents the scene's view-space normals.
+	 * @param {TextureNode} velocityNode - A texture node that represents the scene's velocity.
+	 * @param {PerspectiveCamera} camera - The camera the scene is rendered with.
+	 */
+	constructor( beautyNode, depthNode, normalNode, velocityNode, camera ) {
+
+		super( 'vec4' );
+
+		/**
+		 * The noisy texture node to denoise.
+		 *
+		 * @type {TextureNode}
+		 */
+		this.beautyNode = beautyNode;
+
+		/**
+		 * A texture node that represents the scene's depth.
+		 *
+		 * @type {TextureNode}
+		 */
+		this.depthNode = depthNode;
+
+		/**
+		 * A texture node that represents the scene's view-space normals. If `null`, normals are
+		 * reconstructed from depth in the shader.
+		 *
+		 * @type {?TextureNode}
+		 */
+		this.normalNode = normalNode;
+
+		/**
+		 * A texture node that represents the scene's velocity.
+		 *
+		 * @type {TextureNode}
+		 */
+		this.velocityNode = velocityNode;
+
+		/**
+		 * The camera the scene is rendered with.
+		 *
+		 * @type {PerspectiveCamera}
+		 */
+		this.camera = camera;
+
+		/**
+		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders its
+		 * passes once per frame in `updateBefore()`.
+		 *
+		 * @type {string}
+		 * @default 'frame'
+		 */
+		this.updateBeforeType = NodeUpdateType.FRAME;
+
+		/**
+		 * Number of edge-avoiding à-trous levels. Each level doubles the sampling step.
+		 *
+		 * @type {number}
+		 * @default 5
+		 */
+		this.atrousIterations = 5;
+
+		/**
+		 * Minimum weight given to the current frame during temporal accumulation. Smaller values
+		 * accumulate more history (less noise, more lag). Should be in the range `[0.01, 1]`.
+		 *
+		 * @type {UniformNode<float>}
+		 * @default 0.1
+		 */
+		this.temporalAlpha = uniform( 0.1 );
+
+		/**
+		 * Strength of the adaptive temporal alpha (A-SVGF-style anti-ghosting). The temporal gradient
+		 * (how much the signal changed vs reprojected history) is scaled by this value to raise the
+		 * accumulation weight towards the current frame where change is detected, rejecting stale
+		 * history under motion. `0` disables it (fixed `temporalAlpha`); higher reduces ghosting at
+		 * the cost of more noise on moving regions.
+		 *
+		 * @type {UniformNode<float>}
+		 * @default 4
+		 */
+		this.antiGhosting = uniform( 4 );
+
+		/**
+		 * Relative depth difference above which history is rejected as a disocclusion.
+		 *
+		 * @type {UniformNode<float>}
+		 * @default 0.05
+		 */
+		this.depthRejection = uniform( 0.05 );
+
+		/**
+		 * Depth edge-stopping strength of the à-trous filter (plane distance, in world units).
+		 *
+		 * @type {UniformNode<float>}
+		 * @default 4
+		 */
+		this.depthPhi = uniform( 4 );
+
+		/**
+		 * Normal edge-stopping strength of the à-trous filter.
+		 *
+		 * @type {UniformNode<float>}
+		 * @default 128
+		 */
+		this.normalPhi = uniform( 128 );
+
+		/**
+		 * Luminance edge-stopping strength of the à-trous filter.
+		 *
+		 * @type {UniformNode<float>}
+		 * @default 4
+		 */
+		this.lumaPhi = uniform( 4 );
+
+		// private uniforms
+
+		/**
+		 * The inverse resolution of the effect.
+		 *
+		 * @private
+		 * @type {UniformNode<vec2>}
+		 */
+		this._invSize = uniform( new Vector2() );
+
+		/**
+		 * The current à-trous step size, updated per level in `updateBefore()`.
+		 *
+		 * @private
+		 * @type {UniformNode<float>}
+		 */
+		this._stepSize = uniform( 1 );
+
+		/**
+		 * The camera's inverse projection matrix.
+		 *
+		 * @private
+		 * @type {UniformNode<mat4>}
+		 */
+		this._cameraProjectionMatrixInverse = uniform( camera.projectionMatrixInverse );
+
+		// render targets
+
+		const rtOptions = { depthBuffer: false, type: HalfFloatType };
+
+		/**
+		 * Holds the previous frame's filtered result (the color history fed back each frame). Its
+		 * depth texture stores the previous frame's depth for the disocclusion test.
+		 *
+		 * @private
+		 * @type {RenderTarget}
+		 */
+		this._historyRenderTarget = new RenderTarget( 1, 1, { ...rtOptions, depthTexture: new DepthTexture() } );
+		this._historyRenderTarget.texture.name = 'SVGF.history';
+
+		/**
+		 * Holds the temporally accumulated signal before spatial filtering.
+		 *
+		 * @private
+		 * @type {RenderTarget}
+		 */
+		this._temporalRenderTarget = new RenderTarget( 1, 1, rtOptions );
+		this._temporalRenderTarget.texture.name = 'SVGF.temporal';
+
+		/**
+		 * Ping-pong targets for the à-trous iterations.
+		 *
+		 * @private
+		 * @type {Array<RenderTarget>}
+		 */
+		this._atrousRenderTargets = [ new RenderTarget( 1, 1, rtOptions ), new RenderTarget( 1, 1, rtOptions ) ];
+		this._atrousRenderTargets[ 0 ].texture.name = 'SVGF.atrous0';
+		this._atrousRenderTargets[ 1 ].texture.name = 'SVGF.atrous1';
+
+		/**
+		 * Holds the final filtered result.
+		 *
+		 * @private
+		 * @type {RenderTarget}
+		 */
+		this._resolveRenderTarget = new RenderTarget( 1, 1, rtOptions );
+		this._resolveRenderTarget.texture.name = 'SVGF.resolve';
+
+		/**
+		 * Holds a packed geometry buffer ( view-space normal in rgb, linear view-space Z in a )
+		 * computed once per frame so the à-trous filter does not reconstruct it per tap.
+		 *
+		 * @private
+		 * @type {RenderTarget}
+		 */
+		this._geometryRenderTarget = new RenderTarget( 1, 1, rtOptions );
+		this._geometryRenderTarget.texture.name = 'SVGF.geometry';
+
+		for ( const rt of [ this._historyRenderTarget, this._temporalRenderTarget, this._resolveRenderTarget, this._geometryRenderTarget, ...this._atrousRenderTargets ] ) {
+
+			rt.texture.minFilter = NearestFilter;
+			rt.texture.magFilter = NearestFilter;
+
+		}
+
+		// materials
+
+		/**
+		 * @private
+		 * @type {NodeMaterial}
+		 */
+		this._temporalMaterial = new NodeMaterial();
+		this._temporalMaterial.name = 'SVGF.temporal';
+
+		/**
+		 * @private
+		 * @type {NodeMaterial}
+		 */
+		this._atrousMaterial = new NodeMaterial();
+		this._atrousMaterial.name = 'SVGF.atrous';
+
+		/**
+		 * @private
+		 * @type {NodeMaterial}
+		 */
+		this._geometryMaterial = new NodeMaterial();
+		this._geometryMaterial.name = 'SVGF.geometry';
+
+		/**
+		 * Texture node for the previous frame's depth, used by the disocclusion test.
+		 *
+		 * @private
+		 * @type {TextureNode}
+		 */
+		this._previousDepthNode = texture( new DepthTexture( 1, 1 ) );
+
+		/**
+		 * Texture node holding the history (feedback) color.
+		 *
+		 * @private
+		 * @type {TextureNode}
+		 */
+		this._historyNode = texture( this._historyRenderTarget.texture );
+
+		/**
+		 * Texture node holding the current à-trous input (swapped per iteration).
+		 *
+		 * @private
+		 * @type {TextureNode}
+		 */
+		this._atrousInputNode = texture( this._temporalRenderTarget.texture );
+
+		/**
+		 * Texture node holding the packed geometry buffer ( view normal + linear view Z ).
+		 *
+		 * @private
+		 * @type {TextureNode}
+		 */
+		this._geometryNode = texture( this._geometryRenderTarget.texture );
+
+		/**
+		 * The result of the effect as a separate texture node.
+		 *
+		 * @private
+		 * @type {PassTextureNode}
+		 */
+		this._textureNode = passTexture( this, this._resolveRenderTarget.texture );
+
+	}
+
+	/**
+	 * Returns the result of the effect as a texture node.
+	 *
+	 * @return {PassTextureNode} A texture node that represents the result of the effect.
+	 */
+	getTextureNode() {
+
+		return this._textureNode;
+
+	}
+
+	/**
+	 * Sets the size of the effect.
+	 *
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
+	 */
+	setSize( width, height ) {
+
+		this._invSize.value.set( 1 / width, 1 / height );
+
+		this._historyRenderTarget.setSize( width, height );
+		this._temporalRenderTarget.setSize( width, height );
+		this._resolveRenderTarget.setSize( width, height );
+		this._atrousRenderTargets[ 0 ].setSize( width, height );
+		this._atrousRenderTargets[ 1 ].setSize( width, height );
+		this._geometryRenderTarget.setSize( width, height );
+
+	}
+
+	/**
+	 * This method is used to render the effect once per frame.
+	 *
+	 * @param {NodeFrame} frame - The current node frame.
+	 */
+	updateBefore( frame ) {
+
+		const { renderer } = frame;
+
+		this._cameraProjectionMatrixInverse.value.copy( this.camera.projectionMatrixInverse );
+
+		// keep the effect in sync with the dimensions of the beauty node
+
+		const beautyRenderTarget = ( this.beautyNode.isRTTNode ) ? this.beautyNode.renderTarget : this.beautyNode.passNode.renderTarget;
+		const width = beautyRenderTarget.texture.width;
+		const height = beautyRenderTarget.texture.height;
+
+		const needsRestart = this._historyRenderTarget.width !== width || this._historyRenderTarget.height !== height;
+
+		_rendererState = RendererUtils.resetRendererState( renderer, _rendererState );
+
+		this.setSize( width, height );
+
+		if ( needsRestart === true ) {
+
+			// after a resize, seed the history with the current beauty buffer so the effect does
+			// not fade in from black
+
+			renderer.initRenderTarget( this._historyRenderTarget );
+			renderer.copyTextureToTexture( beautyRenderTarget.texture, this._historyRenderTarget.texture );
+
+		}
+
+		// geometry prepare ( packed view normal + linear view Z ) -> geometry target
+
+		renderer.setRenderTarget( this._geometryRenderTarget );
+		_quadMesh.material = this._geometryMaterial;
+		_quadMesh.name = 'SVGF.geometry';
+		_quadMesh.render( renderer );
+
+		// temporal accumulation -> temporal target
+
+		renderer.setRenderTarget( this._temporalRenderTarget );
+		_quadMesh.material = this._temporalMaterial;
+		_quadMesh.name = 'SVGF.temporal';
+		_quadMesh.render( renderer );
+
+		// edge-avoiding à-trous, ping-pong between targets, last level into the resolve target
+
+		const iterations = this.atrousIterations;
+		let inputTexture = this._temporalRenderTarget.texture;
+
+		_quadMesh.material = this._atrousMaterial;
+		_quadMesh.name = 'SVGF.atrous';
+
+		for ( let i = 0; i < iterations; i ++ ) {
+
+			const target = ( i === iterations - 1 ) ? this._resolveRenderTarget : this._atrousRenderTargets[ i % 2 ];
+
+			this._stepSize.value = 1 << i; // 1, 2, 4, 8, 16, ...
+			this._atrousInputNode.value = inputTexture;
+
+			renderer.setRenderTarget( target );
+			_quadMesh.render( renderer );
+
+			// feed the first à-trous level back as next frame's color history
+
+			if ( i === 0 ) {
+
+				renderer.copyTextureToTexture( target.texture, this._historyRenderTarget.texture );
+
+			}
+
+			inputTexture = target.texture;
+
+		}
+
+		// store the current depth as the previous depth for next frame's disocclusion test
+
+		const size = renderer.getDrawingBufferSize( _size );
+
+		if ( this._historyRenderTarget.width === size.width && this._historyRenderTarget.height === size.height ) {
+
+			renderer.copyTextureToTexture( this.depthNode.value, this._historyRenderTarget.depthTexture );
+			this._previousDepthNode.value = this._historyRenderTarget.depthTexture;
+
+		}
+
+		renderer.setRenderTarget( null );
+
+		RendererUtils.restoreRendererState( renderer, _rendererState );
+
+	}
+
+	/**
+	 * This method is used to setup the effect's TSL code.
+	 *
+	 * @param {NodeBuilder} builder - The current node builder.
+	 * @return {PassTextureNode}
+	 */
+	setup( builder ) {
+
+		if ( builder.renderer.reversedDepthBuffer === true ) {
+
+			this._historyRenderTarget.depthTexture.type = FloatType;
+
+		}
+
+		const sampleDepth = ( uvNode ) => this.depthNode.sample( uvNode ).r;
+		const sampleNormal = ( uvNode ) => ( this.normalNode !== null ) ? this.normalNode.sample( uvNode ).rgb.normalize() : getNormalFromDepth( uvNode, this.depthNode.value, this._cameraProjectionMatrixInverse );
+
+		// --- temporal accumulation pass ---
+
+		const temporal = Fn( () => {
+
+			const uvNode = uv();
+			const size = this.beautyNode.size();
+			const texel = ivec2( uvNode.mul( size ) );
+
+			const current = this.beautyNode.sample( uvNode ).toVar();
+			const depth = sampleDepth( uvNode ).toVar();
+
+			const result = vec4( current ).toVar();
+
+			If( depth.lessThan( 1.0 ), () => {
+
+				// reproject through the velocity buffer ( NDC -> uv )
+
+				const offsetUV = this.velocityNode.load( texel ).xy.mul( vec2( 0.5, - 0.5 ) );
+				const historyUV = uvNode.sub( offsetUV ).toVar();
+
+				const inBounds = historyUV.greaterThanEqual( 0.0 ).all().and( historyUV.lessThanEqual( 1.0 ).all() );
+
+				// depth-based disocclusion test ( compare linear view-space Z )
+
+				const currentZ = getViewPosition( uvNode, depth, this._cameraProjectionMatrixInverse ).z;
+				const previousZ = getViewPosition( historyUV, this._previousDepthNode.sample( historyUV ).r, this._cameraProjectionMatrixInverse ).z;
+				const validDepth = abs( currentZ.sub( previousZ ) ).lessThan( abs( currentZ ).mul( this.depthRejection ) );
+
+				const validHistory = inBounds.and( validDepth );
+
+				const history = this._historyNode.sample( historyUV );
+
+				// A-SVGF-style adaptive temporal alpha. The temporal gradient measures how much the
+				// signal changed versus the reprojected ( denoised ) history. Because the input is
+				// noisy, the current luminance is averaged over a 3×3 neighborhood and a small noise
+				// floor is subtracted, so only real change ( motion, disocclusion, lighting ) raises
+				// alpha towards 1 and rejects stale history. A true A-SVGF gradient would instead
+				// re-shade forward-projected samples with the same random sequence.
+
+				const blurredLuma = float( 0 ).toVar();
+
+				for ( let y = - 1; y <= 1; y ++ ) {
+
+					for ( let x = - 1; x <= 1; x ++ ) {
+
+						blurredLuma.addAssign( luminance( this.beautyNode.sample( uvNode.add( vec2( x, y ).mul( this._invSize ) ) ).rgb ) );
+
+					}
+
+				}
+
+				blurredLuma.mulAssign( 1 / 9 );
+
+				const historyLuma = luminance( history.rgb );
+				const gradient = abs( blurredLuma.sub( historyLuma ) ).div( max( blurredLuma, historyLuma ).add( 0.01 ) );
+				const adaptiveAlpha = max( this.temporalAlpha, gradient.sub( 0.1 ).mul( this.antiGhosting ).clamp() );
+
+				const alpha = validHistory.select( adaptiveAlpha, float( 1.0 ) );
+
+				result.assign( mix( history, current, alpha ) );
+
+			} );
+
+			return result;
+
+		} );
+
+		// --- geometry prepare pass ( view normal + linear view Z, packed once per frame ) ---
+
+		const prepare = Fn( () => {
+
+			const uvNode = uv();
+			const depth = this.depthNode.sample( uvNode ).r;
+			const normal = sampleNormal( uvNode );
+			const viewZ = getViewPosition( uvNode, depth, this._cameraProjectionMatrixInverse ).z;
+
+			// valid view Z is negative; store a positive sentinel for background so the filter skips it
+
+			return vec4( normal, depth.greaterThanEqual( 1.0 ).select( float( 1.0 ), viewZ ) );
+
+		} );
+
+		// --- edge-avoiding à-trous pass ---
+
+		const atrous = Fn( () => {
+
+			const uvNode = uv();
+
+			const centerColor = this._atrousInputNode.sample( uvNode ).toVar();
+			const centerGeometry = this._geometryNode.sample( uvNode ).toVar();
+			const centerZ = centerGeometry.w.toVar();
+
+			const result = vec4( centerColor ).toVar();
+
+			If( centerZ.lessThan( 0.0 ), () => { // valid geometry only
+
+				const centerNormal = centerGeometry.xyz.toVar();
+				const centerLuma = luminance( centerColor.rgb ).toVar();
+
+				const sum = vec4( centerColor ).toVar(); // center tap has weight 1
+				const totalWeight = float( 1.0 ).toVar();
+
+				const step = this._invSize.mul( this._stepSize );
+
+				for ( let y = - 1; y <= 1; y ++ ) {
+
+					for ( let x = - 1; x <= 1; x ++ ) {
+
+						if ( x === 0 && y === 0 ) continue;
+
+						const kernelWeight = _kernel[ x + 1 ] * _kernel[ y + 1 ];
+
+						const sampleUV = uvNode.add( vec2( x, y ).mul( step ) ).toVar();
+
+						const sampleColor = this._atrousInputNode.sample( sampleUV );
+						const sampleGeometry = this._geometryNode.sample( sampleUV );
+
+						// edge-stopping weights ( normal, linear depth, luminance )
+
+						const normalWeight = pow( max( dot( centerNormal, sampleGeometry.xyz ), 0.0 ), this.normalPhi );
+						const depthWeight = max( float( 1.0 ).sub( abs( centerZ.sub( sampleGeometry.w ) ).div( this.depthPhi ) ), 0.0 );
+						const lumaWeight = max( float( 1.0 ).sub( abs( luminance( sampleColor.rgb ).sub( centerLuma ) ).div( this.lumaPhi ) ), 0.0 );
+
+						const weight = float( kernelWeight ).mul( normalWeight ).mul( depthWeight ).mul( lumaWeight );
+
+						sum.addAssign( sampleColor.mul( weight ) );
+						totalWeight.addAssign( weight );
+
+					}
+
+				}
+
+				result.assign( sum.div( totalWeight ) );
+
+			} );
+
+			return result;
+
+		} );
+
+		this._geometryMaterial.fragmentNode = prepare().context( builder.getSharedContext() );
+		this._geometryMaterial.needsUpdate = true;
+
+		this._temporalMaterial.fragmentNode = temporal().context( builder.getSharedContext() );
+		this._temporalMaterial.needsUpdate = true;
+
+		this._atrousMaterial.fragmentNode = atrous().context( builder.getSharedContext() );
+		this._atrousMaterial.needsUpdate = true;
+
+		return this._textureNode;
+
+	}
+
+	/**
+	 * Frees internal resources. This method should be called when the effect is no longer required.
+	 */
+	dispose() {
+
+		this._historyRenderTarget.dispose();
+		this._temporalRenderTarget.dispose();
+		this._resolveRenderTarget.dispose();
+		this._atrousRenderTargets[ 0 ].dispose();
+		this._atrousRenderTargets[ 1 ].dispose();
+		this._geometryRenderTarget.dispose();
+
+		this._temporalMaterial.dispose();
+		this._atrousMaterial.dispose();
+		this._geometryMaterial.dispose();
+
+	}
+
+}
+
+export default SVGFNode;
+
+/**
+ * TSL function for creating an SVGF denoise effect.
+ *
+ * @tsl
+ * @function
+ * @param {Node} beautyNode - The noisy node to denoise (e.g. the SSGI output).
+ * @param {Node<float>} depthNode - A node that represents the scene's depth.
+ * @param {?Node<vec3>} normalNode - A node that represents the scene's view-space normals.
+ * @param {Node} velocityNode - A node that represents the scene's velocity.
+ * @param {PerspectiveCamera} camera - The camera the scene is rendered with.
+ * @returns {SVGFNode}
+ */
+export const svgf = ( beautyNode, depthNode, normalNode, velocityNode, camera ) => new SVGFNode( convertToTexture( beautyNode ), depthNode, normalNode, velocityNode, camera );

--- a/examples/jsm/tsl/display/SVGFNode.js
+++ b/examples/jsm/tsl/display/SVGFNode.js
@@ -539,7 +539,13 @@ class SVGFNode extends TempNode {
 				// and let the raw noise blink through
 
 				const gradient = abs( blurredLuma.sub( historyLuma ) ).div( max( blurredLuma, historyLuma ).add( 0.25 ) );
-				const adaptiveAlpha = max( this.temporalAlpha, gradient.sub( 0.1 ).mul( this.antiGhosting ).clamp() );
+
+				// the gradient compares a single jittered frame against the accumulated history, so it
+				// cannot distinguish sampling jitter from real lighting change. The deadzone must stay
+				// above the per-frame deviation the jitter produces, otherwise the accumulation tracks
+				// the jitter cycle instead of averaging it and the result never settles
+
+				const adaptiveAlpha = max( this.temporalAlpha, gradient.sub( 0.35 ).mul( this.antiGhosting ).clamp() );
 
 				const alpha = validHistory.select( adaptiveAlpha, float( 1.0 ) );
 

--- a/examples/jsm/tsl/display/SVGFNode.js
+++ b/examples/jsm/tsl/display/SVGFNode.js
@@ -531,7 +531,12 @@ class SVGFNode extends TempNode {
 				current.rgb.mulAssign( currentLuma.greaterThan( maxLuma ).select( maxLuma.div( currentLuma ), float( 1.0 ) ) );
 
 				const historyLuma = luminance( history.rgb );
-				const gradient = abs( blurredLuma.sub( historyLuma ) ).div( max( blurredLuma, historyLuma ).add( 0.01 ) );
+
+				// the luminance floor in the denominator keeps the relative gradient from amplifying
+				// sub-noise changes in dark regions, where it would otherwise keep rejecting history
+				// and let the raw noise blink through
+
+				const gradient = abs( blurredLuma.sub( historyLuma ) ).div( max( blurredLuma, historyLuma ).add( 0.25 ) );
 				const adaptiveAlpha = max( this.temporalAlpha, gradient.sub( 0.1 ).mul( this.antiGhosting ).clamp() );
 
 				const alpha = validHistory.select( adaptiveAlpha, float( 1.0 ) );

--- a/examples/jsm/tsl/display/SVGFNode.js
+++ b/examples/jsm/tsl/display/SVGFNode.js
@@ -369,11 +369,11 @@ class SVGFNode extends TempNode {
 
 		this._cameraProjectionMatrixInverse.value.copy( this.camera.projectionMatrixInverse );
 
-		// keep the effect in sync with the dimensions of the beauty node
+		// keep the effect in sync with the dimensions of the beauty texture
 
-		const beautyRenderTarget = ( this.beautyNode.isRTTNode ) ? this.beautyNode.renderTarget : this.beautyNode.passNode.renderTarget;
-		const width = beautyRenderTarget.texture.width;
-		const height = beautyRenderTarget.texture.height;
+		const beautyTexture = this.beautyNode.value;
+		const width = beautyTexture.image.width;
+		const height = beautyTexture.image.height;
 
 		const needsRestart = this._historyRenderTarget.width !== width || this._historyRenderTarget.height !== height;
 
@@ -387,7 +387,7 @@ class SVGFNode extends TempNode {
 			// not fade in from black
 
 			renderer.initRenderTarget( this._historyRenderTarget );
-			renderer.copyTextureToTexture( beautyRenderTarget.texture, this._historyRenderTarget.texture );
+			renderer.copyTextureToTexture( beautyTexture, this._historyRenderTarget.texture );
 
 		}
 
@@ -669,4 +669,17 @@ export default SVGFNode;
  * @param {PerspectiveCamera} camera - The camera the scene is rendered with.
  * @returns {SVGFNode}
  */
-export const svgf = ( beautyNode, depthNode, normalNode, velocityNode, camera ) => new SVGFNode( convertToTexture( beautyNode ), depthNode, normalNode, velocityNode, camera );
+export const svgf = ( beautyNode, depthNode, normalNode, velocityNode, camera ) => {
+
+	// effects that render into an internal target expose it via getTextureNode(), which
+	// avoids re-rendering the input into an intermediate texture
+
+	if ( beautyNode.isTextureNode !== true && typeof beautyNode.getTextureNode === 'function' ) {
+
+		beautyNode = beautyNode.getTextureNode();
+
+	}
+
+	return new SVGFNode( convertToTexture( beautyNode ), depthNode, normalNode, velocityNode, camera );
+
+};

--- a/examples/jsm/tsl/math/BlueNoise.js
+++ b/examples/jsm/tsl/math/BlueNoise.js
@@ -1,5 +1,5 @@
 import { DataTexture, RedFormat, RGFormat, RGBAFormat, UnsignedByteType, RepeatWrapping, TempNode } from 'three/webgpu';
-import { texture, screenCoordinate, frameId, fract, float, vec2, vec4, mod } from 'three/tsl';
+import { texture, screenCoordinate, uniform, fract, float, vec2, vec4 } from 'three/tsl';
 
 /**
  * @module BlueNoise
@@ -399,22 +399,16 @@ class BlueNoiseNode extends TempNode {
 
 		const noise = texture( this._texture, screenCoordinate.div( this.size ) );
 
-		let value = ( this.channels === 1 ) ? noise.r : ( this.channels === 2 ) ? noise.rg : noise;
+		const value = ( this.channels === 1 ) ? noise.r : ( this.channels === 2 ) ? noise.rg : noise;
 
-		if ( this.animated === true ) {
+		const steps = ( this.channels === 1 ) ? float( R1[ 0 ] ) : ( this.channels === 2 ) ? vec2( ...R2 ) : vec4( ...R4 );
 
-			const steps = ( this.channels === 1 ) ? float( R1[ 0 ] ) : ( this.channels === 2 ) ? vec2( ...R2 ) : vec4( ...R4 );
+		// The frame index is bounded to keep the scroll term well within float precision.
+		// The wrap is just another quasirandom offset, so it is seamless under accumulation.
 
-			// The frame index is bounded to keep the scroll term well within float precision.
-			// The wrap is just another quasirandom offset, so it is seamless under accumulation.
+		const frame = uniform( 0, 'float' ).onRenderUpdate( ( nodeFrame ) => ( this.animated === true ) ? nodeFrame.frameId % 4096 : 0 );
 
-			const frame = float( mod( frameId, 4096 ) );
-
-			value = fract( value.add( frame.mul( steps ) ) );
-
-		}
-
-		return value;
+		return fract( value.add( frame.mul( steps ) ) );
 
 	}
 

--- a/examples/jsm/tsl/math/BlueNoise.js
+++ b/examples/jsm/tsl/math/BlueNoise.js
@@ -1,0 +1,449 @@
+import { DataTexture, RedFormat, RGFormat, RGBAFormat, UnsignedByteType, RepeatWrapping, TempNode } from 'three/webgpu';
+import { texture, screenCoordinate, frameId, fract, float, vec2, vec4, mod } from 'three/tsl';
+
+/**
+ * @module BlueNoise
+ * @three_import import { blueNoise } from 'three/addons/tsl/math/BlueNoise.js';
+ */
+
+// Per-channel increments from the R1/R2/R4 quasirandom sequences (Roberts 2018, "The Unreasonable
+// Effectiveness of Quasirandom Sequences"). Each channel advances by its own irrational step so
+// the channels stay jointly well distributed over time.
+const R1 = [ 0.6180339887498949 ];
+const R2 = [ 0.7548776662466927, 0.5698402909980532 ];
+const R4 = [ 0.8566748838545029, 0.7338918566271260, 0.6287067210378086, 0.5385972572236101 ];
+
+/**
+ * Generates tileable blue-noise dither arrays via Ulichney's void-and-cluster method.
+ *
+ * The algorithm builds a per-pixel rank in `[0, size² − 1]` that, when interpreted as a
+ * threshold map, has a flat spectrum at low frequencies (no clustering) and concentrated
+ * energy at high frequencies — the defining property of blue noise.
+ *
+ * ```js
+ * const generator = new BlueNoiseGenerator();
+ * generator.size = 64;
+ * const { data, maxValue } = generator.generate();
+ * ```
+ *
+ * Reference: [Robert Ulichney, "The void-and-cluster method for dither array generation" (1993)](http://cv.ulichney.com/papers/1993-void-cluster.pdf).
+ */
+class BlueNoiseGenerator {
+
+	/**
+	 * Constructs a new blue-noise generator with default parameters.
+	 */
+	constructor() {
+
+		/**
+		 * Output dimension. The generated dither array is `size × size` and tiles seamlessly.
+		 *
+		 * @type {number}
+		 * @default 64
+		 */
+		this.size = 64;
+
+		/**
+		 * Standard deviation (in pixels) of the Gaussian energy filter used to score
+		 * voids and clusters. Smaller σ → higher-frequency / sharper blue noise; larger
+		 * σ → smoother. Ulichney recommends `1.5`.
+		 *
+		 * @type {number}
+		 * @default 1.5
+		 */
+		this.sigma = 1.5;
+
+		/**
+		 * Fraction of pixels seeded as 1s in the initial random pattern. The
+		 * void-and-cluster step equilibrates this into the Initial Binary Pattern (IBP).
+		 *
+		 * @type {number}
+		 * @default 0.1
+		 */
+		this.majorityPointsRatio = 0.1;
+
+		/**
+		 * Seed for the internal LCG, for reproducible output.
+		 *
+		 * @type {number}
+		 * @default 1
+		 */
+		this.seed = 1;
+
+	}
+
+	/**
+	 * Run the void-and-cluster algorithm.
+	 *
+	 * @return {{ data: Uint32Array, maxValue: number }} `data` holds per-pixel ranks
+	 * in row-major order; `maxValue` is `size² − 1` (the highest rank).
+	 */
+	generate() {
+
+		const size = this.size;
+		const total = size * size;
+		const sigma = this.sigma;
+		const sigma2 = sigma * sigma;
+
+		// Toroidal Gaussian filter, truncated to ±5σ (or ±size/2, whichever is smaller).
+		// Beyond ~5σ the weight is < 4e-6 and contributes nothing measurable.
+		const halfSize = ( size / 2 ) | 0;
+		const cutoff = Math.min( halfSize, Math.ceil( sigma * 5 ) );
+		const filterSize = cutoff * 2 + 1;
+		const weights = new Float32Array( filterSize * filterSize );
+		for ( let dy = - cutoff; dy <= cutoff; dy ++ ) {
+
+			for ( let dx = - cutoff; dx <= cutoff; dx ++ ) {
+
+				weights[ ( dy + cutoff ) * filterSize + ( dx + cutoff ) ] = Math.exp( - ( dx * dx + dy * dy ) / ( 2 * sigma2 ) );
+
+			}
+
+		}
+
+		// Working state.
+		const binaryPattern = new Uint8Array( total );
+		const energy = new Float32Array( total );
+
+		// Linear-congruential PRNG, seeded for reproducibility.
+		let rngState = ( this.seed | 0 ) || 1;
+		const random = () => {
+
+			rngState = ( Math.imul( rngState, 1664525 ) + 1013904223 ) | 0;
+			return ( rngState >>> 0 ) / 0x100000000;
+
+		};
+
+		// Place `targetOnes` 1s at random positions via Fisher–Yates.
+		const targetOnes = Math.max( 1, Math.floor( total * this.majorityPointsRatio ) );
+		const shuffled = new Int32Array( total );
+		for ( let i = 0; i < total; i ++ ) shuffled[ i ] = i;
+		for ( let i = total - 1; i > 0; i -- ) {
+
+			const j = Math.floor( random() * ( i + 1 ) );
+			const tmp = shuffled[ i ];
+			shuffled[ i ] = shuffled[ j ];
+			shuffled[ j ] = tmp;
+
+		}
+
+		for ( let i = 0; i < targetOnes; i ++ ) {
+
+			binaryPattern[ shuffled[ i ] ] = 1;
+
+		}
+
+		// Add or remove a 1 at (x, y), splatting the Gaussian into the energy buffer.
+		const splatEnergy = ( x, y, sign ) => {
+
+			for ( let dy = - cutoff; dy <= cutoff; dy ++ ) {
+
+				const sy = ( ( y + dy ) % size + size ) % size;
+				const wRow = ( dy + cutoff ) * filterSize;
+				const eRow = sy * size;
+				for ( let dx = - cutoff; dx <= cutoff; dx ++ ) {
+
+					const sx = ( ( x + dx ) % size + size ) % size;
+					energy[ eRow + sx ] += sign * weights[ wRow + ( dx + cutoff ) ];
+
+				}
+
+			}
+
+		};
+
+		// Tightest cluster: 1-pixel with the highest filter response.
+		const findTightestCluster = () => {
+
+			let maxE = - Infinity;
+			let idx = - 1;
+			for ( let i = 0; i < total; i ++ ) {
+
+				if ( binaryPattern[ i ] === 1 && energy[ i ] > maxE ) {
+
+					maxE = energy[ i ];
+					idx = i;
+
+				}
+
+			}
+
+			return idx;
+
+		};
+
+		// Largest void: 0-pixel with the lowest filter response.
+		const findLargestVoid = () => {
+
+			let minE = Infinity;
+			let idx = - 1;
+			for ( let i = 0; i < total; i ++ ) {
+
+				if ( binaryPattern[ i ] === 0 && energy[ i ] < minE ) {
+
+					minE = energy[ i ];
+					idx = i;
+
+				}
+
+			}
+
+			return idx;
+
+		};
+
+		// Initial energy from the random seed pattern.
+		for ( let i = 0; i < total; i ++ ) {
+
+			if ( binaryPattern[ i ] === 1 ) splatEnergy( i % size, ( i / size ) | 0, + 1 );
+
+		}
+
+		// Step 1: Equilibrate to the Initial Binary Pattern (IBP). Repeatedly move the
+		// tightest cluster's 1 into the largest void; converges when the same pixel is
+		// chosen on both sides.
+		while ( true ) {
+
+			const clusterIdx = findTightestCluster();
+			binaryPattern[ clusterIdx ] = 0;
+			splatEnergy( clusterIdx % size, ( clusterIdx / size ) | 0, - 1 );
+
+			const voidIdx = findLargestVoid();
+			binaryPattern[ voidIdx ] = 1;
+			splatEnergy( voidIdx % size, ( voidIdx / size ) | 0, + 1 );
+
+			if ( clusterIdx === voidIdx ) break;
+
+		}
+
+		// Snapshot the IBP — we'll restore it before the forward pass.
+		const ibpBinary = binaryPattern.slice();
+		const ibpEnergy = energy.slice();
+
+		const ranks = new Uint32Array( total );
+
+		// Phase 1: Reverse-rank the ones in the IBP. Repeatedly remove the tightest
+		// cluster, assigning ranks `targetOnes − 1` down to `0`.
+		for ( let rank = targetOnes - 1; rank >= 0; rank -- ) {
+
+			const idx = findTightestCluster();
+			ranks[ idx ] = rank;
+			binaryPattern[ idx ] = 0;
+			splatEnergy( idx % size, ( idx / size ) | 0, - 1 );
+
+		}
+
+		// Restore IBP.
+		binaryPattern.set( ibpBinary );
+		energy.set( ibpEnergy );
+
+		// Phase 2 + 3: Forward-rank the zeros. Repeatedly fill the largest void,
+		// assigning ranks `targetOnes` up to `total − 1`. The same operation works
+		// past the 50 % mark — picking the 0-pixel with the smallest filter response
+		// is equivalent to picking the tightest cluster on the inverted pattern.
+		for ( let rank = targetOnes; rank < total; rank ++ ) {
+
+			const idx = findLargestVoid();
+			ranks[ idx ] = rank;
+			binaryPattern[ idx ] = 1;
+			splatEnergy( idx % size, ( idx / size ) | 0, + 1 );
+
+		}
+
+		return { data: ranks, maxValue: total - 1 };
+
+	}
+
+}
+
+/**
+ * Generates a blue-noise DataTexture.
+ *
+ * Returns an 8-bit texture with repeat wrapping and nearest filtering, suitable for
+ * sampling in shaders as a tileable noise source. Each channel is an independent
+ * blue-noise pattern, generated with a distinct seed so consumers can read
+ * decorrelated values from a single texture fetch.
+ *
+ * Generation runs on the CPU (roughly 50 ms per channel at `64`) and the cost grows
+ * with the fourth power of `size`, so prefer small textures — a tileable `64` is
+ * plenty for screen-space jitter.
+ *
+ * @param {number} [size=64] - Texture dimension in pixels (the noise is square).
+ * @param {number} [channels=1] - Number of independent noise channels. Must be `1`
+ * (RedFormat), `2` (RGFormat), or `4` (RGBAFormat). Generation cost scales linearly.
+ * @return {DataTexture} The generated blue-noise texture.
+ */
+export function generateBlueNoiseTexture( size = 64, channels = 1 ) {
+
+	if ( channels !== 1 && channels !== 2 && channels !== 4 ) {
+
+		throw new Error( 'generateBlueNoiseTexture: channels must be 1, 2, or 4.' );
+
+	}
+
+	const format = channels === 1 ? RedFormat : channels === 2 ? RGFormat : RGBAFormat;
+
+	const generator = new BlueNoiseGenerator();
+	generator.size = size;
+
+	const pixels = new Uint8Array( size * size * channels );
+
+	// Each channel is regenerated with a distinct seed for an independent pattern.
+	for ( let c = 0; c < channels; c ++ ) {
+
+		generator.seed = c + 1;
+		const { data, maxValue } = generator.generate();
+
+		for ( let i = 0, l = data.length; i < l; i ++ ) {
+
+			pixels[ i * channels + c ] = ( data[ i ] / maxValue ) * 255;
+
+		}
+
+	}
+
+	const texture = new DataTexture( pixels, size, size, format, UnsignedByteType );
+	texture.wrapS = RepeatWrapping;
+	texture.wrapT = RepeatWrapping;
+	texture.needsUpdate = true;
+
+	return texture;
+
+}
+
+/**
+ * A node that supplies per-pixel blue-noise values for screen-space sampling jitter.
+ *
+ * The node lazily generates its own tileable blue-noise texture (see
+ * {@link generateBlueNoiseTexture}) and point-samples it at the fragment's screen
+ * coordinate. When `animated` is enabled, the values are scrolled along a per-channel
+ * quasirandom (R-sequence) increment each frame: every frame keeps the spatial
+ * blue-noise distribution while each pixel follows a low-discrepancy temporal
+ * sequence — ideal input jitter for effects resolved by temporal accumulation
+ * (e.g. `TRAANode`).
+ *
+ * ```js
+ * const giPass = ssgi( scenePassColor, scenePassDepth, sceneNormal, camera );
+ * giPass.noiseNode = blueNoise( 2 );
+ * ```
+ *
+ * @augments TempNode
+ */
+class BlueNoiseNode extends TempNode {
+
+	static get type() {
+
+		return 'BlueNoiseNode';
+
+	}
+
+	/**
+	 * Constructs a new blue-noise node.
+	 *
+	 * @param {number} [channels=1] - Number of decorrelated noise channels. Must be `1`
+	 * (float output), `2` (vec2) or `4` (vec4).
+	 * @param {number} [size=64] - The edge length of the internal noise texture.
+	 */
+	constructor( channels = 1, size = 64 ) {
+
+		super( channels === 1 ? 'float' : channels === 2 ? 'vec2' : 'vec4' );
+
+		/**
+		 * Number of decorrelated noise channels.
+		 *
+		 * @type {number}
+		 * @default 1
+		 */
+		this.channels = channels;
+
+		/**
+		 * The edge length of the internal noise texture.
+		 *
+		 * @type {number}
+		 * @default 64
+		 */
+		this.size = size;
+
+		/**
+		 * Whether the noise is decorrelated over time for temporal accumulation. When
+		 * `false`, the pattern is static — use this when no temporal filtering is in
+		 * place, otherwise the noise would visibly crawl.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.animated = true;
+
+		/**
+		 * The lazily generated blue-noise texture.
+		 *
+		 * @private
+		 * @type {?DataTexture}
+		 */
+		this._texture = null;
+
+	}
+
+	/**
+	 * This method is used to set up the node's TSL code.
+	 *
+	 * @return {Node} The per-pixel noise value.
+	 */
+	setup() {
+
+		if ( this._texture === null ) {
+
+			this._texture = generateBlueNoiseTexture( this.size, this.channels );
+
+		}
+
+		const noise = texture( this._texture, screenCoordinate.div( this.size ) );
+
+		let value = ( this.channels === 1 ) ? noise.r : ( this.channels === 2 ) ? noise.rg : noise;
+
+		if ( this.animated === true ) {
+
+			const steps = ( this.channels === 1 ) ? float( R1[ 0 ] ) : ( this.channels === 2 ) ? vec2( ...R2 ) : vec4( ...R4 );
+
+			// The frame index is bounded to keep the scroll term well within float precision.
+			// The wrap is just another quasirandom offset, so it is seamless under accumulation.
+
+			const frame = float( mod( frameId, 4096 ) );
+
+			value = fract( value.add( frame.mul( steps ) ) );
+
+		}
+
+		return value;
+
+	}
+
+	/**
+	 * Frees internal resources. This method should be called
+	 * when the node is no longer required.
+	 */
+	dispose() {
+
+		super.dispose();
+
+		if ( this._texture !== null ) this._texture.dispose();
+
+	}
+
+}
+
+export default BlueNoiseNode;
+
+/**
+ * TSL function for creating a blue-noise node.
+ *
+ * @tsl
+ * @function
+ * @param {number} [channels=1] - Number of decorrelated noise channels. Must be `1`
+ * (float output), `2` (vec2) or `4` (vec4).
+ * @param {number} [size=64] - The edge length of the internal noise texture.
+ * @returns {BlueNoiseNode}
+ */
+export const blueNoise = ( channels, size ) => new BlueNoiseNode( channels, size );
+
+export { BlueNoiseGenerator, BlueNoiseNode };

--- a/examples/jsm/tsl/math/BlueNoise.js
+++ b/examples/jsm/tsl/math/BlueNoise.js
@@ -375,6 +375,16 @@ class BlueNoiseNode extends TempNode {
 		this.animated = true;
 
 		/**
+		 * Length of the animation loop in frames. A short loop lets temporally accumulated
+		 * results converge to a stable image instead of drifting, while still providing
+		 * enough decorrelated patterns for typical accumulation windows.
+		 *
+		 * @type {number}
+		 * @default 12
+		 */
+		this.cycle = 12;
+
+		/**
 		 * The lazily generated blue-noise texture.
 		 *
 		 * @private
@@ -403,10 +413,7 @@ class BlueNoiseNode extends TempNode {
 
 		const steps = ( this.channels === 1 ) ? float( R1[ 0 ] ) : ( this.channels === 2 ) ? vec2( ...R2 ) : vec4( ...R4 );
 
-		// The frame index is bounded to keep the scroll term well within float precision.
-		// The wrap is just another quasirandom offset, so it is seamless under accumulation.
-
-		const frame = uniform( 0, 'float' ).onRenderUpdate( ( nodeFrame ) => ( this.animated === true ) ? nodeFrame.frameId % 4096 : 0 );
+		const frame = uniform( 0, 'float' ).onRenderUpdate( ( nodeFrame ) => ( this.animated === true ) ? nodeFrame.frameId % this.cycle : 0 );
 
 		return fract( value.add( frame.mul( steps ) ) );
 

--- a/examples/jsm/tsl/math/BlueNoise.js
+++ b/examples/jsm/tsl/math/BlueNoise.js
@@ -1,4 +1,4 @@
-import { DataTexture, RedFormat, RGFormat, RGBAFormat, UnsignedByteType, RepeatWrapping, TempNode } from 'three/webgpu';
+import { DataTexture, MathUtils, RedFormat, RGFormat, RGBAFormat, UnsignedByteType, RepeatWrapping, TempNode } from 'three/webgpu';
 import { texture, screenCoordinate, uniform, fract, float, vec2, vec4 } from 'three/tsl';
 
 /**
@@ -63,7 +63,7 @@ class BlueNoiseGenerator {
 		this.majorityPointsRatio = 0.1;
 
 		/**
-		 * Seed for the internal LCG, for reproducible output.
+		 * Seed of the random initial pattern, for reproducible output.
 		 *
 		 * @type {number}
 		 * @default 1
@@ -105,14 +105,8 @@ class BlueNoiseGenerator {
 		const binaryPattern = new Uint8Array( total );
 		const energy = new Float32Array( total );
 
-		// Linear-congruential PRNG, seeded for reproducibility.
-		let rngState = ( this.seed | 0 ) || 1;
-		const random = () => {
-
-			rngState = ( Math.imul( rngState, 1664525 ) + 1013904223 ) | 0;
-			return ( rngState >>> 0 ) / 0x100000000;
-
-		};
+		MathUtils.seededRandom( this.seed );
+		const random = () => MathUtils.seededRandom();
 
 		// Place `targetOnes` 1s at random positions via Fisher–Yates.
 		const targetOnes = Math.max( 1, Math.floor( total * this.majorityPointsRatio ) );
@@ -447,4 +441,4 @@ export default BlueNoiseNode;
  */
 export const blueNoise = ( channels, size ) => new BlueNoiseNode( channels, size );
 
-export { BlueNoiseGenerator, BlueNoiseNode };
+export { BlueNoiseGenerator };

--- a/examples/webgpu_postprocessing_ssgi.html
+++ b/examples/webgpu_postprocessing_ssgi.html
@@ -39,6 +39,7 @@
 			import { pass, mrt, output, normalView, diffuseColor, velocity, add, vec3, vec4, packNormalToRGB, unpackRGBToNormal, sample } from 'three/tsl';
 			import { ssgi } from 'three/addons/tsl/display/SSGINode.js';
 			import { traa } from 'three/addons/tsl/display/TRAANode.js';
+			import { blueNoise } from 'three/addons/tsl/math/BlueNoise.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
@@ -115,6 +116,9 @@
 				const giPass = ssgi( scenePassColor, scenePassDepth, sceneNormal, camera );
 				giPass.sliceCount.value = 2;
 				giPass.stepCount.value = 8;
+
+				const noiseNode = blueNoise( 2 );
+				giPass.noiseNode = noiseNode;
 
 				// composite
 
@@ -220,7 +224,8 @@
 				//
 
 				const params = {
-					output: 0
+					output: 0,
+					blueNoise: true
 				};
 
 				const types = { Combined: 0, Direct: 3, AO: 1, GI: 2 };
@@ -238,6 +243,12 @@
 				gui.add( giPass.useLinearThickness, 'value' ).name( 'use linear thickness' );
 				gui.add( giPass.useScreenSpaceSampling, 'value' ).name( 'screen-space sampling' );
 				gui.add( giPass, 'useTemporalFiltering' ).name( 'temporal filtering' ).onChange( updatePostprocessing );
+				gui.add( params, 'blueNoise' ).name( 'blue noise' ).onChange( ( value ) => {
+
+					giPass.noiseNode = ( value === true ) ? noiseNode : null;
+					updatePostprocessing( params.output );
+
+				} );
 
 				function updatePostprocessing( value ) {
 

--- a/examples/webgpu_postprocessing_ssgi.html
+++ b/examples/webgpu_postprocessing_ssgi.html
@@ -242,13 +242,16 @@
 				gui.add( giPass.giIntensity, 'value', 0, 100 ).name( 'GI intensity' );
 				gui.add( giPass.useLinearThickness, 'value' ).name( 'use linear thickness' );
 				gui.add( giPass.useScreenSpaceSampling, 'value' ).name( 'screen-space sampling' );
-				gui.add( giPass, 'useTemporalFiltering' ).name( 'temporal filtering' ).onChange( updatePostprocessing );
-				gui.add( params, 'blueNoise' ).name( 'blue noise' ).onChange( ( value ) => {
+				gui.add( giPass, 'useTemporalFiltering' ).name( 'temporal filtering' ).onChange( updateNoise );
+				gui.add( params, 'blueNoise' ).name( 'blue noise' ).onChange( updateNoise );
 
-					giPass.noiseNode = ( value === true ) ? noiseNode : null;
+				function updateNoise() {
+
+					noiseNode.animated = giPass.useTemporalFiltering;
+					giPass.noiseNode = ( params.blueNoise === true ) ? noiseNode : null;
 					updatePostprocessing( params.output );
 
-				} );
+				}
 
 				function updatePostprocessing( value ) {
 

--- a/examples/webgpu_postprocessing_ssgi_ballpool.html
+++ b/examples/webgpu_postprocessing_ssgi_ballpool.html
@@ -136,6 +136,8 @@
 				const giPass = ssgi( scenePassColor, scenePassDepth, sceneNormal, camera );
 				giPass.sliceCount.value = 2;
 				giPass.stepCount.value = 8;
+				giPass.giIntensity.value = 18;
+				giPass.aoIntensity.value = 0.55;
 				giPass.noiseNode = blueNoise( 2 );
 
 				// svgf denoise

--- a/examples/webgpu_postprocessing_ssgi_ballpool.html
+++ b/examples/webgpu_postprocessing_ssgi_ballpool.html
@@ -45,6 +45,7 @@
 			import * as THREE from 'three/webgpu';
 			import { pass, mrt, output, normalView, diffuseColor, velocity, add, vec4, packNormalToRGB, unpackRGBToNormal, sample } from 'three/tsl';
 			import { ssgi } from 'three/addons/tsl/display/SSGINode.js';
+			import { svgf } from 'three/addons/tsl/display/SVGFNode.js';
 			import { traa } from 'three/addons/tsl/display/TRAANode.js';
 			import { blueNoise } from 'three/addons/tsl/math/BlueNoise.js';
 			import { World } from '@perplexdotgg/bounce';
@@ -134,10 +135,14 @@
 				giPass.stepCount.value = 8;
 				giPass.noiseNode = blueNoise( 2 );
 
+				// svgf denoise
+
+				const svgfPass = svgf( giPass, scenePassDepth, sceneNormal, scenePassVelocity, camera );
+
 				// composite
 
-				const gi = giPass.rgb;
-				const ao = giPass.a;
+				const gi = svgfPass.rgb;
+				const ao = svgfPass.a;
 
 				const compositePass = vec4(
 					add( scenePassColor.rgb.mul( ao ), scenePassDiffuse.rgb.mul( gi ) ),

--- a/examples/webgpu_postprocessing_ssgi_ballpool.html
+++ b/examples/webgpu_postprocessing_ssgi_ballpool.html
@@ -46,6 +46,7 @@
 			import { pass, mrt, output, normalView, diffuseColor, velocity, add, vec4, packNormalToRGB, unpackRGBToNormal, sample } from 'three/tsl';
 			import { ssgi } from 'three/addons/tsl/display/SSGINode.js';
 			import { traa } from 'three/addons/tsl/display/TRAANode.js';
+			import { blueNoise } from 'three/addons/tsl/math/BlueNoise.js';
 			import { World } from '@perplexdotgg/bounce';
 
 			const BALL_RADIUS = 0.4;
@@ -131,6 +132,7 @@
 				const giPass = ssgi( scenePassColor, scenePassDepth, sceneNormal, camera );
 				giPass.sliceCount.value = 2;
 				giPass.stepCount.value = 8;
+				giPass.noiseNode = blueNoise( 2 );
 
 				// composite
 

--- a/examples/webgpu_postprocessing_ssgi_ballpool.html
+++ b/examples/webgpu_postprocessing_ssgi_ballpool.html
@@ -50,6 +50,8 @@
 			import { blueNoise } from 'three/addons/tsl/math/BlueNoise.js';
 			import { World } from '@perplexdotgg/bounce';
 
+			import { Inspector } from 'three/addons/inspector/Inspector.js';
+
 			const BALL_RADIUS = 0.4;
 			const FILL_RATIO = 0.4;
 			const PACKING = 0.6;
@@ -94,6 +96,7 @@
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 0.5;
 				renderer.shadowMap.enabled = true;
+				renderer.inspector = new Inspector();
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -141,8 +144,8 @@
 
 				// composite
 
-				const gi = svgfPass.rgb;
-				const ao = svgfPass.a;
+				const gi = svgfPass.rgb.toInspector( 'SSGI' );
+				const ao = svgfPass.a.toInspector( 'AO' );
 
 				const compositePass = vec4(
 					add( scenePassColor.rgb.mul( ao ), scenePassDiffuse.rgb.mul( gi ) ),


### PR DESCRIPTION
Related issue: #33663 #33769 

**Description:**

Sharing what I've so far.

I feel like the examples that we have are hard to work with.

> Improvements to the SSGI pipeline, most visible in the ball pool example.
> 
> **New**
> - `SVGFNode` — spatiotemporal denoiser (velocity-reprojected temporal accumulation with disocclusion rejection and adaptive anti-ghosting, plus an edge-avoiding à-trous filter). Used in the ball pool example.
> - `BlueNoise` TSL module — runtime void-and-cluster generation (no bundled asset; generator adapted from #33663 by @marcofugaro) with a `BlueNoiseNode` that animates along quasirandom sequences for temporal accumulation. Pluggable into SSGI via the new `SSGINode.noiseNode` input.
> - `SSGINode.resolutionScale` — computing the GI at half resolution is ~2× faster end-to-end in the ball pool (the SVGF chain follows the input resolution).
> 
> **Fixes / optimizations**
> - Fireflies are clamped during accumulation and the temporal gradient no longer rejects history on sub-noise changes — dark-area flicker in the ball pool drops ~3×.
> - SSGI shader: ~30% smaller (sampling loop inlined once instead of per direction), cheaper view position reconstruction, step radius computed once per pixel. Output identical.
> - SVGF samples pass outputs directly instead of re-rendering them into an intermediate texture (one less full-resolution pass).
> 
> DEV: https://raw.githack.com/mrdoob/three.js/dev/examples/webgpu_postprocessing_ssgi_ballpool.html
> PR: https://raw.githack.com/mrdoob/three.js/ssgi/examples/webgpu_postprocessing_ssgi_ballpool.html

What should we keep from all this?