### PR TITLE
Inspector: resolve bare three imports in TSL graph loader

### DIFF
--- a/examples/jsm/inspector/extensions/tsl-graph/TSLGraphLoader.js
+++ b/examples/jsm/inspector/extensions/tsl-graph/TSLGraphLoader.js
@@ -4,6 +4,7 @@ import * as THREE from 'three';
 import * as TSL from 'three/tsl';
 
 const _library = {
+	'three': { ...THREE },
 	'three/tsl': { ...TSL }
 };
 


### PR DESCRIPTION
Fixed [33968](https://github.com/mrdoob/three.js/issues/33968)

Description: 

Adds bare `three` import support to the TSL graph loader in the inspector.

This fixes inspector-side TSL graph imports when exported helpers rely on named `three` imports such as `Color`, `Vector2`, or `Vector3`. Previously, the loader only resolved `three/tsl`, which caused errors.

Change:
- register `'three': { ...THREE }` in `TSLGraphLoader` alongside the existing `three/tsl` mapping

[Live Demo](https://raw.githack.com/bhushan6/three.js/bcfe279/examples/webgpu_tsl_graph.html):
