### PR TITLE
WebGPUPipelineUtils: reset shared render-pipeline descriptor before suspending in the async path

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -315,9 +315,16 @@ class WebGPUPipelineUtils {
 
 					let asyncError = null;
 
+					const pipelinePromise = device.createRenderPipelineAsync( _renderPipelineDescriptor );
+
+					// The device consumed the descriptor synchronously; reset it before
+					// suspending so a pipeline creation that interleaves before the
+					// finally runs cannot build from this pipeline's leftover state.
+					_renderPipelineDescriptor.reset();
+
 					try {
 
-						pipelineData.pipeline = await device.createRenderPipelineAsync( _renderPipelineDescriptor );
+						pipelineData.pipeline = await pipelinePromise;
 
 					} catch ( err ) {
 
@@ -339,8 +346,6 @@ class WebGPUPipelineUtils {
 					}
 
 				} finally {
-
-					_renderPipelineDescriptor.reset();
 
 					// Guarantee resolution so `compileAsync`'s Promise.all cannot hang on an
 					// unexpected throw from any await above.

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -314,21 +314,31 @@ class WebGPUPipelineUtils {
 				try {
 
 					let asyncError = null;
-
-					const pipelinePromise = device.createRenderPipelineAsync( _renderPipelineDescriptor );
-
-					// The device consumed the descriptor synchronously; reset it before
-					// suspending so a pipeline creation that interleaves before the
-					// finally runs cannot build from this pipeline's leftover state.
-					_renderPipelineDescriptor.reset();
+					let pipelinePromise = null;
 
 					try {
 
-						pipelineData.pipeline = await pipelinePromise;
+						pipelinePromise = device.createRenderPipelineAsync( _renderPipelineDescriptor );
 
 					} catch ( err ) {
 
 						asyncError = err;
+
+					}
+
+					_renderPipelineDescriptor.reset();
+
+					if ( pipelinePromise !== null ) {
+
+						try {
+
+							pipelineData.pipeline = await pipelinePromise;
+
+						} catch ( err ) {
+
+							asyncError = err;
+
+						}
 
 					}
 


### PR DESCRIPTION
### Problem

Every render pipeline is built from the shared module-level `_renderPipelineDescriptor`. Its `depthStencil` field is only written when the render context has a depth/stencil aspect and is never cleared by the populate step, so correctness depends on `reset()` running between builds.

The sync path resets right after `createRenderPipeline()`. The async path (used by `compileAsync()`) only resets in the `finally`, after `createRenderPipelineAsync()` settles. A synchronous pipeline creation that interleaves before then inherits the stale `depthStencil`, and if its render context is depthless the device rejects the pipeline against the pass — on every frame, since the broken pipeline is cached. Rendering while `compileAsync()` is in flight is normal usage: it is what `compileAsync` exists for, and it yields between objects deliberately.

Live example (dev build): https://jsfiddle.net/jsmn20wa/ — a depth-tested mesh compiles via un-awaited `compileAsync()` while a quad renders into a `depthBuffer: false` target. The quad's pipeline picks up `depthStencilFormat: Depth24Plus`, fails validation every frame, and never draws:

```
GPUValidationError: Attachment state of [RenderPipeline] is not compatible with [RenderPassEncoder].
[RenderPassEncoder] expects { colorTargets: [...], sampleCount: 1 }.
[RenderPipeline] has { colorTargets: [...], depthStencilFormat: TextureFormat::Depth24Plus, sampleCount: 1 }.
```

Set `MODE = 'await'` at the top of the fiddle for the clean control.

### Fix

`createRenderPipelineAsync()` consumes the descriptor at call time — WebGPU descriptors are WebIDL dictionaries, passed by value, so mutating the shared object after the call has no effect on the in-flight creation (verified empirically: scrambling the descriptor right after the call still produces a correct pipeline). Reset the descriptor immediately after the device consumes it, matching the sync path's discipline, and drop the now-redundant reset from the `finally`, which keeps only the resolve guarantee.

PR created using Claude Code with human review
