### PR TITLE
Manual: Add anchor links to headings

### DIFF
--- a/manual/index.html
+++ b/manual/index.html
@@ -226,7 +226,7 @@
 			}
 
 			const categories = list[ language ];
-			const selectedPage = window.location.hash.substring( 1 ).replace( /\.html$/, '' );
+			const selectedPage = getSelectedPage();
 
 			for ( const category in categories ) {
 
@@ -298,7 +298,7 @@
 
 		function updateNavigation() {
 
-			const selectedPage = window.location.hash.substring( 1 ).replace( /\.html$/, '' );
+			const selectedPage = getSelectedPage();
 
 			content.querySelectorAll( 'a' ).forEach( function ( item ) {
 
@@ -432,6 +432,15 @@
 
 		// Routing
 
+		function getSelectedPage() {
+
+			return window.location.hash
+				.substring( 1 )
+				.split( '#' )[ 0 ]
+				.replace( /\.html$/, '' );
+
+		}
+
 		function setUrl( href ) {
 
 			// yea I know this is hacky.
@@ -560,6 +569,9 @@
 		}
 
 		//
+
+		window.setUrl = setUrl;
+		window.setTitle = setTitle;
 
 		console.log( [
 			'    __     __',

--- a/manual/resources/lesson.js
+++ b/manual/resources/lesson.js
@@ -15,7 +15,90 @@
 	}
 
 	const parts = window.location.href.split( '/' );
-	const filename = parts[ parts.length - 1 ];
+	const filename = parts[ parts.length - 1 ].split( '#' )[ 0 ];
+
+	function getHeadingId( heading ) {
+
+		const namedAnchor = heading.querySelector( 'a[name]' );
+
+		if ( namedAnchor ) {
+
+			return namedAnchor.getAttribute( 'name' );
+
+		}
+
+		const id = heading.textContent
+			.trim()
+			.toLowerCase()
+			.normalize( 'NFKD' )
+			.replace( /[\u0300-\u036f]/g, '' )
+			.replace( /[^\p{L}\p{N}]+/gu, '-' )
+			.replace( /^-+|-+$/g, '' );
+
+		return id || 'section';
+
+	}
+
+	function addHeadingIds() {
+
+		const usedIds = new Set();
+
+		document.querySelectorAll( '[id]' ).forEach( element => {
+
+			if ( element.id ) {
+
+				usedIds.add( element.id );
+
+			}
+
+		} );
+
+		document.querySelectorAll( 'h1, h2, h3, h4, h5, h6' ).forEach( heading => {
+
+			if ( heading.id ) return;
+
+			const baseId = getHeadingId( heading );
+			let id = baseId;
+			let suffix = 2;
+
+			while ( usedIds.has( id ) ) {
+
+				id = `${baseId}-${suffix ++}`;
+
+			}
+
+			heading.id = id;
+			usedIds.add( id );
+
+		} );
+
+	}
+
+	function scrollToHash() {
+
+		if ( window.location.hash.length <= 1 ) return;
+
+		let id;
+
+		try {
+
+			id = decodeURIComponent( window.location.hash.substring( 1 ) );
+
+		} catch ( e ) {
+
+			id = window.location.hash.substring( 1 );
+
+		}
+
+		const element = document.getElementById( id ) || document.getElementsByName( id )[ 0 ];
+
+		if ( element ) {
+
+			element.scrollIntoView();
+
+		}
+
+	}
 
 	if ( filename !== 'primitives.html' && filename !== 'prerequisites.html' ) {
 
@@ -30,6 +113,8 @@
 		document.body.innerHTML = text;
 
 	}
+
+	addHeadingIds();
 
 	if ( window.frameElement ) {
 
@@ -68,6 +153,8 @@
 
 	}
 
+	scrollToHash();
+
 	if ( window.prettyPrint ) {
 
 		window.prettyPrint();
@@ -87,6 +174,8 @@
 		window.threejsLessonUtils.afterPrettify();
 
 	}
+
+	scrollToHash();
 
 }() );
 


### PR DESCRIPTION
## Description

Adds anchor links for manual section headings by generating stable IDs for `h1`-`h6` elements loaded by `manual/resources/lesson.js`.

The generated IDs preserve existing heading IDs and existing named anchors, dedupe repeated headings, and allow section links like `/manual/#en/installation#addons` to load directly into the matching section. The manual navigation now ignores the section fragment when selecting the active page in the sidebar.

Fixes #23225.

## Testing

- `npx eslint manual/resources/lesson.js manual/index.html`
- Puppeteer smoke test for `/manual/#en/installation#addons`
- Puppeteer smoke test for redirect from `/manual/en/installation.html#addons`

`npm run lint-manual` still reports existing unrelated lint failures in manual example files (`no-self-assign`, `no-redeclare`, and `prefer-spread`), but not in the changed files.
