### PR TITLE
src: Remove deprecated code

### DIFF
--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -625,7 +625,6 @@ export const viewportDepthTexture = TSL.viewportDepthTexture;
 export const viewportLinearDepth = TSL.viewportLinearDepth;
 export const viewportMipTexture = TSL.viewportMipTexture;
 export const viewportOpaqueMipTexture = TSL.viewportOpaqueMipTexture;
-export const viewportResolution = TSL.viewportResolution;
 export const viewportSafeUV = TSL.viewportSafeUV;
 export const viewportSharedTexture = TSL.viewportSharedTexture;
 export const viewportSize = TSL.viewportSize;

--- a/src/extras/Controls.js
+++ b/src/extras/Controls.js
@@ -1,5 +1,4 @@
 import { EventDispatcher } from '../core/EventDispatcher.js';
-import { warn } from '../utils.js';
 
 /**
  * Abstract base class for controls.
@@ -82,13 +81,6 @@ class Controls extends EventDispatcher {
 	 * @param {HTMLElement} element - The DOM element to connect to.
 	 */
 	connect( element ) {
-
-		if ( element === undefined ) {
-
-			warn( 'Controls: connect() now requires an element.' ); // @deprecated, the warning can be removed with r185
-			return;
-
-		}
 
 		if ( this.domElement !== null ) this.disconnect();
 

--- a/src/nodes/display/ScreenNode.js
+++ b/src/nodes/display/ScreenNode.js
@@ -1,12 +1,9 @@
 import Node from '../core/Node.js';
-import StackTrace from '../core/StackTrace.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
-import { Fn, nodeImmutable, vec2 } from '../tsl/TSLBase.js';
-
+import { nodeImmutable, vec2 } from '../tsl/TSLBase.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Vector4 } from '../../math/Vector4.js';
-import { warn } from '../../utils.js';
 
 let _screenSizeVec, _viewportVec;
 
@@ -278,15 +275,3 @@ export const viewportCoordinate = /*@__PURE__*/ screenCoordinate.sub( viewport.x
  */
 export const viewportUV = /*@__PURE__*/ viewportCoordinate.div( viewportSize );
 
-// Deprecated
-
-/**
- * @deprecated since r169. Use {@link screenSize} instead.
- */
-export const viewportResolution = /*@__PURE__*/ ( Fn( () => { // @deprecated, r169
-
-	warn( 'TSL: "viewportResolution" is deprecated. Use "screenSize" instead.', new StackTrace() );
-
-	return screenSize;
-
-}, 'vec2' ).once() )();


### PR DESCRIPTION
Related issue: #XXXX

**Description**

 - Remove viewportResolution export from TSL — use screenSize instead (deprecated since r169).
 - Remove element === undefined fallback in Controls.connect() — element is now required.
 - Clean up unused imports (StackTrace, Fn, warn) in ScreenNode.js.

`Controls.connect()` removes parameter validation. I'm not sure if this really makes things better. Without parameter validation, developers don't know what to pass. I vaguely remember we previously said not to do parameter validation.

If there is any problem with the PR, please let me know.

> Generated with AI assistance.
