### PR TITLE
PMREMNode: Fix dispose of internal PMREMs.

### DIFF
--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -81,6 +81,31 @@ function _getPMREMFromTexture( texture, renderer, generator ) {
 
 		cacheTexture.pmremVersion = texture.pmremVersion;
 
+		// add dispose event listener for new PMREMs
+
+		if ( cache.has( texture ) === false ) {
+
+			const onDispose = () => {
+
+				texture.removeEventListener( 'dispose', onDispose );
+
+				const pmrem = cache.get( texture );
+
+				if ( pmrem !== undefined ) {
+
+					pmrem.dispose();
+					cache.delete( texture );
+
+				}
+
+			};
+
+			texture.addEventListener( 'dispose', onDispose );
+
+		}
+
+		//
+
 		cache.set( texture, cacheTexture );
 
 	}


### PR DESCRIPTION
Fixed #33846.

**Description**

The PR makes sure `PMREMNode` removes the internal PMRME if a its source texture is disposed of. 
