### PR TITLE
Bindings: Fix `_destroyBindings()`.

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -271,10 +271,14 @@ class Bindings extends DataMap {
 
 							this.backend.destroySampler( binding );
 
-						}
+						} else if ( binding.texture !== null ) {
 
-						const textureData = this.textures.get( binding.texture );
-						if ( textureData.bindGroups !== undefined ) textureData.bindGroups.delete( bindGroup );
+							// untrack destroyed bind group from its texture
+
+							const textureData = this.textures.get( binding.texture );
+							if ( textureData.bindGroups !== undefined ) textureData.bindGroups.delete( bindGroup );
+
+						}
 
 						binding.release();
 


### PR DESCRIPTION
Related issue: #33954

**Description**

Follow-up of #33954. The "untrack" logic that decouples a bind group from its texture may only run if the bindings texture reference is not `null`. It can be `null` if the texture has been disposed of first. In this case, a weakmap error would occur which this PR prevents.
