### PR TITLE
WebGPURenderer: Honor resolve flags in WebGPU backend.

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -900,6 +900,8 @@ class WebGPUBackend extends Backend {
 
 		//
 
+		const renderTarget = renderContext.renderTarget;
+
 		if ( renderContext.depth ) {
 
 			if ( renderContext.clearDepth ) {
@@ -913,7 +915,15 @@ class WebGPUBackend extends Backend {
 
 			}
 
-			depthStencilAttachment.depthStoreOp = GPUStoreOp.Store;
+			if ( renderContext.sampleCount > 1 && renderTarget?.resolveDepthBuffer === false ) {
+
+				depthStencilAttachment.depthStoreOp = GPUStoreOp.Discard;
+
+			} else {
+
+				depthStencilAttachment.depthStoreOp = GPUStoreOp.Store;
+
+			}
 
 		}
 
@@ -930,7 +940,15 @@ class WebGPUBackend extends Backend {
 
 			}
 
-			depthStencilAttachment.stencilStoreOp = GPUStoreOp.Store;
+			if ( renderContext.sampleCount > 1 && renderTarget?.resolveStencilBuffer === false ) {
+
+				depthStencilAttachment.stencilStoreOp = GPUStoreOp.Discard;
+
+			} else {
+
+				depthStencilAttachment.stencilStoreOp = GPUStoreOp.Store;
+
+			}
 
 		}
 


### PR DESCRIPTION
Related issue: - 

**Description**

The PR makes sure the render target flags `resolveDepthBuffer` and `resolveStencilBuffer` are honored in the WebGPU backend as well.

To clarify, both flags control "resolve + discard" in WebGL. In WebGPU, it's not possible to resolve depth/stencil so the flags are only used for the "discard".

The current resolve flags are not ideally implemented since they mix the concepts of storage and resolve. I'm trying to think about a better solution for both renderers. My current plan is: Flags that control how multisampled data should be stored (store vs discard). And then separate flags that only control the resolve/blit operation.