### PR TITLE
Renderers: honor renderOrder with reversed depth buffer.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1692,7 +1692,7 @@ class WebGLRenderer {
 
 			if ( _this.sortObjects === true ) {
 
-				currentRenderList.sort( _opaqueSort, _transparentSort, camera.reversedDepth );
+				currentRenderList.sort( _opaqueSort, _transparentSort );
 
 			}
 
@@ -1875,6 +1875,11 @@ class WebGLRenderer {
 							_vector4.setFromMatrixPosition( object.matrixWorld )
 								.applyMatrix4( _projScreenMatrix );
 
+							// with a reversed depth buffer the projected z is inverted; negate it so
+							// smaller z always means "closer" for render list sorting
+
+							if ( camera.reversedDepth === true ) _vector4.z = - _vector4.z;
+
 						}
 
 						const geometry = objects.update( object );
@@ -1912,6 +1917,8 @@ class WebGLRenderer {
 							_vector4
 								.applyMatrix4( object.matrixWorld )
 								.applyMatrix4( _projScreenMatrix );
+
+							if ( camera.reversedDepth === true ) _vector4.z = - _vector4.z;
 
 						}
 

--- a/src/renderers/common/RenderList.js
+++ b/src/renderers/common/RenderList.js
@@ -384,21 +384,12 @@ class RenderList {
 	 *
 	 * @param {?function(any, any): number} customOpaqueSort - A custom sort function for opaque objects.
 	 * @param {?function(any, any): number} customTransparentSort -  A custom sort function for transparent objects.
-	 * @param {boolean} reversedDepth - Whether a reversed depth buffer is used or not.
 	 */
-	sort( customOpaqueSort, customTransparentSort, reversedDepth ) {
+	sort( customOpaqueSort, customTransparentSort ) {
 
 		if ( this.opaque.length > 1 ) this.opaque.sort( customOpaqueSort || painterSortStable );
 		if ( this.transparentDoublePass.length > 1 ) this.transparentDoublePass.sort( customTransparentSort || reversePainterSortStable );
 		if ( this.transparent.length > 1 ) this.transparent.sort( customTransparentSort || reversePainterSortStable );
-
-		if ( reversedDepth ) {
-
-			this.opaque.reverse();
-			this.transparentDoublePass.reverse();
-			this.transparent.reverse();
-
-		}
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1683,7 +1683,7 @@ class Renderer {
 
 		if ( this.sortObjects === true ) {
 
-			renderList.sort( this._opaqueSort, this._transparentSort, camera.reversedDepth );
+			renderList.sort( this._opaqueSort, this._transparentSort );
 
 		}
 
@@ -3130,6 +3130,11 @@ class Renderer {
 
 						_vector4.setFromMatrixPosition( object.matrixWorld ).applyMatrix4( _projScreenMatrix );
 
+						// with a reversed depth buffer the projected z is inverted; negate it so
+						// smaller z always means "closer" for render list sorting
+
+						if ( camera.reversedDepth === true ) _vector4.z = - _vector4.z;
+
 					}
 
 					const { geometry, material } = object;
@@ -3162,6 +3167,8 @@ class Renderer {
 							.copy( geometry.boundingSphere.center )
 							.applyMatrix4( object.matrixWorld )
 							.applyMatrix4( _projScreenMatrix );
+
+						if ( camera.reversedDepth === true ) _vector4.z = - _vector4.z;
 
 					}
 

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -159,19 +159,11 @@ function WebGLRenderList() {
 
 	}
 
-	function sort( customOpaqueSort, customTransparentSort, reversedDepth ) {
+	function sort( customOpaqueSort, customTransparentSort ) {
 
 		if ( opaque.length > 1 ) opaque.sort( customOpaqueSort || painterSortStable );
 		if ( transmissive.length > 1 ) transmissive.sort( customTransparentSort || reversePainterSortStable );
 		if ( transparent.length > 1 ) transparent.sort( customTransparentSort || reversePainterSortStable );
-
-		if ( reversedDepth ) {
-
-			opaque.reverse();
-			transmissive.reverse();
-			transparent.reverse();
-
-		}
 
 	}
 


### PR DESCRIPTION
Related issue: Fixed #33944

**Description**

Since #33700, `RenderList.sort()` (and `WebGLRenderList.sort()`) reverse the fully sorted render lists when a reversed depth buffer is used. The reversal corrects the z direction, but since the painter sorts compare `groupOrder` → `renderOrder` → `z` → `id`, it also inverts `groupOrder`/`renderOrder` — `renderOrder` is applied exactly backwards (see #33944 for a live example) — and silently reverses the result of custom comparators installed via `setOpaqueSort()` / `setTransparentSort()`.

This PR normalizes the sort key at its source instead: `projectObject()` negates the projected z when `camera.reversedDepth` is set, so "smaller z = closer" always holds for render list sorting, and the `reverse()` calls are removed. This keeps the intent of #33700 — opaque stays front-to-back, transparent stays back-to-front under reversed depth — while `groupOrder`/`renderOrder` precedence and custom sort semantics are preserved. `renderItem.z` is only used for sorting, so negating it has no other effect.

Applied to both renderers (`common/Renderer.js` + `common/RenderList.js`, `WebGLRenderer.js` + `webgl/WebGLRenderLists.js`). Unit tests pass.
