### PR TITLE
NodeBuilder: Make registerDeclaration() more robust.

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2268,28 +2268,29 @@ class NodeBuilder {
 		const shaderStage = this.shaderStage;
 		const declarations = this.declarations[ shaderStage ] || ( this.declarations[ shaderStage ] = {} );
 
-		const property = this.getPropertyName( node );
+		const baseName = node.name;
 
+		let name = baseName;
+		let property = this.getPropertyName( node );
 		let index = 1;
-		let name = property;
 
 		// Automatically renames the property if the name is already in use.
 
-		while ( declarations[ name ] !== undefined ) {
+		while ( declarations[ property ] !== undefined ) {
 
-			name = property + '_' + index ++;
-
-		}
-
-		if ( index > 1 ) {
-
+			name = baseName + '_' + index ++;
 			node.name = name;
-
-			warn( `TSL: Declaration name '${ property }' of '${ node.type }' already in use. Renamed to '${ name }'.` );
+			property = this.getPropertyName( node );
 
 		}
 
-		declarations[ name ] = node;
+		if ( name !== baseName ) {
+
+			warn( `TSL: Declaration name '${ baseName }' of '${ node.type }' already in use. Renamed to '${ name }'.` );
+
+		}
+
+		declarations[ property ] = node;
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

I've noticed a minor issue in the method that checks for name collisions. If you paste below snippet into the [TSL Editor example](https://threejs.org/examples/webgpu_tsl_editor), you get WSL runtime errors.

```js
const { uniform } = await import( 'three/tsl' );

const colorA = uniform( new THREE.Color( 0xff0000 ) ).setName( 'myColor' );
const colorB = uniform( new THREE.Color( 0x00ff00 ) ).setName( 'myColor' );

output = colorA.add( colorB );
```
That's because `registerDeclaration()` writes back an invalid name into `node.name`. In the above case, it's `object.myColor_1` instead of just `myColor_1`. The PR fixes that.