### PR TITLE
Renderer: Fix operator-precedence bug.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -272,7 +272,7 @@ class Renderer {
 		 * @type {number}
 		 * @default 0
 		 */
-		this._samples = samples || ( antialias === true ) ? 4 : 0;
+		this._samples = samples || ( antialias === true ? 4 : 0 );
 
 		/**
 		 * OnCanvasTargetResize callback function.


### PR DESCRIPTION
Related issue: -

**Description**

The PR fixes a operator-precedence bug when evaluating the MSAA samples. The rule should be:

- Use `samples` if defined.
- Otherwise pick `4` or `0` depending on whether `antialias` is `true` or not.
