### PR TITLE
WebGPURenderer: Do not render shadow maps when precompile.

### DIFF
--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -850,7 +850,7 @@ class ShadowNode extends ShadowBaseNode {
 	 */
 	updateBefore( frame ) {
 
-		// like WebGLRenderer.compile(), compileAsync() does not render shadow maps
+		// do not render shadow maps during precompilation
 
 		if ( frame.renderer._isPreCompiling === true ) return;
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -850,6 +850,10 @@ class ShadowNode extends ShadowBaseNode {
 	 */
 	updateBefore( frame ) {
 
+		// like WebGLRenderer.compile(), compileAsync() does not render shadow maps
+
+		if ( frame.renderer._isPreCompiling === true ) return;
+
 		const { shadow } = this;
 
 		let needsUpdate = shadow.needsUpdate || shadow.autoUpdate;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -662,6 +662,16 @@ class Renderer {
 		this._compilationPromises = null;
 
 		/**
+		 * Whether the renderer is currently precompiling a render object in
+		 * `compileAsync()`.
+		 *
+		 * @private
+		 * @type {boolean}
+		 * @default false
+		 */
+		this._isPreCompiling = false;
+
+		/**
 		 * When an override material is in use, this property points to the current
 		 * source material during the rendering of a render object.
 		 *
@@ -1048,10 +1058,12 @@ class Renderer {
 			// Use async node building to yield to main thread
 			await this._nodes.getForRenderAsync( renderObject );
 
+			this._isPreCompiling = true; // note: no awaits are allowed when this flag is true otherwise the state leaks outside of this method
 			this._nodes.updateBefore( renderObject );
 			this._geometries.updateForRender( renderObject );
 			this._nodes.updateForRender( renderObject );
 			this._bindings.updateForRender( renderObject );
+			this._isPreCompiling = false;
 
 			// Wait for pipeline creation
 			const pipelinePromises = [];
@@ -1062,7 +1074,9 @@ class Renderer {
 
 			}
 
+			this._isPreCompiling = true;
 			this._nodes.updateAfter( renderObject );
+			this._isPreCompiling = false;
 
 			// Yield between objects to allow animation frames
 			await yieldToMain();


### PR DESCRIPTION
Fixed #33898.

**Description**

The current percompile mechanism in `WebGPURenderer` triggers shadow map renderings. The PR makes sure that does not happen and aligns the logic to `WebGLRenderer.compileAsync()`.

I think when `WebGPURenderer.compileAsync()` has been added,  it has been overlooked that shadow maps might be rendered which happens a bit hidden inside the shadow nodes (so not explicitly in the renderer). A pre-compile should only warm-up the rendering resources and not perform real renderings. Also, the current shadow map renderings inside the precompile are buggy because it has unexpected side effects like reported in #33898.