### PR TITLE
WebGPURenderer: Track frontFaceCW in needsRenderUpdate.

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2042,6 +2042,7 @@ class WebGPUBackend extends Backend {
 		const colorFormat = utils.getCurrentColorFormat( renderObject.context );
 		const depthStencilFormat = utils.getCurrentDepthStencilFormat( renderObject.context );
 		const primitiveTopology = utils.getPrimitiveTopology( object, material );
+		const frontFaceCW = ( object.isMesh && object.matrixWorld.determinant() < 0 );
 
 		let needsUpdate = false;
 
@@ -2057,6 +2058,7 @@ class WebGPUBackend extends Backend {
 			data.sampleCount !== sampleCount || data.colorSpace !== colorSpace ||
 			data.colorFormat !== colorFormat || data.depthStencilFormat !== depthStencilFormat ||
 			data.primitiveTopology !== primitiveTopology ||
+			data.frontFaceCW !== frontFaceCW ||
 			data.clippingContextCacheKey !== renderObject.clippingContextCacheKey
 		) {
 
@@ -2075,6 +2077,7 @@ class WebGPUBackend extends Backend {
 			data.colorFormat = colorFormat;
 			data.depthStencilFormat = depthStencilFormat;
 			data.primitiveTopology = primitiveTopology;
+			data.frontFaceCW = frontFaceCW;
 			data.clippingContextCacheKey = renderObject.clippingContextCacheKey;
 
 			needsUpdate = true;


### PR DESCRIPTION
### Description

Fixes #33779.

`WebGPUBackend.getRenderCacheKey` includes `frontFaceCW = object.isMesh && object.matrixWorld.determinant() < 0` in the pipeline cache key because the GPU `frontFace` enum is baked into the pre-compiled render pipeline. However, the sibling `WebGPUBackend.needsRenderUpdate` doesn't track the same signal, so when an existing mesh transitions between positive and negative determinant (typical case: editor toggles a mirror/flip via negative scale on an axis), `Pipelines.getForRender` short-circuits on the cached `renderObject.pipeline` and never re-evaluates the cache key. The mesh continues to draw with the stale `frontFace`, culling the visually-outward fragments. For lit opaque materials this results in a fully-black render.

This PR adds `frontFaceCW` to `needsRenderUpdate`'s dirty check so the two sides of the cache surface stay symmetric.

### Reproduction

See linked issue for the JSFiddle live demo (https://jsfiddle.net/fvpbt90h/23/). Before this patch, clicking "flip" causes the `TorusKnot` to disappear (closed convex geometry → all faces culled by stale `frontFace`) and clicking "workaround" makes it reappear. After this patch, "flip" works correctly on its own without needing the manual `material.needsUpdate = true` bump.

### Notes

- Two-line addition mirroring the shape of every other comparison in `needsRenderUpdate`.
- Zero behavioural change for objects whose `matrixWorld.determinant()` never changes sign — the new comparison just stores a stable `false` (or stable `true`) in `data.frontFaceCW`.
- The first frame after a sign change pays one extra pipeline cache lookup; subsequent frames at the new sign hit the cache as before.
- `npm run lint` and `npm run test-unit` (1308 pass / 0 fail) both clean locally.
- Related historical fix in `WebGLShadowMap` along the same lines: #15825.
