### PR TITLE
TSL: Support primitive values in `array()`

### DIFF
--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -429,7 +429,7 @@ class BloomNode extends TempNode {
 
 		// composite material
 
-		const bloomFactors = array( [ float( 1.0 ), float( 0.8 ), float( 0.6 ), float( 0.4 ), float( 0.2 ) ] );
+		const bloomFactors = array( [ 1.0, 0.8, 0.6, 0.4, 0.2 ] );
 		const bloomTintColors = uniformArray( this.bloomTintColors );
 
 		const compositePass = Fn( () => {
@@ -527,8 +527,8 @@ class BloomNode extends TempNode {
 		//
 
 		const colorTexture = texture( null );
-		const gaussianOffsets = array( offsets.map( ( value ) => float( value ) ) );
-		const gaussianWeights = array( weights.map( ( value ) => float( value ) ) );
+		const gaussianOffsets = array( offsets );
+		const gaussianWeights = array( weights );
 		const invSize = uniform( new Vector2() );
 		const direction = uniform( new Vector2( 0.5, 0.5 ) );
 
@@ -569,19 +569,12 @@ class BloomNode extends TempNode {
 
 }
 
-const lerpBloomFactor = Fn( ( [ factor, radius ] ) => {
+const lerpBloomFactor = Fn( ( { factor, radius } ) => {
 
 	const mirrorFactor = float( 1.2 ).sub( factor );
 	return mix( factor, mirrorFactor, radius );
 
-} ).setLayout( {
-	name: 'lerpBloomFactor',
-	type: 'float',
-	inputs: [
-		{ name: 'factor', type: 'float' },
-		{ name: 'radius', type: 'float' },
-	]
-} );
+}, { factor: 'float', radius: 'float', return: 'float' } );
 
 /**
  * TSL function for creating a bloom effect.

--- a/src/nodes/core/ArrayNode.js
+++ b/src/nodes/core/ArrayNode.js
@@ -154,7 +154,7 @@ export const array = ( ...params ) => {
 
 	if ( params.length === 1 ) {
 
-		const values = params[ 0 ];
+		const values = params[ 0 ].map( ( value ) => nodeObject( value ) );
 
 		node = new ArrayNode( null, values.length, values );
 
@@ -167,7 +167,7 @@ export const array = ( ...params ) => {
 
 	}
 
-	return nodeObject( node );
+	return node;
 
 };
 

--- a/src/renderers/common/QuadMesh.js
+++ b/src/renderers/common/QuadMesh.js
@@ -2,7 +2,7 @@ import { BufferGeometry } from '../../core/BufferGeometry.js';
 import { Float32BufferAttribute } from '../../core/BufferAttribute.js';
 import { Mesh } from '../../objects/Mesh.js';
 import { OrthographicCamera } from '../../cameras/OrthographicCamera.js';
-import { vec4, array, float } from '../../nodes/tsl/TSLBase.js';
+import { vec4, array } from '../../nodes/tsl/TSLBase.js';
 import { vertexIndex } from '../../nodes/core/IndexNode.js';
 import { warnOnce } from '../../utils.js';
 
@@ -39,8 +39,8 @@ class QuadGeometry extends BufferGeometry {
 const _geometry = /*@__PURE__*/ new QuadGeometry();
 
 const _vertexNode = /*@__PURE__*/ vec4(
-	array( [ float( - 1.0 ), float( - 1.0 ), float( 3.0 ) ] ).element( vertexIndex ),
-	array( [ float( 3.0 ), float( - 1.0 ), float( - 1.0 ) ] ).element( vertexIndex ),
+	array( [ - 1.0, - 1.0, 3.0 ] ).element( vertexIndex ),
+	array( [ 3.0, - 1.0, - 1.0 ] ).element( vertexIndex ),
 	0.0,
 	1.0
 );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33923#issuecomment-4860012751

**Description**

This PR improves the `array()` syntax by automatically map raw JavaScript values to `nodeObject()`. This eliminates the need to manually wrap every element in `float()` or other primitive values when instantiating arrays, making the code cleaner and more readable.