### PR TITLE
Examples: Clean up

### DIFF
--- a/examples/webgl_shadowmap_pointlight.html
+++ b/examples/webgl_shadowmap_pointlight.html
@@ -54,7 +54,7 @@
 					const light = new THREE.PointLight( color, intensity, 20 );
 					light.castShadow = true;
 					light.shadow.bias = - 0.005; // reduces self-shadowing on double-sided objects
-					light.shadow.mapSize.width = 128;
+					light.shadow.mapSize.setScalar( 128 );
 					light.shadow.radius = 10;
 
 					let geometry = new THREE.SphereGeometry( 0.3, 12, 6 );

--- a/examples/webgpu_shadowmap_pointlight.html
+++ b/examples/webgpu_shadowmap_pointlight.html
@@ -63,7 +63,7 @@
 					const light = new THREE.PointLight( color, intensity, 20 );
 					light.castShadow = true;
 					light.shadow.bias = - 0.005; // reduces self-shadowing on double-sided objects
-					light.shadow.mapSize.width = 128;
+					light.shadow.mapSize.setScalar( 128 );
 					light.shadow.radius = 10;
 
 					let geometry = new THREE.SphereGeometry( 0.3, 12, 6 );


### PR DESCRIPTION
These examples failed to set the shadow map height. Presumably, a square shadow map is desired.