### PR TITLE
Renderers: Disable bump mapping for wireframe rendering.

### DIFF
--- a/src/nodes/display/BumpMapNode.js
+++ b/src/nodes/display/BumpMapNode.js
@@ -88,7 +88,12 @@ class BumpMapNode extends TempNode {
 
 	}
 
-	setup() {
+	setup( builder ) {
+
+		// Screen-space derivatives are unreliable on thin lines, so the bump
+		// effect is disabled for wireframe rendering.
+
+		if ( builder.material.wireframe === true ) return normalView;
 
 		const bumpScale = this.scaleNode !== null ? this.scaleNode : 1;
 		const dHdxy = dHdxy_fwd( { textureNode: this.textureNode, bumpScale } );

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -126,7 +126,7 @@ function WebGLPrograms( renderer, environments, extensions, capabilities, bindin
 		const HAS_ENVMAP = !! envMap;
 		const HAS_AOMAP = !! material.aoMap;
 		const HAS_LIGHTMAP = !! material.lightMap;
-		const HAS_BUMPMAP = !! material.bumpMap;
+		const HAS_BUMPMAP = !! material.bumpMap && material.wireframe === false;
 		const HAS_NORMALMAP = !! material.normalMap;
 		const HAS_DISPLACEMENTMAP = !! material.displacementMap;
 		const HAS_EMISSIVEMAP = !! material.emissiveMap;


### PR DESCRIPTION
Related issue: #31242

**Description**

While working on #33776 I noticed that some models renderer black in wireframe mode.

<img width="909" height="761" alt="Screenshot 2026-06-12 at 15 39 38" src="https://github.com/user-attachments/assets/a32182fd-2c3a-47d3-a9eb-3fedf19e077d" />

Turns out bumpMap was the culprit.

> Bump mapping relies on screen-space derivatives, which are unreliable on thin lines — bump-mapped materials render mostly black in wireframe.
>
> Disables the bump perturbation when `material.wireframe` is `true`, in both `BumpMapNode` and `WebGLPrograms`. Same approach as #31242, which gated `flatShading` (also derivative-based) for the same reason — including the same compromise: toggling `wireframe` at runtime requires `material.needsUpdate = true`.