### PR TITLE
LightsNode: Introduce `getBuiltinLights`

### DIFF
--- a/examples/jsm/tsl/lighting/ClusteredLightsNode.js
+++ b/examples/jsm/tsl/lighting/ClusteredLightsNode.js
@@ -44,7 +44,6 @@ class ClusteredLightsNode extends LightsNode {
 
 		this.materialLights = [];
 		this.clusteredLights = [];
-		this._allLights = [];
 
 		this.maxLights = maxLights;
 		this.tileSize = tileSize;
@@ -206,8 +205,6 @@ class ClusteredLightsNode extends LightsNode {
 
 	setLights( lights ) {
 
-		this._allLights = lights;
-
 		const { clusteredLights, materialLights } = this;
 
 		let materialIndex = 0;
@@ -230,13 +227,13 @@ class ClusteredLightsNode extends LightsNode {
 		materialLights.length = materialIndex;
 		clusteredLights.length = clusteredIndex;
 
-		return super.setLights( materialLights );
+		return super.setLights( lights );
 
 	}
 
-	getLights() {
+	getBuiltinLights() {
 
-		return this._allLights;
+		return this.materialLights;
 
 	}
 
@@ -595,12 +592,6 @@ class ClusteredLightsNode extends LightsNode {
 		this._lightsTexture = lightsTexture;
 		this._zSliceRangesTexture = zSliceRangesTexture;
 		this._zSliceRangesData = zSliceRangesData;
-
-	}
-
-	get hasLights() {
-
-		return super.hasLights || this.clusteredLights.length > 0;
 
 	}
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -222,7 +222,7 @@ class NodeMaterialObserver {
 			data.environmentIntensity = environmentIntensity;
 			data.environmentRotation = environmentRotation.clone();
 
-			data.lights = this.getLightsData( renderObject.lightsNode.getLights(), [] );
+			data.lights = this.getLightsData( renderObject.lightsNode.getBuiltinLights(), [] );
 
 			this.renderObjects.set( renderObject, data );
 
@@ -701,7 +701,7 @@ class NodeMaterialObserver {
 		}
 
 		cached.renderId = renderId;
-		this.getLightsData( lightsNode.getLights(), cached.lightsData );
+		this.getLightsData( lightsNode.getBuiltinLights(), cached.lightsData );
 
 		return cached.lightsData;
 

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -146,11 +146,11 @@ class LightsNode extends Node {
 	 */
 	customCacheKey() {
 
-		const lights = this._lights;
+		const builtinLights = this.getBuiltinLights();
 
-		for ( let i = 0; i < lights.length; i ++ ) {
+		for ( let i = 0; i < builtinLights.length; i ++ ) {
 
-			const light = lights[ i ];
+			const light = builtinLights[ i ];
 
 			_hashData.push( light.id );
 			_hashData.push( light.castShadow ? 1 : 0 );
@@ -241,7 +241,9 @@ class LightsNode extends Node {
 		const previousLightNodes = nodeData.lightNodes || null;
 		const materialLightings = builder.context.materialLightings;
 
-		const lights = sortLights( [ ...materialLightings, ...this._lights ] );
+		const builtinLights = this.getBuiltinLights();
+
+		const lights = sortLights( [ ...materialLightings, ...builtinLights ] );
 		const nodeLibrary = builder.renderer.library;
 
 		for ( const light of lights ) {
@@ -453,6 +455,20 @@ class LightsNode extends Node {
 	 * @return {Array<Light>} The scene's lights.
 	 */
 	getLights() {
+
+		return this._lights;
+
+	}
+
+	/**
+	 * Returns an array of the scene's lights.
+	 *
+	 * The light variations are shader-dependent;
+	 * if this array changes, the shader needs to be recreated.
+	 *
+	 * @return {Array<Light>} The scene's lights.
+	 */
+	getBuiltinLights() {
 
 		return this._lights;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33793

**Description**

Refactors the PR by adding `LightsNode.getBuiltinLights()` which represent built-in lights within the material/shaders, while `LightsNode.getLights()` handles scene-based lights. As a result, this also slightly reduces the loop overhead in `NodeMaterialObserver`.
