### PR TITLE
Prevent normal-flips caused by SimplifyModifier

### DIFF
--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -32,9 +32,10 @@ class SimplifyModifier {
 	 *
 	 * @param {BufferGeometry} geometry - The geometry to modify.
 	 * @param {number} count - The number of vertices to remove.
+	 * @param {Array<string>} [ignoredAttributes=[]] - The attributes to be kept the same and excluded from simplification.
 	 * @return {BufferGeometry} A new, modified geometry.
 	 */
-	modify( geometry, count ) {
+	modify( geometry, count, ignoredAttributes = [] ) {
 
 		geometry = geometry.clone();
 
@@ -43,11 +44,14 @@ class SimplifyModifier {
 		delete geometry.morphAttributes.normal;
 		const attributes = geometry.attributes;
 
-		// this modifier can only process indexed and non-indexed geometries with at least a position attribute
+		//filter ignoredAttributes
+		for ( const name of [ ...ignoredAttributes ] ) {
 
-		for ( const name in attributes ) {
+			if ( attributes[ name ] == undefined ) {
 
-			if ( name !== 'position' && name !== 'uv' && name !== 'normal' && name !== 'tangent' && name !== 'color' ) geometry.deleteAttribute( name );
+				ignoredAttributes.splice( ignoredAttributes.indexOf( name ), 1 );
+
+			}
 
 		}
 
@@ -56,11 +60,6 @@ class SimplifyModifier {
 		//
 		// put data of original geometry in different data structures
 		//
-
-		const vertices = [];
-		const faces = [];
-
-		// add vertices
 
 		const positionAttribute = geometry.getAttribute( 'position' );
 		const uvAttribute = geometry.getAttribute( 'uv' );
@@ -73,9 +72,12 @@ class SimplifyModifier {
 		let nor = null;
 		let col = null;
 
+		const vertices = [];
+
 		for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
 			const v = new Vector3().fromBufferAttribute( positionAttribute, i );
+
 			if ( uvAttribute ) {
 
 				v2 = new Vector2().fromBufferAttribute( uvAttribute, i );
@@ -106,6 +108,7 @@ class SimplifyModifier {
 		}
 
 		// add faces
+		const faces = [];
 
 		let index = geometry.getIndex();
 
@@ -149,21 +152,41 @@ class SimplifyModifier {
 
 		let z = count;
 
+		let err = 0;
+
 		while ( z -- ) {
 
+			// repeat for number of vertices to remove
 			nextVertex = minimumCostEdge( vertices );
 
 			if ( ! nextVertex ) {
 
-				console.log( 'THREE.SimplifyModifier: No next vertex' );
+				console.warn( 'THREE.SimplifyModifier: No next vertex' );
 				break;
 
 			}
 
-			collapse( vertices, faces, nextVertex, nextVertex.collapseNeighbor );
+			if ( nextVertex.collapseCost == Infinity ) {
+
+				console.warn(
+					'THREE.SimplifyModifier: No next vertex; Only border is left',
+				);
+				break;
+
+			}
+
+			err += nextVertex.collapseCost;
+
+			collapse(
+				vertices,
+				faces,
+				nextVertex,
+				nextVertex.collapseNeighbor,
+			);
 
 		}
 
+		this.error = err;
 		//
 
 		const simplifiedGeometry = new BufferGeometry();
@@ -250,14 +273,14 @@ function removeFromArray( array, object ) {
 function computeEdgeCollapseCost( u, v ) {
 
 	// if we collapse edge uv by moving u to v then how
-	// much different will the model change, i.e. the "error".
+	// much different will the model change, i.e. the 'error'.
 
 	const edgelength = v.position.distanceTo( u.position );
 	let curvature = 0;
 
 	const sideFaces = [];
 
-	// find the "sides" triangles that are on the edge uv
+	// find the 'sides' triangles that are on the edge uv
 	for ( let i = 0, il = u.faces.length; i < il; i ++ ) {
 
 		const face = u.faces[ i ];
@@ -302,6 +325,8 @@ function computeEdgeCollapseCost( u, v ) {
 
 	}
 
+	if ( ! testCollapse( u, v ) ) return Infinity;
+
 	const amt = edgelength * curvature + borders;
 
 	return amt;
@@ -327,10 +352,9 @@ function computeEdgeCostAtVertex( v ) {
 
 	}
 
-	v.collapseCost = 100000;
 	v.collapseNeighbor = null;
 
-	// search all neighboring edges for "least cost" edge
+	// search all neighboring edges for 'least cost' edge
 	for ( let i = 0; i < v.neighbors.length; i ++ ) {
 
 		const collapseCost = computeEdgeCollapseCost( v, v.neighbors[ i ] );
@@ -345,11 +369,17 @@ function computeEdgeCostAtVertex( v ) {
 
 		}
 
-		v.costCount ++;
-		v.totalCost += collapseCost;
+		if ( collapseCost !== Infinity ) {
+
+			v.costCount ++;
+			v.totalCost += collapseCost;
+
+		}
+
 
 		if ( collapseCost < v.minCost ) {
 
+			// if collapseCost is lowest store it as smallest collapseCost
 			v.collapseNeighbor = v.neighbors[ i ];
 			v.minCost = collapseCost;
 
@@ -358,8 +388,9 @@ function computeEdgeCostAtVertex( v ) {
 	}
 
 	// we average the cost of collapsing at this vertex
+
 	v.collapseCost = v.totalCost / v.costCount;
-	// v.collapseCost = v.minCost;
+	//v.collapseCost = v.minCost;
 
 }
 
@@ -441,7 +472,6 @@ function collapse( vertices, faces, u, v ) {
 
 	}
 
-
 	// delete triangles on edge uv:
 	for ( let i = u.faces.length - 1; i >= 0; i -- ) {
 
@@ -460,7 +490,6 @@ function collapse( vertices, faces, u, v ) {
 
 	}
 
-
 	removeVertex( u, vertices );
 
 	// recompute the edge collapse costs in neighborhood
@@ -472,7 +501,41 @@ function collapse( vertices, faces, u, v ) {
 
 }
 
+function testCollapse( u, v ) {
 
+	// Collapse the edge uv by moving vertex u onto v
+
+	if ( ! v ) {
+
+		return true;
+
+	}
+
+	// update remaining triangles to have v instead of u
+	for ( let i = u.faces.length - 1; i >= 0; i -- ) {
+
+		if ( ! ( u.faces[ i ] && u.faces[ i ].hasVertex( v ) ) ) {
+
+			u.faces[ i ].computeNormal();
+
+			const oldNormal = u.faces[ i ].normal.clone();
+			u.faces[ i ].computeNormalReplace( u, v );
+			const dotRes = u.faces[ i ].normal.dot( oldNormal );
+			u.faces[ i ].normal.copy( oldNormal );
+
+			if ( dotRes < 0 ) {
+
+				return false;
+
+			}
+
+		}
+
+	}
+
+	return true;
+
+}
 
 function minimumCostEdge( vertices ) {
 
@@ -520,12 +583,57 @@ class Triangle {
 		v2.addUniqueNeighbor( v1 );
 		v2.addUniqueNeighbor( v3 );
 
-
 		v3.faces.push( this );
 		v3.addUniqueNeighbor( v1 );
 		v3.addUniqueNeighbor( v2 );
 
 	}
+
+	getEdges() {
+
+		return [
+			[ this.v1, this.v2 ],
+			[ this.v2, this.v3 ],
+			[ this.v3, this.v1 ],
+		];
+
+	}
+
+	getArea() {
+
+		// use herons formula
+		const a = this.v1.position.distanceTo( this.v2.position );
+		const b = this.v2.position.distanceTo( this.v3.position );
+		const c = this.v3.position.distanceTo( this.v1.position );
+
+		const s = 0.5 * ( a + b + c );
+
+		return Math.sqrt( s * ( s - a ) * ( s - b ) * ( s - c ) );
+
+	}
+
+	getEdgesWith( vertex ) {
+
+		return this.getEdges().filter(
+			( entry ) => entry[ 0 ] == vertex || entry[ 1 ] == vertex,
+		);
+
+	}
+
+	computeNormalReplace( u, v ) {
+
+		const vA = this.v1 === u ? v.position : this.v1.position;
+		const vB = this.v2 === u ? v.position : this.v2.position;
+		const vC = this.v3 === u ? v.position : this.v3.position;
+
+		_cb.subVectors( vC, vB );
+		_ab.subVectors( vA, vB );
+		_cb.cross( _ab ).normalize();
+
+		this.normal.copy( _cb );
+
+	}
+
 
 	computeNormal() {
 
@@ -555,7 +663,6 @@ class Triangle {
 
 		removeFromArray( oldv.faces, this );
 		newv.faces.push( this );
-
 
 		oldv.removeIfNonNeighbor( this.v1 );
 		this.v1.removeIfNonNeighbor( oldv );

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -32,10 +32,9 @@ class SimplifyModifier {
 	 *
 	 * @param {BufferGeometry} geometry - The geometry to modify.
 	 * @param {number} count - The number of vertices to remove.
-	 * @param {Array<string>} [ignoredAttributes=[]] - The attributes to be kept the same and excluded from simplification.
 	 * @return {BufferGeometry} A new, modified geometry.
 	 */
-	modify( geometry, count, ignoredAttributes = [] ) {
+	modify( geometry, count ) {
 
 		geometry = geometry.clone();
 
@@ -45,11 +44,11 @@ class SimplifyModifier {
 		const attributes = geometry.attributes;
 
 		//filter ignoredAttributes
-		for ( const name of [ ...ignoredAttributes ] ) {
+		for ( const name in attributes ) {
 
 			if ( attributes[ name ] == undefined ) {
 
-				ignoredAttributes.splice( ignoredAttributes.indexOf( name ), 1 );
+				if ( name !== 'position' && name !== 'uv' && name !== 'normal' && name !== 'tangent' && name !== 'color' ) geometry.deleteAttribute( name );
 
 			}
 
@@ -586,37 +585,6 @@ class Triangle {
 		v3.faces.push( this );
 		v3.addUniqueNeighbor( v1 );
 		v3.addUniqueNeighbor( v2 );
-
-	}
-
-	getEdges() {
-
-		return [
-			[ this.v1, this.v2 ],
-			[ this.v2, this.v3 ],
-			[ this.v3, this.v1 ],
-		];
-
-	}
-
-	getArea() {
-
-		// use herons formula
-		const a = this.v1.position.distanceTo( this.v2.position );
-		const b = this.v2.position.distanceTo( this.v3.position );
-		const c = this.v3.position.distanceTo( this.v1.position );
-
-		const s = 0.5 * ( a + b + c );
-
-		return Math.sqrt( s * ( s - a ) * ( s - b ) * ( s - c ) );
-
-	}
-
-	getEdgesWith( vertex ) {
-
-		return this.getEdges().filter(
-			( entry ) => entry[ 0 ] == vertex || entry[ 1 ] == vertex,
-		);
 
 	}
 

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -47,11 +47,7 @@ class SimplifyModifier {
 
 		for ( const name in attributes ) {
 
-			if ( attributes[ name ] == undefined ) {
-
-				if ( name !== 'position' && name !== 'uv' && name !== 'normal' && name !== 'tangent' && name !== 'color' ) geometry.deleteAttribute( name );
-
-			}
+			if ( name !== 'position' && name !== 'uv' && name !== 'normal' && name !== 'tangent' && name !== 'color' ) geometry.deleteAttribute( name );
 
 		}
 

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -165,7 +165,7 @@ class SimplifyModifier {
 			if ( nextVertex.collapseCost == Infinity ) {
 
 				console.warn(
-					'THREE.SimplifyModifier: No next vertex; Only border is left',
+					'THREE.SimplifyModifier: No next vertex; Only invalid trinagles (causing normal flips) is left',
 				);
 				break;
 

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -165,7 +165,7 @@ class SimplifyModifier {
 			if ( nextVertex.collapseCost == Infinity ) {
 
 				console.warn(
-					'THREE.SimplifyModifier: No next vertex; Only invalid triangles (causing normal flips) is left',
+					'THREE.SimplifyModifier: No next vertex; Only invalid triangles (causing normal flips) left',
 				);
 				break;
 

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -32,9 +32,13 @@ class SimplifyModifier {
 	 *
 	 * @param {BufferGeometry} geometry - The geometry to modify.
 	 * @param {number} count - The number of vertices to remove.
+	 * @param {Object} [options] - The options.
+	 * @param {boolean} [options.preventNormalFlips=false] - Whether to prevent edge collapses that would flip neighboring face normals. Enabling this changes the simplification result and may remove fewer vertices than requested.
 	 * @return {BufferGeometry} A new, modified geometry.
 	 */
-	modify( geometry, count ) {
+	modify( geometry, count, options = {} ) {
+
+		const { preventNormalFlips = false } = options;
 
 		geometry = geometry.clone();
 
@@ -57,6 +61,11 @@ class SimplifyModifier {
 		// put data of original geometry in different data structures
 		//
 
+		const vertices = [];
+		const faces = [];
+
+		// add vertices
+
 		const positionAttribute = geometry.getAttribute( 'position' );
 		const uvAttribute = geometry.getAttribute( 'uv' );
 		const normalAttribute = geometry.getAttribute( 'normal' );
@@ -68,12 +77,9 @@ class SimplifyModifier {
 		let nor = null;
 		let col = null;
 
-		const vertices = [];
-
 		for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
 			const v = new Vector3().fromBufferAttribute( positionAttribute, i );
-
 			if ( uvAttribute ) {
 
 				v2 = new Vector2().fromBufferAttribute( uvAttribute, i );
@@ -104,7 +110,6 @@ class SimplifyModifier {
 		}
 
 		// add faces
-		const faces = [];
 
 		let index = geometry.getIndex();
 
@@ -148,41 +153,44 @@ class SimplifyModifier {
 
 		let z = count;
 
-		let err = 0;
+		while ( z > 0 ) {
 
-		while ( z -- ) {
-
-			// repeat for number of vertices to remove
 			nextVertex = minimumCostEdge( vertices );
 
 			if ( ! nextVertex ) {
 
-				console.warn( 'THREE.SimplifyModifier: No next vertex' );
+				console.log( 'THREE.SimplifyModifier: No next vertex' );
 				break;
 
 			}
 
-			if ( nextVertex.collapseCost == Infinity ) {
+			if ( preventNormalFlips ) {
 
-				console.warn(
-					'THREE.SimplifyModifier: No next vertex; Only invalid triangles (causing normal flips) left',
-				);
-				break;
+				if ( nextVertex.collapseCost === Infinity ) {
+
+					console.log( 'THREE.SimplifyModifier: No collapsible vertex left, stopping early to prevent normal flips' );
+					break;
+
+				}
+
+				if ( testCollapse( nextVertex, nextVertex.collapseNeighbor ) === false ) {
+
+					// this collapse would flip a neighboring face so exclude the vertex from
+					// selection until a collapse in its neighborhood recomputes its cost
+
+					nextVertex.collapseCost = Infinity;
+					continue;
+
+				}
 
 			}
 
-			err += nextVertex.collapseCost;
+			collapse( vertices, faces, nextVertex, nextVertex.collapseNeighbor );
 
-			collapse(
-				vertices,
-				faces,
-				nextVertex,
-				nextVertex.collapseNeighbor,
-			);
+			z --;
 
 		}
 
-		this.error = err;
 		//
 
 		const simplifiedGeometry = new BufferGeometry();
@@ -269,14 +277,14 @@ function removeFromArray( array, object ) {
 function computeEdgeCollapseCost( u, v ) {
 
 	// if we collapse edge uv by moving u to v then how
-	// much different will the model change, i.e. the 'error'.
+	// much different will the model change, i.e. the "error".
 
 	const edgelength = v.position.distanceTo( u.position );
 	let curvature = 0;
 
 	const sideFaces = [];
 
-	// find the 'sides' triangles that are on the edge uv
+	// find the "sides" triangles that are on the edge uv
 	for ( let i = 0, il = u.faces.length; i < il; i ++ ) {
 
 		const face = u.faces[ i ];
@@ -321,8 +329,6 @@ function computeEdgeCollapseCost( u, v ) {
 
 	}
 
-	if ( ! testCollapse( u, v ) ) return Infinity;
-
 	const amt = edgelength * curvature + borders;
 
 	return amt;
@@ -348,9 +354,10 @@ function computeEdgeCostAtVertex( v ) {
 
 	}
 
+	v.collapseCost = 100000;
 	v.collapseNeighbor = null;
 
-	// search all neighboring edges for 'least cost' edge
+	// search all neighboring edges for "least cost" edge
 	for ( let i = 0; i < v.neighbors.length; i ++ ) {
 
 		const collapseCost = computeEdgeCollapseCost( v, v.neighbors[ i ] );
@@ -365,17 +372,11 @@ function computeEdgeCostAtVertex( v ) {
 
 		}
 
-		if ( collapseCost !== Infinity ) {
-
-			v.costCount ++;
-			v.totalCost += collapseCost;
-
-		}
-
+		v.costCount ++;
+		v.totalCost += collapseCost;
 
 		if ( collapseCost < v.minCost ) {
 
-			// if collapseCost is lowest store it as smallest collapseCost
 			v.collapseNeighbor = v.neighbors[ i ];
 			v.minCost = collapseCost;
 
@@ -384,9 +385,8 @@ function computeEdgeCostAtVertex( v ) {
 	}
 
 	// we average the cost of collapsing at this vertex
-
 	v.collapseCost = v.totalCost / v.costCount;
-	//v.collapseCost = v.minCost;
+	// v.collapseCost = v.minCost;
 
 }
 
@@ -468,6 +468,7 @@ function collapse( vertices, faces, u, v ) {
 
 	}
 
+
 	// delete triangles on edge uv:
 	for ( let i = u.faces.length - 1; i >= 0; i -- ) {
 
@@ -486,6 +487,7 @@ function collapse( vertices, faces, u, v ) {
 
 	}
 
+
 	removeVertex( u, vertices );
 
 	// recompute the edge collapse costs in neighborhood
@@ -499,33 +501,26 @@ function collapse( vertices, faces, u, v ) {
 
 function testCollapse( u, v ) {
 
-	// Collapse the edge uv by moving vertex u onto v
+	// tests whether collapsing the edge uv by moving u onto v would
+	// flip the normal of one of the remaining faces around u
 
-	if ( ! v ) {
+	for ( let i = 0, il = u.faces.length; i < il; i ++ ) {
 
-		return true;
+		const face = u.faces[ i ];
 
-	}
+		// faces shared by u and v are removed by the collapse
 
-	// update remaining triangles to have v instead of u
-	for ( let i = u.faces.length - 1; i >= 0; i -- ) {
+		if ( face.hasVertex( v ) ) continue;
 
-		if ( ! ( u.faces[ i ] && u.faces[ i ].hasVertex( v ) ) ) {
+		const vA = face.v1 === u ? v.position : face.v1.position;
+		const vB = face.v2 === u ? v.position : face.v2.position;
+		const vC = face.v3 === u ? v.position : face.v3.position;
 
-			u.faces[ i ].computeNormal();
+		_cb.subVectors( vC, vB );
+		_ab.subVectors( vA, vB );
+		_cb.cross( _ab );
 
-			const oldNormal = u.faces[ i ].normal.clone();
-			u.faces[ i ].computeNormalReplace( u, v );
-			const dotRes = u.faces[ i ].normal.dot( oldNormal );
-			u.faces[ i ].normal.copy( oldNormal );
-
-			if ( dotRes < 0 ) {
-
-				return false;
-
-			}
-
-		}
+		if ( _cb.dot( face.normal ) < 0 ) return false;
 
 	}
 
@@ -579,26 +574,12 @@ class Triangle {
 		v2.addUniqueNeighbor( v1 );
 		v2.addUniqueNeighbor( v3 );
 
+
 		v3.faces.push( this );
 		v3.addUniqueNeighbor( v1 );
 		v3.addUniqueNeighbor( v2 );
 
 	}
-
-	computeNormalReplace( u, v ) {
-
-		const vA = this.v1 === u ? v.position : this.v1.position;
-		const vB = this.v2 === u ? v.position : this.v2.position;
-		const vC = this.v3 === u ? v.position : this.v3.position;
-
-		_cb.subVectors( vC, vB );
-		_ab.subVectors( vA, vB );
-		_cb.cross( _ab ).normalize();
-
-		this.normal.copy( _cb );
-
-	}
-
 
 	computeNormal() {
 
@@ -628,6 +609,7 @@ class Triangle {
 
 		removeFromArray( oldv.faces, this );
 		newv.faces.push( this );
+
 
 		oldv.removeIfNonNeighbor( this.v1 );
 		this.v1.removeIfNonNeighbor( oldv );

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -43,7 +43,8 @@ class SimplifyModifier {
 		delete geometry.morphAttributes.normal;
 		const attributes = geometry.attributes;
 
-		//filter ignoredAttributes
+		// this modifier can only process indexed and non-indexed geometries with at least a position attribute
+
 		for ( const name in attributes ) {
 
 			if ( attributes[ name ] == undefined ) {

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -165,7 +165,7 @@ class SimplifyModifier {
 			if ( nextVertex.collapseCost == Infinity ) {
 
 				console.warn(
-					'THREE.SimplifyModifier: No next vertex; Only invalid trinagles (causing normal flips) is left',
+					'THREE.SimplifyModifier: No next vertex; Only invalid triangles (causing normal flips) is left',
 				);
 				break;
 

--- a/examples/webgl_modifier_simplifier.html
+++ b/examples/webgl_modifier_simplifier.html
@@ -25,6 +25,7 @@
 			import * as THREE from 'three';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { SimplifyModifier } from 'three/addons/modifiers/SimplifyModifier.js';
 
@@ -81,6 +82,18 @@
 					simplified.position.x = 3;
 					simplified.rotation.y = - Math.PI / 2;
 					scene.add( simplified );
+
+					const params = { preventNormalFlips: false };
+
+					const gui = new GUI();
+					gui.add( params, 'preventNormalFlips' ).onChange( function ( value ) {
+
+						simplified.geometry.dispose();
+						simplified.geometry = modifier.modify( mesh.geometry, count, { preventNormalFlips: value } );
+
+						render();
+
+					} );
 
 					render();
 


### PR DESCRIPTION
Related issue: #34009

**Description**
This PR aims at preventing normal flips when simplifying meshes.

Even a normal simplification like in the example code causes lots of triangle normal flips, as can be seen when looking at the logs [here](https://nils-nonline.github.io/three.js/examples/?q=sim#webgl_modifier_simplifier).
Please note the demo only serves as an example if my code is valid.

To prevent normal flips I added a cost of Infinity for simplifying triangles when one of it's neighbors normals is flipped, while simplifying it. To prevent this from making the average error useless all errors of Infinity are ignored for calculating the average error.