### PR TITLE
Renderer: Fix `compileAsync()`.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1036,12 +1036,11 @@ class Renderer {
 			renderObject.drawRange = item.object.geometry.drawRange;
 			renderObject.group = item.group;
 
-			this._geometries.updateForRender( renderObject );
-
 			// Use async node building to yield to main thread
 			await this._nodes.getForRenderAsync( renderObject );
 
 			this._nodes.updateBefore( renderObject );
+			this._geometries.updateForRender( renderObject );
 			this._nodes.updateForRender( renderObject );
 			this._bindings.updateForRender( renderObject );
 


### PR DESCRIPTION
Related issue: #32984

**Description**

There is a bug in #32984 that prevents the intended usage of `getForRenderAsync()`. If `compileAsync()` calls `geometries.updateForRender()` _before_  `nodes.getForRenderAsync()`, the latter is actually a no-op because `geometries.updateForRender()` requires the node builder state so it actually performs a sync build when not available.

That is the thing we don't want in `compileAsync()`. To let `getForRenderAsync()` do its work, it's required to move the `geometries.updateForRender()` in the expected order.