### PR TITLE
LineSegment2: Don't raycast without a valid resolution.

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -10,7 +10,7 @@ UniformsLib.line = {
 
 	worldUnits: { value: 1 },
 	linewidth: { value: 1 },
-	resolution: { value: new Vector2( 1, 1 ) },
+	resolution: { value: new Vector2() },
 	dashOffset: { value: 0 },
 	dashScale: { value: 1 },
 	dashSize: { value: 1 },

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -326,6 +326,14 @@ class LineSegments2 extends Mesh {
 
 		}
 
+		// early out if no resolution has been set (line was not rendered yet)
+
+		if ( worldUnits === false && ( this.material.resolution.x === 0 || this.material.resolution.y === 0 ) ) {
+
+			return;
+
+		}
+
 		const threshold = ( raycaster.params.Line2 !== undefined ) ? raycaster.params.Line2.threshold || 0 : 0;
 
 		_ray = raycaster.ray;

--- a/examples/jsm/lines/webgpu/LineSegments2.js
+++ b/examples/jsm/lines/webgpu/LineSegments2.js
@@ -324,6 +324,14 @@ class LineSegments2 extends Mesh {
 
 		}
 
+		// early out if no resolution has been set (line was not rendered yet)
+
+		if ( worldUnits === false && ( this._resolution.x === 0 || this._resolution.y === 0 ) ) {
+
+			return;
+
+		}
+
 		const threshold = ( raycaster.params.Line2 !== undefined ) ? raycaster.params.Line2.threshold || 0 : 0;
 
 		_ray = raycaster.ray;


### PR DESCRIPTION
Fixed #29666.

**Description**

The PR makes sure wide lines that never have been rendered once because they are offscreen, do not attempt to run their raycasting logic when `worldUnits` is set to `true`.

The default resolution in `LineMaterial` has been aligned to the WebGPURenderer version of `(0,0)`. If this value is detected inside `raycast()`, the method early-outs because it would result in such large screen-space margins that lines cover the entire screen. The same behavior would be true for (1,1) but (0,0) is a better default to check.

This change fixes the root cause of #29666. There is a remaining issue when a wide line that has been rendered once goes off-screen and the window resizes. The margin wouldn't be correct in this case but to a more negligible degree.
