### PR TITLE
Renderer: Don't use MSAA for fullscreen-passes.

### DIFF
--- a/src/renderers/common/RenderContext.js
+++ b/src/renderers/common/RenderContext.js
@@ -231,6 +231,14 @@ class RenderContext {
 		this.camera = null;
 
 		/**
+		 * Whether a fullscreen pass is rendered or not.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.fullscreenPass = false;
+
+		/**
 		 * This flag can be used for type testing.
 		 *
 		 * @type {boolean}

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1719,6 +1719,7 @@ class Renderer {
 		renderContext.activeCubeFace = activeCubeFace;
 		renderContext.activeMipmapLevel = activeMipmapLevel;
 		renderContext.occlusionQueryCount = renderList.occlusionQueryCount;
+		renderContext.fullscreenPass = scene.isQuadMesh === true;
 
 		//
 
@@ -2489,8 +2490,8 @@ class Renderer {
 	 * The current number of samples used for multi-sample anti-aliasing (MSAA).
 	 *
 	 * When rendering to a custom render target, the number of samples of that render target is used.
-	 * If the renderer needs an internal framebuffer target for tone mapping or color space conversion,
-	 * the number of samples is set to 0.
+	 * The number of samples is set to 0 when the renderer needs an internal framebuffer target for
+	 * tone mapping or color space conversion, or when rendering a fullscreen quad to screen.
 	 *
 	 * @type {number}
 	 */
@@ -2502,7 +2503,7 @@ class Renderer {
 
 			samples = this._renderTarget.samples;
 
-		} else if ( this.needsFrameBufferTarget ) {
+		} else if ( this.needsFrameBufferTarget || this._currentRenderContext?.fullscreenPass === true ) {
 
 			samples = 0;
 


### PR DESCRIPTION
Related issue: #33935

**Description**

While investigating #33935, I have noticed all uses cases where `RenderePipeline` is used with MSAA, the final output pass in `RenderPipeline.render()` uses MSAA as well. 

That is a waste and we already avoid it for the internal color space/tone mapping pass which outputs to the canvas. The same must be done when using custom render pipelines. MSAA never makes sense when rendering fullscreen quads.

For reproduction: https://jsfiddle.net/ac24rkeg/1/

Just set a breakpoint in `Renderer.currentSamples` and see how `samples` ends up always `4` during the fullscreen quad pass.