### PR TITLE
Fix BezierInterpolant evaluating value with stale s powers

### DIFF
--- a/src/math/interpolants/BezierInterpolant.js
+++ b/src/math/interpolants/BezierInterpolant.js
@@ -92,6 +92,14 @@ class BezierInterpolant extends Interpolant {
 
 			}
 
+			// recompute the powers of s since the final Newton step may have updated it
+
+			s2 = s * s;
+			s3 = s2 * s;
+			oneMinusS = 1 - s;
+			oneMinusS2 = oneMinusS * oneMinusS;
+			oneMinusS3 = oneMinusS2 * oneMinusS;
+
 			// Evaluate Bezier Y(s)
 			result[ i ] = oneMinusS3 * v0 + 3 * oneMinusS2 * s * c0y + 3 * oneMinusS * s2 * c1y + s3 * v1;
 

--- a/test/unit/src/math/interpolants/BezierInterpolant.tests.js
+++ b/test/unit/src/math/interpolants/BezierInterpolant.tests.js
@@ -1,0 +1,107 @@
+import { BezierInterpolant } from '../../../../../src/math/interpolants/BezierInterpolant.js';
+
+import { Interpolant } from '../../../../../src/math/Interpolant.js';
+
+export default QUnit.module( 'Maths', () => {
+
+	QUnit.module( 'Interpolants', () => {
+
+		QUnit.module( 'BezierInterpolant', () => {
+
+			// INHERITANCE
+			QUnit.test( 'Extending', ( assert ) => {
+
+				const object = new BezierInterpolant( null, [ 1, 2 ], 1, [] );
+				assert.strictEqual(
+					object instanceof Interpolant, true,
+					'BezierInterpolant extends from Interpolant'
+				);
+
+			} );
+
+			// INSTANCING
+			QUnit.test( 'Instancing', ( assert ) => {
+
+				// parameterPositions, sampleValues, sampleSize, resultBuffer
+				const object = new BezierInterpolant( null, [ 1, 2 ], 1, [] );
+				assert.ok( object, 'Can instantiate a BezierInterpolant.' );
+
+			} );
+
+			// PRIVATE - TEMPLATE METHODS
+			QUnit.test( 'interpolate_', ( assert ) => {
+
+				// Two keyframes at t=0 (value v0) and t=1 (value v1) with COLLADA-style
+				// free tangent control points. The chosen X control points make Bx( s )
+				// non-monotone, so the Newton-Raphson solve does not converge within the
+				// fixed iteration budget and its last step updates s. The value must still
+				// be evaluated with the powers of that final s.
+
+				const t0 = 0, t1 = 1;
+				const v0 = - 3.9409040232346717, v1 = 2.5647222407848815;
+				const c0x = 0.31457929469714085, c0y = - 4.946690276064974;
+				const c1x = 1.6432901810391907, c1y = 4.793039761023614;
+
+				const interpolant = new BezierInterpolant(
+					[ t0, t1 ],
+					[ v0, v1 ],
+					1,
+					[]
+				);
+
+				interpolant.outTangents = [ c0x, c0y, 0, 0 ]; // out-tangent of keyframe 0 ( C0 )
+				interpolant.inTangents = [ 0, 0, c1x, c1y ]; // in-tangent of keyframe 1 ( C1 )
+
+				const t = 0.75;
+				const result = interpolant.interpolate_( 1, t0, t, t1 )[ 0 ];
+
+				// Reference: solve Bx( s ) = t, then evaluate By( s ) with that same s.
+
+				const bx = ( s ) => {
+
+					const o = 1 - s;
+					return o * o * o * t0 + 3 * o * o * s * c0x + 3 * o * s * s * c1x + s * s * s * t1;
+
+				};
+
+				const by = ( s ) => {
+
+					const o = 1 - s;
+					return o * o * o * v0 + 3 * o * o * s * c0y + 3 * o * s * s * c1y + s * s * s * v1;
+
+				};
+
+				const dbx = ( s ) => {
+
+					const o = 1 - s;
+					return 3 * o * o * ( c0x - t0 ) + 6 * o * s * ( c1x - c0x ) + 3 * s * s * ( t1 - c1x );
+
+				};
+
+				let s = ( t - t0 ) / ( t1 - t0 );
+
+				for ( let i = 0; i < 8; i ++ ) {
+
+					const error = bx( s ) - t;
+					if ( Math.abs( error ) < 1e-10 ) break;
+					const derivative = dbx( s );
+					if ( Math.abs( derivative ) < 1e-10 ) break;
+					s = s - error / derivative;
+					s = Math.max( 0, Math.min( 1, s ) );
+
+				}
+
+				const expected = by( s );
+
+				assert.ok(
+					Math.abs( result - expected ) < 1e-3,
+					'interpolate_ evaluates the value with the final solved parameter'
+				);
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -207,6 +207,7 @@ import './src/math/Vector3.tests.js';
 import './src/math/Vector4.tests.js';
 
 //src/math/interpolants
+import './src/math/interpolants/BezierInterpolant.tests.js';
 import './src/math/interpolants/CubicInterpolant.tests.js';
 import './src/math/interpolants/CustomInterpolant.tests.js';
 import './src/math/interpolants/DiscreteInterpolant.tests.js';


### PR DESCRIPTION
## Description

`BezierInterpolant.interpolate_()` evaluates the keyframe value with stale powers of the curve parameter `s`.

The method solves `Bx(s) = t` with Newton-Raphson, then evaluates `By(s)`. The `(1 - s)` and `s` power terms are computed once at the top of each Newton iteration, but the final iteration can update `s` (`s = s - error / derivative`, then clamp) after those powers were computed. `By(s)` at the end then mixes the fresh `s` with the stale powers, which is an inconsistent Bernstein polynomial.

When the X solve does not converge inside its fixed 8-iteration budget (free or steep tangents from COLLADA / Maya / glTF Bezier animation, which this interpolant is built for), the last step moves `s` and the value comes out grossly wrong.

## Reproduction

With free tangents that make `Bx(s)` non-monotone (so the solve does not converge), `interpolate_` returns about `-15.73` where the correct Bezier value is `2.62`. Reachable through the public path `KeyframeTrack` -> `AnimationMixer`.

## Fix

Recompute the five power terms from the final `s` before evaluating `Y(s)`. It is a no-op on the fast-converging path (the powers already correspond to the final `s`), so well-conditioned tangents are unchanged.

## Test

Added `BezierInterpolant.tests.js` (the file had no prior coverage) with a non-converging tangent case comparing `interpolate_` against a reference solve. It fails before the change and passes after; the full unit suite stays green.
