### PR TITLE
Inspector: Add `debounce()`.

### DIFF
--- a/examples/jsm/inspector/ui/Values.js
+++ b/examples/jsm/inspector/ui/Values.js
@@ -10,16 +10,20 @@ class Value extends EventDispatcher {
 		this.domElement.className = 'param-control';
 
 		this._onChangeFunction = null;
+		this._changeTimeout = null;
+		this._debounceTime = 0;
 
 		this.addEventListener( 'change', ( e ) => {
 
 			// defer to avoid issues when changing multiple values in the same call stack
 
-			requestAnimationFrame( () => {
+			clearTimeout( this._changeTimeout );
+
+			this._changeTimeout = setTimeout( () => {
 
 				if ( this._onChangeFunction ) this._onChangeFunction( e.value );
 
-			} );
+			}, this._debounceTime );
 
 		} );
 
@@ -48,6 +52,14 @@ class Value extends EventDispatcher {
 	onChange( callback ) {
 
 		this._onChangeFunction = callback;
+
+		return this;
+
+	}
+
+	debounce( time ) {
+
+		this._debounceTime = time;
 
 		return this;
 

--- a/examples/webgpu_lightprobes.html
+++ b/examples/webgpu_lightprobes.html
@@ -212,14 +212,11 @@
 
 				} );
 
-				let rebakeTimer = null;
 				gui.add( params, 'resolution', 2, 12, 1 ).name( 'Resolution' ).onChange( ( value ) => {
 
-					// Debounce so a slider drag rebakes once it settles, not every step.
-					if ( rebakeTimer !== null ) clearTimeout( rebakeTimer );
-					rebakeTimer = setTimeout( () => bake( value ), 250 );
+					bake( value );
 
-				} );
+				} ).debounce( 250 );
 				gui.add( params, 'showProbes' ).name( 'Show Probes' ).onChange( ( value ) => {
 
 					probesHelper.visible = value;

--- a/examples/webgpu_lightprobes_complex.html
+++ b/examples/webgpu_lightprobes_complex.html
@@ -364,14 +364,11 @@
 
 				} );
 
-				let rebakeTimer = null;
 				gui.add( params, 'resolution', 2, 12, 1 ).name( 'Resolution' ).onChange( ( value ) => {
 
-					// Debounce so a slider drag rebakes once it settles, not every step.
-					if ( rebakeTimer !== null ) clearTimeout( rebakeTimer );
-					rebakeTimer = setTimeout( () => bake( value ), 250 );
+					bake( value );
 
-				} );
+				} ).debounce( 250 );
 				gui.add( params, 'showProbes' ).name( 'Show Probes' ).onChange( ( value ) => {
 
 					probesHelperLeft.visible = value;

--- a/examples/webgpu_postprocessing_ao.html
+++ b/examples/webgpu_postprocessing_ao.html
@@ -538,7 +538,7 @@
 
 				} );
 				const resolutionScaleControl = gui.add( params, 'resolutionScale', 0, 1 ).name( 'resolution' ).onChange( updateParameters );
-				gui.add( params, 'samples', 4, 32, 1 ).onChange( updateParameters );
+				gui.add( params, 'samples', 4, 32, 1 ).onChange( updateParameters ).debounce( 250 );
 				gui.add( params, 'radius', 0.1, 1 ).onChange( updateParameters );
 
 				const gtaoControls = [


### PR DESCRIPTION
Related issue: -

**Description**

Sometimes UI input fields trigger larger tasks like a shader recompilation or a bake. To avoid stuttering when doing many subsequent modifications like when dragging a slider, the PR implements a simple `debounce()` helper. That fully resolves the issue e.g. in the AO and light probe grid demos:
 
For comparison:

PR: https://rawcdn.githack.com/mrdoob/three.js/21c63d43f71c703dbeef621cc2e64ad238e0325f/examples/webgpu_postprocessing_ao.html

dev: https://rawcdn.githack.com/mrdoob/three.js/59360338666f343485b5bf2fd37b546ad24713b8/examples/webgpu_postprocessing_ao.html

The light probe grid demos already use custom debounces which becomes obsolete with this PR.