### PR TITLE
Manual: Add Addons section anchor

### DIFF
--- a/manual/pages/installation.html
+++ b/manual/pages/installation.html
@@ -253,7 +253,7 @@ npm install --save-dev vite
             <i><b>IMPORTANT:</b> Import all dependencies from the same version of three.js, and from the same CDN. Mixing files from different sources may cause duplicate code to be included, or even break the application in unexpected ways.</i>
           </p>
 
-          <h2>Addons</h2>
+          <h2 id="addons">Addons</h2>
 
           <p>
             Out of the box, three.js includes the fundamentals of a 3D engine. Other three.js components — such as controls, loaders, and post-processing effects — are part of the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm addons/] directory. Addons do not need to be <i>installed</i> separately, but do need to be <i>imported</i> separately.

--- a/utils/docs/template/tmpl/container.tmpl
+++ b/utils/docs/template/tmpl/container.tmpl
@@ -42,7 +42,7 @@
 			<article>
 				<?js if (doc.import) { ?>
 				<h2 class="subsection-title">Import</h2>
-				<p><span translate="no"><?js= doc.name ?></span> is an addon, and must be imported explicitly, see <a href="https://threejs.org/manual/#installation">Installation#Addons</a>.</p>
+				<p><span translate="no"><?js= doc.name ?></span> is an addon, and must be imported explicitly, see <a href="https://threejs.org/manual/#installation#addons">Installation#Addons</a>.</p>
 				<pre class="prettyprint source lang-js" translate="no"><code><?js= doc.import ?></code></pre>
 				<?js } ?>
 				<div class="container-overview">


### PR DESCRIPTION
Related issue: #23225

**Description**

Follow-up to #33976 using the source-defined ID approach requested in review.

Adds a stable `addons` ID to the Addons heading in the Installation manual page and updates the addon documentation template to link directly to it. This enables `/manual/#installation#addons` without generating heading IDs at runtime.

The scope is intentionally limited to this section and its existing documentation link so the source-defined anchor direction can be confirmed in review before applying IDs more broadly across the manual.

**Testing**

- `npx eslint manual/pages/installation.html`
- Verified `/manual/#installation#addons`
- Verified `/manual/pages/installation.html#addons`
- Verified the addon documentation template targets the new anchor
