### PR TITLE
TSL: Fix crash in `MRT` when output is not bound by RenderTarget

### DIFF
--- a/src/nodes/core/MRTNode.js
+++ b/src/nodes/core/MRTNode.js
@@ -170,6 +170,10 @@ class MRTNode extends OutputStructNode {
 		for ( const name in outputNodes ) {
 
 			const index = getTextureIndex( textures, name );
+
+			// Ignore if the output exists in the MRT but has never been used.
+			if ( index === - 1 ) continue;
+
 			const type = builder.getOutputType( index );
 
 			members[ index ] = outputNodes[ name ].convert( type );


### PR DESCRIPTION
Related issue: N/A

**Description**

When a material defines an MRT that is not present in the current RenderTarget (e.g. a material defines a custom output name, but the render target/pass only binds `'output'` and `'normal'`), `getTextureIndex()` returns `-1`.

Previously, this would cause a runtime crash during shader compilation when trying to resolve the output type via `builder.getOutputType( -1 )`.

This PR introduces a safety check in `MRTNode.setup()` to skip/ignore output nodes that are not active in the current render target's MRT textures (`index === -1`).

```js
// Pass configured with output and normal
scenePass.setMRT( mrt( {
    output: output,
    normal: normalWorld
} ) );

// it will crash because 'normal' never was used
renderPipeline.outputNode = scenePass.getTextureNode( 'output' );
```

/cc @brunosimon 