### PR TITLE
BloomNode: Add faster blur strategy.

### DIFF
--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -107,15 +107,6 @@ class BloomNode extends TempNode {
 		this.smoothWidth = uniform( 0.01 );
 
 		/**
-		 * Whether to use linear sampling for the Gaussian blur.
-		 *
-		 * @private
-		 * @type {boolean}
-		 * @default false
-		 */
-		this._linearSampling = false;
-
-		/**
 		 * Scale factor for the internal render targets.
 		 *
 		 * @private
@@ -210,15 +201,6 @@ class BloomNode extends TempNode {
 		this._separableBlurMaterials = [];
 
 		/**
-		 * The shared context captured during `setup()`.
-		 *
-		 * @private
-		 * @type {?Object}
-		 * @default null
-		 */
-		this._sharedContext = null;
-
-		/**
 		 * The result of the luminance pass as a texture node for further processing.
 		 *
 		 * @private
@@ -282,32 +264,6 @@ class BloomNode extends TempNode {
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
-
-	}
-
-	/**
-	 * Whether to use linear sampling for the Gaussian blur. When enabled, adjacent
-	 * kernel taps are merged into single bilinear fetches, roughly halving the number
-	 * of texture reads for an approximate similar result. Recommended for mobile.
-	 *
-	 * @type {boolean}
-	 * @default false
-	 */
-	get linearSampling() {
-
-		return this._linearSampling;
-
-	}
-
-	set linearSampling( value ) {
-
-		if ( value !== this._linearSampling ) {
-
-			this._linearSampling = value;
-
-			if ( this._sharedContext !== null ) this._buildSeparableBlurMaterials();
-
-		}
 
 	}
 
@@ -452,8 +408,15 @@ class BloomNode extends TempNode {
 
 		// gaussian blur materials
 
-		this._sharedContext = builder.getSharedContext();
-		this._buildSeparableBlurMaterials();
+		// These sizes have been changed to account for the altered coefficients-calculation to avoid blockiness,
+		// while retaining the same blur-strength. For details see https://github.com/mrdoob/three.js/pull/31528
+		const kernelSizeArray = [ 6, 10, 14, 18, 22 ];
+
+		for ( let i = 0; i < this._nMips; i ++ ) {
+
+			this._separableBlurMaterials.push( this._getSeparableBlurMaterial( builder, kernelSizeArray[ i ] ) );
+
+		}
 
 		// composite material
 
@@ -532,40 +495,14 @@ class BloomNode extends TempNode {
 	}
 
 	/**
-	 * Builds the separable blur materials.
-	 *
-	 * @private
-	 */
-	_buildSeparableBlurMaterials() {
-
-		// These sizes have been changed to account for the altered coefficients-calculation to avoid blockiness,
-		// while retaining the same blur-strength. For details see https://github.com/mrdoob/three.js/pull/31528
-		const kernelSizeArray = [ 6, 10, 14, 18, 22 ];
-
-		for ( let i = 0; i < this._separableBlurMaterials.length; i ++ ) {
-
-			this._separableBlurMaterials[ i ].dispose();
-
-		}
-
-		this._separableBlurMaterials.length = 0;
-
-		for ( let i = 0; i < this._nMips; i ++ ) {
-
-			this._separableBlurMaterials.push( this._getSeparableBlurMaterial( kernelSizeArray[ i ] ) );
-
-		}
-
-	}
-
-	/**
 	 * Create a separable blur material for the given kernel radius.
 	 *
 	 * @private
+	 * @param {NodeBuilder} builder - The current node builder.
 	 * @param {number} kernelRadius - The kernel radius.
 	 * @return {NodeMaterial}
 	 */
-	_getSeparableBlurMaterial( kernelRadius ) {
+	_getSeparableBlurMaterial( builder, kernelRadius ) {
 
 		const coefficients = [];
 		const sigma = kernelRadius / 3;
@@ -576,31 +513,20 @@ class BloomNode extends TempNode {
 
 		}
 
+		// Merge adjacent taps into single bilinear fetches (linear sampling).
+
 		const centerWeight = coefficients[ 0 ];
 		const offsets = [];
 		const weights = [];
 
-		if ( this.linearSampling === false ) {
+		for ( let i = 1; i < kernelRadius; i += 2 ) {
 
-			for ( let i = 1; i < kernelRadius; i ++ ) {
+			const wa = coefficients[ i ];
+			const wb = ( i + 1 ) < kernelRadius ? coefficients[ i + 1 ] : 0;
+			const w = wa + wb;
 
-				offsets.push( i );
-				weights.push( coefficients[ i ] );
-
-			}
-
-		} else {
-
-			for ( let i = 1; i < kernelRadius; i += 2 ) {
-
-				const wa = coefficients[ i ];
-				const wb = ( i + 1 ) < kernelRadius ? coefficients[ i + 1 ] : 0;
-				const w = wa + wb;
-
-				offsets.push( ( i * wa + ( i + 1 ) * wb ) / w );
-				weights.push( w );
-
-			}
+			offsets.push( ( i * wa + ( i + 1 ) * wb ) / w );
+			weights.push( w );
 
 		}
 
@@ -634,7 +560,7 @@ class BloomNode extends TempNode {
 		} );
 
 		const separableBlurMaterial = new NodeMaterial();
-		separableBlurMaterial.fragmentNode = separableBlurPass().context( this._sharedContext );
+		separableBlurMaterial.fragmentNode = separableBlurPass().context( builder.getSharedContext() );
 		separableBlurMaterial.name = 'Bloom_separable';
 		separableBlurMaterial.needsUpdate = true;
 

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -107,6 +107,15 @@ class BloomNode extends TempNode {
 		this.smoothWidth = uniform( 0.01 );
 
 		/**
+		 * Whether to use linear sampling for the Gaussian blur.
+		 *
+		 * @private
+		 * @type {boolean}
+		 * @default false
+		 */
+		this._linearSampling = false;
+
+		/**
 		 * Scale factor for the internal render targets.
 		 *
 		 * @private
@@ -201,6 +210,15 @@ class BloomNode extends TempNode {
 		this._separableBlurMaterials = [];
 
 		/**
+		 * The shared context captured during `setup()`.
+		 *
+		 * @private
+		 * @type {?Object}
+		 * @default null
+		 */
+		this._sharedContext = null;
+
+		/**
 		 * The result of the luminance pass as a texture node for further processing.
 		 *
 		 * @private
@@ -264,6 +282,32 @@ class BloomNode extends TempNode {
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
+
+	}
+
+	/**
+	 * Whether to use linear sampling for the Gaussian blur. When enabled, adjacent
+	 * kernel taps are merged into single bilinear fetches, roughly halving the number
+	 * of texture reads for an approximate similar result. Recommended for mobile.
+	 *
+	 * @type {boolean}
+	 * @default false
+	 */
+	get linearSampling() {
+
+		return this._linearSampling;
+
+	}
+
+	set linearSampling( value ) {
+
+		if ( value !== this._linearSampling ) {
+
+			this._linearSampling = value;
+
+			if ( this._sharedContext !== null ) this._buildSeparableBlurMaterials();
+
+		}
 
 	}
 
@@ -408,15 +452,8 @@ class BloomNode extends TempNode {
 
 		// gaussian blur materials
 
-		// These sizes have been changed to account for the altered coefficients-calculation to avoid blockiness,
-		// while retaining the same blur-strength. For details see https://github.com/mrdoob/three.js/pull/31528
-		const kernelSizeArray = [ 6, 10, 14, 18, 22 ];
-
-		for ( let i = 0; i < this._nMips; i ++ ) {
-
-			this._separableBlurMaterials.push( this._getSeparableBlurMaterial( builder, kernelSizeArray[ i ] ) );
-
-		}
+		this._sharedContext = builder.getSharedContext();
+		this._buildSeparableBlurMaterials();
 
 		// composite material
 
@@ -495,14 +532,40 @@ class BloomNode extends TempNode {
 	}
 
 	/**
+	 * Builds the separable blur materials.
+	 *
+	 * @private
+	 */
+	_buildSeparableBlurMaterials() {
+
+		// These sizes have been changed to account for the altered coefficients-calculation to avoid blockiness,
+		// while retaining the same blur-strength. For details see https://github.com/mrdoob/three.js/pull/31528
+		const kernelSizeArray = [ 6, 10, 14, 18, 22 ];
+
+		for ( let i = 0; i < this._separableBlurMaterials.length; i ++ ) {
+
+			this._separableBlurMaterials[ i ].dispose();
+
+		}
+
+		this._separableBlurMaterials.length = 0;
+
+		for ( let i = 0; i < this._nMips; i ++ ) {
+
+			this._separableBlurMaterials.push( this._getSeparableBlurMaterial( kernelSizeArray[ i ] ) );
+
+		}
+
+	}
+
+	/**
 	 * Create a separable blur material for the given kernel radius.
 	 *
 	 * @private
-	 * @param {NodeBuilder} builder - The current node builder.
 	 * @param {number} kernelRadius - The kernel radius.
 	 * @return {NodeMaterial}
 	 */
-	_getSeparableBlurMaterial( builder, kernelRadius ) {
+	_getSeparableBlurMaterial( kernelRadius ) {
 
 		const coefficients = [];
 		const sigma = kernelRadius / 3;
@@ -513,10 +576,39 @@ class BloomNode extends TempNode {
 
 		}
 
+		const centerWeight = coefficients[ 0 ];
+		const offsets = [];
+		const weights = [];
+
+		if ( this.linearSampling === false ) {
+
+			for ( let i = 1; i < kernelRadius; i ++ ) {
+
+				offsets.push( i );
+				weights.push( coefficients[ i ] );
+
+			}
+
+		} else {
+
+			for ( let i = 1; i < kernelRadius; i += 2 ) {
+
+				const wa = coefficients[ i ];
+				const wb = ( i + 1 ) < kernelRadius ? coefficients[ i + 1 ] : 0;
+				const w = wa + wb;
+
+				offsets.push( ( i * wa + ( i + 1 ) * wb ) / w );
+				weights.push( w );
+
+			}
+
+		}
+
 		//
 
 		const colorTexture = texture( null );
-		const gaussianCoefficients = uniformArray( coefficients );
+		const gaussianOffsets = uniformArray( offsets );
+		const gaussianWeights = uniformArray( weights );
 		const invSize = uniform( new Vector2() );
 		const direction = uniform( new Vector2( 0.5, 0.5 ) );
 
@@ -525,13 +617,12 @@ class BloomNode extends TempNode {
 
 		const separableBlurPass = Fn( () => {
 
-			const diffuseSum = sampleTexel( uvNode ).rgb.mul( gaussianCoefficients.element( 0 ) ).toVar();
+			const diffuseSum = sampleTexel( uvNode ).rgb.mul( centerWeight ).toVar();
 
-			Loop( { start: int( 1 ), end: int( kernelRadius ), type: 'int', condition: '<' }, ( { i } ) => {
+			Loop( { start: int( 0 ), end: int( offsets.length ), type: 'int', condition: '<' }, ( { i } ) => {
 
-				const x = float( i );
-				const w = gaussianCoefficients.element( i );
-				const uvOffset = direction.mul( invSize ).mul( x );
+				const w = gaussianWeights.element( i );
+				const uvOffset = direction.mul( invSize ).mul( gaussianOffsets.element( i ) );
 				const sample1 = sampleTexel( uvNode.add( uvOffset ) ).rgb;
 				const sample2 = sampleTexel( uvNode.sub( uvOffset ) ).rgb;
 				diffuseSum.addAssign( add( sample1, sample2 ).mul( w ) );
@@ -543,7 +634,7 @@ class BloomNode extends TempNode {
 		} );
 
 		const separableBlurMaterial = new NodeMaterial();
-		separableBlurMaterial.fragmentNode = separableBlurPass().context( builder.getSharedContext() );
+		separableBlurMaterial.fragmentNode = separableBlurPass().context( this._sharedContext );
 		separableBlurMaterial.name = 'Bloom_separable';
 		separableBlurMaterial.needsUpdate = true;
 

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -432,21 +432,6 @@ class BloomNode extends TempNode {
 		const bloomFactors = array( [ float( 1.0 ), float( 0.8 ), float( 0.6 ), float( 0.4 ), float( 0.2 ) ] );
 		const bloomTintColors = uniformArray( this.bloomTintColors );
 
-		const lerpBloomFactor = Fn( ( [ factor, radius ] ) => {
-
-			const mirrorFactor = float( 1.2 ).sub( factor );
-			return mix( factor, mirrorFactor, radius );
-
-		} ).setLayout( {
-			name: 'lerpBloomFactor',
-			type: 'float',
-			inputs: [
-				{ name: 'factor', type: 'float' },
-				{ name: 'radius', type: 'float' },
-			]
-		} );
-
-
 		const compositePass = Fn( () => {
 
 			const color0 = lerpBloomFactor( bloomFactors.element( 0 ), this.radius ).mul( vec4( bloomTintColors.element( 0 ), 1.0 ) ).mul( this._textureNodeBlur0 );
@@ -583,6 +568,20 @@ class BloomNode extends TempNode {
 	}
 
 }
+
+const lerpBloomFactor = Fn( ( [ factor, radius ] ) => {
+
+	const mirrorFactor = float( 1.2 ).sub( factor );
+	return mix( factor, mirrorFactor, radius );
+
+} ).setLayout( {
+	name: 'lerpBloomFactor',
+	type: 'float',
+	inputs: [
+		{ name: 'factor', type: 'float' },
+		{ name: 'radius', type: 'float' },
+	]
+} );
 
 /**
  * TSL function for creating a bloom effect.

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -1,5 +1,5 @@
 import { HalfFloatType, RenderTarget, Vector2, Vector3, TempNode, QuadMesh, NodeMaterial, RendererUtils, NodeUpdateType } from 'three/webgpu';
-import { nodeObject, Fn, float, uv, passTexture, uniform, Loop, texture, luminance, smoothstep, mix, vec4, uniformArray, add, int } from 'three/tsl';
+import { nodeObject, Fn, float, uv, passTexture, uniform, Loop, texture, luminance, smoothstep, mix, vec4, uniformArray, add, int, array } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -105,6 +105,15 @@ class BloomNode extends TempNode {
 		 * @type {UniformNode<float>}
 		 */
 		this.smoothWidth = uniform( 0.01 );
+
+		/**
+		 * A per-mip tint color for the bloom, applied during the composite pass.
+		 * Defaults to white (no tint) for each of the mips. Mutate the vectors to
+		 * colorize the bloom (e.g. for a warm or anamorphic look).
+		 *
+		 * @type {Array<Vector3>}
+		 */
+		this.bloomTintColors = [ new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ) ];
 
 		/**
 		 * Scale factor for the internal render targets.
@@ -420,8 +429,8 @@ class BloomNode extends TempNode {
 
 		// composite material
 
-		const bloomFactors = uniformArray( [ 1.0, 0.8, 0.6, 0.4, 0.2 ] );
-		const bloomTintColors = uniformArray( [ new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ) ] );
+		const bloomFactors = array( [ float( 1.0 ), float( 0.8 ), float( 0.6 ), float( 0.4 ), float( 0.2 ) ] );
+		const bloomTintColors = uniformArray( this.bloomTintColors );
 
 		const lerpBloomFactor = Fn( ( [ factor, radius ] ) => {
 
@@ -533,8 +542,8 @@ class BloomNode extends TempNode {
 		//
 
 		const colorTexture = texture( null );
-		const gaussianOffsets = uniformArray( offsets );
-		const gaussianWeights = uniformArray( weights );
+		const gaussianOffsets = array( offsets.map( ( value ) => float( value ) ) );
+		const gaussianWeights = array( weights.map( ( value ) => float( value ) ) );
 		const invSize = uniform( new Vector2() );
 		const direction = uniform( new Vector2( 0.5, 0.5 ) );
 

--- a/examples/webgpu_postprocessing_bloom_emissive.html
+++ b/examples/webgpu_postprocessing_bloom_emissive.html
@@ -158,7 +158,6 @@
 				bloomFolder.add( params, 'type', [ 'Gaussian', 'Dual Kawase' ] ).onChange( updateBloom );
 				bloomFolder.add( strength, 'value', 0.0, 5.0 ).name( 'strength' );
 				bloomFolder.add( radius, 'value', 0.0, 1.0 ).name( 'radius' );
-				bloomFolder.add( bloomPasses[ 'Gaussian' ], 'linearSampling' ).name( 'linear sampling (Gaussian)' );
 
 				const toneMappingFolder = gui.addFolder( 'Tone Mapping' );
 				toneMappingFolder.add( renderer, 'toneMappingExposure', 0.1, 2 ).name( 'exposure' );

--- a/examples/webgpu_postprocessing_bloom_emissive.html
+++ b/examples/webgpu_postprocessing_bloom_emissive.html
@@ -158,6 +158,7 @@
 				bloomFolder.add( params, 'type', [ 'Gaussian', 'Dual Kawase' ] ).onChange( updateBloom );
 				bloomFolder.add( strength, 'value', 0.0, 5.0 ).name( 'strength' );
 				bloomFolder.add( radius, 'value', 0.0, 1.0 ).name( 'radius' );
+				bloomFolder.add( bloomPasses[ 'Gaussian' ], 'linearSampling' ).name( 'linear sampling (Gaussian)' );
 
 				const toneMappingFolder = gui.addFolder( 'Tone Mapping' );
 				toneMappingFolder.add( renderer, 'toneMappingExposure', 0.1, 2 ).name( 'exposure' );


### PR DESCRIPTION
Related issue: #33920

**Description**

This PR implements a faster blur in `BloomNode` by merging adjacent taps into single bilinear fetches. That should lower the number of texel fetches almost by half and produce a good approximation of the default bloom quality.

PR: https://rawcdn.githack.com/mrdoob/three.js/17c586b4e8ee8223bec6182827ba6ee2df01b51f/examples/index.html?q=webgpu%20bloom
Prod: https://threejs.org/examples/?q=webgpu%20bloom