### PR TITLE
ShadowNode: Fix `WeakMap` usage.

### DIFF
--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -860,13 +860,13 @@ class ShadowNode extends ShadowBaseNode {
 
 		if ( needsUpdate ) {
 
-			if ( this._cameraFrameId[ frame.camera ] === frame.frameId ) {
+			if ( this._cameraFrameId.get( frame.camera ) === frame.frameId ) {
 
 				needsUpdate = false;
 
 			}
 
-			this._cameraFrameId[ frame.camera ] = frame.frameId;
+			this._cameraFrameId.set( frame.camera, frame.frameId );
 
 		}
 


### PR DESCRIPTION
Fixed #33963.

**Description**

In `ShadowNode`, the cache `_cameraFrameId` is `WeakMap` but it is treated like an object in `updateBefore()`. The PR fixes that by using the intended `WeakMap` interface.
