### PR TITLE
Morph: Fix individual `morphTargetInfluences` per object

### DIFF
--- a/src/nodes/accessors/Morph.js
+++ b/src/nodes/accessors/Morph.js
@@ -198,11 +198,12 @@ export const morphReference = /*@__PURE__*/ Fn( ( [ mesh ] ) => {
 
 	let morphInfluenceData = _morphInfluencesData.get( mesh );
 
-	if ( morphInfluenceData === undefined ) {
+	if ( morphInfluenceData === undefined || morphInfluenceData.count !== morphTargetsCount ) {
 
 		morphInfluenceData = {
 			base: uniform( 1 ),
-			influences: buffer( new Float32Array( morphTargetsCount ), 'float', morphTargetsCount )
+			influences: buffer( new Float32Array( morphTargetsCount ), 'float', morphTargetsCount ),
+			count: morphTargetsCount
 		};
 
 		_morphInfluencesData.set( mesh, morphInfluenceData );

--- a/src/nodes/accessors/Morph.js
+++ b/src/nodes/accessors/Morph.js
@@ -286,6 +286,7 @@ export const morphReference = /*@__PURE__*/ Fn( ( [ mesh ] ) => {
 		if ( influences ) {
 
 			influences.array = object.morphTargetInfluences;
+			influences.update();
 
 		}
 

--- a/src/nodes/accessors/Morph.js
+++ b/src/nodes/accessors/Morph.js
@@ -11,7 +11,7 @@ import { DataArrayTexture } from '../../textures/DataArrayTexture.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Vector4 } from '../../math/Vector4.js';
 import { FloatType } from '../../constants.js';
-import { buffer } from './BufferNode.js';
+import { uniformArray } from './UniformArrayNode.js';
 
 const _morphTextures = /*@__PURE__*/ new WeakMap();
 const _morphVec4 = /*@__PURE__*/ new Vector4();
@@ -202,7 +202,7 @@ export const morphReference = /*@__PURE__*/ Fn( ( [ mesh ] ) => {
 
 		morphInfluenceData = {
 			base: uniform( 1 ),
-			influences: mesh.morphTargetInfluences ? buffer( new Float32Array( mesh.morphTargetInfluences ), 'float', morphTargetsCount ) : null,
+			influences: mesh.morphTargetInfluences ? uniformArray( mesh.morphTargetInfluences, 'float' ) : null,
 			count: morphTargetsCount
 		};
 
@@ -285,7 +285,7 @@ export const morphReference = /*@__PURE__*/ Fn( ( [ mesh ] ) => {
 
 		if ( influences ) {
 
-			influences.value.set( object.morphTargetInfluences );
+			influences.array = object.morphTargetInfluences;
 
 		}
 

--- a/src/nodes/accessors/Morph.js
+++ b/src/nodes/accessors/Morph.js
@@ -202,7 +202,7 @@ export const morphReference = /*@__PURE__*/ Fn( ( [ mesh ] ) => {
 
 		morphInfluenceData = {
 			base: uniform( 1 ),
-			influences: buffer( new Float32Array( morphTargetsCount ), 'float', morphTargetsCount ),
+			influences: mesh.morphTargetInfluences ? buffer( new Float32Array( mesh.morphTargetInfluences ), 'float', morphTargetsCount ) : null,
 			count: morphTargetsCount
 		};
 
@@ -283,7 +283,11 @@ export const morphReference = /*@__PURE__*/ Fn( ( [ mesh ] ) => {
 
 		}
 
-		influences.value.set( object.morphTargetInfluences );
+		if ( influences ) {
+
+			influences.value.set( object.morphTargetInfluences );
+
+		}
 
 	} );
 

--- a/src/nodes/accessors/Morph.js
+++ b/src/nodes/accessors/Morph.js
@@ -1,6 +1,5 @@
 
 import { float, Fn, ivec2, int, If, uniform } from '../tsl/TSLBase.js';
-import { reference } from './ReferenceNode.js';
 import { Loop } from '../utils/LoopNode.js';
 import { OnObjectUpdate } from '../utils/EventNode.js';
 import { textureLoad } from './TextureNode.js';
@@ -12,10 +11,11 @@ import { DataArrayTexture } from '../../textures/DataArrayTexture.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Vector4 } from '../../math/Vector4.js';
 import { FloatType } from '../../constants.js';
+import { buffer } from './BufferNode.js';
 
 const _morphTextures = /*@__PURE__*/ new WeakMap();
 const _morphVec4 = /*@__PURE__*/ new Vector4();
-const _morphBaseInfluences = /*@__PURE__*/ new WeakMap();
+const _morphInfluencesData = /*@__PURE__*/ new WeakMap();
 
 /**
  * TSL function that retrieves and scales the morphed attribute (position or normal) texel value.
@@ -175,13 +175,6 @@ function getEntry( geometry ) {
 }
 
 /**
- * TSL object representing a reference to the mesh's morphTargetInfluences array.
- *
- * @type {ReferenceNode<float>}
- */
-export const morphTargetInfluences = /*@__PURE__*/ reference( 'morphTargetInfluences', 'float' );
-
-/**
  * TSL function representing the vertex shader morph targets blend setup.
  * Dynamically computes morph targets weights and updates positionLocal and normalLocal in-place.
  *
@@ -201,33 +194,29 @@ export const morphReference = /*@__PURE__*/ Fn( ( [ mesh ] ) => {
 
 	if ( morphTargetsCount === 0 ) return;
 
-	let morphBaseInfluence = _morphBaseInfluences.get( mesh );
+	// Init
 
-	if ( ! morphBaseInfluence ) {
+	let morphInfluenceData = _morphInfluencesData.get( mesh );
 
-		morphBaseInfluence = uniform( 1 );
-		_morphBaseInfluences.set( mesh, morphBaseInfluence );
+	if ( morphInfluenceData === undefined ) {
 
-		OnObjectUpdate( ( { object } ) => {
+		morphInfluenceData = {
+			base: uniform( 1 ),
+			influences: buffer( new Float32Array( morphTargetsCount ), 'float', morphTargetsCount )
+		};
 
-			if ( object.geometry.morphTargetsRelative ) {
-
-				morphBaseInfluence.value = 1;
-
-			} else {
-
-				morphBaseInfluence.value = 1 - object.morphTargetInfluences.reduce( ( a, b ) => a + b, 0 );
-
-			}
-
-		} );
+		_morphInfluencesData.set( mesh, morphInfluenceData );
 
 	}
 
+	const { base, influences } = morphInfluenceData;
+
+	// Shader
+
 	const { texture: bufferMap, stride, size } = getEntry( geometry );
 
-	if ( hasMorphPosition === true ) positionLocal.mulAssign( morphBaseInfluence );
-	if ( hasMorphNormals === true ) normalLocal.mulAssign( morphBaseInfluence );
+	if ( hasMorphPosition === true ) positionLocal.mulAssign( base );
+	if ( hasMorphNormals === true ) normalLocal.mulAssign( base );
 
 	const width = int( size.width );
 
@@ -241,7 +230,7 @@ export const morphReference = /*@__PURE__*/ Fn( ( [ mesh ] ) => {
 
 		} else {
 
-			influence.assign( morphTargetInfluences.element( i ).toVar() );
+			influence.assign( influences.element( i ).toVar() );
 
 		}
 
@@ -274,6 +263,26 @@ export const morphReference = /*@__PURE__*/ Fn( ( [ mesh ] ) => {
 			}
 
 		} );
+
+	} );
+
+	// Update
+
+	OnObjectUpdate( ( { object } ) => {
+
+		const { base, influences } = morphInfluenceData;
+
+		if ( object.geometry.morphTargetsRelative ) {
+
+			base.value = 1;
+
+		} else {
+
+			base.value = 1 - object.morphTargetInfluences.reduce( ( a, b ) => a + b, 0 );
+
+		}
+
+		influences.value.set( object.morphTargetInfluences );
 
 	} );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33674

**Description**

An alternative fix of https://github.com/mrdoob/three.js/pull/33771

This PR solves individual `morphTargetInfluences` per object by replacing the global `ReferenceNode` with a per-mesh caching mechanism that manages a dedicated `uniformArray` of the related with `morphTargetsCount` for each mesh.