### PR TITLE
Refresh external links in /examples

### DIFF
--- a/examples/misc_controls_arcball.html
+++ b/examples/misc_controls_arcball.html
@@ -15,7 +15,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - arcball controls<br/>
-			<a href="http://www.polycount.com/forum/showthread.php?t=130641" target="_blank" rel="noopener">Cerberus(FFVII Gun) model</a> by Andrew Maximov.
+			<a href="https://www.polycount.com/forum/showthread.php?t=130641" target="_blank" rel="noopener">Cerberus(FFVII Gun) model</a> by Andrew Maximov.
 		</div>
 
 		<script type="importmap">

--- a/examples/models/obj/female02/readme.txt
+++ b/examples/models/obj/female02/readme.txt
@@ -1,3 +1,3 @@
 Model by Reallusion iClone from Google 3d Warehouse:
 
-http://sketchup.google.com/3dwarehouse/details?mid=2c6fd128fca34052adc5f5b98d513da1
+https://3dwarehouse.sketchup.com/model/2c6fd128fca34052adc5f5b98d513da1

--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -23,7 +23,7 @@
 	<div id="container"></div>
 	<div id="info">
 		<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> webaudio - orientation<br/>
-		music by <a href="http://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener noreferrer">skullbeatz</a>
+		music by <a href="https://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener noreferrer">skullbeatz</a>
 	</div>
 
 	<script type="importmap">

--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -28,9 +28,9 @@
 		</div>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webaudio - sandbox<br/>
-			music by <a href="http://www.newgrounds.com/audio/listen/358232" target="_blank" rel="noopener">larrylarrybb</a>,
-			<a href="http://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener">skullbeatz</a> and
-			<a href="http://opengameart.org/content/project-utopia-seamless-loop" target="_blank" rel="noopener">congusbongus</a><br/><br/>
+			music by <a href="https://www.newgrounds.com/audio/listen/358232" target="_blank" rel="noopener">larrylarrybb</a>,
+			<a href="https://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener">skullbeatz</a> and
+			<a href="https://opengameart.org/content/project-utopia-seamless-loop" target="_blank" rel="noopener">congusbongus</a><br/><br/>
 			navigate with WASD / arrows / mouse
 		</div>
 

--- a/examples/webaudio_visualizer.html
+++ b/examples/webaudio_visualizer.html
@@ -52,7 +52,7 @@
 		<div id="container"></div>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> webaudio - visualizer<br/>
-			music by <a href="http://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener">skullbeatz</a>
+			music by <a href="https://www.newgrounds.com/audio/listen/376737" target="_blank" rel="noopener">skullbeatz</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_buffergeometry_selective_draw.html
+++ b/examples/webgl_buffergeometry_selective_draw.html
@@ -166,7 +166,7 @@
 
 			function updateCount() {
 
-				const str = '1 draw call, ' + numLat * numLng + ' lines, ' + numLinesCulled + ' culled (<a target="_blank" href="http://callum.com">author</a>)';
+				const str = '1 draw call, ' + numLat * numLng + ' lines, ' + numLinesCulled + ' culled (<a target="_blank" href="https://callum.com">author</a>)';
 				document.getElementById( 'title' ).innerHTML = str.replace( /\B(?=(\d{3})+(?!\d))/g, ',' );
 
 			}

--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -56,7 +56,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">threejs</a> webgl - depth texture<br/>
 			Stores render target depth in a texture attachment.<br/>
-			Created by <a href="http://twitter.com/mattdesl" target="_blank" rel="noopener">@mattdesl</a>.
+			Created by <a href="https://twitter.com/mattdesl" target="_blank" rel="noopener">@mattdesl</a>.
 
 			<div id="error" style="display: none;">
 			Your browser does not support <strong>WEBGL_depth_texture</strong>.<br/><br/>

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -22,7 +22,7 @@
 	<body>
 
 		<div id="container"></div>
