### PR TITLE
WebGLRenderer: Fix normal maps with `DoubleSide`+ flat shading.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
@@ -39,7 +39,7 @@ float faceDirection = gl_FrontFacing ? 1.0 : - 1.0;
 
 	#endif
 
-	#if defined( DOUBLE_SIDED ) && ! defined( FLAT_SHADED )
+	#ifdef DOUBLE_SIDED
 
 		tbn[0] *= faceDirection;
 		tbn[1] *= faceDirection;
@@ -60,7 +60,7 @@ float faceDirection = gl_FrontFacing ? 1.0 : - 1.0;
 
 	#endif
 
-	#if defined( DOUBLE_SIDED ) && ! defined( FLAT_SHADED )
+	#ifdef DOUBLE_SIDED
 
 		tbn2[0] *= faceDirection;
 		tbn2[1] *= faceDirection;


### PR DESCRIPTION
Fixed #26788.

**Description**

The PR makes sure tangent-space normal maps render correctly when the material is double sided and uses flat shading.

The error can be reproduced with below fiddles. The back sides of both planes are not rendered correctly with `WebGLRenderer`:

WebGLRenderer (broken): https://jsfiddle.net/vtd3npLa/2/
WebGPURenderer (already working): https://jsfiddle.net/vtd3npLa/1/

The PR aligns `WebGLRenderer` to `WebGPURenderer`.

@WestLangley I believe what happened in #25693 was:

- The face direction flip was moved from `perturbNormal2Arb()` into `normal_fragment_begin`.
- In `perturbNormal2Arb()`, the flip was done _unconditionally_ (flat shaded or not).
- But in `normal_fragment_begin`, the flip was guarded via `! defined( FLAT_SHADED )` so it was not done anymore for flat shading.