### PR TITLE
WebGLRenderer: Fix `clearLayerUpdates()` call.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1065,8 +1065,6 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 											}
 
-											texture.clearLayerUpdates();
-
 										} else {
 
 											state.compressedTexSubImage3D( _gl.TEXTURE_2D_ARRAY, i, 0, 0, 0, mipmap.width, mipmap.height, image.depth, glFormat, mipmap.data );
@@ -1106,6 +1104,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 						}
 
 					}
+
+					if ( texture.layerUpdates.size > 0 ) texture.clearLayerUpdates();
 
 				} else {
 


### PR DESCRIPTION
Fixed #33982.

**Description**

With this PR, `WebGLRenderer` makes sure to use the texture layer updates state for all mipmaps of an instance of `CompressedArrayTexture`, not just for the first one. 

The reproduction code from the fiddle (see #33982) behaves now as expected (tested locally).