### PR TITLE
TSL: Generate native WGSL switch statement (#33548)

### DIFF
--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -31,6 +31,7 @@ export { default as ParameterNode } from './core/ParameterNode.js';
 export { default as PropertyNode } from './core/PropertyNode.js';
 export { default as StackNode } from './core/StackNode.js';
 export { default as StackTrace } from './core/StackTrace.js';
+export { default as SwitchNode } from './core/SwitchNode.js';
 export { default as StructNode } from './core/StructNode.js';
 export { default as StructTypeNode } from './core/StructTypeNode.js';
 export { default as SubBuildNode } from './core/SubBuildNode.js';

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -1,6 +1,7 @@
 import Node from './Node.js';
 import StackTrace from '../core/StackTrace.js';
 import { select } from '../math/ConditionalNode.js';
+import SwitchNode from './SwitchNode.js';
 import { ShaderNode, nodeProxy, getCurrentStack, setCurrentStack, nodeObject } from '../tsl/TSLBase.js';
 import { error } from '../../utils.js';
 
@@ -60,14 +61,14 @@ class StackNode extends Node {
 		this._currentCond = null;
 
 		/**
-		 * The expression node. Only
+		 * The current switch node. Only
 		 * relevant for Switch/Case.
 		 *
 		 * @private
-		 * @type {Node}
+		 * @type {?SwitchNode}
 		 * @default null
 		 */
-		this._expressionNode = null;
+		this._currentSwitch = null;
 
 		/**
 		 * The current node being processed.
@@ -230,17 +231,17 @@ class StackNode extends Node {
 	}
 
 	/**
-	 * Represents a `switch` statement in TSL.
+	 * Represents a `switch` statement in TSL. The case blocks are defined with
+	 * subsequent `Case()` calls and an optional `Default()` call.
 	 *
-	 * @param {any} expression - Represents the expression.
-	 * @param {Function} method - TSL code which is executed if the condition evaluates to `true`.
+	 * @param {any} expression - The integer expression to switch on.
 	 * @return {StackNode} A reference to this stack node.
 	 */
 	Switch( expression ) {
 
-		this._expressionNode = nodeObject( expression );
+		this._currentSwitch = new SwitchNode( nodeObject( expression ) );
 
-		return this;
+		return this.addToStack( this._currentSwitch );
 
 	}
 
@@ -253,69 +254,34 @@ class StackNode extends Node {
 	 */
 	Case( ...params ) {
 
-		const caseNodes = [];
-
-		// extract case nodes from the parameter list
-
-		if ( params.length >= 2 ) {
-
-			for ( let i = 0; i < params.length - 1; i ++ ) {
-
-				caseNodes.push( this._expressionNode.equal( nodeObject( params[ i ] ) ) );
-
-			}
-
-		} else {
+		if ( params.length < 2 ) {
 
 			error( 'TSL: Invalid parameter length. Case() requires at least two parameters.', new StackTrace() );
-
-		}
-
-		// extract method
-
-		const method = params[ params.length - 1 ];
-		const methodNode = new ShaderNode( method );
-
-		// chain multiple cases when using Case( 1, 2, 3, () => {} )
-
-		let caseNode = caseNodes[ 0 ];
-
-		for ( let i = 1; i < caseNodes.length; i ++ ) {
-
-			caseNode = caseNode.or( caseNodes[ i ] );
-
-		}
-
-		// build condition
-
-		const condNode = select( caseNode, methodNode );
-
-		if ( this._currentCond === null ) {
-
-			this._currentCond = condNode;
-
-			return this.addToStack( this._currentCond );
-
-		} else {
-
-			this._currentCond.elseNode = condNode;
-			this._currentCond = condNode;
 
 			return this;
 
 		}
+
+		// the last parameter is the callback method, the preceding ones are the case selectors
+
+		const method = params[ params.length - 1 ];
+		const conditions = params.slice( 0, - 1 ).map( ( value ) => nodeObject( value ) );
+
+		this._currentSwitch.addCase( conditions, new ShaderNode( method ) );
+
+		return this;
 
 	}
 
 	/**
 	 * Represents the default code block of a Switch/Case statement.
 	 *
-	 * @param {Function} method - TSL code which is executed in the `else` case.
+	 * @param {Function} method - TSL code which is executed in the `default` case.
 	 * @return {StackNode} A reference to this stack node.
 	 */
 	Default( method ) {
 
-		this.Else( method );
+		this._currentSwitch.setDefault( new ShaderNode( method ) );
 
 		return this;
 

--- a/src/nodes/core/SwitchNode.js
+++ b/src/nodes/core/SwitchNode.js
@@ -1,0 +1,200 @@
+import Node from './Node.js';
+
+/**
+ * Represents a `switch` statement in TSL. It is constructed by the
+ * `Switch()` / `Case()` / `Default()` chaining methods of {@link StackNode}
+ * and is therefore not meant to be created directly.
+ *
+ * On the WebGPU backend it generates a native WGSL `switch` statement. On the
+ * WebGL backend it falls back to an equivalent `if` / `else if` / `else` chain.
+ *
+ * @augments Node
+ */
+class SwitchNode extends Node {
+
+	static get type() {
+
+		return 'SwitchNode';
+
+	}
+
+	/**
+	 * Constructs a new switch node.
+	 *
+	 * @param {Node} expressionNode - The node that defines the switch expression.
+	 */
+	constructor( expressionNode ) {
+
+		super();
+
+		/**
+		 * The node that defines the switch expression.
+		 *
+		 * @type {Node}
+		 */
+		this.expressionNode = expressionNode;
+
+		/**
+		 * The list of cases. Each entry holds the case selector value nodes and
+		 * the body that is executed when one of the selectors matches.
+		 *
+		 * @type {Array<{conditions: Array<Node>, body: Node}>}
+		 */
+		this.cases = [];
+
+		/**
+		 * The body of the `default` clause. May be `null` if no default is defined.
+		 *
+		 * @type {?Node}
+		 * @default null
+		 */
+		this.defaultNode = null;
+
+		/**
+		 * This flag can be used for type testing.
+		 *
+		 * @type {boolean}
+		 * @readonly
+		 * @default true
+		 */
+		this.isSwitchNode = true;
+
+	}
+
+	/**
+	 * Adds a new case to the switch statement.
+	 *
+	 * @param {Array<Node>} conditions - The case selector value nodes.
+	 * @param {Node} body - The body executed when one of the selectors matches.
+	 * @return {SwitchNode} A reference to this node.
+	 */
+	addCase( conditions, body ) {
+
+		this.cases.push( { conditions, body } );
+
+		return this;
+
+	}
+
+	/**
+	 * Defines the body of the `default` clause.
+	 *
+	 * @param {Node} body - The body executed when no case matches.
+	 * @return {SwitchNode} A reference to this node.
+	 */
+	setDefault( body ) {
+
+		this.defaultNode = body;
+
+		return this;
+
+	}
+
+	setup( builder ) {
+
+		const currentNodeBlock = builder.context.nodeBlock;
+
+		const properties = builder.getNodeProperties( this );
+
+		const setupBody = ( node ) => {
+
+			const isolated = node.isolate();
+
+			builder.getDataFromNode( isolated ).parentNodeBlock = currentNodeBlock;
+
+			return isolated.context( { nodeBlock: isolated } );
+
+		};
+
+		properties.expressionNode = this.expressionNode;
+		properties.cases = this.cases.map( ( { conditions, body } ) => ( { conditions, body: setupBody( body ) } ) );
+		properties.defaultNode = this.defaultNode ? setupBody( this.defaultNode ) : null;
+
+	}
+
+	generate( builder ) {
+
+		const { expressionNode, cases, defaultNode } = builder.getNodeProperties( this );
+
+		// a switch operates on an integer selector, so both the expression and the
+		// case selectors are emitted as `int` (or `uint`) regardless of their source type
+
+		const switchType = expressionNode.getNodeType( builder ) === 'uint' ? 'uint' : 'int';
+
+		const expressionSnippet = expressionNode.build( builder, switchType );
+
+		const isWebGPUBackend = builder.renderer.backend.isWebGPUBackend === true;
+
+		const selectorSnippet = ( condition ) => {
+
+			const selector = switchType === 'uint' ? condition.toUint() : condition.toInt();
+
+			return selector.build( builder, switchType );
+
+		};
+
+		// emits `<open><indented body><close>` for a single clause
+
+		const buildClause = ( open, body, close ) => {
+
+			builder.addFlowCode( open ).addFlowTab();
+
+			if ( body !== null ) body.build( builder, 'void' );
+
+			builder.removeFlowTab().addFlowCode( close );
+
+		};
+
+		if ( isWebGPUBackend ) {
+
+			// native WGSL switch statement
+
+			builder.addFlowCode( `\n${ builder.tab }switch ( ${ expressionSnippet } ) {\n\n` ).addFlowTab();
+
+			for ( const { conditions, body } of cases ) {
+
+				const selectors = conditions.map( selectorSnippet ).join( ', ' );
+
+				buildClause( `${ builder.tab }case ${ selectors }: {\n\n`, body, `\n${ builder.tab }}\n\n` );
+
+			}
+
+			// WGSL requires a `default` clause
+
+			buildClause( `${ builder.tab }default: {\n\n`, defaultNode, `\n${ builder.tab }}\n\n` );
+
+			builder.removeFlowTab().addFlowCode( `${ builder.tab }}\n\n` );
+
+		} else {
+
+			// WebGL fallback: if / else if / else chain
+
+			builder.addFlowCode( `\n${ builder.tab }` );
+
+			for ( let i = 0; i < cases.length; i ++ ) {
+
+				const { conditions, body } = cases[ i ];
+
+				const condition = conditions.map( ( c ) => `( ${ expressionSnippet } == ${ selectorSnippet( c ) } )` ).join( ' || ' );
+
+				buildClause( `${ i === 0 ? '' : ' else ' }if ( ${ condition } ) {\n\n`, body, `\n${ builder.tab }}` );
+
+			}
+
+			if ( defaultNode !== null ) {
+
+				buildClause( ' else {\n\n', defaultNode, `\n${ builder.tab }}` );
+
+			}
+
+			builder.addFlowCode( '\n\n' );
+
+		}
+
+		return '';
+
+	}
+
+}
+
+export default SwitchNode;


### PR DESCRIPTION
Related issue: #33548

**Description**

`Switch()` / `Case()` / `Default()` previously desugared into a nested `if / else` chain on every
  backend. This adds a dedicated `SwitchNode` that emits a native WGSL `switch` statement on the
  WebGPU backend, while the WebGL backend keeps the equivalent `if / else if / else` fallback (GLSL
  behaviour unchanged).

  - multi-value cases (`Case( 1, 2, 3, … )`) generate `case 1, 2, 3:`
  - a `default` clause is always emitted on WGSL (required by the spec)
  - selectors are coerced to the integer (`i32` / `u32`) type of the switch expression

  Verified identical rendering on both the WebGPU and WebGL backends for single/multi-value cases,
  with and without a `Default()`.

