### PR TITLE
Inspector: Fix slider using `step()` after define the value

### DIFF
--- a/examples/jsm/inspector/ui/Values.js
+++ b/examples/jsm/inspector/ui/Values.js
@@ -276,6 +276,7 @@ class ValueSlider extends Value {
 
 		this.slider.step = value;
 		this.numberInput.step = value;
+		this.slider.value = parseFloat( this.numberInput.value );
 
 		return this;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33783

**Description**

When creating a numeric slider via the `Inspector` with a custom range (e.g., `parameterGroup.add( node, 'value', 0.0, 0.0008 ).step( 0.000001 )`), the `ValueSlider` is constructed using the default step size of `0.01` before the chained `.step(...)` is called.
