### PR TITLE
WebGPURenderer: Add support for `TRANSIENT_ATTACHMENT`.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -365,6 +365,20 @@ class WebGPUTextureUtils {
 
 		}
 
+		const renderTarget = texture.renderTarget;
+
+		// when the multisampled data are discarded, try to use a transient attachment if possible
+
+		if ( texture.isDepthTexture === true && primarySamples > 1 && GPUTextureUsage.TRANSIENT_ATTACHMENT !== undefined ) {
+
+			if ( renderTarget?.storeMultisampledDepthBuffer === false && ( renderTarget.stencilBuffer === false || renderTarget.storeMultisampledStencilBuffer === false ) ) {
+
+				usage = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TRANSIENT_ATTACHMENT;
+
+			}
+
+		}
+
 		const textureDescriptorGPU = new GPUTextureDescriptor();
 		textureDescriptorGPU.label = texture.name;
 		textureDescriptorGPU.size.width = width;
@@ -412,6 +426,14 @@ class WebGPUTextureUtils {
 			msaaTextureDescriptorGPU.label = msaaTextureDescriptorGPU.label + '-msaa';
 			msaaTextureDescriptorGPU.sampleCount = samples;
 			msaaTextureDescriptorGPU.mipLevelCount = 1; // See https://www.w3.org/TR/webgpu/#texture-creation
+
+			// when the multisampled data are discarded, try to use a transient attachment if possible
+
+			if ( renderTarget?.storeMultisampledColorBuffer === false && GPUTextureUsage.TRANSIENT_ATTACHMENT !== undefined ) {
+
+				msaaTextureDescriptorGPU.usage = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TRANSIENT_ATTACHMENT;
+
+			}
 
 			textureData.msaaTexture = backend.device.createTexture( msaaTextureDescriptorGPU );
 


### PR DESCRIPTION
Related issue: #33974

**Description**

This PR make use of the new MSAA flags to opt-in the usage of `TRANSIENT_ATTACHMENT`. This is new feature in Chrome which was suggested by @greggman in https://github.com/mrdoob/three.js/pull/33946#issuecomment-4882542202.

If a render target is configured to store no multisampled data, we can use `GPUTextureUsage.TRANSIENT_ATTACHMENT` as a performance hint so multisampled data are more likely to stay in tile memory.

Additional information: https://www.webgpu.com/news/chrome-149-150-webgpu-immediates/