### PR TITLE
Renderers: Refactor sort key negate.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1875,11 +1875,6 @@ class WebGLRenderer {
 							_vector4.setFromMatrixPosition( object.matrixWorld )
 								.applyMatrix4( _projScreenMatrix );
 
-							// with a reversed depth buffer the projected z is inverted; negate it so
-							// smaller z always means "closer" for render list sorting
-
-							if ( camera.reversedDepth === true ) _vector4.z = - _vector4.z;
-
 						}
 
 						const geometry = objects.update( object );
@@ -1887,7 +1882,7 @@ class WebGLRenderer {
 
 						if ( material.visible ) {
 
-							currentRenderList.push( object, geometry, material, groupOrder, _vector4.z, null );
+							currentRenderList.push( object, geometry, material, groupOrder, _vector4.z, null, camera );
 
 						}
 
@@ -1918,8 +1913,6 @@ class WebGLRenderer {
 								.applyMatrix4( object.matrixWorld )
 								.applyMatrix4( _projScreenMatrix );
 
-							if ( camera.reversedDepth === true ) _vector4.z = - _vector4.z;
-
 						}
 
 						if ( Array.isArray( material ) ) {
@@ -1933,7 +1926,7 @@ class WebGLRenderer {
 
 								if ( groupMaterial && groupMaterial.visible ) {
 
-									currentRenderList.push( object, geometry, groupMaterial, groupOrder, _vector4.z, group );
+									currentRenderList.push( object, geometry, groupMaterial, groupOrder, _vector4.z, group, camera );
 
 								}
 
@@ -1941,7 +1934,7 @@ class WebGLRenderer {
 
 						} else if ( material.visible ) {
 
-							currentRenderList.push( object, geometry, material, groupOrder, _vector4.z, null );
+							currentRenderList.push( object, geometry, material, groupOrder, _vector4.z, null, camera );
 
 						}
 

--- a/src/renderers/common/RenderList.js
+++ b/src/renderers/common/RenderList.js
@@ -300,6 +300,10 @@ class RenderList {
 	 */
 	push( object, geometry, material, groupOrder, z, group, clippingContext ) {
 
+		// with a reversed depth buffer the projected z is inverted
+
+		if ( this.camera.reversedDepth === true ) z = - z;
+
 		const renderItem = this.getNextRenderItem( object, geometry, material, groupOrder, z, group, clippingContext );
 
 		if ( object.occlusionTest === true && this._lastOcclusionObject !== object ) {

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -3145,11 +3145,6 @@ class Renderer {
 
 						_vector4.setFromMatrixPosition( object.matrixWorld ).applyMatrix4( _projScreenMatrix );
 
-						// with a reversed depth buffer the projected z is inverted; negate it so
-						// smaller z always means "closer" for render list sorting
-
-						if ( camera.reversedDepth === true ) _vector4.z = - _vector4.z;
-
 					}
 
 					const { geometry, material } = object;
@@ -3182,8 +3177,6 @@ class Renderer {
 							.copy( geometry.boundingSphere.center )
 							.applyMatrix4( object.matrixWorld )
 							.applyMatrix4( _projScreenMatrix );
-
-						if ( camera.reversedDepth === true ) _vector4.z = - _vector4.z;
 
 					}
 

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -119,7 +119,11 @@ function WebGLRenderList() {
 
 	}
 
-	function push( object, geometry, material, groupOrder, z, group ) {
+	function push( object, geometry, material, groupOrder, z, group, camera ) {
+
+		// with a reversed depth buffer the projected z is inverted
+
+		if ( camera.reversedDepth === true ) z = - z;
 
 		const renderItem = getNextRenderItem( object, geometry, material, groupOrder, z, group );
 

--- a/test/unit/src/renderers/webgl/WebGLRenderLists.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLRenderLists.tests.js
@@ -1,5 +1,6 @@
 import { WebGLRenderLists, WebGLRenderList } from '../../../../../src/renderers/webgl/WebGLRenderLists.js';
 import { Scene } from '../../../../../src/scenes/Scene.js';
+import { Camera } from '../../../../../src/cameras/Camera.js';
 
 export default QUnit.module( 'Renderers', () => {
 
@@ -30,12 +31,13 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'init', ( assert ) => {
 
 				const list = new WebGLRenderList();
+				const camera = new Camera();
 
 				assert.ok( list.transparent.length === 0, 'Transparent list defaults to length 0.' );
 				assert.ok( list.opaque.length === 0, 'Opaque list defaults to length 0.' );
 
-				list.push( {}, {}, { transparent: true }, 0, 0, {} );
-				list.push( {}, {}, { transparent: false }, 0, 0, {} );
+				list.push( {}, {}, { transparent: true }, 0, 0, {}, camera );
+				list.push( {}, {}, { transparent: false }, 0, 0, {}, camera );
 
 				assert.ok( list.transparent.length === 1, 'Transparent list is length 1 after adding transparent item.' );
 				assert.ok( list.opaque.length === 1, 'Opaque list is length 1 after adding opaque item.' );
@@ -50,6 +52,8 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'push', ( assert ) => {
 
 				const list = new WebGLRenderList();
+				const camera = new Camera();
+
 				const objA = { id: 'A', renderOrder: 0 };
 				const matA = { transparent: true };
 				const geoA = {};
@@ -66,7 +70,7 @@ export default QUnit.module( 'Renderers', () => {
 				const matD = { transparent: false };
 				const geoD = {};
 
-				list.push( objA, geoA, matA, 0, 0.5, {} );
+				list.push( objA, geoA, matA, 0, 0.5, {}, camera );
 				assert.ok( list.transparent.length === 1, 'Transparent list is length 1 after adding transparent item.' );
 				assert.ok( list.opaque.length === 0, 'Opaque list is length 0 after adding transparent item.' );
 				assert.deepEqual(
@@ -85,7 +89,7 @@ export default QUnit.module( 'Renderers', () => {
 					'The first transparent render list item is structured correctly.'
 				);
 
-				list.push( objB, geoB, matB, 1, 1.5, {} );
+				list.push( objB, geoB, matB, 1, 1.5, {}, camera );
 				assert.ok( list.transparent.length === 2, 'Transparent list is length 2 after adding second transparent item.' );
 				assert.ok( list.opaque.length === 0, 'Opaque list is length 0 after adding second transparent item.' );
 				assert.deepEqual(
@@ -104,7 +108,7 @@ export default QUnit.module( 'Renderers', () => {
 					'The second transparent render list item is structured correctly.'
 				);
 
-				list.push( objC, geoC, matC, 2, 2.5, {} );
+				list.push( objC, geoC, matC, 2, 2.5, {}, camera );
 				assert.ok( list.transparent.length === 2, 'Transparent list is length 2 after adding first opaque item.' );
 				assert.ok( list.opaque.length === 1, 'Opaque list is length 1 after adding first opaque item.' );
 				assert.deepEqual(
@@ -123,7 +127,7 @@ export default QUnit.module( 'Renderers', () => {
 					'The first opaque render list item is structured correctly.'
 				);
 
-				list.push( objD, geoD, matD, 3, 3.5, {} );
+				list.push( objD, geoD, matD, 3, 3.5, {}, camera );
 				assert.ok( list.transparent.length === 2, 'Transparent list is length 2 after adding second opaque item.' );
 				assert.ok( list.opaque.length === 2, 'Opaque list is length 2 after adding second opaque item.' );
 				assert.deepEqual(
@@ -245,12 +249,14 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'sort', ( assert ) => {
 
 				const list = new WebGLRenderList();
+				const camera = new Camera();
+
 				const items = [ { id: 4 }, { id: 5 }, { id: 2 }, { id: 3 } ];
 
 				items.forEach( item => {
 
-					list.push( item, {}, { transparent: true }, 0, 0, {} );
-					list.push( item, {}, { transparent: false }, 0, 0, {} );
+					list.push( item, {}, { transparent: true }, 0, 0, {}, camera );
+					list.push( item, {}, { transparent: false }, 0, 0, {}, camera );
 
 				} );
 


### PR DESCRIPTION
Related issue: #33945

**Description**

Follow-up of #33945. It's better if we move the sort key modifications for reversed depth buffer into the render lists as before.
