### PR TITLE
UniformArrayNode: Fix `update()` overwrite.

### DIFF
--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -186,13 +186,38 @@ class UniformArrayNode extends BufferNode {
 
 	}
 
-	/**
-	 * The update makes sure to correctly transfer the data from the (complex) objects
-	 * in the array to the internal, correctly padded value buffer.
-	 *
-	 * @param {NodeFrame} frame - A reference to the current node frame.
-	 */
 	update( /*frame*/ ) {
+
+		this.updateBuffer();
+
+	}
+
+	/**
+	 * Composes a user-defined update with the buffer transfer.
+	 *
+	 * @param {Function} callback - The update function.
+	 * @param {string} updateType - The update type.
+	 * @return {UniformArrayNode} A reference to this node.
+	 */
+	onUpdate( callback, updateType ) {
+
+		callback = callback.bind( this );
+
+		return super.onUpdate( ( frame, self ) => {
+
+			callback( frame, self );
+
+			this.updateBuffer();
+
+		}, updateType );
+
+	}
+
+	/**
+	 * The method makes sure to correctly transfer the data from the (complex) objects
+	 * in the array to the internal, correctly padded value buffer.
+	 */
+	updateBuffer() {
 
 		const { array, value } = this;
 
@@ -315,7 +340,7 @@ class UniformArrayNode extends BufferNode {
 		this.bufferCount = length;
 		this.bufferType = paddedType;
 
-		this.update(); // initialize the buffer values
+		this.updateBuffer(); // initialize the buffer values
 
 		return super.setup( builder );
 


### PR DESCRIPTION
Fixed #33957.

**Description**

#31615 introduces a subtle issue. When using `onRenderUpdate()` on an instance of `UniformArrayNode`, it overwrites the existing `update()` method which is responsible for the data transfer to the internal buffer. This causes two bugs:

- The data are not updated anymore.
- `setup()` throws since it calls a different `update()` (the one of `onRenderUpdate()`). This causes the runtime error from `#33957` since the new callback is called without the `frame` parameter.

The fix is easy:

- Moving the buffer update into a new method `updateBuffer()` and use it in `setup()` and `update()`.
- Apply the same approach from `UniformNode` and compose the internal update logic with the user defined one. This is done by overwriting `onUpdate()`. 