### PR TITLE
USDAParser: Fix inline-brace prim definitions being silently dropped

### DIFF
--- a/examples/jsm/loaders/usd/USDAParser.js
+++ b/examples/jsm/loaders/usd/USDAParser.js
@@ -85,6 +85,8 @@ class USDAParser {
 
 			} else if ( line.endsWith( '{' ) ) {
 
+				string = line.slice( 0, - 1 ).trim() || string;
+
 				const group = target[ string ] || {};
 				stack.push( group );
 


### PR DESCRIPTION
## Related issue / context

Most USDA files emitted by `usdcat`, Pixar's USD reference toolchain, Houdini, Maya/Omniverse, Blender's USD exporter, and any tool that round-trips through `pxr.Usd.Stage.Export()` use the **brace-on-same-line** prim form:

```usda
def Mesh "M" {
    point3f[] points = [(0,0,0),(1,0,0),(0,1,0)]
    int[] faceVertexCounts = [3]
    int[] faceVertexIndices = [0,1,2]
}
```

`USDAParser` currently fails to load these — every prim is stored under whatever string-valued line preceded the `{` (often `#usda 1.0` from the file header, or `""`), so `findMeshes()` / `findGeometry()` never sees them and the resulting `Group` is empty. Only the non-standard brace-on-next-line form works today:

```usda
def Mesh "M"
{
    ...
}
```

Both forms are valid per the [USD ASCII (`usda`) grammar](https://openusd.org/release/sdf_file_format.html) — the official USD repo's own test fixtures use both interchangeably (e.g. see the same-line form in [`pxr/usd/usd/testenv/testUsdStage/`](https://github.com/PixarAnimationStudios/OpenUSD/tree/release/pxr/usd/usd/testenv) and the `usdGenSchema` outputs).

## Root cause

In `USDAParser.parseText()`, the `else if ( line.endsWith( '{' ) )` branch reuses a `string` variable that is only updated when a bare prim header (no brace) precedes it. For inline-brace input, `string` is whatever was set on the prior non-special line — typically empty or junk — and `target[ string ] = group;` puts the prim's children under the wrong key, invisible to subsequent walks.

The parallel branch for `(` blocks already handles this correctly at line 109:
```js
string = line.split( '(' )[ 0 ].trim() || string;
```

## Fix

Mirror the same idiom for `{` blocks: extract the label from the current line, fall back to `string` when the brace is on its own line.

```diff
  } else if ( line.endsWith( '{' ) ) {

+     string = line.slice( 0, - 1 ).trim() || string;
+
      const group = target[ string ] || {};
      stack.push( group );

      target[ string ] = group;
      target = group;

  }
```

## Repro

Minimal USDA, inline-brace form:

```usda
#usda 1.0
(
    defaultPrim = "Root"
)
def Xform "Root" {
    def Mesh "M" {
        point3f[] points = [(0,0,0),(1,0,0),(0,1,0)]
        int[] faceVertexCounts = [3]
        int[] faceVertexIndices = [0,1,2]
    }
}
```

Wrap in a ZIP as `M.usda` → `M.usdz`, then:

```js
new USDLoader().parse( arrayBuffer ); // before: empty Group; after: Group with one Mesh
```

The same file with `def Xform "Root"\n{` (brace on next line) loads correctly both before and after this PR.

## Impact

Two-line change, scoped to one branch of `USDAParser.parseText()`. The `|| string` fallback preserves existing behavior for brace-on-next-line input, so no existing example regresses. Local test against the three.js examples (`webgl_loader_usdz`, `webgl_loader_usdz_blender`) still loads fine.