### PR TITLE
WebGPUBackend - Fix type of _getDefaultRenderPassDescriptor

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -430,12 +430,12 @@ class WebGPUBackend extends Backend {
 	 * pass descriptor even when rendering directly to screen.
 	 *
 	 * @private
-	 * @return {Object} The render pass descriptor.
+	 * @return {GPURenderPassDescriptor} The render pass descriptor.
 	 */
 	_getDefaultRenderPassDescriptor() {
 
 		const renderer = this.renderer;
-		const canvasTarget = renderer.getCanvasTarget();
+		const canvasTarget = /** @type {CanvasTarget} */ ( renderer.getCanvasTarget() );
 		const canvasData = this.get( canvasTarget );
 		const samples = renderer.currentSamples;
 
@@ -2405,6 +2405,7 @@ class WebGPUBackend extends Backend {
 
 		renderContextData.currentSets = renderContextData._currentSets;
 		renderContextData.currentPass = renderContextData._currentPass;
+		renderContextData._currentPass = null;
 
 	}
 
@@ -2923,6 +2924,68 @@ class WebGPUBackend extends Backend {
 			this.device.destroy();
 
 		}
+
+	}
+
+
+	/**
+	 * Backend data associated with a render context.
+	 *
+	 * @typedef {Object} WebGPURenderContextData
+	 * @property {GPUCommandEncoder} [encoder] - The command encoder the render context's passes are recorded into.
+	 * @property {GPURenderPassEncoder | GPURenderBundleEncoder} [currentPass] - The active render pass encoder or render bundle pass encoder associated with the provided render context.
+	 * @property {GPURenderPassDescriptor} [descriptor] - The render pass descriptor used to create the render context's current render pass encoder.
+	 * @property {{attributes: BufferAttribute[], bindingGroups: Array, pipeline: ?GPURenderPipeline, index: ?BufferAttribute}} [currentSets] - State already set on the current render pass encoder, tracked to avoid redundant calls.
+	 * @property {GPURenderPassEncoder} [_currentPass] Stash of the render pass encoder while a bundle encoder temporarily takes its place. Can be checked against as a pseudo-flag for whether the current pass encoder is a bundle encoder.
+	 * @property {Object} [_currentSets] - Stash of the state of a render pass encoder whose place is temporarily taken by a bundle encoder.
+	 * @property {Array<GPURenderBundle>} [renderBundles] - An array of render bundles to execute on the current render pass encoder in finishRender().
+	 * @property {number} [currentStencilRef] - The stencil reference value set on the current render pass encoder.
+	 * @property {GPUQuerySet} [occlusionQuerySet] - The query set for occlusion queries of the current frame.
+	 * @property {number} [occlusionQueryIndex] - The index of the next occlusion query.
+	 * @property {Array<Object3D>} [occlusionQueryObjects] - The 3D objects an occlusion query has been issued for.
+	 * @property {GPUBuffer} [occlusionQueryBuffer] - The buffer occlusion query results are copied into for read-back.
+	 * @property {?Object3D} [lastOcclusionObject] - The last 3D object an occlusion query state change was evaluated for.
+	 * @property {GPUQuerySet} [currentOcclusionQuerySet] - The previous frame's query set, kept alive until its results are resolved.
+	 * @property {GPUBuffer} [currentOcclusionQueryBuffer] - The previous frame's result buffer, currently being mapped.
+	 * @property {Array<Object3D>} [currentOcclusionQueryObjects] - The previous frame's query objects.
+	 * @property {WeakSet<Object3D>} [occluded] - The 3D objects determined occluded by the last resolved queries.
+	 * @property {Array<Object>} [layerDescriptors] - Per-layer render pass descriptors for layered (array camera) render targets.
+	 * @property {Array<GPURenderBundleEncoder>} [bundleEncoders] - Per-camera bundle encoders for layered render targets.
+	 * @property {Array<Object>} [bundleSets] - Per-camera state tracking for the bundle encoders.
+	 */
+
+	/**
+	 * Backend data associated with a render target.
+	 *
+	 * All properties are created lazily, so any of them can be `undefined` before
+	 * the corresponding code path has run.
+	 *
+	 * @typedef {Object} WebGPURenderTargetData
+	 * @property {GPURenderPassDescriptor} [descriptor] - Cached render pass descriptor of the current render context's render pass encoder.
+	 * @property {GPUCanvasContext} [context] - The WebGPU rendering context of a <canvas> element.
+	 * @property {number} [samples] - The current number of samples used for multi-sample anti-aliasing (MSAA).
+	 */
+
+	/**
+	 * Returns the backend-specific data dictionary of the given object.
+	 *
+	 * @overload
+	 * @param {RenderTarget} object - The render target.
+	 * @return {WebGPURenderTargetData} The render target data.
+	 */
+	/**
+	 * @overload
+	 * @param {RenderContext} object - The render context.
+	 * @return {WebGPURenderContextData} The render context data.
+	 */
+	/**
+	 * @overload
+	 * @param {Object} object - The object.
+	 * @return {Object} The object's data dictionary.
+	 */
+	get( object ) {
+
+		return super.get( object );
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -435,7 +435,7 @@ class WebGPUBackend extends Backend {
 	_getDefaultRenderPassDescriptor() {
 
 		const renderer = this.renderer;
-		const canvasTarget = /** @type {CanvasTarget} */ ( renderer.getCanvasTarget() );
+		const canvasTarget = renderer.getCanvasTarget();
 		const canvasData = this.get( canvasTarget );
 		const samples = renderer.currentSamples;
 
@@ -2946,7 +2946,7 @@ class WebGPUBackend extends Backend {
 	 * @property {GPUBuffer} [occlusionQueryBuffer] - The buffer occlusion query results are copied into for read-back.
 	 * @property {?Object3D} [lastOcclusionObject] - The last 3D object an occlusion query state change was evaluated for.
 	 * @property {GPUQuerySet} [currentOcclusionQuerySet] - The previous frame's query set, kept alive until its results are resolved.
-	 * @property {GPUBuffer} [currentOcclusionQueryBuffer] - The previous frame's result buffer, currently being mapped.
+	 * @property {GPUBuffer} [currentOcclusionQueryBuffer] - The previous frame's result buffer, reset in beginRender() and replaced with the read data from the last frame's query set.
 	 * @property {Array<Object3D>} [currentOcclusionQueryObjects] - The previous frame's query objects.
 	 * @property {WeakSet<Object3D>} [occluded] - The 3D objects determined occluded by the last resolved queries.
 	 * @property {Array<Object>} [layerDescriptors] - Per-layer render pass descriptors for layered (array camera) render targets.
@@ -2955,12 +2955,9 @@ class WebGPUBackend extends Backend {
 	 */
 
 	/**
-	 * Backend data associated with a render target.
+	 * Backend data associated with a canvas target.
 	 *
-	 * All properties are created lazily, so any of them can be `undefined` before
-	 * the corresponding code path has run.
-	 *
-	 * @typedef {Object} WebGPURenderTargetData
+	 * @typedef {Object} WebGPUCanvasTargetData
 	 * @property {GPURenderPassDescriptor} [descriptor] - Cached render pass descriptor of the current render context's render pass encoder.
 	 * @property {GPUCanvasContext} [context] - The WebGPU rendering context of a <canvas> element.
 	 * @property {number} [samples] - The current number of samples used for multi-sample anti-aliasing (MSAA).
@@ -2970,8 +2967,8 @@ class WebGPUBackend extends Backend {
 	 * Returns the backend-specific data dictionary of the given object.
 	 *
 	 * @overload
-	 * @param {RenderTarget} object - The render target.
-	 * @return {WebGPURenderTargetData} The render target data.
+	 * @param {CanvasTarget} object - The canvas target.
+	 * @return {WebGPUCanvasTargetData} The render target data.
 	 */
 	/**
 	 * @overload

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2928,65 +2928,6 @@ class WebGPUBackend extends Backend {
 
 	}
 
-
-	/**
-	 * Backend data associated with a render context.
-	 *
-	 * @typedef {Object} WebGPURenderContextData
-	 * @property {GPUCommandEncoder} [encoder] - The command encoder the render context's passes are recorded into.
-	 * @property {GPURenderPassEncoder | GPURenderBundleEncoder} [currentPass] - The active render pass encoder or render bundle pass encoder associated with the provided render context.
-	 * @property {GPURenderPassDescriptor} [descriptor] - The render pass descriptor used to create the render context's current render pass encoder.
-	 * @property {{attributes: BufferAttribute[], bindingGroups: Array, pipeline: ?GPURenderPipeline, index: ?BufferAttribute}} [currentSets] - State already set on the current render pass encoder, tracked to avoid redundant calls.
-	 * @property {GPURenderPassEncoder} [_currentPass] Stash of the render pass encoder while a bundle encoder temporarily takes its place. Can be checked against as a pseudo-flag for whether the current pass encoder is a bundle encoder.
-	 * @property {Object} [_currentSets] - Stash of the state of a render pass encoder whose place is temporarily taken by a bundle encoder.
-	 * @property {Array<GPURenderBundle>} [renderBundles] - An array of render bundles to execute on the current render pass encoder in finishRender().
-	 * @property {number} [currentStencilRef] - The stencil reference value set on the current render pass encoder.
-	 * @property {GPUQuerySet} [occlusionQuerySet] - The query set for occlusion queries of the current frame.
-	 * @property {number} [occlusionQueryIndex] - The index of the next occlusion query.
-	 * @property {Array<Object3D>} [occlusionQueryObjects] - The 3D objects an occlusion query has been issued for.
-	 * @property {GPUBuffer} [occlusionQueryBuffer] - The buffer occlusion query results are copied into for read-back.
-	 * @property {?Object3D} [lastOcclusionObject] - The last 3D object an occlusion query state change was evaluated for.
-	 * @property {GPUQuerySet} [currentOcclusionQuerySet] - The previous frame's query set, kept alive until its results are resolved.
-	 * @property {GPUBuffer} [currentOcclusionQueryBuffer] - The previous frame's result buffer, reset in beginRender() and replaced with the read data from the last frame's query set.
-	 * @property {Array<Object3D>} [currentOcclusionQueryObjects] - The previous frame's query objects.
-	 * @property {WeakSet<Object3D>} [occluded] - The 3D objects determined occluded by the last resolved queries.
-	 * @property {Array<Object>} [layerDescriptors] - Per-layer render pass descriptors for layered (array camera) render targets.
-	 * @property {Array<GPURenderBundleEncoder>} [bundleEncoders] - Per-camera bundle encoders for layered render targets.
-	 * @property {Array<Object>} [bundleSets] - Per-camera state tracking for the bundle encoders.
-	 */
-
-	/**
-	 * Backend data associated with a canvas target.
-	 *
-	 * @typedef {Object} WebGPUCanvasTargetData
-	 * @property {GPURenderPassDescriptor} [descriptor] - Cached render pass descriptor of the current render context's render pass encoder.
-	 * @property {GPUCanvasContext} [context] - The WebGPU rendering context of a <canvas> element.
-	 * @property {number} [samples] - The current number of samples used for multi-sample anti-aliasing (MSAA).
-	 */
-
-	/**
-	 * Returns the backend-specific data dictionary of the given object.
-	 *
-	 * @overload
-	 * @param {CanvasTarget} object - The canvas target.
-	 * @return {WebGPUCanvasTargetData} The render target data.
-	 */
-	/**
-	 * @overload
-	 * @param {RenderContext} object - The render context.
-	 * @return {WebGPURenderContextData} The render context data.
-	 */
-	/**
-	 * @overload
-	 * @param {Object} object - The object.
-	 * @return {Object} The object's data dictionary.
-	 */
-	get( object ) {
-
-		return super.get( object );
-
-	}
-
 }
 
 export default WebGPUBackend;

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -435,7 +435,7 @@ class WebGPUBackend extends Backend {
 	_getDefaultRenderPassDescriptor() {
 
 		const renderer = this.renderer;
-		const canvasTarget = /** @type {CanvasTarget} */ ( renderer.getCanvasTarget() );
+		const canvasTarget = renderer.getCanvasTarget();
 		const canvasData = this.get( canvasTarget );
 		const samples = renderer.currentSamples;
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2946,7 +2946,7 @@ class WebGPUBackend extends Backend {
 	 * @property {GPUBuffer} [occlusionQueryBuffer] - The buffer occlusion query results are copied into for read-back.
 	 * @property {?Object3D} [lastOcclusionObject] - The last 3D object an occlusion query state change was evaluated for.
 	 * @property {GPUQuerySet} [currentOcclusionQuerySet] - The previous frame's query set, kept alive until its results are resolved.
-	 * @property {GPUBuffer} [currentOcclusionQueryBuffer] - The previous frame's result buffer, currently being mapped.
+	 * @property {GPUBuffer} [currentOcclusionQueryBuffer] - The previous frame's result buffer, reset in beginRender() and replaced with the read data from the last frame's query set.
 	 * @property {Array<Object3D>} [currentOcclusionQueryObjects] - The previous frame's query objects.
 	 * @property {WeakSet<Object3D>} [occluded] - The 3D objects determined occluded by the last resolved queries.
 	 * @property {Array<Object>} [layerDescriptors] - Per-layer render pass descriptors for layered (array camera) render targets.
@@ -2955,12 +2955,9 @@ class WebGPUBackend extends Backend {
 	 */
 
 	/**
-	 * Backend data associated with a render target.
+	 * Backend data associated with a canvas target.
 	 *
-	 * All properties are created lazily, so any of them can be `undefined` before
-	 * the corresponding code path has run.
-	 *
-	 * @typedef {Object} WebGPURenderTargetData
+	 * @typedef {Object} WebGPUCanvasTargetData
 	 * @property {GPURenderPassDescriptor} [descriptor] - Cached render pass descriptor of the current render context's render pass encoder.
 	 * @property {GPUCanvasContext} [context] - The WebGPU rendering context of a <canvas> element.
 	 * @property {number} [samples] - The current number of samples used for multi-sample anti-aliasing (MSAA).
@@ -2970,8 +2967,8 @@ class WebGPUBackend extends Backend {
 	 * Returns the backend-specific data dictionary of the given object.
 	 *
 	 * @overload
-	 * @param {RenderTarget} object - The render target.
-	 * @return {WebGPURenderTargetData} The render target data.
+	 * @param {CanvasTarget} object - The canvas target.
+	 * @return {WebGPUCanvasTargetData} The render target data.
 	 */
 	/**
 	 * @overload

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2406,6 +2406,7 @@ class WebGPUBackend extends Backend {
 		renderContextData.currentSets = renderContextData._currentSets;
 		renderContextData.currentPass = renderContextData._currentPass;
 		renderContextData._currentPass = null;
+		renderContextData._currentSets = null;
 
 	}
 


### PR DESCRIPTION
**Description**

~Adds type hints for internal calls to the WebGPUBackend's .get() function.~

~Also makes two minor changes to existing code~

~1. Sets the renderContextData._currentPass to null so it can be used as a pseudo-flag to determine whether the currentPass is a renderPassEncoder or a renderBundleEncoder (as far as I'm aware, there is no flag on the encoder itself).~

~2. Specifies that _getDefaultRenderPassDescriptor returns a GPURenderPassDescriptor.~

Nulls out _currentPass and _currentSets at end of finishBundle and fixes type of defaultRenderPassDescriptor function.