### PR TITLE
Inspector: Inline extensions configuration and remove `extensions.json`

### DIFF
--- a/examples/jsm/inspector/extensions/extensions.json
+++ b/examples/jsm/inspector/extensions/extensions.json
@@ -1,6 +1,0 @@
-[
-	{
-		"name": "TSL Graph",
-		"url": "./tsl-graph/TSLGraphEditor.js"
-	}
-]

--- a/examples/jsm/inspector/tabs/Settings.js
+++ b/examples/jsm/inspector/tabs/Settings.js
@@ -2,7 +2,13 @@ import { Parameters } from './Parameters.js';
 import { WebGPURenderer, WebGLBackend, Node } from 'three/webgpu';
 import { getItem, setItem } from '../Inspector.js';
 
-const _EXTENSIONS_PATH = '../extensions/extensions.json';
+const _extensions = [
+	{
+		name: 'TSL Graph',
+		url: '../extensions/tsl-graph/TSLGraphEditor.js'
+	}
+];
+
 
 const _init = WebGPURenderer.prototype.init;
 
@@ -261,7 +267,7 @@ Shares the same state across any page within the current origin.` );
 
 		extension.active = true;
 
-		const extUrl = new URL( extension.url, new URL( _EXTENSIONS_PATH, import.meta.url ) ).href;
+		const extUrl = new URL( extension.url, import.meta.url ).href;
 
 		const module = await import( extUrl );
 
@@ -282,11 +288,7 @@ Shares the same state across any page within the current origin.` );
 
 	async _getExtensions() {
 
-		const url = new URL( _EXTENSIONS_PATH, import.meta.url );
-
-		const extensions = await fetch( url ).then( res => res.json() );
-
-		return extensions;
+		return _extensions;
 
 	}
 

--- a/examples/jsm/inspector/tabs/Settings.js
+++ b/examples/jsm/inspector/tabs/Settings.js
@@ -9,7 +9,6 @@ const _extensions = [
 	}
 ];
 
-
 const _init = WebGPURenderer.prototype.init;
 
 function forceWebGL( enable ) {


### PR DESCRIPTION
Closes https://github.com/mrdoob/three.js/issues/33785

**Description**

Inlines the extensions configuration inside `Settings.js` and removes the redundant `extensions.json` file. This avoids a 404 network fetch error and console warning when using the Inspector in projects without a custom `extensions.json`.