### PR TITLE
Ray: Handle empty spheres in intersectSphere().

### DIFF
--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -306,6 +306,8 @@ class Ray {
 	 */
 	intersectSphere( sphere, target ) {
 
+		if ( sphere.radius < 0 ) return null; // handle empty spheres, see #31187
+
 		_vector.subVectors( sphere.center, this.origin );
 		const tca = _vector.dot( this.direction );
 		const d2 = _vector.dot( _vector ) - tca * tca;

--- a/test/unit/src/math/Ray.tests.js
+++ b/test/unit/src/math/Ray.tests.js
@@ -260,6 +260,13 @@ export default QUnit.module( 'Maths', () => {
 			a0.intersectSphere( b, point );
 			assert.ok( point.distanceTo( new Vector3( 0, 0, - 5 ) ) < TOL, 'Passed!' );
 
+			// empty sphere ( negative radius ) can never be intersected, so the
+			// target must be left untouched and the return value must be null,
+			// consistent with intersectsSphere()
+			b = new Sphere( new Vector3( 0, 0, - 1 ), - 1 );
+			assert.strictEqual( a0.intersectSphere( b, point.copy( posInf3 ) ), null, 'Passed!' );
+			assert.ok( point.equals( posInf3 ), 'Passed!' );
+
 		} );
 
 		QUnit.test( 'intersectsSphere', ( assert ) => {


### PR DESCRIPTION
`Ray.intersectsSphere()` was updated to return `false` for empty spheres (`radius < 0`) in #31200, but the point-returning `Ray.intersectSphere()` was missed and still reports a spurious intersection point for an empty sphere.

Since `Sphere.isEmpty()` is defined as `radius < 0`, an empty sphere has no surface and can never be intersected. This adds the same guard to `intersectSphere()` so the two methods stay consistent, and covers it in the `Ray` unit test.

**Before:** `ray.intersectSphere( emptySphere, target )` returns a point and writes it into `target`.
**After:** it returns `null` and leaves `target` untouched, matching `intersectsSphere()`.
