### PR TITLE
Renderer: Clear inactive render lists.

### DIFF
--- a/src/renderers/common/RenderList.js
+++ b/src/renderers/common/RenderList.js
@@ -193,6 +193,14 @@ class RenderList {
 		this.occlusionQueryCount = 0;
 
 		/**
+		 * The ID of the frame the render list was last used in.
+		 *
+		 * @type {number}
+		 * @default -1
+		 */
+		this.frameId = - 1;
+
+		/**
 		 * The last object that was counted for occlusion query testing. Used to
 		 * avoid counting an object more than once when it produces multiple render
 		 * items (e.g. a mesh with multiple material groups), since such an object
@@ -420,21 +428,52 @@ class RenderList {
 
 			if ( renderItem.id === null ) break;
 
-			renderItem.id = null;
-			renderItem.object = null;
-			renderItem.geometry = null;
-			renderItem.material = null;
-			renderItem.groupOrder = null;
-			renderItem.renderOrder = null;
-			renderItem.z = null;
-			renderItem.group = null;
-			renderItem.clippingContext = null;
+			resetRenderItem( renderItem );
 
 		}
 
 		this._lastOcclusionObject = null;
 
 	}
+
+	/**
+	 * This method is called when the render list has become inactive.
+	 */
+	clear() {
+
+		// Clear all references from the render items so scene objects
+		// are not retained when the render list is not used anymore.
+
+		for ( let i = 0, il = this.renderItems.length; i < il; i ++ ) {
+
+			const renderItem = this.renderItems[ i ];
+
+			if ( renderItem.id === null ) break;
+
+			resetRenderItem( renderItem );
+
+		}
+
+		this.opaque.length = 0;
+		this.transparentDoublePass.length = 0;
+		this.transparent.length = 0;
+		this.bundles.length = 0;
+
+	}
+
+}
+
+function resetRenderItem( renderItem ) {
+
+	renderItem.id = null;
+	renderItem.object = null;
+	renderItem.geometry = null;
+	renderItem.material = null;
+	renderItem.groupOrder = null;
+	renderItem.renderOrder = null;
+	renderItem.z = null;
+	renderItem.group = null;
+	renderItem.clippingContext = null;
 
 }
 

--- a/src/renderers/common/RenderLists.js
+++ b/src/renderers/common/RenderLists.js
@@ -32,6 +32,23 @@ class RenderLists {
 		 */
 		this.lists = new ChainMap();
 
+		/**
+		 * The render lists which are currently in use. Lists are removed
+		 * as soon as they become stale.
+		 *
+		 * @private
+		 * @type {Set<RenderList>}
+		 */
+		this._activeLists = new Set();
+
+		/**
+		 * The current frame ID.
+		 *
+		 * @private
+		 * @type {number}
+		 */
+		this._frameId = - 1;
+
 	}
 
 	/**
@@ -60,7 +77,40 @@ class RenderLists {
 		_chainKeys[ 0 ] = null;
 		_chainKeys[ 1 ] = null;
 
+		//
+
+		list.frameId = this._frameId;
+		this._activeLists.add( list );
+
 		return list;
+
+	}
+
+	/**
+	 * Must be called when a new frame begins.
+	 *
+	 * @param {number} frameId - The current frame ID.
+	 */
+	update( frameId ) {
+
+		if ( frameId === this._frameId ) return;
+
+		this._frameId = frameId;
+
+		for ( const list of this._activeLists ) {
+
+			// if a render list has not been used within 10 frames, consider
+			// it as inactive and clear it
+
+			if ( frameId - list.frameId > 10 ) {
+
+				list.clear();
+
+				this._activeLists.delete( list );
+
+			}
+
+		}
 
 	}
 
@@ -70,6 +120,9 @@ class RenderLists {
 	dispose() {
 
 		this.lists = new ChainMap();
+
+		this._activeLists.clear();
+		this._frameId = - 1;
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1674,6 +1674,8 @@ class Renderer {
 
 		}
 
+		this._renderLists.update( nodeFrame.frameId );
+
 		const renderList = this._renderLists.get( scene, camera );
 		renderList.begin();
 


### PR DESCRIPTION
Fixed #33937.

**Description**

It turned out render lists can keep references to 3D objects, geometries and materials since there is no mechanism in the engine that detects "inactive" render lists. Inactive render lists can appear in difference scenarios e.g. in #33937.

The idea of this PR is to keep track of the frame ID a render lists was used last. If the render list has not been used for a period of time (I've picked 10 frames as a threshold), the list is cleared and removed from the set of "active render lists". 

The new `RenderList.clear()` is different compared to `finish()` because it clears _all_ render items in the list, not just the unused ones.

Because the entries in `_activeLists` are automatically cleared, it can't be the source of a memory leak.