### PR TITLE
WebGPURenderer: Fix background rotation with nodes.

### DIFF
--- a/src/nodes/accessors/SceneProperties.js
+++ b/src/nodes/accessors/SceneProperties.js
@@ -31,7 +31,7 @@ export const backgroundRotation = /*@__PURE__*/ uniform( new Matrix4() ).setGrou
 
 	const background = scene.background;
 
-	if ( background !== null && background.isTexture && background.mapping !== UVMapping ) {
+	if ( ( background !== null && background.isTexture && background.mapping !== UVMapping ) || ( scene.backgroundNode && scene.backgroundNode.isNode ) ) {
 
 		// note: since the matrix is orthonormal, we can use the more-efficient transpose() in lieu of invert()
 		_m1.makeRotationFromEuler( scene.backgroundRotation ).transpose();


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/33883#issuecomment-4816873382

**Description**

The PR makes sure that the scene's background rotation has an effect when `scene.backgroundNode` is configured.


