### PR TITLE
Matrix4: Rename `determinant3x3()` to `determinantAffine()`.

### DIFF
--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -655,6 +655,8 @@ class Matrix4 {
 	 *
 	 * For affine matrices (like an object's world matrix), this value equals the
 	 * full 4x4 {@link Matrix4#determinant} but is cheaper to compute.
+	 * 
+	 * Assumes the bottom row is [0, 0, 0, 1].
 	 *
 	 * @return {number} The determinant of the matrix.
 	 */

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -238,7 +238,7 @@ class Matrix4 {
 	 */
 	extractBasis( xAxis, yAxis, zAxis ) {
 
-		if ( this.determinant3x3() === 0 ) {
+		if ( this.determinantAffine() === 0 ) {
 
 			xAxis.set( 1, 0, 0 );
 			yAxis.set( 0, 1, 0 );
@@ -288,7 +288,7 @@ class Matrix4 {
 	 */
 	extractRotation( m ) {
 
-		if ( m.determinant3x3() === 0 ) {
+		if ( m.determinantAffine() === 0 ) {
 
 			return this.identity();
 
@@ -650,14 +650,15 @@ class Matrix4 {
 	}
 
 	/**
-	 * Computes and returns the determinant of the upper-left 3x3 submatrix.
+	 * Computes and returns the determinant of the 4x4 matrix, but assumes the
+	 * matrix is affine, saving some computations.
 	 *
 	 * For affine matrices (like an object's world matrix), this value equals the
 	 * full 4x4 {@link Matrix4#determinant} but is cheaper to compute.
 	 *
-	 * @return {number} The determinant of the upper-left 3x3 submatrix.
+	 * @return {number} The determinant of the matrix.
 	 */
-	determinant3x3() {
+	determinantAffine() {
 
 		const te = this.elements;
 
@@ -1080,7 +1081,7 @@ class Matrix4 {
 		position.y = te[ 13 ];
 		position.z = te[ 14 ];
 
-		const det = this.determinant3x3();
+		const det = this.determinantAffine();
 
 		if ( det === 0 ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1185,7 +1185,7 @@ class WebGLRenderer {
 
 			if ( scene === null ) scene = _emptyScene; // renderBufferDirect second parameter used to be fog (could be null)
 
-			const frontFaceCW = ( object.isMesh && object.matrixWorld.determinant3x3() < 0 );
+			const frontFaceCW = ( object.isMesh && object.matrixWorld.determinantAffine() < 0 );
 
 			const program = setProgram( camera, scene, geometry, material, object );
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1080,7 +1080,7 @@ class WebGLBackend extends Backend {
 
 		this._bindUniforms( renderObject.getBindings() );
 
-		const frontFaceCW = ( object.isMesh && object.matrixWorld.determinant3x3() < 0 );
+		const frontFaceCW = ( object.isMesh && object.matrixWorld.determinantAffine() < 0 );
 
 		state.setMaterial( material, frontFaceCW, hardwareClippingPlanes );
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2058,7 +2058,7 @@ class WebGPUBackend extends Backend {
 		const colorFormat = utils.getCurrentColorFormat( renderObject.context );
 		const depthStencilFormat = utils.getCurrentDepthStencilFormat( renderObject.context );
 		const primitiveTopology = utils.getPrimitiveTopology( object, material );
-		const frontFaceCW = ( object.isMesh && object.matrixWorld.determinant3x3() < 0 );
+		const frontFaceCW = ( object.isMesh && object.matrixWorld.determinantAffine() < 0 );
 
 		let needsUpdate = false;
 
@@ -2120,7 +2120,7 @@ class WebGPUBackend extends Backend {
 		// meshes with negative scale have a different frontFace render pipeline
 		// descriptor value so the following must be honored in the cache key
 
-		const frontFaceCW = ( object.isMesh && object.matrixWorld.determinant3x3() < 0 );
+		const frontFaceCW = ( object.isMesh && object.matrixWorld.determinantAffine() < 0 );
 
 		return [
 			material.transparent, material.blending, material.premultipliedAlpha,

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -847,7 +847,7 @@ class WebGPUPipelineUtils {
 
 		let flipSided = ( material.side === BackSide );
 
-		if ( object.isMesh && object.matrixWorld.determinant3x3() < 0 ) flipSided = ! flipSided;
+		if ( object.isMesh && object.matrixWorld.determinantAffine() < 0 ) flipSided = ! flipSided;
 
 		descriptor.frontFace = ( flipSided === true ) ? GPUFrontFace.CW : GPUFrontFace.CCW;
 

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -467,7 +467,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'determinant3x3', ( assert ) => {
+		QUnit.test( 'determinantAffine', ( assert ) => {
 
 			// for affine matrices (the typical object world matrix), the 3x3 result
 			// equals the full 4x4 determinant since the bottom row is [ 0, 0, 0, 1 ]
@@ -479,28 +479,28 @@ export default QUnit.module( 'Maths', () => {
 			// translation + rotation + non-uniform scale
 
 			a.compose( position, quaternion, new Vector3( 2, 3, 0.5 ) );
-			assert.ok( Math.abs( a.determinant3x3() - a.determinant() ) <= eps, 'Affine matrix: Passed!' );
+			assert.ok( Math.abs( a.determinantAffine() - a.determinant() ) <= eps, 'Affine matrix: Passed!' );
 
 			// reflection (negative scale on one axis flips the winding order)
 
 			a.compose( position, quaternion, new Vector3( 2, 3, - 0.5 ) );
-			assert.ok( a.determinant3x3() < 0, 'Reflection produces a negative determinant!' );
-			assert.ok( Math.abs( a.determinant3x3() - a.determinant() ) <= eps, 'Reflection matrix: Passed!' );
+			assert.ok( a.determinantAffine() < 0, 'Reflection produces a negative determinant!' );
+			assert.ok( Math.abs( a.determinantAffine() - a.determinant() ) <= eps, 'Reflection matrix: Passed!' );
 
 			// shear
 
 			a.multiply( new Matrix4().makeShear( 0.5, 0, 0.2, 0, 0.7, 0 ) );
-			assert.ok( Math.abs( a.determinant3x3() - a.determinant() ) <= eps, 'Shear matrix: Passed!' );
+			assert.ok( Math.abs( a.determinantAffine() - a.determinant() ) <= eps, 'Shear matrix: Passed!' );
 
 		} );
 
-		QUnit.test( 'determinant3x3 (projective matrix)', ( assert ) => {
+		QUnit.test( 'determinantAffine (projective matrix)', ( assert ) => {
 
 			// for non-affine (projective) matrices, the bottom row is not [ 0, 0, 0, 1 ]
 			// and so the 3x3 result generally differs from the full 4x4 determinant
 
 			const a = new Matrix4().makePerspective( - 1, 1, 1, - 1, 1, 100 );
-			assert.ok( Math.abs( a.determinant3x3() - a.determinant() ) > eps, 'Passed!' );
+			assert.ok( Math.abs( a.determinantAffine() - a.determinant() ) > eps, 'Passed!' );
 
 		} );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33814#issuecomment-4713465482

**Description**

Like suggested in https://github.com/mrdoob/three.js/pull/33814#issuecomment-4713465482, the PR renames  `determinant3x3()` to `determinantAffine()`.