### PR TITLE
Renderer: Save/restore `frameId` in `compileAsync()`.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -892,6 +892,7 @@ class Renderer {
 		const nodeFrame = this._nodes.nodeFrame;
 
 		const previousRenderId = nodeFrame.renderId;
+		const previousFrameId = nodeFrame.frameId;
 		const previousRenderContext = this._currentRenderContext;
 		const previousRenderObjectFunction = this._currentRenderObjectFunction;
 		const previousHandleObjectFunction = this._handleObjectFunction;
@@ -921,10 +922,7 @@ class Renderer {
 		this._compilationPromises = compilationPromises;
 
 		nodeFrame.renderId ++;
-
-		//
-
-		nodeFrame.update();
+		nodeFrame.frameId ++;
 
 		//
 
@@ -1063,6 +1061,10 @@ class Renderer {
 			await yieldToMain();
 
 		}
+
+		// Restore the frame id last so the temporary bump above does not persist.
+
+		nodeFrame.frameId = previousFrameId;
 
 	}
 


### PR DESCRIPTION
Fixed #33898.

**Description**

Next to the `renderId`, it's important to save and restore the `frameId` as well to avoid side effects on the first frame after the pre-compile.

Also `NodeFrame.update()` should not be called in `compileAsync()` since that might corrupt the time values for the next frame as well.

@Ninfendo Can you please check if that solves the issue?