### PR TITLE
GLTFLoader: Skip skinning without skin attributes

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3842,18 +3842,17 @@ class GLTFParser {
 						primitive.mode === WEBGL_CONSTANTS.TRIANGLE_FAN ||
 						primitive.mode === undefined ) {
 
-					const isSkinnedMesh = meshDef.isSkinnedMesh === true
-						&& geometry.attributes.skinIndex !== undefined
-						&& geometry.attributes.skinWeight !== undefined;
+					const needsSkinning = meshDef.isSkinnedMesh === true;
+					const hasSkinningAttributes = geometry.hasAttribute( 'skinIndex' ) && geometry.hasAttribute( 'skinWeight' );
 
-					if ( meshDef.isSkinnedMesh === true && isSkinnedMesh === false ) {
+					if ( needsSkinning && hasSkinningAttributes === false ) {
 
 						console.warn( 'THREE.GLTFLoader: Missing skinIndex or skinWeight attributes. Skinning disabled.' );
 
 					}
 
 					// .isSkinnedMesh isn't in glTF spec. See ._markDefs()
-					mesh = isSkinnedMesh === true
+					mesh = ( needsSkinning && hasSkinningAttributes )
 						? new SkinnedMesh( geometry, material )
 						: new Mesh( geometry, material );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3842,8 +3842,18 @@ class GLTFParser {
 						primitive.mode === WEBGL_CONSTANTS.TRIANGLE_FAN ||
 						primitive.mode === undefined ) {
 
+					const isSkinnedMesh = meshDef.isSkinnedMesh === true
+						&& geometry.attributes.skinIndex !== undefined
+						&& geometry.attributes.skinWeight !== undefined;
+
+					if ( meshDef.isSkinnedMesh === true && isSkinnedMesh === false ) {
+
+						console.warn( 'THREE.GLTFLoader: Missing skinIndex or skinWeight attributes. Skinning disabled.' );
+
+					}
+
 					// .isSkinnedMesh isn't in glTF spec. See ._markDefs()
-					mesh = meshDef.isSkinnedMesh === true
+					mesh = isSkinnedMesh === true
 						? new SkinnedMesh( geometry, material )
 						: new Mesh( geometry, material );
 


### PR DESCRIPTION
**Description**

Some models reference skins from mesh nodes while their primitives do not provide both skinIndex and skinWeight attributes. Previously, these malformed assets could fail while loading around `normalizeSkinWeights`.

Handle this case permissively by logging a warning and creating a regular Mesh instead of a SkinnedMesh for the affected primitive. This allows the asset to remain visible, with skinning disabled for that primitive.

This PR is pretty much all authored with Codex (GPT-5.5).

**Review points**

- Is it a legit strategy to load invalid glTF?
- I thought regression test is not needed since GLTFLoader does not have any test cases so far. Is it right?
