### PR TITLE
WebGLRenderer: Fix normal maps with `BackSide` and vertex tangents.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
@@ -53,11 +53,5 @@ transformedNormal = normalMatrix * transformedNormal;
 
 	transformedTangent = ( modelViewMatrix * vec4( transformedTangent, 0.0 ) ).xyz;
 
-	#ifdef FLIP_SIDED
-
-		transformedTangent = - transformedTangent;
-
-	#endif
-
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/normal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_vertex.glsl.js
@@ -8,6 +8,12 @@ export default /* glsl */`
 		vTangent = normalize( transformedTangent );
 		vBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );
 
+		#ifdef FLIP_SIDED
+
+			vBitangent = - vBitangent;
+
+		#endif
+
 	#endif
 
 #endif


### PR DESCRIPTION
Fixed #25701.

**Description**

The PR fixes how the TBN matrix is build in `WebGLRenderer`. 

| TBN (BackSide) | vTangent | vBitangent | vNormal |
|----------------|:--------:|:----------:|:-------:|
| before         | −T       | +B         | −N      |
| after          | +T       | +B         | −N      |

The correct back-side frame is the front frame with only the normal flipped (+T, +B, −N): the U/V perturbation directions stay the same and just the surface normal inverts, so extrusions read as indentations. The old basis (−T, +B, −N) had the tangent inverted relative to the bitangent, mirroring the normal map along the tangent (U) axis — the specular highlight pointed the wrong way horizontally. Moving the inversion from the tangent to the bitangent yields a consistent frame and resolves it.

Live examples:

WebGLRenderer (wrong): https://jsfiddle.net/f91rwuc4/3/
WebGPURenderer (correct): https://jsfiddle.net/f91rwuc4/2/

The expected behavior is you should only see the front side of the left mesh. When moving the camera around, you see the back side of both planes. However, normals are not correct for the second (back-side only) mesh with `WebGLRenderer`. You can easily see that at the specular lighting which has a wrong orientation when vertex tangents are in place. Comment out `computeTangents()` to see the correct lighting or compare with `WebGPURenderer`.