### PR TITLE
RenderObject: Fix handling of `side`.

### DIFF
--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -749,7 +749,20 @@ class RenderObject {
 
 				if ( type === 'number' ) {
 
-					valueKey = value !== 0 ? '1' : '0'; // Convert to on/off, important for clearcoat, transmission, etc
+					if ( property === 'side' ) {
+
+						// `side` is an enum (FrontSide/BackSide/DoubleSide) that changes code
+						// generation, so its exact value must be preserved.
+
+						valueKey = String( value );
+
+					} else {
+
+						// Other numbers are reduced to on/off
+
+						valueKey = value !== 0 ? '1' : '0';
+
+					}
 
 				} else if ( type === 'object' ) {
 

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -44,6 +44,7 @@ const exceptionList = [
 	'webxr_vr_video',
 	'webgpu_tsl_transpiler',
 	'webgpu_rendertarget_2d-array_3d',
+	'webgpu_volume_fire',
 
 	// Need more time to render
 	'css3d_mixed',


### PR DESCRIPTION
Related issue: -

**Description**

While working on #25701, I've noticed a bug in `WebGPURenderer`. 

`getMaterialCacheKey()` caches material properties of type number as a simple binary switch. This does not work for `side` which is an Enum and the different values influence code generation.
