### PR TITLE
GTAONode: Speed up the AO pass.

### DIFF
--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -1,5 +1,5 @@
 import { DataTexture, RenderTarget, RepeatWrapping, Vector2, Vector3, Vector4, TempNode, QuadMesh, NodeMaterial, RendererUtils, RedFormat, WebGPUCoordinateSystem } from 'three/webgpu';
-import { reference, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getNormalFromDepth, getViewPosition, getScreenPositionFromClip, nodeObject, Fn, float, NodeUpdateType, uv, uniform, Loop, vec2, vec3, vec4, int, dot, max, min, pow, abs, If, textureSize, sin, cos, PI, texture, passTexture, mat3, add, normalize, cross, mix, acos, clamp, interleavedGradientNoise, screenCoordinate, rand } from 'three/tsl';
+import { reference, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getNormalFromDepth, getViewPosition, getScreenPositionFromClip, nodeObject, Fn, float, NodeUpdateType, uv, uniform, Loop, vec2, vec3, vec4, int, dot, max, min, pow, abs, If, textureSize, sin, cos, PI, texture, passTexture, mat3, normalize, cross, mix, acos, clamp, interleavedGradientNoise, screenCoordinate, rand } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -149,12 +149,11 @@ class GTAONode extends TempNode {
 
 		/**
 		 * How many samples are used to compute the AO.
-		 * A higher value results in better quality but also
-		 * in a more expensive runtime behavior.
 		 *
-		 * @type {UniformNode<float>}
+		 * @private
+		 * @type {number}
 		 */
-		this.samples = uniform( 16 );
+		this._samples = 16;
 
 		/**
 		 * Whether to use temporal filtering or not. Setting this property to
@@ -278,12 +277,48 @@ class GTAONode extends TempNode {
 		this._material.name = 'GTAO';
 
 		/**
+		 * Recreates the material's fragment node. Set up during `setup()` and
+		 * invoked when a property that is baked into the shader changes.
+		 *
+		 * @private
+		 * @type {?Function}
+		 */
+		this._updateFragmentNode = null;
+
+		/**
 		 * The result of the effect is represented as a separate texture node.
 		 *
 		 * @private
 		 * @type {PassTextureNode}
 		 */
 		this._textureNode = passTexture( this, this._aoRenderTarget.texture );
+
+	}
+
+	/**
+	 * How many samples are used to compute the AO.
+	 * A higher value results in better quality but also
+	 * in a more expensive runtime behavior. The value is baked
+	 * into the shader so changing it rebuilds the effect's material.
+	 *
+	 * @type {number}
+	 * @default 16
+	 */
+	get samples() {
+
+		return this._samples;
+
+	}
+
+	set samples( value ) {
+
+		if ( this._samples !== value ) {
+
+			this._samples = value;
+
+			if ( this._updateFragmentNode !== null ) this._updateFragmentNode();
+
+		}
 
 	}
 
