### PR TITLE
Geometries: Delete the disposed geometry's own attributes.

### DIFF
--- a/src/renderers/common/Geometries.js
+++ b/src/renderers/common/Geometries.js
@@ -187,7 +187,6 @@ class Geometries extends DataMap {
 			this.info.memory.geometries --;
 
 			const index = geometry.index;
-			const geometryAttributes = renderObject.getAttributes();
 
 			if ( index !== null ) {
 
@@ -195,9 +194,15 @@ class Geometries extends DataMap {
 
 			}
 
-			for ( const geometryAttribute of geometryAttributes ) {
+			// Delete the disposed geometry's own attributes. They must not be read
+			// from the render object: if the 3D object was switched to another
+			// geometry before this dispose fires, the render object already reports
+			// the new geometry's attributes, and deleting those would destroy GPU
+			// buffers that are still in use (while leaking the disposed ones).
 
-				this.attributes.delete( geometryAttribute );
+			for ( const name of Object.keys( geometry.attributes ) ) {
+
+				this.attributes.delete( geometry.attributes[ name ] );
 
 			}
 

--- a/src/renderers/common/Geometries.js
+++ b/src/renderers/common/Geometries.js
@@ -186,6 +186,8 @@ class Geometries extends DataMap {
 
 			this.info.memory.geometries --;
 
+			// index
+
 			const index = geometry.index;
 
 			if ( index !== null ) {
@@ -194,17 +196,15 @@ class Geometries extends DataMap {
 
 			}
 
-			// Delete the disposed geometry's own attributes. They must not be read
-			// from the render object: if the 3D object was switched to another
-			// geometry before this dispose fires, the render object already reports
-			// the new geometry's attributes, and deleting those would destroy GPU
-			// buffers that are still in use (while leaking the disposed ones).
+			// geometry attributes
 
-			for ( const name of Object.keys( geometry.attributes ) ) {
+			for ( const attribute of Object.values( geometry.attributes ) ) {
 
-				this.attributes.delete( geometry.attributes[ name ] );
+				this.attributes.delete( attribute );
 
 			}
+
+			// wireframe attributes
 
 			const wireframeAttribute = this.wireframes.get( geometry );
 
@@ -213,6 +213,22 @@ class Geometries extends DataMap {
 				this.attributes.delete( wireframeAttribute );
 
 			}
+
+			// node attributes (TODO: Remove this bit once we support BufferAttribute.dispose())
+
+			const currentAttributes = new Set( Object.values( renderObject.geometry.attributes ) );
+
+			for ( const attribute of renderObject.getAttributes() ) {
+
+				if ( currentAttributes.has( attribute ) === false ) {
+
+					this.attributes.delete( attribute );
+
+				}
+
+			}
+
+			//
 
 			geometry.removeEventListener( 'dispose', onDispose );
 


### PR DESCRIPTION
### Problem

`Geometries.initGeometry()` registers a dispose listener that determines which attribute buffers to release by calling `renderObject.getAttributes()` **at dispose time**:

```js
const geometryAttributes = renderObject.getAttributes();
...
for ( const geometryAttribute of geometryAttributes ) {
    this.attributes.delete( geometryAttribute );
}
```

If the 3D object's geometry is exchanged before the old geometry is disposed — a common streaming pattern, and the default lifecycle in react-three-fiber (attach new geometry, then dispose the old one) — the render object already reports the **new** geometry's attributes. Disposing the old geometry then:

1. destroys the **live** geometry's GPU buffers (subsequent draws fail validation with `Vertex buffer slot N required by [RenderPipeline ...] was not set`, which invalidates the command buffer, so `Queue.Submit` rejects and the canvas freezes on WebGPU), and
2. never releases the disposed geometry's own buffers — a GPU memory leak that grows with every geometry exchange.

In an application that streams point clouds (rebuilds geometry per playback tick), we measured the leak and the validation spam directly with hooks on `GPUDevice.createBuffer` / `GPUBuffer.destroy`; after this fix, create/destroy accounting is balanced and the freeze no longer reproduces.

### Reproduction sketch

```js
const mesh = new THREE.Mesh( geometryA, material );
scene.add( mesh );
renderer.render( scene, camera );      // renderObject tracks geometryA

mesh.geometry = geometryB;
renderer.render( scene, camera );      // renderObject switches to geometryB

geometryA.dispose();                    // deletes geometryB's buffers, leaks geometryA's
renderer.render( scene, camera );
```

### Fix

The dispose listener now deletes the disposed geometry's **own** `geometry.attributes` (plus index and wireframe attribute, as before) instead of asking the render object, which may have moved on.

Related but distinct: #30398 / #30409 fixed the observer side of geometry exchange; this addresses the buffer-release side.
