### PR TITLE
Editor: Make size of vertex normals helper configurable.

### DIFF
--- a/editor/js/Sidebar.Geometry.js
+++ b/editor/js/Sidebar.Geometry.js
@@ -204,7 +204,7 @@ function SidebarGeometry( editor ) {
 
 		if ( editor.helpers[ object.id ] === undefined ) {
 
-			editor.addHelper( object, new VertexNormalsHelper( object ) );
+			editor.addHelper( object, new VertexNormalsHelper( object, vertexNormalsSize.getValue() ) );
 
 		} else {
 
@@ -216,6 +216,22 @@ function SidebarGeometry( editor ) {
 
 	} );
 	helpersRow.add( vertexNormalsButton );
+
+	const vertexNormalsSize = new UINumber( 1 ).setWidth( '30px' ).setMarginLeft( '7px' ).setRange( 0, Infinity ).onChange( function () {
+
+		const object = editor.selected;
+		const helper = editor.helpers[ object.id ];
+
+		if ( helper !== undefined && helper.isVertexNormalsHelper === true ) {
+
+			helper.size = vertexNormalsSize.getValue();
+
+			signals.objectChanged.dispatch( object );
+
+		}
+
+	} );
+	helpersRow.add( vertexNormalsSize );
 
 	// Export JSON
 
@@ -317,7 +333,7 @@ function SidebarGeometry( editor ) {
 			if ( helper !== undefined && helper.isVertexNormalsHelper === true ) {
 
 				editor.removeHelper( object );
-				editor.addHelper( object, new VertexNormalsHelper( object ) );
+				editor.addHelper( object, new VertexNormalsHelper( object, vertexNormalsSize.getValue() ) );
 
 			}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/33781#issuecomment-4691761620

**Description**

As suggested in https://github.com/mrdoob/three.js/issues/33781#issuecomment-4691761620, the PR makes the size of vertex normals helper configurable. This makes it easier to see them with very large models or to avoid clutter with small scaled models.

https://github.com/user-attachments/assets/9fe5a450-e55e-48db-9c82-d5892148b374