### PR TITLE
ShapePath: Fix containment test.

### DIFF
--- a/examples/models/svg/tests/letter.svg
+++ b/examples/models/svg/tests/letter.svg
@@ -1,0 +1,3 @@
+<svg id="color-fill" xmlns="http://www.w3.org/2000/svg" version="1.1" width="300" height="300" viewBox="-2 -77 67 81" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g><path d="M39.4 0L23.2 0L23.2-67.3L39.4-67.3L39.4 0ZM62.0-59.4L1.0-59.4L1.0-74.9L62.0-74.9L62.0-59.4Z"/></g>
+</svg>

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -127,6 +127,7 @@
 					'emoji': 'models/svg/emoji.svg',
 					'blueprint': 'models/svg/blueprint.svg',
 					'wideStroke': 'models/svg/tests/wideStroke.svg',
+					'letter': 'models/svg/tests/letter.svg',
 
 				} ).name( 'SVG File' ).onChange( update );
 

--- a/src/extras/core/ShapePath.js
+++ b/src/extras/core/ShapePath.js
@@ -285,7 +285,8 @@ class ShapePath {
 			for ( let j = i - 1; j >= 0; j -- ) {
 
 				const candidate = entries[ j ];
-				if ( ! candidate.boundingBox.containsPoint( entry.interiorPoint ) ) continue;
+
+				if ( ! candidate.boundingBox.containsBox( entry.boundingBox ) ) continue;
 				if ( ! pointInPolygon( entry.interiorPoint, candidate.points ) ) continue;
 
 				entry.container = candidate.exclude ? candidate.container : candidate;


### PR DESCRIPTION
Fixed #33884.

**Description**

`ShapePath.toShapes()` can drop a subpath when two same-winding subpaths partially overlap (e.g. the crossing strokes of a 'T' like in the issue). The PR fixes that by requiring a container's bounding box to fully enclose an entry's before treating it as nesting.