### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_postprocessing_sss.html
+++ b/examples/webgpu_postprocessing_sss.html
@@ -73,6 +73,7 @@
 				dirLight.castShadow = true;
 				dirLight.shadow.bias = - 0.001; // remove self-shadowing artifacts
 				dirLight.shadow.camera.top = 4;
+				dirLight.shadow.radius = 2;
 				dirLight.shadow.camera.bottom = - 4;
 				dirLight.shadow.camera.left = - 4;
 				dirLight.shadow.camera.right = 4;


### PR DESCRIPTION
Related issue: #33987

**Description**

After removing `PCFSoftShadowMap`, I've checked the affected WebGPU examples and at least one demo must slightly update its shadow radius to make the shadows softer to match the previous look. Otherwise shadows look too blocky.
