### PR TITLE
Refactor texture size node to handle multisampling

### DIFF
--- a/src/nodes/accessors/TextureSizeNode.js
+++ b/src/nodes/accessors/TextureSizeNode.js
@@ -57,7 +57,12 @@ class TextureSizeNode extends Node {
 		const textureProperty = this.textureNode.build( builder, 'property' );
 		const level = this.levelNode === null ? '0' : this.levelNode.build( builder, 'int' );
 
-		return builder.format( `${ builder.getMethod( 'textureDimensions' ) }( ${ textureProperty }, ${ level } )`, this.getNodeType( builder ), output );
+		const sampleData = builder.renderer.backend.utils.getTextureSampleData?.( this.textureNode.value );
+		const isMultisampled = sampleData?.primarySamples > 1;
+
+		const params = isMultisampled ? textureProperty : `${ textureProperty }, ${ level }`;
+
+		return builder.format( `${ builder.getMethod( 'textureDimensions' ) }( ${ params } )`, this.getNodeType( builder ), output );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33921#discussion_r3504687644

**Description**

Bumped into this while working on the `SSAONode` but eventually I didn't need it.
Leaving the change here in case it's useful. Feel free to close.