### PR TITLE
Inspector/Debug- WebGPUinfo

### DIFF
--- a/examples/jsm/inspector/Inspector.js
+++ b/examples/jsm/inspector/Inspector.js
@@ -243,6 +243,7 @@ class Inspector extends RendererInspector {
 		if ( renderer.backend.isWebGPUBackend ) {
 
 			sign += 'WebGPU';
+			this.memory.addWebGPUMemory();
 
 		} else if ( renderer.backend.isWebGLBackend ) {
 

--- a/examples/jsm/inspector/tabs/Memory.js
+++ b/examples/jsm/inspector/tabs/Memory.js
@@ -74,6 +74,36 @@ class Memory extends Tab {
 		this.memoryStats.add( this.uniformBuffers );
 
 		this.graph = graph;
+		this.memoryList = memoryList;
+
+	}
+
+	addWebGPUMemory() {
+
+		this.backendResourceStats = new Item( 'Backend Resources', '', 'N/A' );
+		this.backendResourceStats.domElement.firstChild.classList.add( 'no-hover' );
+		this.memoryList.add( this.backendResourceStats );
+
+		this.renderPassEncoders = new Item( 'Render Pass Encoders', createValueSpan(), 'N/A' );
+		this.backendResourceStats.add( this.renderPassEncoders );
+
+		this.renderBundleEncoders = new Item( 'Render Bundle Encoders', createValueSpan(), 'N/A' );
+		this.backendResourceStats.add( this.renderBundleEncoders );
+
+		this.computePassEncoders = new Item( 'Compute Pass Encoders', createValueSpan(), 'N/A' );
+		this.backendResourceStats.add( this.computePassEncoders );
+
+		this.commandEncoders = new Item( 'Command Encoders', createValueSpan(), 'N/A' );
+		this.backendResourceStats.add( this.commandEncoders );
+
+		this.deviceEncoderSubmits = new Item( 'Device Submits', createValueSpan(), 'N/A' );
+		this.backendResourceStats.add( this.deviceEncoderSubmits );
+
+		this.renderPipelines = new Item( 'Render Pipelines', createValueSpan(), 'N/A' );
+		this.backendResourceStats.add( this.renderPipelines );
+
+		this.computePipelines = new Item( 'Compute Pipelines', createValueSpan(), 'N/A' );
+		this.backendResourceStats.add( this.computePipelines );
 
 	}
 
@@ -128,6 +158,20 @@ class Memory extends Tab {
 
 		setText( this.uniformBuffers.data[ 1 ], memory.uniformBuffers.toString() );
 		setText( this.uniformBuffers.data[ 2 ], formatBytes( memory.uniformBuffersSize ) );
+
+		if ( this.backendResourceStats ) {
+
+			const backendInfo = renderer.info.backendInfo;
+
+			setText( this.renderPassEncoders.data[ 1 ], backendInfo.renderPassEncoders.toString() );
+			setText( this.renderBundleEncoders.data[ 1 ], backendInfo.renderBundleEncoders.toString() );
+			setText( this.computePassEncoders.data[ 1 ], backendInfo.computePassEncoders.toString() );
+			setText( this.commandEncoders.data[ 1 ], backendInfo.commandEncoders.toString() );
+			setText( this.deviceEncoderSubmits.data[ 1 ], backendInfo.deviceEncoderSubmits.toString() );
+			setText( this.renderPipelines.data[ 1 ], backendInfo.renderPipelines.toString() );
+			setText( this.computePipelines.data[ 1 ], backendInfo.computePipelines.toString() );
+
+		}
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -37,6 +37,7 @@ import { reference } from '../../nodes/accessors/ReferenceNode.js';
 import { highpModelNormalViewMatrix, highpModelViewMatrix } from '../../nodes/accessors/ModelNode.js';
 import { context } from '../../nodes/core/ContextNode.js';
 import { error, warn, warnOnce, yieldToMain } from '../../utils.js';
+import WebGPUInfo from '../webgpu/WebGPUInfo.js';
 
 const _scene = /*@__PURE__*/ new Scene();
 const _drawingBufferSize = /*@__PURE__*/ new Vector2();
@@ -234,7 +235,7 @@ class Renderer {
 		 *
 		 * @type {Info}
 		 */
-		this.info = new Info();
+		this.info = this.backend.isWebGPUBackend ? new WebGPUInfo() : new Info();
 
 		/**
 		 * A global context node that stores override nodes for specific transformations or calculations.

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -971,6 +971,7 @@ class WebGPUBackend extends Backend {
 		//
 
 		_commandEncoderDescriptor.label = 'renderContext_' + renderContext.id;
+		this.renderer.info.backendInfo.commandEncoders ++;
 		const encoder = device.createCommandEncoder( _commandEncoderDescriptor );
 		_commandEncoderDescriptor.reset();
 
@@ -1020,6 +1021,7 @@ class WebGPUBackend extends Backend {
 
 		} else {
 
+			this.renderer.info.backendInfo.renderPassEncoders ++;
 			const currentPass = encoder.beginRenderPass( descriptor );
 			renderContextData.currentPass = currentPass;
 
@@ -1239,6 +1241,8 @@ class WebGPUBackend extends Backend {
 				if ( i < bundles.length ) {
 
 					const layerDescriptor = renderContextData.layerDescriptors[ i ];
+
+					this.renderer.info.backendInfo.renderPassEncoders ++;
 					const renderPass = encoder.beginRenderPass( layerDescriptor );
 
 					if ( renderContext.viewport ) {
@@ -1311,6 +1315,7 @@ class WebGPUBackend extends Backend {
 
 		}
 
+		this.renderer.info.backendInfo.deviceEncoderSubmits ++;
 		submit( this.device, renderContextData.encoder.finish() );
 
 
@@ -1579,9 +1584,11 @@ class WebGPUBackend extends Backend {
 		//
 
 		_commandEncoderDescriptor.label = 'clear';
+		this.renderer.info.backendInfo.commandEncoders ++;
 		const encoder = device.createCommandEncoder( _commandEncoderDescriptor );
 		_commandEncoderDescriptor.reset();
 
+		this.renderer.info.backendInfo.renderPassEncoders ++;
 		const currentPass = encoder.beginRenderPass( {
 			colorAttachments,
 			depthStencilAttachment
@@ -1589,6 +1596,7 @@ class WebGPUBackend extends Backend {
 
 		currentPass.end();
 
+		this.renderer.info.backendInfo.deviceEncoderSubmits ++;
 		submit( device, encoder.finish() );
 
 	}
@@ -1614,7 +1622,9 @@ class WebGPUBackend extends Backend {
 
 		this.initTimestampQuery( TimestampQuery.COMPUTE, this.getTimestampUID( computeGroup ), _computePassDescriptor );
 
+		this.renderer.info.backendInfo.commandEncoders ++;
 		groupGPU.cmdEncoderGPU = this.device.createCommandEncoder( _commandEncoderDescriptor );
+		this.renderer.info.backendInfo.computePassEncoders ++;
 		groupGPU.passEncoderGPU = groupGPU.cmdEncoderGPU.beginComputePass( _computePassDescriptor );
 		groupGPU.currentPipeline = null;
 
@@ -1647,6 +1657,7 @@ class WebGPUBackend extends Backend {
 
 		if ( groupGPU.currentPipeline !== pipelineGPU ) {
 
+			this.renderer.info.backendInfo.computePipelines ++;
 			passEncoderGPU.setPipeline( pipelineGPU );
 			groupGPU.currentPipeline = pipelineGPU;
 
@@ -1746,6 +1757,7 @@ class WebGPUBackend extends Backend {
 
 		groupData.passEncoderGPU.end();
 
+		this.renderer.info.backendInfo.deviceEncoderSubmits ++;
 		submit( this.device, groupData.cmdEncoderGPU.finish() );
 
 	}
@@ -1775,6 +1787,7 @@ class WebGPUBackend extends Backend {
 
 		if ( currentSets.pipeline !== pipelineGPU ) {
 
+			this.renderer.info.backendInfo.renderPipelines ++;
 			passEncoderGPU.setPipeline( pipelineGPU );
 			currentSets.pipeline = pipelineGPU;
 
@@ -2724,6 +2737,7 @@ class WebGPUBackend extends Backend {
 		}
 
 		_commandEncoderDescriptor.label = 'copyTextureToTexture_' + srcTexture.id + '_' + dstTexture.id;
+		this.renderer.info.backendInfo.commandEncoders ++;
 		const encoder = this.device.createCommandEncoder( _commandEncoderDescriptor );
 		_commandEncoderDescriptor.reset();
 
@@ -2756,6 +2770,7 @@ class WebGPUBackend extends Backend {
 		_texelCopyTextureInfoDst.reset();
 		_extent3D.reset();
 
+		this.renderer.info.backendInfo.deviceEncoderSubmits ++;
 		submit( this.device, encoder.finish() );
 
 		if ( dstLevel === 0 && dstTexture.generateMipmaps ) {
@@ -2826,6 +2841,7 @@ class WebGPUBackend extends Backend {
 		} else {
 
 			_commandEncoderDescriptor.label = 'copyFramebufferToTexture_' + texture.id;
+			this.renderer.info.backendInfo.commandEncoders ++;
 			encoder = this.device.createCommandEncoder( _commandEncoderDescriptor );
 			_commandEncoderDescriptor.reset();
 
@@ -2872,6 +2888,7 @@ class WebGPUBackend extends Backend {
 			if ( renderContext.depth ) descriptor.depthStencilAttachment.depthLoadOp = GPULoadOp.Load;
 			if ( renderContext.stencil ) descriptor.depthStencilAttachment.stencilLoadOp = GPULoadOp.Load;
 
+			this.renderer.info.backendInfo.renderPassEncoders ++;
 			renderContextData.currentPass = encoder.beginRenderPass( descriptor );
 			renderContextData.currentSets = { attributes: {}, bindingGroups: [], pipeline: null, index: null };
 
@@ -2889,6 +2906,7 @@ class WebGPUBackend extends Backend {
 
 		} else {
 
+			this.renderer.info.backendInfo.deviceEncoderSubmits ++;
 			submit( this.device, encoder.finish() );
 
 		}

--- a/src/renderers/webgpu/WebGPUInfo.js
+++ b/src/renderers/webgpu/WebGPUInfo.js
@@ -1,0 +1,70 @@
+import Info from '../common/Info.js';
+
+/**
+ * This renderer module provides a series of statistical information
+ * specific to the rendering process of the WebGPUBackend. Useful for debugging
+ * and monitoring.
+ *
+ * Updates to parameters specific to the WebGPUBackend should only occur in
+ * WebGPUBackend.js or other WebGPUBackend classes (WebGPUPipelineUtils.js,
+ * WebGPUBindingUtils.js, etc)
+ */
+class WebGPUInfo extends Info {
+
+	/**
+	 * Constructs a new info component.
+	 */
+	constructor() {
+
+		super();
+
+		/**
+		 * Metrics related to the WebGPU backend of the current renderer.
+		 *
+		 * @type {Object}
+		 * @readonly
+		 * @property {number} renderPassEncoders - The number of renderPassEncoders created in the current render thread.
+		 * @property {number} renderBundleEncoders - The number of renderBundleEncoders created in the current render thread.
+		 * @property {number} computePassEncoders - The number of computePassEncoders created in the current compute thread.
+		 * @property {number} commandEncoders - The number of commandEncoders created for the current render/compute thread.
+		 * @property {number} deviceEncoderSubmits - The number of calls to device.queue.submit within the current render/compute thread.
+		 * @property {number} renderPipelines - The number of calls to GPURenderPassEncoder.setPipeline() within a render thread.
+		 * @property {number} computePipelines - The number of calls to GPUComputePassEncoder.setPipeline() within a compute thread.
+		 */
+		this.backendInfo = {
+			// Pass Encoders
+			renderPassEncoders: 0,
+			renderBundleEncoders: 0,
+			computePassEncoders: 0,
+			// Command and Device
+			commandEncoders: 0,
+			deviceEncoderSubmits: 0,
+			// Pipelines
+			renderPipelines: 0,
+			computePipelines: 0
+		};
+
+	}
+
+	/**
+	 * Resets frame related metrics.
+	 */
+	reset() {
+
+		super.reset();
+
+		this.backendInfo.renderPassEncoders = 0;
+		this.backendInfo.renderBundleEncoders = 0;
+		this.backendInfo.computePassEncoders = 0;
+		this.backendInfo.commandEncoders = 0;
+		this.backendInfo.deviceEncoderSubmits = 0;
+
+		this.backendInfo.renderPipelines = 0;
+		this.backendInfo.computePipelines = 0;
+
+	}
+
+}
+
+
+export default WebGPUInfo;

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -466,6 +466,7 @@ class WebGPUAttributeUtils {
 
 		// copy the data
 		_commandEncoderDescriptor.label = `readback_encoder_${ attribute.name }`;
+		this.backend.renderer.info.backendInfo.commandEncoders ++;
 		const cmdEncoder = device.createCommandEncoder( _commandEncoderDescriptor );
 		_commandEncoderDescriptor.reset();
 
@@ -478,6 +479,7 @@ class WebGPUAttributeUtils {
 		);
 
 		const gpuCommands = cmdEncoder.finish();
+		this.backend.renderer.info.backendInfo.deviceEncoderSubmits ++;
 		submit( device, gpuCommands );
 
 		// map the data to the CPU

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -363,6 +363,7 @@ class WebGPUPipelineUtils {
 		_renderBundleEncoderDescriptor.depthStencilFormat = depthStencilFormat;
 		_renderBundleEncoderDescriptor.sampleCount = sampleCount;
 
+		this.backend.renderer.info.backendInfo.renderBundleEncoders ++;
 		const bundleEncoder = device.createRenderBundleEncoder( _renderBundleEncoderDescriptor );
 
 		_renderBundleEncoderDescriptor.reset();

--- a/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
@@ -243,6 +243,7 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 		const copyTransferPipeline = this.getTransferPipeline( format, textureGPU.textureBindingViewDimension );
 		const flipTransferPipeline = this.getTransferPipeline( format, tempTexture.textureBindingViewDimension );
 
+		this.backend.renderer.info.backendInfo.commandEncoders ++;
 		const commandEncoder = this.device.createCommandEncoder( _commandEncoderDescriptor );
 
 		const pass = ( pipeline, sourceTexture, sourceArrayLayer, destinationTexture, destinationArrayLayer, flipY ) => {
@@ -287,11 +288,13 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 
 			_renderPassDescriptor.colorAttachments.push( _colorAttachment );
 
+			this.backend.renderer.info.backendInfo.renderPassEncoders ++;
 			const passEncoder = commandEncoder.beginRenderPass( _renderPassDescriptor );
 
 			_renderPassDescriptor.reset();
 			_colorAttachment.reset();
 
+			this.backend.renderer.info.backendInfo.renderPipelines ++;
 			passEncoder.setPipeline( pipeline );
 			passEncoder.setBindGroup( 0, bindGroup );
 			passEncoder.draw( 3, 1, 0, sourceArrayLayer );
@@ -302,6 +305,7 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 		pass( copyTransferPipeline, textureGPU, baseArrayLayer, tempTexture, 0, false );
 		pass( flipTransferPipeline, tempTexture, 0, textureGPU, baseArrayLayer, true );
 
+		this.backend.renderer.info.backendInfo.deviceEncoderSubmits ++;
 		submit( this.device, commandEncoder.finish() );
 
 		tempTexture.destroy();
@@ -325,6 +329,7 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 		if ( commandEncoder === null ) {
 
 			_commandEncoderDescriptor.label = 'mipmapEncoder';
+			this.backend.renderer.info.backendInfo.commandEncoders ++;
 			commandEncoder = this.device.createCommandEncoder( _commandEncoderDescriptor );
 			_commandEncoderDescriptor.reset();
 
@@ -332,7 +337,12 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 
 		this._mipmapRunBundles( commandEncoder, passes );
 
-		if ( encoder === null ) submit( this.device, commandEncoder.finish() );
+		if ( encoder === null ) {
+
+			this.backend.renderer.info.backendInfo.deviceEncoderSubmits ++;
+			submit( this.device, commandEncoder.finish() );
+
+		}
 
 		textureData.layers = passes;
 
@@ -402,10 +412,12 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 
 				_renderBundleEncoderDescriptor.colorFormats = [ textureGPU.format ];
 
+				this.backend.renderer.info.backendInfo.renderBundleEncoders ++;
 				const passEncoder = this.device.createRenderBundleEncoder( _renderBundleEncoderDescriptor );
 
 				_renderBundleEncoderDescriptor.reset();
 
+				this.backend.renderer.info.backendInfo.renderPipelines ++;
 				passEncoder.setPipeline( pipeline );
 				passEncoder.setBindGroup( 0, bindGroup );
 				passEncoder.draw( 3, 1, 0, baseArrayLayer );
@@ -437,6 +449,7 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 
 			const pass = passes[ i ];
 
+			this.backend.renderer.info.backendInfo.renderPassEncoders ++;
 			const passEncoder = commandEncoder.beginRenderPass( pass.passDescriptor );
 
 			passEncoder.executeBundles( pass.renderBundles );

--- a/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
@@ -33,18 +33,25 @@ class WebGPUTexturePassUtils extends DataMap {
 	/**
 	 * Constructs a new utility object.
 	 *
-	 * @param {GPUDevice} device - The WebGPU device.
+	 * @param {WebGPUBackend} backend - The WebGPU backend.
 	 */
-	constructor( device ) {
+	constructor( backend ) {
 
 		super();
+
+		/**
+		 * The renderer's backend.
+		 *
+		 * @type {Backend}
+		 */
+		this.backend = backend;
 
 		/**
 		 * The WebGPU device.
 		 *
 		 * @type {GPUDevice}
 		 */
-		this.device = device;
+		this.device = this.backend.device;
 
 		const mipmapSource = `
 struct VarysStruct {
@@ -127,14 +134,14 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 		 *
 		 * @type {GPUSampler}
 		 */
-		this.mipmapSampler = device.createSampler( { minFilter: GPUFilterMode.Linear } );
+		this.mipmapSampler = this.device.createSampler( { minFilter: GPUFilterMode.Linear } );
 
 		/**
 		 * The flipY GPU sampler.
 		 *
 		 * @type {GPUSampler}
 		 */
-		this.flipYSampler = device.createSampler( { minFilter: GPUFilterMode.Nearest } ); //@TODO?: Consider using textureLoad()
+		this.flipYSampler = this.device.createSampler( { minFilter: GPUFilterMode.Nearest } ); //@TODO?: Consider using textureLoad()
 
 		/**
 		 * flip uniform buffer
@@ -143,11 +150,11 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 		_bufferDescriptor.size = 4;
 		_bufferDescriptor.usage = GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST;
 
-		this.flipUniformBuffer = device.createBuffer( _bufferDescriptor );
+		this.flipUniformBuffer = this.device.createBuffer( _bufferDescriptor );
 
 		_bufferDescriptor.reset();
 
-		device.queue.writeBuffer( this.flipUniformBuffer, 0, new Uint32Array( [ 1 ] ) );
+		this.device.queue.writeBuffer( this.flipUniformBuffer, 0, new Uint32Array( [ 1 ] ) );
 
 		/**
 		 * no flip uniform buffer
@@ -156,7 +163,7 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 		_bufferDescriptor.size = 4;
 		_bufferDescriptor.usage = GPUBufferUsage.UNIFORM;
 
-		this.noFlipUniformBuffer = device.createBuffer( _bufferDescriptor );
+		this.noFlipUniformBuffer = this.device.createBuffer( _bufferDescriptor );
 
 		_bufferDescriptor.reset();
 
@@ -176,7 +183,7 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 		_shaderModuleDescriptor.label = 'mipmap';
 		_shaderModuleDescriptor.code = mipmapSource;
 
-		this.mipmapShaderModule = device.createShaderModule( _shaderModuleDescriptor );
+		this.mipmapShaderModule = this.device.createShaderModule( _shaderModuleDescriptor );
 
 		_shaderModuleDescriptor.reset();
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -982,7 +982,7 @@ class WebGPUTextureUtils {
 
 		if ( passUtils === null ) {
 
-			this._passUtils = passUtils = new WebGPUTexturePassUtils( this.backend.device );
+			this._passUtils = passUtils = new WebGPUTexturePassUtils( this.backend );
 
 		}
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -764,6 +764,7 @@ class WebGPUTextureUtils {
 
 		_bufferDescriptor.reset();
 
+		this.backend.renderer.info.backendInfo.commandEncoders ++;
 		const encoder = device.createCommandEncoder( _commandEncoderDescriptor );
 
 		_texelCopyTextureInfo.texture = textureGPU;
@@ -789,6 +790,8 @@ class WebGPUTextureUtils {
 
 		const typedArrayType = this._getTypedArrayType( format );
 
+
+		this.backend.renderer.info.backendInfo.deviceEncoderSubmits ++;
 		submit( device, encoder.finish() );
 
 		await readBuffer.mapAsync( GPUMapMode.READ );


### PR DESCRIPTION
**Description**

Adds a simple extension over the existing renderer.info class to track the WebGPUBackend specific device resources that are created within a render/compute thread ( a 'render thread' just being my nomenclature for a single call to renderer.render or renderer.compute).

In the future, if we have multiple render calls that are coalesced into a single device.queue.submit (as suggested in https://github.com/mrdoob/three.js/issues/33821#issuecomment-4776667418), then the info resetting will be adjusted to account for that use case. For now, since each renderer.render/renderer.compute call completes by calling device.queue.submit, deviceEncoderSubmits, this is only really tracking metrics within those calls.

Currently, I switch between the backend specific info objects within the Renderer.js file, but if there are concerns with using backend specific nomenclature within the generic Renderer class, I can find another place to move the info constructor.

EDIT: Additionally, I have intentionally not tracked any of the TimeStampQuery resource creation since I think that's outside the realm of tracking the render and compute paths.