### PR TITLE
ClusteredLightsNode: include clustered lights in getLights()

### DIFF
--- a/examples/jsm/tsl/lighting/ClusteredLightsNode.js
+++ b/examples/jsm/tsl/lighting/ClusteredLightsNode.js
@@ -44,6 +44,7 @@ class ClusteredLightsNode extends LightsNode {
 
 		this.materialLights = [];
 		this.clusteredLights = [];
+		this._allLights = [];
 
 		this.maxLights = maxLights;
 		this.tileSize = tileSize;
@@ -205,6 +206,8 @@ class ClusteredLightsNode extends LightsNode {
 
 	setLights( lights ) {
 
+		this._allLights = lights;
+
 		const { clusteredLights, materialLights } = this;
 
 		let materialIndex = 0;
@@ -228,6 +231,12 @@ class ClusteredLightsNode extends LightsNode {
 		clusteredLights.length = clusteredIndex;
 
 		return super.setLights( materialLights );
+
+	}
+
+	getLights() {
+
+		return this._allLights;
 
 	}
 


### PR DESCRIPTION

`ClusteredLightsNode.setLights()` partitions its input into `clusteredLights` and `materialLights`, but the inherited `getLights()` returns only the material lights. Since #33737 the renderer snapshots `getLights()` before every render and replays it through `setLights()` after (`Lighting.beginRender` / `finishRender`), so every render drops the clustered point lights from the node:

```js
const node = new ClusteredLighting().createNode( [ pointLight, spotLight ] );
node.setLights( node.getLights() ); // clusteredLights: 1 -> 0
```

In a plain forward loop this stays invisible — the render list reassigns the scene's lights at the start of the next render. But when the same scene renders again within a frame (reflections, dynamic environment probes), the restore lands mid-frame: the node re-uploads a light count of 0 and every clustered point light stops contributing.

Live example (dev build), `ClusteredLighting` plus a `reflector()` floor wired as in `webgpu_lights_clustered` and `webgpu_reflection`: https://jsfiddle.net/nwyz3erm/ — the scene renders black every frame. Set `PATCHED = true` at the top to see the expected red and green light pools.

Plain `LightsNode` doesn't show this because its `getLights()` returns the live `_lights` array, which the render list mutates in place — the snapshot aliases the current set. `ClusteredLightsNode` breaks that aliasing by partitioning into its own arrays.

PR created using Claude Code with human review
