### PR TITLE
ClusteredLightsNode: keep castShadow point lights on the material-lights path

### DIFF
--- a/examples/jsm/tsl/lighting/ClusteredLightsNode.js
+++ b/examples/jsm/tsl/lighting/ClusteredLightsNode.js
@@ -212,7 +212,7 @@ class ClusteredLightsNode extends LightsNode {
 
 		for ( const light of lights ) {
 
-			if ( light.isPointLight === true ) {
+			if ( light.isPointLight === true && light.castShadow !== true ) {
 
 				clusteredLights[ clusteredIndex ++ ] = light;
 


### PR DESCRIPTION
### Problem

With `ClusteredLighting` installed, `PointLight.castShadow = true` is silently ignored: the light illuminates the scene but casts no shadow, with no warning.

`ClusteredLightsNode.setLights()` routes every point light into the clustered path, and the clustered shading (`directPointLight` with color / lightVector / cutoff / decay) has no shadow term — clustered lights never reach `AnalyticLightNode`, so neither the shadow map nor the shadow factor is ever created.

Live example (dev build): https://jsfiddle.net/ryzu6ec5/

A floor, a box, and one shadow-casting point light, rendered with default lighting and again with `ClusteredLighting` installed as in `webgpu_lights_clustered`. The pixel in the box's shadow reads `rgb(2,2,2)` under default lighting and `rgb(227,227,227)` under clustered; an unshadowed reference pixel is identical in both passes.

### Fix

Route `castShadow === true` point lights to the standard material-lights path, where shadows work. This mirrors `DynamicLightsNode`, whose `canBatchLight()` already excludes `castShadow !== true` lights from batching for the same reason.

Shadow-casting point lights are typically few (shadow maps bound their count in practice), so excluding them from the clustered path costs little, and `castShadow` keeps working instead of being silently dropped. If clustered shading gains a shadow term later, this routing can be removed.

PR created with Claude Code but I looked it over before posting.
