### PR TITLE
add shadowmap for static or dynamic objects

### DIFF
--- a/src/lights/LightShadow.js
+++ b/src/lights/LightShadow.js
@@ -120,7 +120,7 @@ class LightShadow {
 		 * @default null
 		 */
 		this.map = null;
-
+		this.staticMap = null;
 		/**
 		 * The distribution map generated using the internal camera; an occlusion is
 		 * calculated based on the distribution of depths. Computed internally during
@@ -158,6 +158,13 @@ class LightShadow {
 		 */
 		this.needsUpdate = false;
 		/**
+		 * When set to `true`, static shadow maps will be updated in the next `render` call.
+		 * @default false
+		 * @type {boolean}
+		 */
+		this.staticNeedsUpdate = false;
+
+		/**
 		 * Layer used to compare with other object layer to check if it needs to be rendered on its shadow map pass
 		 *
 		 * @type {Layers}
@@ -165,7 +172,14 @@ class LightShadow {
 		this.shadowLayers = new Layers();
 
 		this.shadowLayers.enableAll();
-
+		this.staticLayer = 0;
+		this.dynamicLayer = 0;
+		/**
+		 * Define if you need double render pass for static and dynamic shadow
+		 *
+		 * @type {number}
+		 */
+		this.requireDualPass = 0;
 		this._frustum = new Frustum();
 		this._frameExtents = new Vector2( 1, 1 );
 
@@ -276,6 +290,12 @@ class LightShadow {
 	dispose() {
 
 		if ( this.map ) {
+
+			this.map.dispose();
+
+		}
+
+		if ( this.staticMap ) {
 
 			this.map.dispose();
 

--- a/src/lights/LightShadow.js
+++ b/src/lights/LightShadow.js
@@ -4,6 +4,7 @@ import { Vector3 } from '../math/Vector3.js';
 import { Vector4 } from '../math/Vector4.js';
 import { Frustum } from '../math/Frustum.js';
 import { UnsignedByteType, WebGPUCoordinateSystem } from '../constants.js';
+import { Layers } from '../core/Layers.js';
 
 const _projScreenMatrix = /*@__PURE__*/ new Matrix4();
 const _lightPositionWorld = /*@__PURE__*/ new Vector3();
@@ -156,6 +157,14 @@ class LightShadow {
 		 * @default false
 		 */
 		this.needsUpdate = false;
+		/**
+		 * Layer used to compare with other object layer to check if it needs to be rendered on its shadow map pass
+		 *
+		 * @type {Layers}
+		 */
+		this.shadowLayers = new Layers();
+
+		this.shadowLayers.enableAll();
 
 		this._frustum = new Frustum();
 		this._frameExtents = new Vector2( 1, 1 );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2624,15 +2624,33 @@ class WebGLRenderer {
 
 				}
 
+				if ( lights.state.directionalStaticShadowMap.length > 0 ) {
+
+					p_uniforms.setValue( _gl, 'directionalStaticShadowMap', lights.state.directionalStaticShadowMap, textures );
+
+				}
+
 				if ( lights.state.spotShadowMap.length > 0 ) {
 
 					p_uniforms.setValue( _gl, 'spotShadowMap', lights.state.spotShadowMap, textures );
 
 				}
 
+				if ( lights.state.spotStaticShadowMap.length > 0 ) {
+
+					p_uniforms.setValue( _gl, 'spotStaticShadowMap', lights.state.spotStaticShadowMap, textures );
+
+				}
+
 				if ( lights.state.pointShadowMap.length > 0 ) {
 
 					p_uniforms.setValue( _gl, 'pointShadowMap', lights.state.pointShadowMap, textures );
+
+				}
+
+				if ( lights.state.pointStaticShadowMap.length > 0 ) {
+
+					p_uniforms.setValue( _gl, 'pointStaticShadowMap', lights.state.pointStaticShadowMap, textures );
 
 				}
 

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -60,6 +60,9 @@ IncidentLight directLight;
 	PointLight pointLight;
 	#if defined( USE_SHADOWMAP ) && NUM_POINT_LIGHT_SHADOWS > 0
 	PointLightShadow pointLightShadow;
+	float staticShadow;
+	float dynamicShadow;
+	float finalShadow;
 	#endif
 
 	#pragma unroll_loop_start
@@ -71,7 +74,18 @@ IncidentLight directLight;
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_POINT_LIGHT_SHADOWS ) && ( defined( SHADOWMAP_TYPE_PCF ) || defined( SHADOWMAP_TYPE_BASIC ) )
 		pointLightShadow = pointLightShadows[ i ];
-		directLight.color *= ( directLight.visible && receiveShadow ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowIntensity, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;
+		dynamicShadow = ( directLight.visible && receiveShadow ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowIntensity, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;
+		staticShadow = ( directLight.visible && receiveShadow ) ? getPointShadow( pointStaticShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowIntensity, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;
+		if ( pointLightShadow.requireDualPass > 0.5 ) {
+
+		   finalShadow = min(dynamicShadow,staticShadow);
+
+		} else {
+
+		   finalShadow = dynamicShadow;
+
+		}
+		directLight.color *= finalShadow;
 		#endif
 
 		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
@@ -90,6 +104,9 @@ IncidentLight directLight;
 
 	#if defined( USE_SHADOWMAP ) && NUM_SPOT_LIGHT_SHADOWS > 0
 	SpotLightShadow spotLightShadow;
+	float staticShadow;
+	float dynamicShadow;
+	float finalShadow;
 	#endif
 
 	#pragma unroll_loop_start
@@ -119,7 +136,18 @@ IncidentLight directLight;
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )
 		spotLightShadow = spotLightShadows[ i ];
-		directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowIntensity, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotLightCoord[ i ] ) : 1.0;
+		dynamicShadow = ( directLight.visible && receiveShadow ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowIntensity, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotLightCoord[ i ] ) : 1.0;
+		staticShadow = ( directLight.visible && receiveShadow ) ? getShadow( spotStaticShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowIntensity, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotLightCoord[ i ] ) : 1.0;
+		if ( spotLightShadow.requireDualPass > 0.5 ) {
+
+		   finalShadow = min(dynamicShadow,staticShadow);
+
+		} else {
+
+		   finalShadow = dynamicShadow;
+
+		}
+		directLight.color *= finalShadow;
 		#endif
 
 		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
@@ -134,6 +162,9 @@ IncidentLight directLight;
 	DirectionalLight directionalLight;
 	#if defined( USE_SHADOWMAP ) && NUM_DIR_LIGHT_SHADOWS > 0
 	DirectionalLightShadow directionalLightShadow;
+	float staticShadow;
+	float dynamicShadow;
+	float finalShadow;
 	#endif
 
 	#pragma unroll_loop_start
@@ -145,7 +176,19 @@ IncidentLight directLight;
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 		directionalLightShadow = directionalLightShadows[ i ];
-		directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowIntensity, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		dynamicShadow = ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowIntensity, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		staticShadow = ( directLight.visible && receiveShadow ) ? getShadow( directionalStaticShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowIntensity, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		if ( directionalLightShadow.requireDualPass > 0.5 ) {
+
+		   finalShadow = min(dynamicShadow,staticShadow);
+
+		} else {
+
+		   finalShadow = dynamicShadow;
+
+		}
+		directLight.color *= finalShadow;
+
 		#endif
 
 		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -18,10 +18,14 @@ export default /* glsl */`
 		#if defined( SHADOWMAP_TYPE_PCF )
 
 			uniform sampler2DShadow directionalShadowMap[ NUM_DIR_LIGHT_SHADOWS ];
+			uniform sampler2DShadow directionalStaticShadowMap[ NUM_DIR_LIGHT_SHADOWS ];
+
 
 		#else
 
 			uniform sampler2D directionalShadowMap[ NUM_DIR_LIGHT_SHADOWS ];
+			uniform sampler2D directionalStaticShadowMap[ NUM_DIR_LIGHT_SHADOWS ];
+
 
 		#endif
 
@@ -33,6 +37,8 @@ export default /* glsl */`
 			float shadowNormalBias;
 			float shadowRadius;
 			vec2 shadowMapSize;
+			float requireDualPass;
+
 		};
 
 		uniform DirectionalLightShadow directionalLightShadows[ NUM_DIR_LIGHT_SHADOWS ];
@@ -44,10 +50,12 @@ export default /* glsl */`
 		#if defined( SHADOWMAP_TYPE_PCF )
 
 			uniform sampler2DShadow spotShadowMap[ NUM_SPOT_LIGHT_SHADOWS ];
+			uniform sampler2DShadow spotStaticShadowMap[ NUM_SPOT_LIGHT_SHADOWS ];
 
 		#else
 
 			uniform sampler2D spotShadowMap[ NUM_SPOT_LIGHT_SHADOWS ];
+			uniform sampler2D spotStaticShadowMap[ NUM_SPOT_LIGHT_SHADOWS ];
 
 		#endif
 
@@ -57,6 +65,7 @@ export default /* glsl */`
 			float shadowNormalBias;
 			float shadowRadius;
 			vec2 shadowMapSize;
+			float requireDualPass;
 		};
 
 		uniform SpotLightShadow spotLightShadows[ NUM_SPOT_LIGHT_SHADOWS ];
@@ -68,10 +77,13 @@ export default /* glsl */`
 		#if defined( SHADOWMAP_TYPE_PCF )
 
 			uniform samplerCubeShadow pointShadowMap[ NUM_POINT_LIGHT_SHADOWS ];
+			uniform samplerCubeShadow pointStaticShadowMap[ NUM_POINT_LIGHT_SHADOWS ];
+
 
 		#elif defined( SHADOWMAP_TYPE_BASIC )
 
 			uniform samplerCube pointShadowMap[ NUM_POINT_LIGHT_SHADOWS ];
+			uniform samplerCube pointStaticShadowMap[ NUM_POINT_LIGHT_SHADOWS ];
 
 		#endif
 
@@ -85,6 +97,8 @@ export default /* glsl */`
 			vec2 shadowMapSize;
 			float shadowCameraNear;
 			float shadowCameraFar;
+			float requireDualPass;
+
 		};
 
 		uniform PointLightShadow pointLightShadows[ NUM_POINT_LIGHT_SHADOWS ];
@@ -185,7 +199,7 @@ export default /* glsl */`
 					float hard_shadow = step( shadowCoord.z, mean );
 
 				#endif
-				
+
 				// Early return if fully lit
 				if ( hard_shadow == 1.0 ) {
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_vertex.glsl.js
@@ -20,6 +20,7 @@ export default /* glsl */`
 			float shadowNormalBias;
 			float shadowRadius;
 			vec2 shadowMapSize;
+			float requireDualPass;
 		};
 
 		uniform DirectionalLightShadow directionalLightShadows[ NUM_DIR_LIGHT_SHADOWS ];
@@ -34,6 +35,7 @@ export default /* glsl */`
 			float shadowNormalBias;
 			float shadowRadius;
 			vec2 shadowMapSize;
+			float requireDualPass;
 		};
 
 		uniform SpotLightShadow spotLightShadows[ NUM_SPOT_LIGHT_SHADOWS ];
@@ -53,6 +55,8 @@ export default /* glsl */`
 			vec2 shadowMapSize;
 			float shadowCameraNear;
 			float shadowCameraFar;
+			float requireDualPass;
+
 		};
 
 		uniform PointLightShadow pointLightShadows[ NUM_POINT_LIGHT_SHADOWS ];

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -184,11 +184,13 @@ function WebGLLights( extensions ) {
 		directional: [],
 		directionalShadow: [],
 		directionalShadowMap: [],
+		directionalStaticShadowMap: [],
 		directionalShadowMatrix: [],
 		spot: [],
 		spotLightMap: [],
 		spotShadow: [],
 		spotShadowMap: [],
+		spotStaticShadowMap: [],
 		spotLightMatrix: [],
 		rectArea: [],
 		rectAreaLTC1: null,
@@ -196,6 +198,7 @@ function WebGLLights( extensions ) {
 		point: [],
 		pointShadow: [],
 		pointShadowMap: [],
+		pointStaticShadowMap: [],
 		pointShadowMatrix: [],
 		hemi: [],
 		numSpotLightShadowsWithMaps: 0,
@@ -241,6 +244,7 @@ function WebGLLights( extensions ) {
 			const distance = light.distance;
 
 			let shadowMap = null;
+			let staticShadowMap = null;
 
 			if ( light.shadow && light.shadow.map ) {
 
@@ -253,6 +257,22 @@ function WebGLLights( extensions ) {
 
 					// Other types use depth texture
 					shadowMap = light.shadow.map.depthTexture || light.shadow.map.texture;
+
+				}
+
+			}
+
+			if ( light.shadow && light.shadow.staticMap ) {
+
+				if ( light.shadow.staticMap.texture.format === RGFormat ) {
+
+					// VSM uses color texture with blurred mean/std_dev
+					staticShadowMap = light.shadow.staticMap.texture;
+
+				} else {
+
+					// Other types use depth texture
+					staticShadowMap = light.shadow.staticMap.depthTexture || light.shadow.staticMap.texture;
 
 				}
 
@@ -291,9 +311,11 @@ function WebGLLights( extensions ) {
 					shadowUniforms.shadowNormalBias = shadow.normalBias;
 					shadowUniforms.shadowRadius = shadow.radius;
 					shadowUniforms.shadowMapSize = shadow.mapSize;
+					shadowUniforms.requireDualPass = shadow.requireDualPass;
 
 					state.directionalShadow[ directionalLength ] = shadowUniforms;
 					state.directionalShadowMap[ directionalLength ] = shadowMap;
+					state.directionalStaticShadowMap[ directionalLength ] = ( shadow.requireDualPass > 0 ) ? staticShadowMap : shadowMap;
 					state.directionalShadowMatrix[ directionalLength ] = light.shadow.matrix;
 
 					numDirectionalShadows ++;
@@ -348,6 +370,7 @@ function WebGLLights( extensions ) {
 
 					state.spotShadow[ spotLength ] = shadowUniforms;
 					state.spotShadowMap[ spotLength ] = shadowMap;
+					state.spotStaticShadowMap[ spotLength ] = ( shadow.requireDualPass > 0 ) ? staticShadowMap : shadowMap;
 
 					numSpotShadows ++;
 
@@ -392,6 +415,7 @@ function WebGLLights( extensions ) {
 
 					state.pointShadow[ pointLength ] = shadowUniforms;
 					state.pointShadowMap[ pointLength ] = shadowMap;
+					state.pointStaticShadowMap[ pointLength ] = ( shadow.requireDualPass > 0 ) ? staticShadowMap : shadowMap;
 					state.pointShadowMatrix[ pointLength ] = light.shadow.matrix;
 
 					numPointShadows ++;

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -509,8 +509,11 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 		if ( object.visible === false ) return;
 
 		const visible = object.layers.test( camera.layers );
+		const shadowLayerVisible = ! light.shadow.shadowLayers || object.layers.test(
+			light.shadow.shadowLayers
+		);
 
-		if ( visible && ( object.isMesh || object.isLine || object.isPoints ) ) {
+		if ( visible && shadowLayerVisible && ( object.isMesh || object.isLine || object.isPoints ) ) {
 
 			if ( ( object.castShadow || ( object.receiveShadow && type === VSMShadowMap ) ) && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -106,7 +106,6 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 		const currentRenderTarget = renderer.getRenderTarget();
 		const activeCubeFace = renderer.getActiveCubeFace();
 		const activeMipmapLevel = renderer.getActiveMipmapLevel();
-
 		const _state = renderer.state;
 
 		// Set GL state for depth map.
@@ -159,6 +158,8 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 			const light = lights[ i ];
 			const shadow = light.shadow;
+			const requireTwoRenderPass = shadow.staticLayer !== shadow.dynamicLayer;
+			shadow.requireDualPass = requireTwoRenderPass ? 1 : 0;
 
 			if ( shadow === undefined ) {
 
@@ -215,6 +216,19 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 				}
 
+				if ( shadow.staticMap !== null ) {
+
+					if ( shadow.staticMap.depthTexture !== null ) {
+
+						shadow.staticMap.depthTexture.dispose();
+						shadow.staticMap.depthTexture = null;
+
+					}
+
+					shadow.staticMap.dispose();
+
+				}
+
 				if ( this.type === VSMShadowMap ) {
 
 					if ( light.isPointLight ) {
@@ -241,22 +255,46 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 					shadow.map.depthTexture.minFilter = NearestFilter;
 					shadow.map.depthTexture.magFilter = NearestFilter;
 
+					shadow.staticMap = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y, {
+						format: RGFormat,
+						type: HalfFloatType,
+						minFilter: LinearFilter,
+						magFilter: LinearFilter,
+						generateMipmaps: false
+					} );
+					shadow.staticMap.texture.name = light.name + '.staticShadowMap';
+
+					// Native depth texture for VSM - depth is captured here, then blurred into the color texture
+					shadow.staticMap.depthTexture = new DepthTexture( _shadowMapSize.x, _shadowMapSize.y, FloatType );
+					shadow.staticMap.depthTexture.name = light.name + '.staticShadowMapDepth';
+					shadow.staticMap.depthTexture.format = DepthFormat;
+					shadow.staticMap.depthTexture.compareFunction = null; // For regular sampling (not shadow comparison)
+					shadow.staticMap.depthTexture.minFilter = NearestFilter;
+					shadow.staticMap.depthTexture.magFilter = NearestFilter;
+
 				} else {
 
 					if ( light.isPointLight ) {
 
 						shadow.map = new WebGLCubeRenderTarget( _shadowMapSize.x );
 						shadow.map.depthTexture = new CubeDepthTexture( _shadowMapSize.x, UnsignedIntType );
+						shadow.staticMap = new WebGLCubeRenderTarget( _shadowMapSize.x );
+						shadow.staticMap.depthTexture = new CubeDepthTexture( _shadowMapSize.x, UnsignedIntType );
 
 					} else {
 
 						shadow.map = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y );
 						shadow.map.depthTexture = new DepthTexture( _shadowMapSize.x, _shadowMapSize.y, UnsignedIntType );
+						shadow.staticMap = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y );
+						shadow.staticMap.depthTexture = new DepthTexture( _shadowMapSize.x, _shadowMapSize.y, UnsignedIntType );
 
 					}
 
 					shadow.map.depthTexture.name = light.name + '.shadowMap';
 					shadow.map.depthTexture.format = DepthFormat;
+
+					shadow.staticMap.depthTexture.name = light.name + '.staticShadowMap';
+					shadow.staticMap.depthTexture.format = DepthFormat;
 
 					if ( this.type === PCFShadowMap ) {
 
@@ -264,13 +302,22 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 						shadow.map.depthTexture.minFilter = LinearFilter;
 						shadow.map.depthTexture.magFilter = LinearFilter;
 
+						shadow.staticMap.depthTexture.compareFunction = reversedDepthBuffer ? GreaterEqualCompare : LessEqualCompare;
+						shadow.staticMap.depthTexture.minFilter = LinearFilter;
+						shadow.staticMap.depthTexture.magFilter = LinearFilter;
+
 					} else {
 
 						shadow.map.depthTexture.compareFunction = null;
 						shadow.map.depthTexture.minFilter = NearestFilter;
 						shadow.map.depthTexture.magFilter = NearestFilter;
 
+						shadow.staticMap.depthTexture.compareFunction = null;
+						shadow.staticMap.depthTexture.minFilter = NearestFilter;
+						shadow.staticMap.depthTexture.magFilter = NearestFilter;
+
 					}
+
 
 				}
 
@@ -347,16 +394,105 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 				}
 
 				_frustum = shadow.getFrustum();
+				if ( requireTwoRenderPass ) {
+
+					shadow.shadowLayers.set( light.shadow.dynamicLayer );
+
+				}
 
 				renderObject( scene, camera, shadow.camera, light, this.type );
 
 			}
 
+			if ( requireTwoRenderPass && shadow.staticNeedsUpdate ) {
+
+				const faceCountStatic = shadow.staticMap.isWebGLCubeRenderTarget ? 6 : 1;
+
+				for ( let face = 0; face < faceCountStatic; face ++ ) {
+
+					// For cube render targets, render to each face separately
+					if ( shadow.staticMap.isWebGLCubeRenderTarget ) {
+
+						renderer.setRenderTarget( shadow.staticMap, face );
+						renderer.clear();
+
+					} else {
+
+						// For 2D render targets, use viewports
+						if ( face === 0 ) {
+
+							renderer.setRenderTarget( shadow.staticMap );
+							renderer.clear();
+
+						}
+
+						const viewport = shadow.getViewport( face );
+
+						_viewport.set(
+							_viewportSize.x * viewport.x,
+							_viewportSize.y * viewport.y,
+							_viewportSize.x * viewport.z,
+							_viewportSize.y * viewport.w
+						);
+
+						_state.viewport( _viewport );
+
+					}
+
+					if ( light.isPointLight ) {
+
+						const camera = shadow.camera;
+						const shadowMatrix = shadow.matrix;
+
+						const far = light.distance || camera.far;
+
+						if ( far !== camera.far ) {
+
+							camera.far = far;
+							camera.updateProjectionMatrix();
+
+						}
+
+						_lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
+						camera.position.copy( _lightPositionWorld );
+
+						_lookTarget.copy( camera.position );
+						_lookTarget.add( _cubeDirections[ face ] );
+						camera.up.copy( _cubeUps[ face ] );
+						camera.lookAt( _lookTarget );
+						camera.updateMatrixWorld();
+
+						shadowMatrix.makeTranslation( - _lightPositionWorld.x, - _lightPositionWorld.y, - _lightPositionWorld.z );
+
+						_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
+						shadow._frustum.setFromProjectionMatrix( _projScreenMatrix, camera.coordinateSystem, camera.reversedDepth );
+
+					} else {
+
+						shadow.updateMatrices( light );
+
+					}
+
+					_frustum = shadow.getFrustum();
+					shadow.shadowLayers.set( light.shadow.staticLayer );
+
+					renderObject( scene, camera, shadow.camera, light, this.type );
+
+				}
+
+				shadow.staticNeedsUpdate = false;
+
+			}
 			// do blur pass for VSM
 
 			if ( shadow.isPointLightShadow !== true && this.type === VSMShadowMap ) {
 
-				VSMPass( shadow, camera );
+				VSMPass( shadow, camera, shadow.map );
+				if ( requireTwoRenderPass ) {
+
+					VSMPass( shadow, camera, shadow.staticMap );
+
+				}
 
 			}
 
@@ -372,7 +508,7 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 	};
 
-	function VSMPass( shadow, camera ) {
+	function VSMPass( shadow, camera, target ) {
 
 		const geometry = objects.update( fullScreenMesh );
 
@@ -397,7 +533,7 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 		// vertical pass - read from native depth texture
 
-		shadowMaterialVertical.uniforms.shadow_pass.value = shadow.map.depthTexture;
+		shadowMaterialVertical.uniforms.shadow_pass.value = target.depthTexture;
 		shadowMaterialVertical.uniforms.resolution.value = shadow.mapSize;
 		shadowMaterialVertical.uniforms.radius.value = shadow.radius;
 		renderer.setRenderTarget( shadow.mapPass );
@@ -409,7 +545,7 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 		shadowMaterialHorizontal.uniforms.shadow_pass.value = shadow.mapPass.texture;
 		shadowMaterialHorizontal.uniforms.resolution.value = shadow.mapSize;
 		shadowMaterialHorizontal.uniforms.radius.value = shadow.radius;
-		renderer.setRenderTarget( shadow.map );
+		renderer.setRenderTarget( target );
 		renderer.clear();
 		renderer.renderBufferDirect( camera, null, geometry, shadowMaterialHorizontal, fullScreenMesh, null );
 
@@ -514,7 +650,6 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 		);
 
 		if ( visible && shadowLayerVisible && ( object.isMesh || object.isLine || object.isPoints ) ) {
-
 			if ( ( object.castShadow || ( object.receiveShadow && type === VSMShadowMap ) ) && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
 
 				object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );


### PR DESCRIPTION
helllo this is a new feature for webgl havent touch webgpu but i beleie that is comptely different and detached from webgl 

Feature: 

allow define lightning shadow for static or dynamic objects, reduce the latency to generate shadowmap for static objects, so  static object will only render shadowmap when needed  while dynamic objects will still render shadow everytime ,  object of dynamic layer will need to have the same layer as the dynamic lighing , doesntr affect lighing layer pipeline by itself since im not using the normal layers but anew layer called shadowLayers

    const sunStatic = new THREE.DirectionalLight(0xffffff, 0.75);
    sunStatic.shadow.autoUpdate = false;
    sunStatic.shadow.shadowLayers.set(world.STATIC_SHADOWMAP);

    const sunDynamic = new THREE.DirectionalLight(0xffffff, 0.75);
    sunDynamic.shadow.autoUpdate = true;
    sunDynamic.shadow.shadowLayers.set(world.DYNAMIC_SHADOWMAP);


everytime time you need a new shadow map update for static object  you run 

        this.sunStatic.shadow.needsUpdate = true

 so far i have tested it with many scenario including multiple source of lighting over multiple type of objects  
 
let me know if you have doubt or if i need to improve something @mrdoob 