@@ -464,9 +499,13 @@ class GTAONode extends TempNode {
 			const bitangent = vec3( tangent.y.mul( - 1.0 ), tangent.x, 0.0 );
 			const kernelMatrix = mat3( tangent, bitangent, vec3( 0.0, 0.0, 1.0 ) );
 
-			const DIRECTIONS = this.samples.lessThan( 30 ).select( 3, 5 ).toVar();
-			const STEPS = add( this.samples, DIRECTIONS.sub( 1 ) ).div( DIRECTIONS ).toVar();
-			const invSteps = STEPS.reciprocal().toVar();
+			// The direction and step counts are baked as constants so the loops below can be
+			// unrolled. The step count keeps its fractional part as the ray-length divisor to
+			// preserve the sample distribution ( e.g. 32 samples: 7 steps, divided by 7.2 ).
+
+			const dirCount = this._samples < 30 ? 3 : 5;
+			const stepCountF = ( this._samples + dirCount - 1 ) / dirCount;
+			const stepCount = Math.floor( stepCountF );
 
 			const ao = float( 0 ).toVar();
 
@@ -476,9 +515,9 @@ class GTAONode extends TempNode {
 			const noiseJitterIdx = this._temporalDirection.mul( 0.02 );
 			const stepJitter = interleavedGradientNoise( screenCoordinate.add( this._temporalOffset ) ).add( rand( uvNode.add( noiseJitterIdx ).mul( 2 ).sub( 1 ) ) );
 
-			Loop( { start: int( 0 ), end: DIRECTIONS, type: 'int', condition: '<' }, ( { i } ) => {
+			Loop( { start: int( 0 ), end: int( dirCount ), type: 'int', condition: '<' }, ( { i } ) => {
 
-				const angle = float( i ).div( float( DIRECTIONS ) ).mul( PI ).add( this._temporalDirection ).toVar();
+				const angle = float( i ).div( dirCount ).mul( PI ).add( this._temporalDirection ).toVar();
 				const sampleDir = kernelMatrix.mul( vec3( cos( angle ), sin( angle ), 0 ) ).toVar();
 				const clipDirRadius = this._cameraProjectionMatrix.mul( vec4( sampleDir, 0.0 ) ).mul( radius ).toVar();
 
@@ -504,11 +543,11 @@ class GTAONode extends TempNode {
 
 				// For each slice, the inner loop performs ray marching to find the horizons.
 
-				Loop( { end: STEPS, type: 'int', name: 'j', condition: '<' }, ( { j } ) => {
+				Loop( { end: int( stepCount ), type: 'int', name: 'j', condition: '<' }, ( { j } ) => {
 
 					// Quadratic step distribution ( sampleDist = t² ) concentrates samples in the
 					// near-field. (Blender's Eevee adaptation)
-					const t = float( j ).add( 1.0 ).add( stepJitter ).mul( invSteps ).toVar();
+					const t = float( j ).add( 1.0 ).add( stepJitter ).mul( 1 / stepCountF ).toVar();
 					const sampleDist = t.mul( t );
 					const clipOffset = clipDirRadius.mul( sampleDist ).toVar();
 
@@ -576,15 +615,24 @@ class GTAONode extends TempNode {
 
 			} );
 
-			ao.assign( clamp( ao.div( DIRECTIONS ), 0, 1 ) );
+			ao.assign( clamp( ao.div( dirCount ), 0, 1 ) );
 			ao.assign( pow( ao, this.scale ) );
 
 			return ao;
 
 		} );
 
-		this._material.fragmentNode = ao().context( builder.getSharedContext() );
-		this._material.needsUpdate = true;
+		// a new call node gets a new cache key, which forces a shader rebuild
+		// when a baked property like the sample count changes
+
+		this._updateFragmentNode = () => {
+
+			this._material.fragmentNode = ao().context( builder.getSharedContext() );
+			this._material.needsUpdate = true;
+
+		};
+
+		this._updateFragmentNode();
 
 		//
 

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -389,6 +389,7 @@ class GTAONode extends TempNode {
 			const viewNormal = sampleNormal( uvNode ).toVar();
 
 			const radius = this.radius;
+			const invRadius = radius.reciprocal().toVar();
 			const viewDir = normalize( viewPosition.xyz.negate() ).toVar();
 			const clipPosition = this._cameraProjectionMatrix.mul( vec4( viewPosition, 1.0 ) ).toVar();
 
@@ -404,6 +405,7 @@ class GTAONode extends TempNode {
 
 			const DIRECTIONS = this.samples.lessThan( 30 ).select( 3, 5 ).toVar();
 			const STEPS = add( this.samples, DIRECTIONS.sub( 1 ) ).div( DIRECTIONS ).toVar();
+			const invSteps = STEPS.reciprocal().toVar();
 
 			const ao = float( 0 ).toVar();
 
@@ -445,7 +447,7 @@ class GTAONode extends TempNode {
 
 					// Quadratic step distribution ( sampleDist = t² ) concentrates samples in the
 					// near-field. (Blender's Eevee adaptation)
-					const t = float( j ).add( 1.0 ).add( stepJitter ).div( STEPS ).toVar();
+					const t = float( j ).add( 1.0 ).add( stepJitter ).mul( invSteps ).toVar();
 					const sampleDist = t.mul( t );
 					const clipOffset = clipDirRadius.mul( sampleDist ).toVar();
 
@@ -460,13 +462,13 @@ class GTAONode extends TempNode {
 					const lenX = viewDeltaX.length().toVar();
 
 					// Manual normalize guards against zero-length delta.
-					const sHX = dot( viewDir, viewDeltaX.div( max( lenX, float( 0.0001 ) ) ) );
+					const sHX = dot( viewDir, viewDeltaX ).div( max( lenX, float( 0.0001 ) ) );
 
 					// Sphere falloff: ( dist / radius )² fades the sample's horizon contribution
 					// back toward the prior horizon as it approaches the radius boundary.
 					// (squared variant of the paper's near-field attenuation;
 					// Activision GTAO paper, Section 4.3 "Bounding the sampling area")
-					const distFacX = min( lenX.div( radius ), 1 );
+					const distFacX = min( lenX.mul( invRadius ), 1 );
 					const distFacSqX = distFacX.mul( distFacX );
 
 					If( abs( viewDeltaX.z ).lessThan( this.thickness ), () => {
@@ -483,9 +485,9 @@ class GTAONode extends TempNode {
 					const viewDeltaY = sampleSceneViewPositionY.sub( viewPosition ).toVar();
 					const lenY = viewDeltaY.length().toVar();
 
-					const sHY = dot( viewDir, viewDeltaY.div( max( lenY, float( 0.0001 ) ) ) );
+					const sHY = dot( viewDir, viewDeltaY ).div( max( lenY, float( 0.0001 ) ) );
 
-					const distFacY = min( lenY.div( radius ), 1 );
+					const distFacY = min( lenY.mul( invRadius ), 1 );
 					const distFacSqY = distFacY.mul( distFacY );
 
 					If( abs( viewDeltaY.z ).lessThan( this.thickness ), () => {

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -1,4 +1,4 @@
-import { DataTexture, RenderTarget, RepeatWrapping, Vector2, Vector3, Vector4, TempNode, QuadMesh, NodeMaterial, RendererUtils, RedFormat, WebGPUCoordinateSystem } from 'three/webgpu';
+import { DataTexture, RenderTarget, RepeatWrapping, Vector2, Vector3, TempNode, QuadMesh, NodeMaterial, RendererUtils, RedFormat, WebGPUCoordinateSystem } from 'three/webgpu';
 import { reference, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getNormalFromDepth, getViewPosition, getScreenPositionFromClip, nodeObject, Fn, float, NodeUpdateType, uv, uniform, Loop, vec2, vec3, vec4, int, dot, max, min, pow, abs, If, textureSize, sin, cos, PI, texture, passTexture, mat3, normalize, cross, mix, acos, clamp, interleavedGradientNoise, screenCoordinate, rand } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
@@ -226,24 +226,6 @@ class GTAONode extends TempNode {
 		this._cameraFar = reference( 'far', 'float', camera );
 
 		/**
-		 * Sparse coefficients of the inverse projection matrix ( i00, i11, i30, i31 )
-		 * used to reconstruct view-space XY in the perspective fast path.
-		 *
-		 * @private
-		 * @type {UniformNode<vec4>}
-		 */
-		this._unprojectXY = uniform( new Vector4() );
-
-		/**
-		 * Sparse coefficients of the inverse projection matrix ( i23, i33 )
-		 * used to reconstruct the view-space perspective divisor.
-		 *
-		 * @private
-		 * @type {UniformNode<vec2>}
-		 */
-		this._unprojectW = uniform( new Vector2() );
-
-		/**
 		 * Temporal direction that influences the rotation angle for each slice.
 		 *
 		 * @private
@@ -377,12 +359,6 @@ class GTAONode extends TempNode {
 
 		}
 
-		// sparse inverse projection coefficients for the perspective fast path (column-major)
-
-		const e = this._camera.projectionMatrixInverse.elements;
-		this._unprojectXY.value.set( e[ 0 ], e[ 5 ], e[ 12 ], e[ 13 ] );
-		this._unprojectW.value.set( e[ 11 ], e[ 15 ] );
-
 		//
 
 		const size = renderer.getDrawingBufferSize( _size );
@@ -416,9 +392,15 @@ class GTAONode extends TempNode {
 
 		const uvNode = uv();
 
+		// read once so no closure retains the builder beyond setup()
+
+		const logarithmicDepthBuffer = builder.renderer.logarithmicDepthBuffer === true;
+		const isWebGPU = builder.renderer.coordinateSystem === WebGPUCoordinateSystem;
+		const sharedContext = builder.getSharedContext();
+
 		const linearizeDepth = ( depth ) => {
 
-			if ( builder.renderer.logarithmicDepthBuffer === true ) {
+			if ( logarithmicDepthBuffer === true ) {
 
 				const viewZ = logarithmicDepthToViewZ( depth, this._cameraNear, this._cameraFar );
 
@@ -457,19 +439,21 @@ class GTAONode extends TempNode {
 
 			if ( this._camera.isPerspectiveCamera === true ) {
 
+				const im = this._cameraProjectionMatrixInverse;
+
 				const ndcXY = clipPosition.xy.mul( clipPosition.w.reciprocal() ).toVar();
-				const sampleUv = vec2( ndcXY.x.mul( 0.5 ).add( 0.5 ), float( 0.5 ).sub( ndcXY.y.mul( 0.5 ) ) );
+				const sampleUv = ndcXY.mul( vec2( 0.5, - 0.5 ) ).add( 0.5 );
 				const depth = sampleDepth( sampleUv );
 
-				const ndcZ = ( builder.renderer.coordinateSystem === WebGPUCoordinateSystem ) ? depth : depth.mul( 2.0 ).sub( 1.0 );
-				const w = ndcZ.mul( this._unprojectW.x ).add( this._unprojectW.y );
+				const ndcZ = isWebGPU ? depth : depth.mul( 2.0 ).sub( 1.0 );
+				const w = ndcZ.mul( im.element( 2 ).w ).add( im.element( 3 ).w );
 
-				return vec3( ndcXY.mul( this._unprojectXY.xy ).add( this._unprojectXY.zw ), - 1.0 ).mul( w.reciprocal() );
+				return vec3( ndcXY.mul( vec2( im.element( 0 ).x, im.element( 1 ).y ) ).add( im.element( 3 ).xy ), - 1.0 ).mul( w.reciprocal() );
 
 			}
 
 			const screenPosition = getScreenPositionFromClip( clipPosition ).toVar();
-			const depth = sampleDepth( screenPosition ).toVar();
+			const depth = sampleDepth( screenPosition );
 
 			return getViewPosition( screenPosition, depth, this._cameraProjectionMatrixInverse );
 
@@ -551,46 +535,34 @@ class GTAONode extends TempNode {
 					const sampleDist = t.mul( t );
 					const clipOffset = clipDirRadius.mul( sampleDist ).toVar();
 
-					// The loop marches in two opposite directions (x and y) along the slice's line to find the horizon on both sides.
+					// The loop marches in two opposite directions along the slice's line to find the horizon on both sides.
 
-					// x
+					const march = ( sampleClipPosition, horizon ) => {
 
-					const sampleSceneViewPositionX = sampleViewPosition( clipPosition.add( clipOffset ) ).toVar();
-					const viewDeltaX = sampleSceneViewPositionX.sub( viewPosition ).toVar();
-					const lenX = viewDeltaX.length().toVar();
+						const sampleSceneViewPosition = sampleViewPosition( sampleClipPosition ).toVar();
+						const viewDelta = sampleSceneViewPosition.sub( viewPosition ).toVar();
+						const len = viewDelta.length().toVar();
 
-					// Manual normalize guards against zero-length delta.
-					const sHX = dot( viewDir, viewDeltaX ).div( max( lenX, float( 0.0001 ) ) );
+						// Manual normalize guards against zero-length delta.
+						const sH = dot( viewDir, viewDelta ).div( max( len, float( 0.0001 ) ) );
 
-					// Sphere falloff: ( dist / radius )² fades the sample's horizon contribution
-					// back toward the prior horizon as it approaches the radius boundary.
-					// (squared variant of the paper's near-field attenuation;
-					// Activision GTAO paper, Section 4.3 "Bounding the sampling area")
-					const distFacX = min( lenX.mul( invRadius ), 1 );
-					const distFacSqX = distFacX.mul( distFacX );
+						// Sphere falloff: ( dist / radius )² fades the sample's horizon contribution
+						// back toward the prior horizon as it approaches the radius boundary.
+						// (squared variant of the paper's near-field attenuation;
+						// Activision GTAO paper, Section 4.3 "Bounding the sampling area")
+						const distFac = min( len.mul( invRadius ), 1 );
+						const distFacSq = distFac.mul( distFac );
 
-					If( abs( viewDeltaX.z ).lessThan( this.thickness ), () => {
+						If( abs( viewDelta.z ).lessThan( this.thickness ), () => {
 
-						cosHorizons.x.assign( mix( max( cosHorizons.x, sHX ), cosHorizons.x, distFacSqX ) );
+							horizon.assign( mix( max( horizon, sH ), horizon, distFacSq ) );
 
-					} );
+						} );
 
-					// y
+					};
 
-					const sampleSceneViewPositionY = sampleViewPosition( clipPosition.sub( clipOffset ) ).toVar();
-					const viewDeltaY = sampleSceneViewPositionY.sub( viewPosition ).toVar();
-					const lenY = viewDeltaY.length().toVar();
-
-					const sHY = dot( viewDir, viewDeltaY ).div( max( lenY, float( 0.0001 ) ) );
-
-					const distFacY = min( lenY.mul( invRadius ), 1 );
-					const distFacSqY = distFacY.mul( distFacY );
-
-					If( abs( viewDeltaY.z ).lessThan( this.thickness ), () => {
-
-						cosHorizons.y.assign( mix( max( cosHorizons.y, sHY ), cosHorizons.y, distFacSqY ) );
-
-					} );
+					march( clipPosition.add( clipOffset ), cosHorizons.x );
+					march( clipPosition.sub( clipOffset ), cosHorizons.y );
 
 				} );
 
@@ -627,7 +599,7 @@ class GTAONode extends TempNode {
 
 		this._updateFragmentNode = () => {
 
-			this._material.fragmentNode = ao().context( builder.getSharedContext() );
+			this._material.fragmentNode = ao().context( sharedContext );
 			this._material.needsUpdate = true;
 
 		};

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -1,4 +1,4 @@
-import { DataTexture, RenderTarget, RepeatWrapping, Vector2, Vector3, TempNode, QuadMesh, NodeMaterial, RendererUtils, RedFormat } from 'three/webgpu';
+import { DataTexture, RenderTarget, RepeatWrapping, Vector2, Vector3, Vector4, TempNode, QuadMesh, NodeMaterial, RendererUtils, RedFormat, WebGPUCoordinateSystem } from 'three/webgpu';
 import { reference, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getNormalFromDepth, getViewPosition, getScreenPositionFromClip, nodeObject, Fn, float, NodeUpdateType, uv, uniform, Loop, vec2, vec3, vec4, int, dot, max, min, pow, abs, If, textureSize, sin, cos, PI, texture, passTexture, mat3, add, normalize, cross, mix, acos, clamp, interleavedGradientNoise, screenCoordinate, rand } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
@@ -187,6 +187,14 @@ class GTAONode extends TempNode {
 		this._noiseNode = texture( generateMagicSquareNoise() );
 
 		/**
+		 * The camera the scene is rendered with.
+		 *
+		 * @private
+		 * @type {Camera}
+		 */
+		this._camera = camera;
+
+		/**
 		 * Represents the projection matrix of the scene's camera.
 		 *
 		 * @private
@@ -217,6 +225,24 @@ class GTAONode extends TempNode {
 		 * @type {ReferenceNode<float>}
 		 */
 		this._cameraFar = reference( 'far', 'float', camera );
+
+		/**
+		 * Sparse coefficients of the inverse projection matrix ( i00, i11, i30, i31 )
+		 * used to reconstruct view-space XY in the perspective fast path.
+		 *
+		 * @private
+		 * @type {UniformNode<vec4>}
+		 */
+		this._unprojectXY = uniform( new Vector4() );
+
+		/**
+		 * Sparse coefficients of the inverse projection matrix ( i23, i33 )
+		 * used to reconstruct the view-space perspective divisor.
+		 *
+		 * @private
+		 * @type {UniformNode<vec2>}
+		 */
+		this._unprojectW = uniform( new Vector2() );
 
 		/**
 		 * Temporal direction that influences the rotation angle for each slice.
@@ -316,6 +342,12 @@ class GTAONode extends TempNode {
 
 		}
 
+		// sparse inverse projection coefficients for the perspective fast path (column-major)
+
+		const e = this._camera.projectionMatrixInverse.elements;
+		this._unprojectXY.value.set( e[ 0 ], e[ 5 ], e[ 12 ], e[ 13 ] );
+		this._unprojectW.value.set( e[ 11 ], e[ 15 ] );
+
 		//
 
 		const size = renderer.getDrawingBufferSize( _size );
@@ -378,6 +410,35 @@ class GTAONode extends TempNode {
 
 		const sampleNoise = ( uv ) => this._noiseNode.sample( uv );
 		const sampleNormal = ( uv ) => ( this.normalNode !== null ) ? this.normalNode.sample( uv ).rgb.normalize() : getNormalFromDepth( uv, this.depthNode.value, this._cameraProjectionMatrixInverse );
+
+		// Reconstructs the view-space position of the scene surface at a clip-space sample position.
+		// For perspective cameras the inverse projection matrix is sparse and collapses to
+		//
+		// viewPos = vec3( ndc.x * i00 + i30, ndc.y * i11 + i31, -1 ) / ( ndc.z * i23 + i33 )
+		//
+		// which avoids a full mat4 unprojection per sample.
+
+		const sampleViewPosition = ( clipPosition ) => {
+
+			if ( this._camera.isPerspectiveCamera === true ) {
+
+				const ndcXY = clipPosition.xy.mul( clipPosition.w.reciprocal() ).toVar();
+				const sampleUv = vec2( ndcXY.x.mul( 0.5 ).add( 0.5 ), float( 0.5 ).sub( ndcXY.y.mul( 0.5 ) ) );
+				const depth = sampleDepth( sampleUv );
+
+				const ndcZ = ( builder.renderer.coordinateSystem === WebGPUCoordinateSystem ) ? depth : depth.mul( 2.0 ).sub( 1.0 );
+				const w = ndcZ.mul( this._unprojectW.x ).add( this._unprojectW.y );
+
+				return vec3( ndcXY.mul( this._unprojectXY.xy ).add( this._unprojectXY.zw ), - 1.0 ).mul( w.reciprocal() );
+
+			}
+
+			const screenPosition = getScreenPositionFromClip( clipPosition ).toVar();
+			const depth = sampleDepth( screenPosition ).toVar();
+
+			return getViewPosition( screenPosition, depth, this._cameraProjectionMatrixInverse );
+
+		};
 
 		const ao = Fn( () => {
 
@@ -455,9 +516,7 @@ class GTAONode extends TempNode {
 
 					// x
 
-					const sampleScreenPositionX = getScreenPositionFromClip( clipPosition.add( clipOffset ) ).toVar();
-					const sampleDepthX = sampleDepth( sampleScreenPositionX ).toVar();
-					const sampleSceneViewPositionX = getViewPosition( sampleScreenPositionX, sampleDepthX, this._cameraProjectionMatrixInverse ).toVar();
+					const sampleSceneViewPositionX = sampleViewPosition( clipPosition.add( clipOffset ) ).toVar();
 					const viewDeltaX = sampleSceneViewPositionX.sub( viewPosition ).toVar();
 					const lenX = viewDeltaX.length().toVar();
 
@@ -479,9 +538,7 @@ class GTAONode extends TempNode {
 
 					// y
 
-					const sampleScreenPositionY = getScreenPositionFromClip( clipPosition.sub( clipOffset ) ).toVar();
-					const sampleDepthY = sampleDepth( sampleScreenPositionY ).toVar();
-					const sampleSceneViewPositionY = getViewPosition( sampleScreenPositionY, sampleDepthY, this._cameraProjectionMatrixInverse ).toVar();
+					const sampleSceneViewPositionY = sampleViewPosition( clipPosition.sub( clipOffset ) ).toVar();
 					const viewDeltaY = sampleSceneViewPositionY.sub( viewPosition ).toVar();
 					const lenY = viewDeltaY.length().toVar();
 

--- a/examples/webgpu_postprocessing_ao.html
+++ b/examples/webgpu_postprocessing_ao.html
@@ -577,11 +577,11 @@
 
 			function updateParameters() {
 
-				aoPass.samples.value = params.samples;
 				aoPass.radius.value = params.radius;
 
 				if ( params.aoType === 'SSAO' ) {
 
+					aoPass.samples.value = params.samples;
 					aoPass.intensity.value = params.intensity;
 					aoPass.bias.value = params.bias;
 					aoPass.blurEnabled = params.blurEnabled;
@@ -589,6 +589,7 @@
 
 				} else {
 
+					aoPass.samples = params.samples;
 					aoPass.scale.value = params.scale;
 					aoPass.thickness.value = params.thickness;
 					aoPass.useTemporalFiltering = params.temporalFiltering;


### PR DESCRIPTION
**Description**

Asked Fable to look for performance optimizations and then made a commit for each.

@Mugen87 Feel free to take whatever you find worth it from here.

> Makes the GTAO pass about **1.3-1.4× faster** with no visible quality change:
> 
> - **Fewer per-sample divisions.** Divide the dot product by the delta length instead of normalizing the vec3, and replace per-sample divisions with hoisted reciprocal multiplies.
> - **Sparse perspective unproject.** Ray samples were reconstructed with a full `mat4` unprojection (~36× per pixel). For perspective cameras the inverse projection matrix is sparse, so this collapses to a few multiply-adds. Orthographic cameras keep the generic path.
> - **Baked sample count.** `samples` as a uniform kept the compiler from unrolling the horizon-search loops; the counts are now compile-time constants.
> 
> ### Performance
> 
> Apple Silicon / Metal, 1800×1200, AO pass isolated (same pipeline, AO update on vs frozen):
> 
> | Config | `dev` | this PR | speedup |
> | --- | --- | --- | --- |
> | 16 samples, full res | 10.20 ms | 7.46 ms | **1.38×** |
> | 32 samples, full res | 17.80 ms | 12.52 ms | **1.43×** |
> | 16 samples, half res (example) | 2.60 ms | 2.01 ms | **1.29×** |
> 
> ### Quality
> 
> AO output diffed against `dev` on both backends: the first two changes stay within 1-2/255 everywhere; the baked loop bounds flip isolated pixels at depth edges (max ~34/255 on 0.003% of pixels, no bias).
>
> ### API change
>
> `samples` is baked into the shader, so it is now a plain number property; assigning it rebuilds the material. `aoPass.samples.value = 16` → `aoPass.samples = 16`. Example updated; needs a migration guide entry. `SSAONode` has the same unroll blocker and could get the same treatment in a follow-up.