### PR TITLE
USDZExporter: Basic normal scale support.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -1075,8 +1075,13 @@ function buildMaterial( material, textures, quickLookCompatible = false ) {
 
 		if ( mapType === 'normal' ) {
 
-			textureNode.addProperty( 'float4 inputs:scale = (2, 2, 2, 1)' );
-			textureNode.addProperty( 'float4 inputs:bias = (-1, -1, -1, 0)' );
+			// Similar to GLTFExporter, only the x component is used so the y-negation that
+			// GLTFLoader applies to tangent-less glTF assets is not baked into the export.
+
+			const scale = material.normalScale.x;
+
+			textureNode.addProperty( `float4 inputs:scale = (${ 2 * scale }, ${ 2 * scale }, 2, 1)` );
+			textureNode.addProperty( `float4 inputs:bias = (${ - scale }, ${ - scale }, -1, 0)` );
 
 		}
 


### PR DESCRIPTION
Fixed #28450.

**Description**

The PR adds normal scale support in the same way as `GLTFExporter`.

Meaning the `y` component is ignored because `GLTFLoader` might flip its sign as a _three.js-renderer-specific compensation_ for the handedness of the screen-space-derivative tangent basis. This negation is _not_ a property of the asset's actual normal map orientation.

By supporting just a uniform normal scale, users can still give their normals more influence during rendering. We also avoid any regression since the default value of `normalScale.x` is 1 (also with glTF assets) and thus has no influence on existing setups.