-		<div id="info"><a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - <a href="http://www.minecraft.net/" target="_blank" rel="noopener">minecraft</a> demo. featuring <a href="http://painterlypack.net/" target="_blank" rel="noopener">painterly pack</a><br />(left click: forward, right click: backward)</div>
+		<div id="info"><a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - <a href="https://www.minecraft.net/" target="_blank" rel="noopener">minecraft</a> demo. featuring <a href="https://painterlypack.net/" target="_blank" rel="noopener">painterly pack</a><br />(left click: forward, right click: backward)</div>
 
 		<script type="importmap">
 			{

--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -23,7 +23,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl gpgpu birds + GLTF mesh<br/>
-			Flamingo by <a href="https://mirada.com/" target="_blank" rel="noopener">mirada</a> from <a href="http://www.ro.me/" target="_blank" rel="noopener">rome</a><br/>
+			Flamingo by <a href="https://mirada.com/" target="_blank" rel="noopener">mirada</a> from <a href="https://www.ro.me/" target="_blank" rel="noopener">rome</a><br/>
 			Move mouse to disturb birds.
 		</div>
 

--- a/examples/webgl_lensflares.html
+++ b/examples/webgl_lensflares.html
@@ -14,7 +14,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - lensflares<br/>
-			textures from <a href="http://www.ro.me" target="_blank" rel="noopener">ro.me</a><br/>
+			textures from <a href="https://www.ro.me" target="_blank" rel="noopener">ro.me</a><br/>
 			fly with WASD/RF/QE + mouse
 		</div>
 

--- a/examples/webgl_lights_hemisphere.html
+++ b/examples/webgl_lights_hemisphere.html
@@ -23,7 +23,7 @@
 		<div id="container"></div>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl hemisphere light example<br/>
-			flamingo by <a href="https://mirada.com/" target="_blank" rel="noopener">mirada</a> from <a href="http://www.ro.me" target="_blank" rel="noopener">ro.me</a>
+			flamingo by <a href="https://mirada.com/" target="_blank" rel="noopener">mirada</a> from <a href="https://www.ro.me" target="_blank" rel="noopener">ro.me</a>
 		</div>
 
 		<script type="x-shader/x-vertex" id="vertexShader">

--- a/examples/webgl_lights_physical.html
+++ b/examples/webgl_lights_physical.html
@@ -14,7 +14,7 @@
 
 		<div id="container"></div>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Physically accurate incandescent bulb by <a href="http://clara.io" target="_blank" rel="noopener">Ben Houston</a><br />
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Physically accurate incandescent bulb by <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a><br />
 			Real world scale: Brick cube is 50 cm in size. Globe is 50 cm in diameter.<br/>
 			Reinhard inline tonemapping with real-world light falloff (decay = 2).
 		</div>

--- a/examples/webgl_lights_rectarealight.html
+++ b/examples/webgl_lights_rectarealight.html
@@ -14,7 +14,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - THREE.RectAreaLight<br/>
-			by <a href="http://github.com/abelnation" target="_blank" rel="noopener">abelnation</a>
+			by <a href="https://github.com/abelnation" target="_blank" rel="noopener">abelnation</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_lines_colors.html
+++ b/examples/webgl_lines_colors.html
@@ -14,7 +14,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - color lines<br/>
-			<a href="http://en.wikipedia.org/wiki/Hilbert_curve">Hilbert curve</a> thanks to <a href="https://openprocessing.org/user/5654">Thomas Diewald</a>
+			<a href="https://en.wikipedia.org/wiki/Hilbert_curve">Hilbert curve</a> thanks to <a href="https://openprocessing.org/user/5654">Thomas Diewald</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_loader_3mf.html
+++ b/examples/webgl_loader_3mf.html
@@ -18,7 +18,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a>
-			<a href="http://3mf.io" target="_blank" rel="noopener">3MF File format</a>
+			<a href="https://3mf.io" target="_blank" rel="noopener">3MF File format</a>
 			<div>3MF loader test by <a href="https://github.com/technohippy" target="_blank" rel="noopener">technohippy</a></div>
 			<div>Files from <a href="https://github.com/3MFConsortium/3mf-samples" target="_blank" rel="noopener">3mf-samples</a></div>
 		</div>

--- a/examples/webgl_loader_3mf_materials.html
+++ b/examples/webgl_loader_3mf_materials.html
@@ -18,7 +18,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> -
-			<a href="http://3mf.io" target="_blank" rel="noopener">3MF</a> file with materials
+			<a href="https://3mf.io" target="_blank" rel="noopener">3MF</a> file with materials
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_loader_gltf_anisotropy.html
+++ b/examples/webgl_loader_gltf_anisotropy.html
@@ -14,7 +14,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - GLTFLoader + <a href="https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_anisotropy" target="_blank" rel="noopener">KHR_materials_anisotropy</a><br />
-			Anisotropy Barn Lamp from <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/AnisotropyBarnLamp" target="_blank" rel="noopener">glTF-Sample-Models</a><br />
+			Anisotropy Barn Lamp from <a href="https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/AnisotropyBarnLamp" target="_blank" rel="noopener">glTF-Sample-Models</a><br />
 			<a href="https://hdrihaven.com/hdri/?h=royal_esplanade" target="_blank" rel="noopener">Royal Esplanade</a> from <a href="https://hdrihaven.com/" target="_blank" rel="noopener">HDRI Haven</a>
 		</div>
 

--- a/examples/webgl_loader_gltf_avif.html
+++ b/examples/webgl_loader_gltf_avif.html
@@ -24,7 +24,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - GLTFLoader +
-			<a href="https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_texture_avif" target="_blank" rel="noopener" >EXT_texture_avif</a><br />
+			EXT_texture_avif<br />
 			Forest House by <a href="https://sketchfab.com/peachyroyalty" target="_blank" rel="noopener">peachyroyalty</a><br />
 		</div>
 

--- a/examples/webgl_loader_gltf_instancing.html
+++ b/examples/webgl_loader_gltf_instancing.html
@@ -15,7 +15,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - GLTFLoader + <a href="https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/README.md" target="_blank" rel="noopener">EXT_mesh_gpu_instancing</a><br />
 			Battle Damaged Sci-fi Helmet by
-			<a href="https://sketchfab.com/theblueturtle_" target="_blank" rel="noopener">theblueturtle_</a><br />
+			theblueturtle_<br />
 			<a href="https://hdrihaven.com/hdri/?h=royal_esplanade" target="_blank" rel="noopener">Royal Esplanade</a> from <a href="https://hdrihaven.com/" target="_blank" rel="noopener">HDRI Haven</a>
 		</div>
 

--- a/examples/webgl_loader_gltf_transmission.html
+++ b/examples/webgl_loader_gltf_transmission.html
@@ -14,7 +14,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - GLTFLoader + <a href="https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_transmission" target="_blank" rel="noopener">KHR_materials_transmission</a><br />
-			Iridescent Dish With Olives by <a href="https://github.com/echadwick-wayfair" target="_blank" rel="noopener">Eric Chadwick</a><br />
+			Iridescent Dish With Olives by <a href="https://github.com/echadwick-artist" target="_blank" rel="noopener">Eric Chadwick</a><br />
 			<a href="https://hdrihaven.com/hdri/?h=royal_esplanade" target="_blank" rel="noopener">Royal Esplanade</a> from <a href="https://hdrihaven.com/" target="_blank" rel="noopener">HDRI Haven</a>
 		</div>
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -382,9 +382,9 @@
 		<!-- LDraw.org CC BY 2.0 Parts Library attribution -->
 		<div style="display: block; position: absolute; bottom: 8px; left: 8px; width: 160px; padding: 10px; background-color: #F3F7F8;">
 			<center>
-				<a href="http://www.ldraw.org"><img style="width: 145px" src="models/ldraw/ldraw_org_logo/Stamp145.png"></a>
+				<a href="https://www.ldraw.org"><img style="width: 145px" src="models/ldraw/ldraw_org_logo/Stamp145.png"></a>
 				<br />
-				<a href="http://www.ldraw.org/">This software uses the LDraw Parts Library</a>
+				<a href="https://www.ldraw.org/">This software uses the LDraw Parts Library</a>
 			</center>
 		</div>
 

--- a/examples/webgl_loader_ply.html
+++ b/examples/webgl_loader_ply.html
@@ -14,7 +14,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> -
 			PLY loader test by <a href="https://github.com/menway" target="_blank" rel="noopener">Wei Meng</a>.<br/>
-			Image from <a href="http://people.sc.fsu.edu/~jburkardt/data/ply/ply.html">John Burkardt</a>
+			Image from <a href="https://people.sc.fsu.edu/~jburkardt/data/ply/ply.html">John Burkardt</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_loader_stl.html
+++ b/examples/webgl_loader_stl.html
@@ -14,7 +14,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> -
 			STL loader test by <a href="https://github.com/aleeper" target="_blank" rel="noopener">aleeper</a>.<br/>
-			PR2 head from <a href="http://www.ros.org/wiki/pr2_description">www.ros.org</a>
+			PR2 head from <a href="https://www.ros.org/wiki/pr2_description">www.ros.org</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_loader_texture_dds.html
+++ b/examples/webgl_loader_texture_dds.html
@@ -14,7 +14,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl - compressed textures<br/>
-			leaf texture by <a href="http://opengameart.org/node/10505">lauris71</a>, explosion texture by <a href="http://opengameart.org/node/7728">bart</a>
+			leaf texture by <a href="https://opengameart.org/node/10505">lauris71</a>, explosion texture by <a href="https://opengameart.org/node/7728">bart</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_loader_texture_exr.html
+++ b/examples/webgl_loader_texture_exr.html
@@ -14,7 +14,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl EXR texture loader example<br/>
-			Image courtesy of <a href="http://www.pauldebevec.com/Research/HDR/" target="_blank" rel="noopener">Paul Debevec</a>.
+			Image courtesy of <a href="https://www.pauldebevec.com/Research/HDR/" target="_blank" rel="noopener">Paul Debevec</a>.
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_loader_texture_hdr.html
+++ b/examples/webgl_loader_texture_hdr.html
@@ -14,7 +14,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl HDR (RGBE) texture loader example<br/>
-			Image courtesy of <a href="http://www.pauldebevec.com/Research/HDR/" target="_blank" rel="noopener">Paul Debevec</a>.
+			Image courtesy of <a href="https://www.pauldebevec.com/Research/HDR/" target="_blank" rel="noopener">Paul Debevec</a>.
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_materials_channels.html
+++ b/examples/webgl_materials_channels.html
@@ -14,7 +14,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - <span id="description">Normal, Velocity, and Depth Materials</span><br/>
-			ninja head from <a href="https://gpuopen.com/archive/gamescgi/amd-gpu-meshmapper/" target="_blank" rel="noopener">AMD GPU MeshMapper</a>
+			ninja head from <a href="https://web.archive.org/web/2024/https://gpuopen.com/archive/gamescgi/amd-gpu-meshmapper/" target="_blank" rel="noopener">AMD GPU MeshMapper</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -15,7 +15,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - (normal + ao + displacement + environment) map demo.<br />
-			ninja head from <a href="https://gpuopen.com/archive/gamescgi/amd-gpu-meshmapper/" target="_blank" rel="noopener">AMD GPU MeshMapper</a>
+			ninja head from <a href="https://web.archive.org/web/2024/https://gpuopen.com/archive/gamescgi/amd-gpu-meshmapper/" target="_blank" rel="noopener">AMD GPU MeshMapper</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -14,7 +14,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl environment mapping example<br/>
-			Equirectangular Map by <a href="http://www.flickr.com/photos/jonragnarsson/2294472375/" target="_blank" rel="noopener">J&oacute;n Ragnarsson</a>.
+			Equirectangular Map by <a href="https://www.flickr.com/photos/jonragnarsson/2294472375/" target="_blank" rel="noopener">J&oacute;n Ragnarsson</a>.
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -15,7 +15,7 @@
 		<div id="container"></div>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">threejs</a> - High dynamic range (RGBE) Image-based Lighting (IBL)<br />using run-time generated pre-filtered roughness mipmaps (PMREM)<br/>
-			Created by Prashant Sharma and <a href="http://clara.io/" target="_blank" rel="noopener">Ben Houston</a>.
+			Created by Prashant Sharma and <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a>.
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_materials_normalmap_object_space.html
+++ b/examples/webgl_materials_normalmap_object_space.html
@@ -15,7 +15,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl object-space normalmap demo<br />
 			Nefertiti Bust by
-			<a href="http://www.cultlab3d.de/" target="_blank" rel="noopener">CultLab3D</a><br />
+			<a href="https://web.archive.org/web/20210225044515/https://www.cultlab3d.de/" target="_blank" rel="noopener">CultLab3D</a><br />
 
 		</div>
 

--- a/examples/webgl_materials_texture_filters.html
+++ b/examples/webgl_materials_texture_filters.html
@@ -24,7 +24,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - texture filtering example<br/>
-			painting by <a href="http://en.wikipedia.org/wiki/Basket_of_Fruit_%28Caravaggio%29">Caravaggio</a>
+			painting by <a href="https://en.wikipedia.org/wiki/Basket_of_Fruit_%28Caravaggio%29">Caravaggio</a>
 		</div>
 
 		<div id="lbl_left" class="lbl">

--- a/examples/webgl_materials_texture_manualmipmap.html
+++ b/examples/webgl_materials_texture_manualmipmap.html
@@ -24,7 +24,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - texture manual mipmapping example<br/>
-			painting by <a href="http://en.wikipedia.org/wiki/Basket_of_Fruit_%28Caravaggio%29">Caravaggio</a>
+			painting by <a href="https://en.wikipedia.org/wiki/Basket_of_Fruit_%28Caravaggio%29">Caravaggio</a>
 		</div>
 
 		<div id="lbl_left" class="lbl">

--- a/examples/webgl_materials_video.html
+++ b/examples/webgl_materials_video.html
@@ -16,7 +16,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl video demo<br/>
-			playing <a href="http://durian.blender.org/" target="_blank" rel="noopener">sintel</a> trailer
+			playing <a href="https://durian.blender.org/" target="_blank" rel="noopener">sintel</a> trailer
 		</div>
 
 		<video id="video" loop muted crossOrigin="anonymous" playsinline style="display:none">

--- a/examples/webgl_morphtargets_horse.html
+++ b/examples/webgl_morphtargets_horse.html
@@ -23,7 +23,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - morph targets - horse<br/>
-			model by <a href="https://mirada.com/" target="_blank" rel="noopener">mirada</a> from <a href="http://www.ro.me" target="_blank" rel="noopener">rome</a>
+			model by <a href="https://mirada.com/" target="_blank" rel="noopener">mirada</a> from <a href="https://www.ro.me" target="_blank" rel="noopener">rome</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_panorama_equirectangular.html
+++ b/examples/webgl_panorama_equirectangular.html
@@ -14,7 +14,7 @@
 
 		<div id="container"></div>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js webgl</a> - equirectangular panorama demo. photo by <a href="http://www.flickr.com/photos/jonragnarsson/2294472375/" target="_blank" rel="noopener">Jón Ragnarsson</a>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js webgl</a> - equirectangular panorama demo. photo by <a href="https://www.flickr.com/photos/jonragnarsson/2294472375/" target="_blank" rel="noopener">Jón Ragnarsson</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_performance.html
+++ b/examples/webgl_performance.html
@@ -15,7 +15,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Performance<br />
 			Dungeon - Low Poly Game Level Challenge by
-			<a href="https://sketchfab.com/warkarma" target="_blank" rel="noopener">Warkarma</a><br />
+			Warkarma<br />
 			<a href="https://hdrihaven.com/hdri/?h=royal_esplanade" target="_blank" rel="noopener">Royal Esplanade</a> from <a href="https://hdrihaven.com/" target="_blank" rel="noopener">HDRI Haven</a>
 		</div>
 

--- a/examples/webgl_points_dynamic.html
+++ b/examples/webgl_points_dynamic.html
@@ -15,8 +15,8 @@
 		<div id="container"></div>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl dynamic particles + postprocessing<br/>
-			models by <a href="http://sketchup.google.com/3dwarehouse/details?mid=2c6fd128fca34052adc5f5b98d513da1" target="_blank" rel="noopener">Reallusion</a>
-			<a href="http://sketchup.google.com/3dwarehouse/details?mid=f526cc4abf7cb68d76cab47c765b7255" target="_blank" rel="noopener">iClone</a>
+			models by <a href="https://3dwarehouse.sketchup.com/model/2c6fd128fca34052adc5f5b98d513da1" target="_blank" rel="noopener">Reallusion</a>
+			<a href="https://3dwarehouse.sketchup.com/model/f526cc4abf7cb68d76cab47c765b7255" target="_blank" rel="noopener">iClone</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_points_sprites.html
+++ b/examples/webgl_points_sprites.html
@@ -14,7 +14,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl particle sprites example<br/>
-			snowflakes by <a href="http://en.wikipedia.org/wiki/File:Sketch_of_snow_crystal_by_Ren%C3%A9_Descartes.jpg">Ren&eacute;  Descartes</a>
+			snowflakes by <a href="https://en.wikipedia.org/wiki/File:Sketch_of_snow_crystal_by_Ren%C3%A9_Descartes.jpg">Ren&eacute;  Descartes</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_postprocessing_3dlut.html
+++ b/examples/webgl_postprocessing_3dlut.html
@@ -15,7 +15,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - 3D LUTs<br />
 			Battle Damaged Sci-fi Helmet by
-			<a href="https://sketchfab.com/theblueturtle_" target="_blank" rel="noopener">theblueturtle_</a><br />
+			theblueturtle_<br />
 			<a href="https://hdrihaven.com/hdri/?h=royal_esplanade" target="_blank" rel="noopener">Royal Esplanade</a> from <a href="https://hdrihaven.com/" target="_blank" rel="noopener">HDRI Haven</a><br />
 			LUTs from <a href="https://www.rocketstock.com/free-after-effects-templates/35-free-luts-for-color-grading-videos/">RocketStock</a>, <a href="https://www.freepresets.com/product/free-luts-cinematic/">FreePresets.com</a>
 		</div>

--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -13,7 +13,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Backgrounds: ClearPass, TexturePass and CubeTexturePass<br/>
-			by <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a>
+			by <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a>
 		</div>
 
 		<div id="container"></div>

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -13,7 +13,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl realistic depth-of-field bokeh example<br/>
-			shader ported from <a href="http://blenderartists.org/forum/showthread.php?237488-GLSL-depth-of-field-with-bokeh-v2-4-(update)">Martins Upitis</a>
+			shader ported from <a href="https://blenderartists.org/forum/showthread.php?237488-GLSL-depth-of-field-with-bokeh-v2-4-(update)">Martins Upitis</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_postprocessing_outline.html
+++ b/examples/webgl_postprocessing_outline.html
@@ -12,7 +12,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Outline Pass by <a href="http://eduperiment.com" target="_blank" rel="noopener">Prashant Sharma</a> and <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Outline Pass by <a href="https://github.com/spidersharma03" target="_blank" rel="noopener">Prashant Sharma</a> and <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_postprocessing_procedural.html
+++ b/examples/webgl_postprocessing_procedural.html
@@ -12,7 +12,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Procedural Effects Example by <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Procedural Effects Example by <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
 		</div>
 
 		<script id="procedural-vert" type="x-shader/x-vertex">

--- a/examples/webgl_postprocessing_sao.html
+++ b/examples/webgl_postprocessing_sao.html
@@ -13,7 +13,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> - Scalable Ambient Occlusion (SAO)<br/>
-			shader by <a href="http://clara.io">Ben Houston</a> / Post-processing pass by <a href="http://ludobaka.github.io">Ludobaka</a>
+			shader by <a href="https://ben3d.ca/">Ben Houston</a> / Post-processing pass by <a href="https://ludobaka.github.io">Ludobaka</a>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -12,7 +12,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Unbiased Manual Supersampling Anti-Aliasing (SSAA) pass by <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Unbiased Manual Supersampling Anti-Aliasing (SSAA) pass by <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
 			This example shows how to unbias the rounding errors accumulated using high number of SSAA samples on a 8-bit per channel buffer.<br/><br/>
 			Turn off the "unbiased" feature to see the banding that results from accumulated rounding errors.
 		</div>

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -12,7 +12,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Temporal Anti-Aliasing (TAA) pass by <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Temporal Anti-Aliasing (TAA) pass by <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
 			When there is no motion in the scene, the TAA render pass accumulates jittered camera samples<br/>
 			across frames to create a high quality anti-aliased result.<br/><br/>
 			Texture interpolation, mipmapping and anisotropic sampling is disabled to emphasize<br/> the effect SSAA levels have one the resulting render quality.

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -22,10 +22,10 @@
 		<div id="container"></div>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Bloom pass by <a href="http://eduperiment.com" target="_blank" rel="noopener">Prashant Sharma</a> and <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Bloom pass by <a href="https://github.com/spidersharma03" target="_blank" rel="noopener">Prashant Sharma</a> and <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a>
 			<br/>
 			Model: <a href="https://blog.sketchfab.com/art-spotlight-primary-ion-drive/" target="_blank" rel="noopener">Primary Ion Drive</a> by
-			<a href="http://mjmurdock.com/" target="_blank" rel="noopener">Mike Murdock</a>, CC Attribution.
+			<a href="https://mjmurdock.com/" target="_blank" rel="noopener">Mike Murdock</a>, CC Attribution.
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -13,7 +13,7 @@
 	<body>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> Click on a sphere to toggle bloom<br>By <a href="http://github.com/Temdog007" target="_blank" rel="noopener">Temdog007</a>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> Click on a sphere to toggle bloom<br>By <a href="https://github.com/Temdog007" target="_blank" rel="noopener">Temdog007</a>
 		</div>
 
 		<script type="x-shader/x-vertex" id="vertexshader">

--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -445,9 +445,9 @@
 		<!-- LDraw.org CC BY 2.0 Parts Library attribution -->
 		<div style="display: block; position: absolute; bottom: 8px; left: 8px; width: 160px; padding: 10px; background-color: #F3F7F8;">
 			<center>
-				<a href="http://www.ldraw.org"><img style="width: 145px" src="models/ldraw/ldraw_org_logo/Stamp145.png"></a>
+				<a href="https://www.ldraw.org"><img style="width: 145px" src="models/ldraw/ldraw_org_logo/Stamp145.png"></a>
 				<br />
-				<a href="http://www.ldraw.org/">This software uses the LDraw Parts Library</a>
+				<a href="https://www.ldraw.org/">This software uses the LDraw Parts Library</a>
 			</center>
 		</div>
 

--- a/examples/webgl_shader_lava.html
+++ b/examples/webgl_shader_lava.html
@@ -13,7 +13,7 @@
 	<body>
 
 		<div id="container"></div>
-		<div id="info"><a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - shader material demo. featuring lava shader by <a href="http://irrlicht.sourceforge.net/phpBB2/viewtopic.php?t=21057" target="_blank" rel="noopener">TheGameMaker</a></div>
+		<div id="info"><a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - shader material demo. featuring lava shader by <a href="https://irrlicht.sourceforge.net/phpBB2/viewtopic.php?t=21057" target="_blank" rel="noopener">TheGameMaker</a></div>
 
 		<script id="fragmentShader" type="x-shader/x-fragment">
 

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -14,7 +14,7 @@
 	<body>
 
 		<div id="info">
-		<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - shadowmap - models by <a href="https://mirada.com/" target="_blank" rel="noopener">mirada</a> from <a href="http://www.ro.me" target="_blank" rel="noopener">rome</a><br />
+		<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - shadowmap - models by <a href="https://mirada.com/" target="_blank" rel="noopener">mirada</a> from <a href="https://www.ro.me" target="_blank" rel="noopener">rome</a><br />
 		t: toggle HUD
 		</div>
 

--- a/examples/webgl_shadowmap_pcss.html
+++ b/examples/webgl_shadowmap_pcss.html
@@ -21,7 +21,7 @@
 	</head>
 
 	<body>
-		<div id="info">Percent Closer Soft-Shadows (PCSS) by <a href="http://eduperiment.com">spidersharma03</a></div>
+		<div id="info">Percent Closer Soft-Shadows (PCSS) by <a href="https://github.com/spidersharma03">spidersharma03</a></div>
 
 		<script type="x-shader/x-fragment" id="PCSS">
 

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -14,7 +14,7 @@
 	<body>
 
 		<div id="info">
-		<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - shadowmap - models by <a href="https://mirada.com/" target="_blank" rel="noopener">mirada</a> from <a href="http://www.ro.me" target="_blank" rel="noopener">rome</a><br />
+		<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - shadowmap - models by <a href="https://mirada.com/" target="_blank" rel="noopener">mirada</a> from <a href="https://www.ro.me" target="_blank" rel="noopener">rome</a><br />
 		move camera with WASD / RF + mouse
 		</div>
 

--- a/examples/webgl_shadowmap_progressive.html
+++ b/examples/webgl_shadowmap_progressive.html
@@ -14,7 +14,7 @@
 		<div id="container"></div>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Progressive Lightmaps by <a href="https://github.com/zalo" target="_blank" rel="noopener">zalo</a><br/>
-			[Inspired by <a href="http://madebyevan.com/shaders/lightmap/" target="_blank" rel="noopener">evanw's Lightmap Generation</a>]
+			[Inspired by <a href="https://madebyevan.com/shaders/lightmap/" target="_blank" rel="noopener">evanw's Lightmap Generation</a>]
 		</div>
 
 		<script type="importmap">

--- a/examples/webgl_simple_gi.html
+++ b/examples/webgl_simple_gi.html
@@ -13,7 +13,7 @@
 	<body>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - simple global illumination (<a href="http://www.iquilezles.org/www/articles/simplegi/simplegi.htm">article</a>)
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - simple global illumination (<a href="https://iquilezles.org/articles/simplegi/">article</a>)
 		</div>
 
 		<script type="importmap">

--- a/examples/webgpu_animation_retargeting_readyplayer.html
+++ b/examples/webgpu_animation_retargeting_readyplayer.html
@@ -19,7 +19,7 @@
 			</div>
 
 			<small>
-				Animation Retargeting from <a href="https://www.mixamo.com/" target="_blank" rel="noopener">Mixamo</a> to <a href="https://readyplayer.me/" target="_blank" rel="noopener">readyplayer.me</a>.
+				Animation Retargeting from <a href="https://www.mixamo.com/" target="_blank" rel="noopener">Mixamo</a> to readyplayer.me.
 			</small>
 		</div>
 

--- a/examples/webgpu_compute_rasterizer_ibl.html
+++ b/examples/webgpu_compute_rasterizer_ibl.html
@@ -19,7 +19,7 @@
 				<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a><span>GPU-Driven Compute Rasterizer — IBL</span>
 			</div>
 
-			<small>Rendering <span id="triangleCount"></span> triangles.<br/>Battle Damaged Sci-fi Helmet by <a href="https://sketchfab.com/theblueturtle_" target="_blank" rel="noopener">theblueturtle_</a></small>
+			<small>Rendering <span id="triangleCount"></span> triangles.<br/>Battle Damaged Sci-fi Helmet by theblueturtle_</small>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgpu_compute_reduce.html
+++ b/examples/webgpu_compute_reduce.html
@@ -162,7 +162,7 @@
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a>
 			<br /> This example demonstrates the performance of various simple parallel reduction kernels.
 			<br /> Reference implementations are translated from the CUDA/WGSL code present in the following books/repos:
-			<br /> Impl. 0 - 2: <a href="https://www.cambridge.org/core/books/programming-in-parallel-with-cuda/C43652A69033C25AD6933368CDBE084C"><i>Programming in Parallel with CUDA</i></a> by <a href="https://people.bss.phy.cam.ac.uk/~rea1/">Richard Ansorge</a>
+			<br /> Impl. 0 - 2: <a href="https://www.cambridge.org/core/books/programming-in-parallel-with-cuda/C43652A69033C25AD6933368CDBE084C"><i>Programming in Parallel with CUDA</i></a> by <a href="https://github.com/RichardAns">Richard Ansorge</a>
 			<br /> Impl. 3: <a href="https://github.com/frost-beta/betann/blob/main/betann/wgsl/reduce_all.wgsl"><i>betann reduce_all kernel</i></a> by <a href="https://github.com/zcbenz">zcbenz</a>
 			<br /> Impl. 4: <a href="https://github.com/b0nes164/GPUPrefixSums/blob/main/GPUPrefixSumsWebGPUapis/SharedShaders/rts.wgsl"><i>GPUPrefixSums reduction approach</i></a> by <a href="https://github.com/b0nes164">b0nes164</a>
 			<div id="left_side_display" style="position: absolute;top: 150px;left: 0;padding: 10px;background: rgba( 0, 0, 0, 0.5 );color: #fff;font-family: monospace;font-size: 12px;line-height: 1.5;pointer-events: none;text-align: left;"></div>

--- a/examples/webgpu_cubemap_adjustments.html
+++ b/examples/webgpu_cubemap_adjustments.html
@@ -21,7 +21,7 @@
 
 			<small>
 				Adjust/modify the scene's background and environment.<br/>
-				Battle Damaged Sci-fi Helmet by <a href="https://sketchfab.com/theblueturtle_" target="_blank" rel="noopener">theblueturtle_</a>.<br/>
+				Battle Damaged Sci-fi Helmet by theblueturtle_.<br/>
 				HDR by <a href="https://polyhaven.com/" target="_blank" rel="noopener">Poly Haven</a> and <a href="https://hdri-skies.com/free-hdris/" target="_blank" rel="noopener">HDRI Skies</a>.
 			</small>
 		</div>

--- a/examples/webgpu_cubemap_mix.html
+++ b/examples/webgpu_cubemap_mix.html
@@ -21,7 +21,7 @@
 
 			<small>
 				Mixing two cube maps.<br/>
-				Battle Damaged Sci-fi Helmet by <a href="https://sketchfab.com/theblueturtle_" target="_blank" rel="noopener">theblueturtle_</a>
+				Battle Damaged Sci-fi Helmet by theblueturtle_
 			</small>
 		</div>
 		<script type="importmap">

--- a/examples/webgpu_custom_fog_background.html
+++ b/examples/webgpu_custom_fog_background.html
@@ -21,7 +21,7 @@
 
 			<small>
 				Custom Fog Background via Post-Processing.<br/>
-				Battle Damaged Sci-fi Helmet by <a href="https://sketchfab.com/theblueturtle_" target="_blank" rel="noopener">theblueturtle_</a>.
+				Battle Damaged Sci-fi Helmet by theblueturtle_.
 				<a href="https://hdrihaven.com/hdri/?h=royal_esplanade" target="_blank" rel="noopener">Royal Esplanade</a> by <a href="https://hdrihaven.com/" target="_blank" rel="noopener">HDRI Haven</a>.
 			</small>
 		</div>

--- a/examples/webgpu_equirectangular.html
+++ b/examples/webgpu_equirectangular.html
@@ -20,7 +20,7 @@
 			</div>
 
 			<small>
-				Photo by <a href="http://www.flickr.com/photos/jonragnarsson/2294472375/" target="_blank" rel="noopener">Jón Ragnarsson</a>.
+				Photo by <a href="https://www.flickr.com/photos/jonragnarsson/2294472375/" target="_blank" rel="noopener">Jón Ragnarsson</a>.
 			</small>
 		</div>
 

--- a/examples/webgpu_lensflares.html
+++ b/examples/webgpu_lensflares.html
@@ -22,7 +22,7 @@
 
 			<small>
 				Fly with WASD/RF/QE + mouse.<br/>
-				Textures from <a href="http://www.ro.me" target="_blank" rel="noopener">ro.me</a>
+				Textures from <a href="https://www.ro.me" target="_blank" rel="noopener">ro.me</a>
 			</small>
 		</div>
 

--- a/examples/webgpu_lights_physical.html
+++ b/examples/webgpu_lights_physical.html
@@ -22,7 +22,7 @@
 			</div>
 
 			<small>
-				Physically accurate incandescent bulb by <a href="http://clara.io" target="_blank" rel="noopener">Ben Houston</a><br />
+				Physically accurate incandescent bulb by <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a><br />
 				Real world scale: Brick cube is 50 cm in size. Globe is 50 cm in diameter.<br/>
 				Reinhard tonemapping with real-world light falloff (decay = 2).
 			</small>

--- a/examples/webgpu_lights_rectarealight.html
+++ b/examples/webgpu_lights_rectarealight.html
@@ -20,7 +20,7 @@
 			</div>
 
 			<small>
-				Rect area light by <a href="http://github.com/abelnation" target="_blank" rel="noopener">abelnation</a>.
+				Rect area light by <a href="https://github.com/abelnation" target="_blank" rel="noopener">abelnation</a>.
 			</small>
 		</div>
 

--- a/examples/webgpu_loader_gltf_anisotropy.html
+++ b/examples/webgpu_loader_gltf_anisotropy.html
@@ -22,7 +22,7 @@
 
 			<small>
 				<a href="https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_anisotropy" target="_blank" rel="noopener">KHR_materials_anisotropy</a>
-				Anisotropy Barn Lamp from <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/AnisotropyBarnLamp" target="_blank" rel="noopener">glTF-Sample-Models</a><br />
+				Anisotropy Barn Lamp from <a href="https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/AnisotropyBarnLamp" target="_blank" rel="noopener">glTF-Sample-Models</a><br />
 				<a href="https://hdrihaven.com/hdri/?h=royal_esplanade" target="_blank" rel="noopener">Royal Esplanade</a> from <a href="https://hdrihaven.com/" target="_blank" rel="noopener">HDRI Haven</a>
 			</small>
 		</div>

--- a/examples/webgpu_loader_gltf_transmission.html
+++ b/examples/webgpu_loader_gltf_transmission.html
@@ -20,7 +20,7 @@
 			</div>
 
 			<small>
-				<a href="https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_transmission" target="_blank" rel="noopener">KHR_materials_transmission</a> Iridescent Dish With Olives by <a href="https://github.com/echadwick-wayfair" target="_blank" rel="noopener">Eric Chadwick</a><br />
+				<a href="https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_transmission" target="_blank" rel="noopener">KHR_materials_transmission</a> Iridescent Dish With Olives by <a href="https://github.com/echadwick-artist" target="_blank" rel="noopener">Eric Chadwick</a><br />
 				<a href="https://hdrihaven.com/hdri/?h=royal_esplanade" target="_blank" rel="noopener">Royal Esplanade</a> from <a href="https://hdrihaven.com/" target="_blank" rel="noopener">HDRI Haven</a>
 			</small>
 		</div>

--- a/examples/webgpu_materials_displacementmap.html
+++ b/examples/webgpu_materials_displacementmap.html
@@ -22,7 +22,7 @@
 
 			<small>
 				( normal + ao + displacement + environment ) maps.<br />
-				Ninja head from <a href="https://gpuopen.com/archive/gamescgi/amd-gpu-meshmapper/" target="_blank" rel="noopener">AMD GPU MeshMapper</a>.
+				Ninja head from <a href="https://web.archive.org/web/2024/https://gpuopen.com/archive/gamescgi/amd-gpu-meshmapper/" target="_blank" rel="noopener">AMD GPU MeshMapper</a>.
 			</small>
 		</div>
 

--- a/examples/webgpu_materials_envmaps.html
+++ b/examples/webgpu_materials_envmaps.html
@@ -20,7 +20,7 @@
 			</div>
 
 			<small>
-				Equirectangular Map by <a href="http://www.flickr.com/photos/jonragnarsson/2294472375/" target="_blank" rel="noopener">J&oacute;n Ragnarsson</a>.
+				Equirectangular Map by <a href="https://www.flickr.com/photos/jonragnarsson/2294472375/" target="_blank" rel="noopener">J&oacute;n Ragnarsson</a>.
 			</small>
 		</div>
 

--- a/examples/webgpu_materials_texture_manualmipmap.html
+++ b/examples/webgpu_materials_texture_manualmipmap.html
@@ -31,7 +31,7 @@
 			</div>
 
 			<small>
-				Painting by <a href="http://en.wikipedia.org/wiki/Basket_of_Fruit_%28Caravaggio%29">Caravaggio</a>.
+				Painting by <a href="https://en.wikipedia.org/wiki/Basket_of_Fruit_%28Caravaggio%29">Caravaggio</a>.
 			</small>
 		</div>
 

--- a/examples/webgpu_materials_video.html
+++ b/examples/webgpu_materials_video.html
@@ -22,7 +22,7 @@
 			</div>
 
 			<small>
-				Playing <a href="http://durian.blender.org/" target="_blank" rel="noopener">sintel</a> trailer.
+				Playing <a href="https://durian.blender.org/" target="_blank" rel="noopener">sintel</a> trailer.
 			</small>
 		</div>
 

--- a/examples/webgpu_performance.html
+++ b/examples/webgpu_performance.html
@@ -22,7 +22,7 @@
 
 			<small>
 				Dungeon - Low Poly Game Level Challenge by
-				<a href="https://sketchfab.com/warkarma" target="_blank" rel="noopener">Warkarma</a><br />
+				Warkarma<br />
 				<a href="https://hdrihaven.com/hdri/?h=royal_esplanade" target="_blank" rel="noopener">Royal Esplanade</a> from <a href="https://hdrihaven.com/" target="_blank" rel="noopener">HDRI Haven</a>.
 			</small>
 		</div>

--- a/examples/webgpu_postprocessing_bloom.html
+++ b/examples/webgpu_postprocessing_bloom.html
@@ -20,9 +20,9 @@
 			</div>
 
 			<small>
-				Bloom pass by <a href="http://eduperiment.com" target="_blank" rel="noopener">Prashant Sharma</a> and <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a>.<br/>
+				Bloom pass by <a href="https://github.com/spidersharma03" target="_blank" rel="noopener">Prashant Sharma</a> and <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a>.<br/>
 				<a href="https://blog.sketchfab.com/art-spotlight-primary-ion-drive/" target="_blank" rel="noopener">Primary Ion Drive</a>
-				by <a href="http://mjmurdock.com/" target="_blank" rel="noopener">Mike Murdock</a> is licensed under <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">Creative Commons Attribution</a>.<br />
+				by <a href="https://mjmurdock.com/" target="_blank" rel="noopener">Mike Murdock</a> is licensed under <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">Creative Commons Attribution</a>.<br />
 			</small>
 		</div>
 

--- a/examples/webgpu_postprocessing_outline.html
+++ b/examples/webgpu_postprocessing_outline.html
@@ -19,7 +19,7 @@
 				<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a><span>Outline</span>
 			</div>
 
-			<small>Outline Pass by <a href="http://eduperiment.com" target="_blank" rel="noopener">Prashant Sharma</a> and <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a>.</small>
+			<small>Outline Pass by <a href="https://github.com/spidersharma03" target="_blank" rel="noopener">Prashant Sharma</a> and <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a>.</small>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgpu_postprocessing_ssaa.html
+++ b/examples/webgpu_postprocessing_ssaa.html
@@ -19,7 +19,7 @@
 				<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a><span>SSAA</span>
 			</div>
 
-			<small>Unbiased Manual Supersampling Anti-Aliasing (SSAA) pass by <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a>.</small>
+			<small>Unbiased Manual Supersampling Anti-Aliasing (SSAA) pass by <a href="https://ben3d.ca/" target="_blank" rel="noopener">Ben Houston</a>.</small>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgpu_postprocessing_ssr_denoise.html
+++ b/examples/webgpu_postprocessing_ssr_denoise.html
@@ -41,7 +41,7 @@
 		<small>
 			Screen Space Reflections with Spatiotemporal Denoising by <a href="https://x.com/0beqz" target="_blank" rel="noopener">0beqz</a>.<br />
 			Dungeon - Low Poly Game Level Challenge by
-			<a href="https://sketchfab.com/warkarma" target="_blank" rel="noopener">Warkarma</a>.<br />
+			Warkarma.<br />
 		</small>
 	</div>
 

--- a/examples/webgpu_shadowmap_progressive.html
+++ b/examples/webgpu_shadowmap_progressive.html
@@ -22,7 +22,7 @@
 			</div>
 
 			<small>
-				By <a href="https://github.com/zalo" target="_blank" rel="noopener">zalo</a>. Inspired by <a href="http://madebyevan.com/shaders/lightmap/" target="_blank" rel="noopener">evanw's Lightmap Generation</a>.
+				By <a href="https://github.com/zalo" target="_blank" rel="noopener">zalo</a>. Inspired by <a href="https://madebyevan.com/shaders/lightmap/" target="_blank" rel="noopener">evanw's Lightmap Generation</a>.
 			</small>
 		</div>
 


### PR DESCRIPTION
**Description**

Audited all external links in `examples/` using [bhouston-link-checker](https://github.com/bhouston/bhouston-link-checker) and fixed every broken or degraded URL found.

Specifically I used this command line:

```npx bhouston-link-checker http://localhost:8080 --exclude-url-match node_modules --exclude-url-match UnitTests.html --concurrency 20 --allow-external > report.txt```

**Changes:**

- **http → https** upgrades across ~40 files for domains that now require HTTPS: `3mf.io`, `blenderartists.org`, `callum.com`, `durian.blender.org`, `en.wikipedia.org`, `github.com`, `irrlicht.sourceforge.net`, `ludobaka.github.io`, `madebyevan.com`, `mjmurdock.com`, `opengameart.org`, `painterlypack.net`, `people.sc.fsu.edu`, `twitter.com`, `flickr.com`, `ldraw.org`, `minecraft.net`, `newgrounds.com`, `pauldebevec.com`, `polycount.com`, `ro.me`, `ros.org`

- **`clara.io` → `https://ben3d.ca/`** in 13 files — the original domain is unreachable; replaced with the author's (Ben Houston) current site

- **`eduperiment.com` → `https://github.com/spidersharma03`** in 5 files — defunct personal site replaced with the author's (Prashant Sharma) active GitHub profile

- **`http://www.iquilezles.org/www/articles/simplegi/simplegi.htm` → `https://iquilezles.org/articles/simplegi/`** — updated to the site's current canonical URL structure

- **glTF-Sample-Models → glTF-Sample-Assets** in 2 files — the Khronos sample model repository was renamed and restructured

- **`echadwick-wayfair` → `echadwick-artist`** in 2 files — GitHub username changed

- **`gpuopen.com/archive/gamescgi/amd-gpu-meshmapper/` → Wayback Machine archive** in 3 files — page no longer exists

- **`cultlab3d.de` → Wayback Machine archive** in 1 file — site no longer live

- **`people.bss.phy.cam.ac.uk/~rea1/` → `https://github.com/RichardAns`** in 1 file — university page inaccessible; replaced with the author's GitHub

- **SketchUp 3D Warehouse URLs** updated to new domain (`3dwarehouse.sketchup.com`) in 1 file

- **Dead `sketchfab.com` user accounts** (`theblueturtle_`, `warkarma`) — removed broken link wrappers in 9 files, kept plain-text credit

- **`readyplayer.me`** — removed hyperlink in 1 file (service discontinued after acquisition by Netflix); plain-text label kept

- **`EXT_texture_avif` Khronos link** — removed dead link (extension no longer present in that repository); plain-text label kept