### PR TITLE
TSL: Fixing rbmax / rbmin calculation of `getParallaxCorrectNormal()`.

### DIFF
--- a/examples/webgpu_materials_envmaps_bpcem.html
+++ b/examples/webgpu_materials_envmaps_bpcem.html
@@ -95,7 +95,7 @@
 				defaultMat.metalnessNode = float( 1 );
 
 				const boxProjectedMat = new THREE.MeshStandardNodeMaterial();
-				boxProjectedMat.envNode = pmremTexture( renderTarget.texture, getParallaxCorrectNormal( reflectVector, vec3( 200, 100, 100 ), vec3( 0, - 50, 0 ) ) );
+				boxProjectedMat.envNode = pmremTexture( renderTarget.texture, getParallaxCorrectNormal( reflectVector, vec3( 200, 200, 100 ), vec3( 0, - 50, 0 ) ) );
 				boxProjectedMat.roughnessNode = texture( rMap ).mul( roughnessUniform );
 				boxProjectedMat.metalnessNode = float( 1 );
 

--- a/src/nodes/functions/material/getParallaxCorrectNormal.js
+++ b/src/nodes/functions/material/getParallaxCorrectNormal.js
@@ -1,5 +1,5 @@
 import { positionWorld } from '../../accessors/Position.js';
-import { float, Fn, min, normalize, sub, vec3 } from '../../tsl/TSLBase.js';
+import { float, Fn, min, normalize, vec3 } from '../../tsl/TSLBase.js';
 
 /**
  * This computes a parallax corrected normal which is used for box-projected cube mapping (BPCEM).
@@ -21,8 +21,8 @@ import { float, Fn, min, normalize, sub, vec3 } from '../../tsl/TSLBase.js';
 const getParallaxCorrectNormal = /*@__PURE__*/ Fn( ( [ normal, cubeSize, cubePos ] ) => {
 
 	const nDir = normalize( normal ).toVar();
-	const rbmax = sub( float( 0.5 ).mul( cubeSize.sub( cubePos ) ), positionWorld ).div( nDir ).toVar();
-	const rbmin = sub( float( - 0.5 ).mul( cubeSize.sub( cubePos ) ), positionWorld ).div( nDir ).toVar();
+	const rbmax = cubeSize.mul( 0.5 ).add( cubePos ).sub( positionWorld ).div( nDir ).toVar();
+	const rbmin = cubeSize.mul( - 0.5 ).add( cubePos ).sub( positionWorld ).div( nDir ).toVar();
 	const rbminmax = vec3().toVar();
 	rbminmax.x = nDir.x.greaterThan( float( 0 ) ).select( rbmax.x, rbmin.x );
 	rbminmax.y = nDir.y.greaterThan( float( 0 ) ).select( rbmax.y, rbmin.y );


### PR DESCRIPTION
Fixed #34006.

**Description**

Applies https://github.com/mrdoob/three.js/commit/cd887bb66caf3444a53b1e4c5cb2a3dc853b97fa which was overlooked when porting over the original BPCEM code from #15897.
