### PR TITLE
GTAONode: Bake sample count into the shader.

### DIFF
--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -1,5 +1,5 @@
 import { DataTexture, RenderTarget, RepeatWrapping, Vector2, Vector3, TempNode, QuadMesh, NodeMaterial, RendererUtils, RedFormat } from 'three/webgpu';
-import { reference, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getNormalFromDepth, getViewPosition, getScreenPositionFromClip, nodeObject, Fn, float, NodeUpdateType, uv, uniform, Loop, vec2, vec3, vec4, int, dot, max, min, pow, abs, If, textureSize, sin, cos, PI, texture, passTexture, mat3, add, normalize, cross, mix, acos, clamp, interleavedGradientNoise, screenCoordinate, rand } from 'three/tsl';
+import { reference, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getNormalFromDepth, getViewPosition, getScreenPositionFromClip, nodeObject, Fn, float, NodeUpdateType, uv, uniform, Loop, vec2, vec3, vec4, int, dot, max, min, pow, abs, If, textureSize, sin, cos, PI, texture, passTexture, mat3, normalize, cross, mix, acos, clamp, interleavedGradientNoise, screenCoordinate, rand } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -152,6 +152,8 @@ class GTAONode extends TempNode {
 		 * A higher value results in better quality but also
 		 * in a more expensive runtime behavior.
 		 *
+		 * Note: Changing this member triggers a shader recompilation.
+		 *
 		 * @type {UniformNode<float>}
 		 */
 		this.samples = uniform( 16 );
@@ -243,6 +245,32 @@ class GTAONode extends TempNode {
 		this._resolutionScale = uniform( 0 );
 
 		/**
+		 * The TSL function that computes the AO. Required for rebuild.
+		 *
+		 * @private
+		 * @type {?Function}
+		 * @default null
+		 */
+		this._ao = null;
+
+		/**
+		 * The sample count currently baked into the shader.
+		 *
+		 * @private
+		 * @type {number}
+		 */
+		this._currentSamples = - 1;
+
+		/**
+		 * The shared builder context.  Required for rebuild.
+		 *
+		 * @private
+		 * @type {?Object}
+		 * @default null
+		 */
+		this._sharedContext = null;
+
+		/**
 		 * The material that is used to render the effect.
 		 *
 		 * @private
@@ -316,6 +344,17 @@ class GTAONode extends TempNode {
 
 		}
 
+		// rebuild the material if the sample count has changed
+
+		if ( this.samples.value !== this._currentSamples ) {
+
+			this._currentSamples = this.samples.value;
+
+			this._material.fragmentNode = this._ao().context( this._sharedContext );
+			this._material.needsUpdate = true;
+
+		}
+
 		//
 
 		const size = renderer.getDrawingBufferSize( _size );
@@ -379,7 +418,7 @@ class GTAONode extends TempNode {
 		const sampleNoise = ( uv ) => this._noiseNode.sample( uv );
 		const sampleNormal = ( uv ) => ( this.normalNode !== null ) ? this.normalNode.sample( uv ).rgb.normalize() : getNormalFromDepth( uv, this.depthNode.value, this._cameraProjectionMatrixInverse );
 
-		const ao = Fn( () => {
+		this._ao = Fn( () => {
 
 			const depth = this._resolutionScale.lessThan( 1 ).select( sampleCenterDepth( uvNode ), sampleDepth( uvNode ) ).toConst();
 
@@ -403,9 +442,12 @@ class GTAONode extends TempNode {
 			const bitangent = vec3( tangent.y.mul( - 1.0 ), tangent.x, 0.0 );
 			const kernelMatrix = mat3( tangent, bitangent, vec3( 0.0, 0.0, 1.0 ) );
 
-			const DIRECTIONS = this.samples.lessThan( 30 ).select( 3, 5 ).toConst();
-			const STEPS = add( this.samples, DIRECTIONS.sub( 1 ) ).div( DIRECTIONS ).toConst();
-			const invSteps = STEPS.reciprocal().toConst();
+			// The sample count is baked into the shader so loop unrolling works
+
+			const SAMPLES = this.samples.value;
+			const DIRECTIONS = SAMPLES < 30 ? 3 : 5;
+			const STEPS = Math.ceil( SAMPLES / DIRECTIONS );
+			const invSteps = 1 / STEPS;
 
 			const ao = float( 0 ).toVar();
 
@@ -415,9 +457,9 @@ class GTAONode extends TempNode {
 			const noiseJitterIdx = this._temporalDirection.mul( 0.02 );
 			const stepJitter = interleavedGradientNoise( screenCoordinate.add( this._temporalOffset ) ).add( rand( uvNode.add( noiseJitterIdx ).mul( 2 ).sub( 1 ) ) );
 
-			Loop( { start: int( 0 ), end: DIRECTIONS, type: 'int', condition: '<' }, ( { i } ) => {
+			Loop( { start: int( 0 ), end: int( DIRECTIONS ), type: 'int', condition: '<' }, ( { i } ) => {
 
-				const angle = float( i ).div( float( DIRECTIONS ) ).mul( PI ).add( this._temporalDirection ).toConst();
+				const angle = float( i ).div( DIRECTIONS ).mul( PI ).add( this._temporalDirection ).toConst();
 				const sampleDir = kernelMatrix.mul( vec3( cos( angle ), sin( angle ), 0 ) ).toConst();
 				const clipDirRadius = this._cameraProjectionMatrix.mul( vec4( sampleDir, 0.0 ) ).mul( radius ).toConst();
 
@@ -443,7 +485,7 @@ class GTAONode extends TempNode {
 
 				// For each slice, the inner loop performs ray marching to find the horizons.
 
-				Loop( { end: STEPS, type: 'int', name: 'j', condition: '<' }, ( { j } ) => {
+				Loop( { end: int( STEPS ), type: 'int', name: 'j', condition: '<' }, ( { j } ) => {
 
 					// Quadratic step distribution ( sampleDist = t² ) concentrates samples in the
 					// near-field. (Blender's Eevee adaptation)
@@ -526,7 +568,10 @@ class GTAONode extends TempNode {
 
 		} );
 
-		this._material.fragmentNode = ao().context( builder.getSharedContext() );
+		this._sharedContext = builder.getSharedContext();
+		this._currentSamples = this.samples.value;
+
+		this._material.fragmentNode = this._ao().context( this._sharedContext );
 		this._material.needsUpdate = true;
 
 		//


### PR DESCRIPTION
Related issue: #33928

**Description**

Baking the samples count into the shader was a nice find in #33928. We should not treat such data as uniforms since this indeed makes a loop unroll impossible for the shader compiler.

When I understand this correctly, the changes of this PR do not necessarily _guarantee_ an unroll since that decision is done by the compiler. But we now ensure the _requirements_ for this process are met since baked values are known for the compiler (which is no true for uniforms). 

The PR implements this feature without any API changes.
