### PR TITLE
Bindings: Remove cached bind groups in `_destroyBindings()`.

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -273,6 +273,9 @@ class Bindings extends DataMap {
 
 						}
 
+						const textureData = this.textures.get( binding.texture );
+						if ( textureData.bindGroups !== undefined ) textureData.bindGroups.delete( bindGroup );
+
 						binding.release();
 
 					}


### PR DESCRIPTION
Fixed #33952.

**Description**

The PR makes sure to when bindings are destroyed, bind groups are removed from the cache that connects a texture with bindings using it. This cache has been introduced via #33011 and we must make sure to honor it not just during a texture disposal but also when bindings are destroyed.