### PR TITLE
VolumetricLightingModel: Fix crash when used with clustered lights

### DIFF
--- a/src/nodes/functions/VolumetricLightingModel.js
+++ b/src/nodes/functions/VolumetricLightingModel.js
@@ -172,9 +172,10 @@ class VolumetricLightingModel extends LightingModel {
 
 	direct( { lightNode, lightColor }, builder ) {
 
-		// Ignore lights with infinite distance
+		// Clustered lights are accumulated in bulk and expose no single `light` reference,
+		// and directional/hemisphere lights have an infinite distance — skip both here.
 
-		if ( lightNode.light.distance === undefined ) return;
+		if ( lightNode.light === undefined || lightNode.light.distance === undefined ) return;
 
 		// TODO: We need a viewportOpaque*() ( output, depth ) to fit with modern rendering approaches
 

--- a/src/nodes/functions/VolumetricLightingModel.js
+++ b/src/nodes/functions/VolumetricLightingModel.js
@@ -172,8 +172,7 @@ class VolumetricLightingModel extends LightingModel {
 
 	direct( { lightNode, lightColor }, builder ) {
 
-		// Only analytic point lights (finite distance) scatter here. Skip non-analytic nodes
-		// like clustered lights, as well as directional/hemisphere lights (infinite distance).
+		// Ignore non-analytical lights and lights with infinite distance
 
 		if ( lightNode.isAnalyticLightNode !== true || lightNode.light.distance === undefined ) return;
 

--- a/src/nodes/functions/VolumetricLightingModel.js
+++ b/src/nodes/functions/VolumetricLightingModel.js
@@ -172,10 +172,10 @@ class VolumetricLightingModel extends LightingModel {
 
 	direct( { lightNode, lightColor }, builder ) {
 
-		// Clustered lights are accumulated in bulk and expose no single `light` reference,
-		// and directional/hemisphere lights have an infinite distance — skip both here.
+		// Only analytic point lights (finite distance) scatter here. Skip non-analytic nodes
+		// like clustered lights, as well as directional/hemisphere lights (infinite distance).
 
-		if ( lightNode.light === undefined || lightNode.light.distance === undefined ) return;
+		if ( lightNode.isAnalyticLightNode !== true || lightNode.light.distance === undefined ) return;
 
 		// TODO: We need a viewportOpaque*() ( output, depth ) to fit with modern rendering approaches
 


### PR DESCRIPTION
Related issue: #33894

**Description**
When `ClusteredLighting` is active and a clustered point light takes part in a volumetric pass (e.g. via `light.layers.enable( 10 )` in the volumetric-lighting examples), the renderer crashes with:

`TypeError: Cannot read properties of undefined (reading 'distance')`

`ClusteredLightsNode` passes itself as the `lightNode` when setting up direct lighting, so it has no single `.light` reference. `VolumetricLightingModel.direct()` assumed an `AnalyticLightNode` and read `lightNode.light.distance` directly, which throws on the clustered node.

This guards that access — clustered lights (no `.light`) are skipped here, the same way infinite-distance directional/hemisphere lights already are.

Verified by patching `webgpu_volume_lighting_rectarea` with `ClusteredLighting` + a `PointLight` on the volumetric layer: the crash is gone, and the existing `webgpu_volume_lighting_rectarea`, `webgpu_volume_lighting` and `webgpu_lights_clustered` examples render unchanged. Lint passes.
