### PR TITLE
WebGLOutput: Match depth texture format to stencil setting.

### DIFF
--- a/src/renderers/webgl/WebGLOutput.js
+++ b/src/renderers/webgl/WebGLOutput.js
@@ -8,7 +8,9 @@ import {
 	NeutralToneMapping,
 	CustomToneMapping,
 	SRGBTransfer,
-	HalfFloatType
+	HalfFloatType,
+	DepthStencilFormat,
+	UnsignedInt248Type
 } from '../../constants.js';
 import { BufferGeometry } from '../../core/BufferGeometry.js';
 import { Float32BufferAttribute } from '../../core/BufferAttribute.js';
@@ -31,13 +33,31 @@ const toneMappingMap = {
 
 function WebGLOutput( type, width, height, antialias, depth, stencil ) {
 
+	// the format of the depth texture must match the stencil setting, otherwise the
+	// multisample resolve blit fails with a depth/stencil format mismatch
+
+	let depthTexture;
+
+	if ( depth === true ) {
+
+		depthTexture = new DepthTexture( width, height );
+
+		if ( stencil === true ) {
+
+			depthTexture.format = DepthStencilFormat;
+			depthTexture.type = UnsignedInt248Type;
+
+		}
+
+	}
+
 	// render targets for scene and post-processing
 	const targetA = new WebGLRenderTarget( width, height, {
 		type: type,
 		depthBuffer: depth,
 		stencilBuffer: stencil,
 		samples: antialias ? 4 : 0,
-		depthTexture: depth ? new DepthTexture( width, height ) : undefined
+		depthTexture: depthTexture
 	} );
 
 	const targetB = new WebGLRenderTarget( width, height, {

--- a/src/renderers/webgl/WebGLOutput.js
+++ b/src/renderers/webgl/WebGLOutput.js
@@ -33,8 +33,7 @@ const toneMappingMap = {
 
 function WebGLOutput( type, width, height, antialias, depth, stencil ) {
 
-	// the format of the depth texture must match the stencil setting, otherwise the
-	// multisample resolve blit fails with a depth/stencil format mismatch
+	// make sure depth texture matches renderer settings
 
 	let depthTexture;
 


### PR DESCRIPTION
Related issue: -

**Description**

Since r184, `WebGLOutput` creates its scene render target with `samples: 4` when `antialias` is enabled (#33446) and an attached `DepthTexture` (c0553ae). The depth texture is always created with the default `DepthFormat`, even when the renderer is created with `stencil: true`.

When all three options are combined (`antialias: true`, `stencil: true`, `outputBufferType: HalfFloatType`), the multisample resolve in `WebGLTextures.updateMultisampleRenderTarget()` blits between mismatched depth formats:

- multisampled depth renderbuffer: `DEPTH24_STENCIL8` (derived from `stencilBuffer: true`)
- resolve-side depth texture: `DEPTH_COMPONENT24` (default `DepthFormat`)

`blitFramebuffer` requires the depth formats of the read/draw framebuffers to be identical, so every frame produces:

```
GL_INVALID_OPERATION: glBlitFramebuffer: Depth/stencil buffer format combination not allowed for blit.
```

After 256 errors Chrome stops reporting ("WebGL: too many errors") and eventually the WebGL context is lost, so rendering breaks down entirely.

Minimal reproduction (fails on r184/r185, clean with this fix):

```js
const renderer = new THREE.WebGLRenderer( {
	antialias: true,
	stencil: true,
	outputBufferType: THREE.HalfFloatType
} );
renderer.setSize( 256, 256 );
renderer.toneMapping = THREE.ACESFilmicToneMapping; // any tone mapping, so WebGLOutput is active
document.body.appendChild( renderer.domElement );

const scene = new THREE.Scene();
const camera = new THREE.PerspectiveCamera( 50, 1, 0.1, 100 );
camera.position.z = 3;
scene.add( new THREE.Mesh( new THREE.BoxGeometry(), new THREE.MeshBasicMaterial() ) );

const gl = renderer.getContext();
renderer.render( scene, camera );
console.log( gl.getError().toString( 16 ) ); // '502' (GL_INVALID_OPERATION) before this fix, '0' after
```

This PR creates the depth texture with `DepthStencilFormat` / `UnsignedInt248Type` when `stencil` is enabled, matching the format of the multisampled depth/stencil renderbuffer.