### PR TITLE
RenderObject: Optimize `getKeys()`.

### DIFF
--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -1,36 +1,44 @@
 import { hash, hashString } from '../../nodes/core/NodeUtils.js';
 
 let _id = 0;
+const _protoKeysCache = new WeakMap();
 
 function getKeys( obj ) {
 
 	const keys = Object.keys( obj );
 
-	let proto = Object.getPrototypeOf( obj );
+	let protoKeys = _protoKeysCache.get( obj.constructor );
 
-	while ( proto ) {
+	if ( protoKeys === undefined ) {
 
-		const descriptors = Object.getOwnPropertyDescriptors( proto );
+		protoKeys = [];
+		let proto = Object.getPrototypeOf( obj );
 
-		for ( const key in descriptors ) {
+		while ( proto ) {
 
-			if ( descriptors[ key ] !== undefined ) {
+			const descriptors = Object.getOwnPropertyDescriptors( proto );
+
+			for ( const key in descriptors ) {
 
 				const descriptor = descriptors[ key ];
 
 				if ( descriptor && typeof descriptor.get === 'function' ) {
 
-					keys.push( key );
+					protoKeys.push( key );
 
 				}
 
 			}
 
+			proto = Object.getPrototypeOf( proto );
+
 		}
 
-		proto = Object.getPrototypeOf( proto );
+		_protoKeysCache.set( obj.constructor, protoKeys );
 
 	}
+
+	for ( let i = 0; i < protoKeys.length; i ++ ) keys.push( protoKeys[ i ] );
 
 	return keys;
 


### PR DESCRIPTION
Related issue: #33797

**Description**

In `RenderObject`, the `getKeys()` function returns a list of a material's property names: The instance's own enumerable keys plus all getter-defined accessor properties inherited from its prototype chain.

The prototype-chain walk as well as the `getOwnPropertyDescriptors()` is actually the expensive part of this function. It seems it is possible to cache that aspect since it is equal for every material instance of a specific ctor. With such a cache in place, `getKeys()` performs much better.
