### PR TITLE
MathNode: Fix integer `min()`/`max()` on the WebGL backend

### DIFF
--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -258,11 +258,6 @@ class MathNode extends TempNode {
 
 			} else if ( coordinateSystem === WebGLCoordinateSystem && ( method === MathNode.MIN || method === MathNode.MAX ) ) {
 
-				// GLSL only offers a mixed-type overload where the second operand is a scalar
-				// of the input's component type ( e.g. min( ivec2, int ), min( vec3, float ) ).
-				// Coerce a scalar second operand to that component type so integer inputs don't
-				// generate an invalid min( int, float( ... ) ).
-
 				params.push(
 					a.build( builder, inputType ),
 					b.build( builder, builder.getTypeLength( b.getNodeType( builder ) ) === 1 ? builder.getComponentType( inputType ) : inputType )

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -258,9 +258,14 @@ class MathNode extends TempNode {
 
 			} else if ( coordinateSystem === WebGLCoordinateSystem && ( method === MathNode.MIN || method === MathNode.MAX ) ) {
 
+				// GLSL only offers a mixed-type overload where the second operand is a scalar
+				// of the input's component type ( e.g. min( ivec2, int ), min( vec3, float ) ).
+				// Coerce a scalar second operand to that component type so integer inputs don't
+				// generate an invalid min( int, float( ... ) ).
+
 				params.push(
 					a.build( builder, inputType ),
-					b.build( builder, builder.getTypeLength( b.getNodeType( builder ) ) === 1 ? 'float' : inputType )
+					b.build( builder, builder.getTypeLength( b.getNodeType( builder ) ) === 1 ? builder.getComponentType( inputType ) : inputType )
 				);
 
 			} else if ( method === MathNode.REFRACT ) {


### PR DESCRIPTION
On the WebGL backend, `min()`/`max()` with a scalar second operand always coerced that operand to `float`, to satisfy GLSL's mixed `min( vecN, float )` overload. For integer inputs this produced invalid GLSL such as `min( int, float( ... ) )`, failing shader compilation.

Coerce the scalar operand to the component type of the inputs instead, so integer inputs generate `min( int, int )` / `min( ivec2, int )` while float inputs are unchanged.

### Context

I stumbled over this when using [three-text](https://github.com/countertype/three-text/blob/7eb1984c76c70367fc62776fae016979cf6eaad1/src/vector/slug/slugTSL.ts#L160-L163) which was doing this:

```
    const bandIdxX = max(min(
      renderCoord.x.mul(bandTransform.x).add(bandTransform.z).toInt(),
      bandMaxX
    ), int(0));
```

which then caused this compilation error:

```
  THREE.WebGLProgram: Shader Error 0 - VALIDATE_STATUS false

  Program Info Log: Fragment shader is not compiled.


  FRAGMENT

  ERROR: 0:172: 'min' : no matching overloaded function found
  ERROR: 0:172: '+' : wrong operand types - no operation '+' exists that takes a left-hand operand of type 'highp int' and a right operand of type 'const mediump float' (or there is no acceptable conversion)
  ERROR: 0:349: 'min' : no matching overloaded function found
  ERROR: 0:349: '+' : wrong operand types - no operation '+' exists that takes a left-hand operand of type 'highp int' and a right operand of type 'const mediump float' (or there is no acceptable conversion)


    167:
    168:        nodeVar0 = 0.0;
    169:        nodeVar1 = 0.0;
    170:        nodeVar2 = 0;
    171:        nodeVar3 = ( int( v_glyph.w ) & 255 );
  > 172:        nodeVar4 = ivec2( ( int( v_glyph.x ) + max( min( int( ( ( v_texcoord.y * v_banding.y ) + v_banding.w ) ), float( nodeVar3 ) ), 0.0 ) ), int( v_gl) );
    173:        nodeVar6 = bool( nodeUniform2 );
    174:
    175:        if ( nodeVar6 ) {
    176:
    177:                nodeVar5 = ivec2( nodeVar4.x, ( ( int( textureSize( nodeUniform1, 0 ).y ) - nodeVar4.y ) - 1 ) );
    178:
```

