### PR TITLE
Manual: Add anchors to headings

### DIFF
--- a/manual/pages/animation-system.html
+++ b/manual/pages/animation-system.html
@@ -27,7 +27,7 @@
       <div class="lesson">
         <div class="lesson-main">
  
-          <h2>Overview</h2>
+          <h2 id="overview">Overview</h2>
 
 		<p class="desc">
 			Within the three.js animation system you can animate various properties of your models:
@@ -46,7 +46,7 @@
 
 		</p>
 
-		<h3>Animation Clips</h3>
+		<h3 id="animation-clips">Animation Clips</h3>
 
 		<p class="desc">
 
@@ -63,7 +63,7 @@
 
 		</p>
 
-		<h3>Keyframe Tracks</h3>
+		<h3 id="keyframe-tracks">Keyframe Tracks</h3>
 
 		<p class="desc">
 
@@ -81,7 +81,7 @@
 
 		</p>
 
-		<h3>Animation Mixer</h3>
+		<h3 id="animation-mixer">Animation Mixer</h3>
 
 		<p class="desc">
 
@@ -92,7 +92,7 @@
 
 		</p>
 
-		<h3>Animation Actions</h3>
+		<h3 id="animation-actions">Animation Actions</h3>
 
 		<p class="desc">
 
@@ -105,7 +105,7 @@
 
 		</p>
 
-		<h3>Animation Object Groups</h3>
+		<h3 id="animation-object-groups">Animation Object Groups</h3>
 
 		<p class="desc">
 
@@ -114,7 +114,7 @@
 
 		</p>
 
-		<h3>Supported Formats and Loaders</h3>
+		<h3 id="supported-formats-and-loaders">Supported Formats and Loaders</h3>
 
 		<p class="desc">
 			Note that not all model formats include animation (OBJ notably does not), and that only some
@@ -135,7 +135,7 @@
 			on the same timeline) directly to a single file.
 		</p>
 
-		<h2>Example</h2>
+		<h2 id="example">Example</h2>
 
 <pre class="prettyprint notranslate lang-js" translate="no">
 let mesh;

--- a/manual/pages/color-management.html
+++ b/manual/pages/color-management.html
@@ -69,7 +69,7 @@
       <div class="lesson">
         <div class="lesson-main">
         
-			<h2>What is a color space?</h2>
+			<h2 id="what-is-a-color-space">What is a color space?</h2>
 
 	<p>
 		Every color space is a collection of several design decisions, chosen together to support a
@@ -159,7 +159,7 @@
 		</p>
 	</blockquote>
 
-	<h2>Roles of color spaces</h2>
+	<h2 id="roles-of-color-spaces">Roles of color spaces</h2>
 
 	<p>
 		Linear workflows — required for modern rendering methods — generally involve more than
@@ -167,7 +167,7 @@
 		appropriate for different roles, explained below.
 	</p>
 
-	<h3>Input color space</h3>
+	<h3 id="input-color-space">Input color space</h3>
 
 	<p>
 		Colors supplied to three.js — from color pickers, textures, 3D models, and other sources —
@@ -218,7 +218,7 @@ THREE.ColorManagement.enabled = true;
 		</p>
 	</blockquote>
 
-	<h3>Working color space</h3>
+	<h3 id="working-color-space">Working color space</h3>
 
 	<p>
 		Rendering, interpolation, and many other operations must be performed in an open domain
@@ -226,7 +226,7 @@ THREE.ColorManagement.enabled = true;
 		illumination. In three.js, the working color space is Linear-sRGB.
 	</p>
 
-	<h3>Output color space</h3>
+	<h3 id="output-color-space">Output color space</h3>
 
 	<p>
 		Output to a display device, image, or video may involve conversion from the open domain
@@ -263,7 +263,7 @@ THREE.ColorManagement.enabled = true;
 		For instances of `ShaderMaterial`, adding the `colorspace_fragment` shader chunk to the fragment shader's `main()` function should be sufficient.
 	</p>
 
-	<h2>Working with THREE.Color instances</h2>
+	<h2 id="working-with-three-color-instances">Working with THREE.Color instances</h2>
 
 	<p>
 		Methods reading or modifying `Color` instances assume data is already in the
@@ -308,7 +308,7 @@ console.log( color.getHex( LinearSRGBColorSpace ) ); // → 0x808080
 console.log( color.getHex( SRGBColorSpace ) ); // → 0xBCBCBC
 </pre>
 
-	<h2>Common mistakes</h2>
+	<h2 id="common-mistakes">Common mistakes</h2>
 
 	<p>
 		When an individual color or texture is misconfigured, it will appear darker or lighter than
@@ -327,7 +327,7 @@ console.log( color.getHex( SRGBColorSpace ) ); // → 0xBCBCBC
 		("display referred").
 	</p>
 
-	<h2>Further reading</h2>
+	<h2 id="further-reading">Further reading</h2>
 
 	<ul>
 		<li>

--- a/manual/pages/creating-a-scene.html
+++ b/manual/pages/creating-a-scene.html
@@ -29,13 +29,13 @@
             
           <p>The goal of this section is to give a brief introduction to three.js. We will start by setting up a scene, with a spinning cube. A working example is provided at the bottom of the page in case you get stuck and need help.</p>
 
-		<h2>Before we start</h2>
+		<h2 id="before-we-start">Before we start</h2>
 
 		<p>
 			If you haven't yet, go through the `Installation` guide. We'll assume you've already set up the same project structure (including <i>index.html</i> and <i>main.js</i>), have installed three.js, and are either running a build tool, or using a local server with a CDN and import maps.
 		</p>
 
-		<h2>Creating the scene</h2>
+		<h2 id="creating-the-scene">Creating the scene</h2>
 
 		<p>To actually be able to display anything with three.js, we need three things: scene, camera and renderer, so that we can render the scene with camera.</p>
 
@@ -87,7 +87,7 @@ camera.position.z = 5;
 
 		<p>By default, when we call `scene.add()`, the thing we add will be added to the coordinates `(0,0,0)`. This would cause both the camera and the cube to be inside each other. To avoid this, we simply move the camera out a bit.</p>
 
-		<h2>Rendering the scene</h2>
+		<h2 id="rendering-the-scene">Rendering the scene</h2>
 
 		<p>If you copied the code from above into the main.js file we created earlier, you wouldn't be able to see anything. This is because we're not actually rendering anything yet. For that, we need what's called a render or animation loop.</p>
 
@@ -100,7 +100,7 @@ renderer.setAnimationLoop( animate );
 
 		<p>This will create a loop that causes the renderer to draw the scene every time the screen is refreshed (on a typical screen this means 60 times per second). If you're new to writing games in the browser, you might say <em>"why don't we just create a setInterval ?"</em> The thing is - we could, but `requestAnimationFrame` which is internally used in `WebGLRenderer` has a number of advantages. Perhaps the most important one is that it pauses when the user navigates to another browser tab, hence not wasting their precious processing power and battery life.</p>
 
-		<h2>Animating the cube</h2>
+		<h2 id="animating-the-cube">Animating the cube</h2>
 
 		<p>If you insert all the code above into the file you created before we began, you should see a green box. Let's make it all a little more interesting by rotating it.</p>
 
@@ -113,7 +113,7 @@ cube.rotation.y = time / 1000;
 
 		<p>This will be run every frame (normally 60 times per second), and give the cube a nice rotation animation. Basically, anything you want to move or change while the app is running has to go through the animation loop. You can of course call other functions from there, so that you don't end up with an `animate` function that's hundreds of lines.</p>
 
-		<h2>The result</h2>
+		<h2 id="the-result">The result</h2>
 		<p>Congratulations! You have now completed your first three.js application. It's simple, but you have to start somewhere.</p>
 
 		<p>The full code is available below and as an editable [link:https://jsfiddle.net/zycqb61k/ live example]. Play around with it to get a better understanding of how it works.</p>

--- a/manual/pages/creating-text.html
+++ b/manual/pages/creating-text.html
@@ -34,7 +34,7 @@
             </p>
           </div>
       
-          <h2>1. DOM + CSS</h2>
+          <h2 id="dom-css">1. DOM + CSS</h2>
           <div>
             <p>
               Using HTML is generally the easiest and fastest manner to add text. This is the method
@@ -63,7 +63,7 @@
           </div>
       
           
-          <h2>2. Use `CSS2DRenderer` or `CSS3DRenderer`</h2>
+          <h2 id="use-css2drenderer-or-css3drenderer">2. Use `CSS2DRenderer` or `CSS3DRenderer`</h2>
           <div>
             <p>
               Use these renderers to draw high-quality text contained in DOM elements to your three.js scene.
@@ -72,19 +72,19 @@
           </div>
           
       
-          <h2>3. Draw text to canvas and use as a `Texture`</h2>
+          <h2 id="draw-text-to-canvas-and-use-as-a-texture">3. Draw text to canvas and use as a `Texture`</h2>
           <div>
             <p>Use this method if you wish to draw text easily on a plane in your three.js scene.</p>
           </div>
       
       
-          <h2>4. Create a model in your favourite 3D application and export to three.js</h2>
+          <h2 id="create-a-model-in-your-favourite-3d-application-and-export-to-threejs">4. Create a model in your favourite 3D application and export to three.js</h2>
           <div>
             <p>Use this method if you prefer working with your 3d applications and importing the models to three.js.</p>
           </div>
       
       
-          <h2>5. Procedural Text Geometry</h2>
+          <h2 id="procedural-text-geometry">5. Procedural Text Geometry</h2>
           <div>
             <p>
               If you prefer to work purely in THREE.js or to create procedural and dynamic 3D
@@ -101,7 +101,7 @@
               accepted parameter, and a list of the JSON fonts that come with the THREE.js distribution itself.
             </p>
 
-            <h3>Examples</h3>
+            <h3 id="procedural-text-geometry-examples">Examples</h3>
 
             <p>
               [example:webgl_geometry_text WebGL / geometry / text]<br />
@@ -117,7 +117,7 @@
           </div>
       
       
-          <h2>6. Bitmap Fonts</h2>
+          <h2 id="bitmap-fonts">6. Bitmap Fonts</h2>
           <div>
             <p>
               BMFonts (bitmap fonts) allow batching glyphs into a single BufferGeometry. BMFont rendering
@@ -141,7 +141,7 @@
           </div>
       
       
-          <h2>7. Troika Text</h2>
+          <h2 id="troika-text">7. Troika Text</h2>
           <div>
             <p>
               The [link:https://www.npmjs.com/package/troika-three-text troika-three-text] package renders 

--- a/manual/pages/faq.html
+++ b/manual/pages/faq.html
@@ -27,7 +27,7 @@
       <div class="lesson">
         <div class="lesson-main">
           
-          <h2>Which 3D model format is best supported?</h2>
+          <h2 id="which-3d-model-format-is-best-supported">Which 3D model format is best supported?</h2>
           <div>
             <p>
               The recommended format for importing and exporting assets is glTF (GL Transmission Format). Because glTF is focused on runtime asset delivery, it is compact to transmit and fast to load.
@@ -37,7 +37,7 @@
             </p>
           </div>
       
-          <h2>Why are there meta viewport tags in examples?</h2>
+          <h2 id="why-are-there-meta-viewport-tags-in-examples">Why are there meta viewport tags in examples?</h2>
           <div>
             <pre class="prettyprint notranslate lang-js" translate="no">&lt;meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"&gt;</pre>
       
@@ -48,7 +48,7 @@
               <p>[link:https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
           </div>
       
-          <h2>How can scene scale be preserved on resize?</h2>
+          <h2 id="how-can-scene-scale-be-preserved-on-resize">How can scene scale be preserved on resize?</h2>
           <p>
             We want all objects, regardless of their distance from the camera, to appear the same size, even as the window is resized.
       
@@ -62,19 +62,19 @@
             [link:http://jsfiddle.net/Q4Jpu/ Example].
           </p>
       
-          <h2>Why is part of my object invisible?</h2>
+          <h2 id="why-is-part-of-my-object-invisible">Why is part of my object invisible?</h2>
           <p>
             This could be because of face culling. Faces have an orientation that decides which side is which. And the culling removes the backside in normal circumstances. 
             To see if this is your problem, change the material side to THREE.DoubleSide.
             <pre class="prettyprint notranslate lang-js" translate="no">material.side = THREE.DoubleSide</pre>
           </p>
       
-          <h2>Why does three.js sometimes return strange results for invalid inputs?</h2>
+          <h2 id="why-does-threejs-sometimes-return-strange-results-for-invalid-inputs">Why does three.js sometimes return strange results for invalid inputs?</h2>
           <p>
             For performance reasons, three.js doesn't validate inputs in most cases. It's your app's responsibility to make sure that all inputs are valid.
           </p>
       
-          <h2>Can I use three.js in Node.js?</h2>
+          <h2 id="can-i-use-threejs-in-nodejs">Can I use three.js in Node.js?</h2>
           <p>
             Because three.js is built for the web, it depends on browser and DOM APIs that don't always exist in Node.js. Some of these issues can be avoided by using shims like 
             [link:https://github.com/stackgl/headless-gl headless-gl] and [link:https://github.com/rstacruz/jsdom-global jsdom-global], or by replacing components like `TextureLoader` 

--- a/manual/pages/fundamentals.html
+++ b/manual/pages/fundamentals.html
@@ -354,7 +354,7 @@ a different color.</p>
 <p>I hope this short intro helps to get things started. <a href="responsive.html">Next up we'll cover
 making our code responsive so it is adaptable to multiple situations</a>.</p>
 <div id="es6" class="threejs_bottombar">
-<h3>es6 modules, three.js, and folder structure</h3>
+<h3 id="es6-modules-threejs-and-folder-structure">es6 modules, three.js, and folder structure</h3>
 <p>As of version r147 the preferred way to use three.js is via <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import">es6 modules</a> and import maps.</p>
 <p>
 es6 modules can be loaded via the <code class="notranslate" translate="no">import</code> keyword in a script

--- a/manual/pages/how-to-create-vr-content.html
+++ b/manual/pages/how-to-create-vr-content.html
@@ -32,7 +32,7 @@
             made with three.js.
           </p>
         
-          <h2>Workflow</h2>
+          <h2 id="workflow">Workflow</h2>
         
           <p>
             First, you have to include [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/webxr/VRButton.js VRButton.js]
@@ -75,7 +75,7 @@ renderer.setAnimationLoop( function () {
 } );
 </pre>
         
-          <h2>Next Steps</h2>
+          <h2 id="next-steps">Next Steps</h2>
         
           <p>
             Have a look at one of the official WebVR examples to see this workflow in action.<br /><br />

--- a/manual/pages/how-to-dispose-of-objects.html
+++ b/manual/pages/how-to-dispose-of-objects.html
@@ -35,7 +35,7 @@
             This guide provides a brief overview about how this API is used and what objects are relevant in this context.
           </p>
         
-          <h2>Geometries</h2>
+          <h2 id="geometries">Geometries</h2>
         
           <p>
             A geometry usually represents vertex information defined as a collection of attributes. *three.js* internally creates an object of type [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLBuffer WebGLBuffer]
@@ -43,7 +43,7 @@
             execute the method to free all related resources.
           </p>
         
-          <h2>Materials</h2>
+          <h2 id="materials">Materials</h2>
         
           <p>
             A material defines how objects are rendered. *three.js* uses the information of a material definition in order to construct a shader program for rendering.
@@ -52,7 +52,7 @@
             executing `Material.dispose()`.
           </p>
         
-          <h2>Textures</h2>
+          <h2 id="textures">Textures</h2>
         
           <p>
             The disposal of a material has no effect on textures. They are handled separately since a single texture can be used by multiple materials at the same time.
@@ -65,7 +65,7 @@
             An automated call of `ImageBitmap.close()` in `Texture.dispose()` is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
           </p>
         
-          <h2>Render Targets</h2>
+          <h2 id="render-targets">Render Targets</h2>
         
           <p>
             Objects of type `WebGLRenderTarget` not only allocate an instance of [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture WebGLTexture] but also
@@ -73,23 +73,23 @@
             for realizing custom rendering destinations. These objects are only deallocated by executing `WebGLRenderTarget.dispose()`.
           </p>
         
-          <h2>Skinned Mesh</h2>
+          <h2 id="skinned-mesh">Skinned Mesh</h2>
         
           <p>
             Skinned meshes represent their bone hierarchy as skeletons. If you don't need a skinned mesh anymore, consider to call `Skeleton.dispose()` on the skeleton to free internal resources.
             Keep in mind that skeletons can be shared across multiple skinned meshes, so only call `dispose()` if the skeleton is not used by other active skinned meshes.
           </p>
         
-          <h2>Miscellaneous</h2>
+          <h2 id="miscellaneous">Miscellaneous</h2>
         
           <p>
             There are other classes from the examples directory like controls or post processing passes which provide `dispose()` methods in order to remove internal event listeners
             or render targets. In general, it's recommended to check the API or documentation of a class and watch for `dispose()`. If present, you should use it when cleaning things up.
           </p>
         
-          <h2>FAQ</h2>
+          <h2 id="faq">FAQ</h2>
         
-          <h3>Why can't *three.js* dispose objects automatically?</h3>
+          <h3 id="why-cant-threejs-dispose-objects-automatically">Why can't *three.js* dispose objects automatically?</h3>
         
           <p>
             This question was asked many times by the community so it's important to clarify this matter. Fact is that *three.js* does not know the lifetime or scope
@@ -98,13 +98,13 @@
             `dispose()` method.
           </p>
         
-          <h3>Does removing a mesh from the scene also dispose its geometry and material?</h3>
+          <h3 id="does-removing-a-mesh-from-the-scene-also-dispose-its-geometry-and-material">Does removing a mesh from the scene also dispose its geometry and material?</h3>
         
           <p>
             No, you have to explicitly dispose the geometry and material via *dispose()*. Keep in mind that geometries and materials can be shared among 3D objects like meshes.
           </p>
         
-          <h3>Does *three.js* provide information about the amount of cached objects?</h3>
+          <h3 id="does-threejs-provide-information-about-the-amount-of-cached-objects">Does *three.js* provide information about the amount of cached objects?</h3>
         
           <p>
             Yes. It's possible to evaluate `renderer.info`, a special property of the renderer with a series of statistical information about the graphics board memory
@@ -112,14 +112,14 @@
             in your application, it's a good idea to debug this property in order to easily identify a memory leak.
           </p>
         
-          <h3>What happens when you call `dispose()` on a texture but the image is not loaded yet?</h3>
+          <h3 id="what-happens-when-you-call-dispose-on-a-texture-but-the-image-is-not-loaded-yet">What happens when you call `dispose()` on a texture but the image is not loaded yet?</h3>
         
           <p>
             Internal resources for a texture are only allocated if the image has fully loaded. If you dispose a texture before the image was loaded,
             nothing happens. No resources were allocated so there is also no need for clean up.
           </p>
         
-          <h3>What happens when I call `dispose()` and then use the respective object at a later point?</h3>
+          <h3 id="what-happens-when-i-call-dispose-and-then-use-the-respective-object-at-a-later-point">What happens when I call `dispose()` and then use the respective object at a later point?</h3>
         
           <p>
             That depends. For geometries, materials, textures, render targets and post processing passes the deleted internal resources can be created again by the engine.
@@ -128,7 +128,7 @@
             Controls and renderers are an exception. Instances of these classes can not be used after `dispose()` has been called. You have to create new instances in this case.
           </p>
         
-          <h3>How should I manage *three.js* objects in my app? When do I know how to dispose things?</h3>
+          <h3 id="how-should-i-manage-threejs-objects-in-my-app">How should I manage *three.js* objects in my app? When do I know how to dispose things?</h3>
         
           <p>
             In general, there is no definite recommendation for this. It highly depends on the specific use case when calling `dispose()` is appropriate. It's important to highlight that
@@ -137,7 +137,7 @@
             produce a runtime error if you dispose an object that is actually still in use. The worst thing that can happen is performance drop for a single frame.
           </p>
         
-          <h3>Why `renderer.info.memory` is still reporting geometries and textures after traversing the scene and disposing all reachable textures and geometries?</h3>
+          <h3 id="renderer-info-memory-after-dispose">Why `renderer.info.memory` is still reporting geometries and textures after traversing the scene and disposing all reachable textures and geometries?</h3>
         
           <p>
             In certain cases, there are some textures and geometries used internally by Three.js
@@ -149,7 +149,7 @@
             or other contexts that would require the engine to create textures or geometries for internal use.
           </p>
         
-          <h2>Examples that demonstrate the usage of dispose()</h2>
+          <h2 id="dispose-usage-examples">Examples that demonstrate the usage of dispose()</h2>
         
           <p>
             [example:webgl_test_memory WebGL / test / memory]<br />

--- a/manual/pages/how-to-update-things.html
+++ b/manual/pages/how-to-update-things.html
@@ -50,7 +50,7 @@ object.matrixAutoUpdate = false;
 object.updateMatrix();
 </pre>
       
-          <h2>BufferGeometry</h2>
+          <h2 id="buffergeometry">BufferGeometry</h2>
           <div>
             <p>
               BufferGeometries store information (such as vertex positions, face indices, normals, colors,
@@ -140,7 +140,7 @@ line.geometry.computeBoundingSphere();
               [link:https://jsfiddle.net/t4m85pLr/1/ Here is a fiddle] showing an animated line which you can adapt to your use case.
             </p>
       
-            <h3>Examples</h3>
+            <h3 id="buffergeometry-examples">Examples</h3>
       
             <p>
               [example:webgl_custom_attributes WebGL / custom / attributes]<br />
@@ -149,7 +149,7 @@ line.geometry.computeBoundingSphere();
       
           </div>
       
-          <h2>Materials</h2>
+          <h2 id="materials">Materials</h2>
           <div>
             <p>All uniforms values can be changed freely (e.g. colors, textures, opacity, etc), values are sent to the shader every frame.</p>
       
@@ -180,12 +180,12 @@ line.geometry.computeBoundingSphere();
       
             <p>You can freely change the material used for geometry chunks, however you cannot change how an object is divided into chunks (according to face materials). </p>
       
-            <h3>If you need to have different configurations of materials during runtime:</h3>
+            <h3 id="if-you-need-to-have-different-configurations-of-materials-during-runtime">If you need to have different configurations of materials during runtime:</h3>
             <p>If the number of materials / chunks is small, you could pre-divide the object beforehand (e.g. hair / face / body / upper clothes / trousers for a human, front / sides / top / glass / tire / interior for a car). </p>
       
             <p>If the number is large (e.g. each face could be potentially different), consider a different solution, such as using attributes / textures to drive different per-face look.</p>
       
-            <h3>Examples</h3>
+            <h3 id="materials-examples">Examples</h3>
             <p>
               [example:webgl_materials_car WebGL / materials / car]<br />
               [example:webgl_postprocessing_dof WebGL / webgl_postprocessing / dof]
@@ -193,7 +193,7 @@ line.geometry.computeBoundingSphere();
           </div>
       
       
-          <h2>Textures</h2>
+          <h2 id="textures">Textures</h2>
           <div>
             <p>Image, canvas, video and data textures need to have the following flag set if they are changed:</p>
             <code>
@@ -201,7 +201,7 @@ line.geometry.computeBoundingSphere();
             </code>
             <p>Render targets update automatically.</p>
       
-            <h3>Examples</h3>
+            <h3 id="textures-examples">Examples</h3>
             <p>
               [example:webgl_materials_video WebGL / materials / video]<br />
               [example:webgl_rtt WebGL / rtt]
@@ -209,7 +209,7 @@ line.geometry.computeBoundingSphere();
       
           </div>
       
-          <h2>Cameras</h2>
+          <h2 id="cameras">Cameras</h2>
           <div>
             <p>A camera's position and target is updated automatically. If you need to change</p>
             <ul>
@@ -235,7 +235,7 @@ camera.updateProjectionMatrix();
 </pre>
           </div>
       
-          <h2>InstancedMesh</h2>
+          <h2 id="instancedmesh">InstancedMesh</h2>
           <div>
             <p>
               `InstancedMesh` is a class for conveniently access instanced rendering in `three.js`. Certain library features like view frustum culling or
@@ -253,7 +253,7 @@ instancedMesh.computeBoundingSphere();
       
           </div>
       
-          <h2>SkinnedMesh</h2>
+          <h2 id="skinnedmesh">SkinnedMesh</h2>
           <div>
             <p>
               `SkinnedMesh` follows the same principles like `InstancedMesh` in context of bounding volumes. Meaning the class has its own version of

--- a/manual/pages/how-to-use-post-processing.html
+++ b/manual/pages/how-to-use-post-processing.html
@@ -38,7 +38,7 @@
             three.js provides a complete post-processing solution via `EffectComposer` to implement such a workflow.
           </p>
       
-          <h2>Workflow</h2>
+          <h2 id="workflow">Workflow</h2>
       
           <p>
             The first step in the process is to import all necessary files from the examples directory. The guide assumes you are using the official
@@ -99,14 +99,14 @@ composer.addPass( outputPass );
             Check out this [link:https://threejs.org/examples/webgl_postprocessing_glitch live example] to see it in action.
           </p>
       
-          <h2>Built-in Passes</h2>
+          <h2 id="built-in-passes">Built-in Passes</h2>
       
           <p>
             You can use a wide range of pre-defined post-processing passes provided by the engine. They are located in the
             [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/postprocessing postprocessing] directory.
           </p>
       
-          <h2>Custom Passes</h2>
+          <h2 id="custom-passes">Custom Passes</h2>
       
           <p>
             Sometimes you want to write a custom post-processing shader and include it into the chain of post-processing passes. For this scenario,

--- a/manual/pages/installation.html
+++ b/manual/pages/installation.html
@@ -27,7 +27,7 @@
       <div class="lesson">
         <div class="lesson-main">
           
-          <h2>Project structure</h2>
+          <h2 id="project-structure">Project structure</h2>
 
           <p>
             Every three.js project needs at least one HTML file to define the webpage, and a JavaScript file to run your three.js code. The structure and naming choices below aren't required, but will be used throughout this guide for consistency.
@@ -74,9 +74,9 @@ import * as THREE from 'three';
             Now that we've set up the basic project structure, we need a way to run the project locally and access it through a web browser. Installation and local development can be accomplished with npm and a build tool, or by importing three.js from a CDN. Both options are explained in the sections below.
           </p>
 
-          <h2>Option 1: Install with NPM and a build tool</h2>
+          <h2 id="npm-and-build-tool">Option 1: Install with NPM and a build tool</h2>
 
-          <h3>Development</h3>
+          <h3 id="npm-development">Development</h3>
 
           <p>
             Installing from the [link:https://www.npmjs.com/ npm package registry] and using a [link:https://eloquentjavascript.net/10_modules.html#h_zWTXAU93DC build tool] is the recommended approach for most users — the more dependencies your project needs, the more likely you are to run into problems that the static hosting cannot easily resolve. With a build tool, importing local JavaScript files and npm packages should work out of the box, without import maps.
@@ -153,15 +153,15 @@ npm install --save-dev vite
             </li>
           </ul>
 
-          <h3>Production</h3>
+          <h3 id="npm-production">Production</h3>
 
           <p>
             Later, when you're ready to deploy your web application, you'll just need to tell Vite to run a production build — <i>npx vite build</i>. Everything used by the application will be compiled, optimized, and copied into the <i>dist/</i> folder. The contents of that folder are ready to be hosted on your website.
           </p>
 
-          <h2>Option 2: Import from a CDN</h2>
+          <h2 id="cdn">Option 2: Import from a CDN</h2>
 
-          <h3>Development</h3>
+          <h3 id="cdn-development">Development</h3>
 
           <p>Installing without build tools will require some changes to the project structure given above.</p>
 
@@ -209,7 +209,7 @@ npm install --save-dev vite
           <details>
             <summary>More local servers</summary>
 
-            <h3>Command Line</h3>
+            <h3 id="local-server-command-line">Command Line</h3>
 
             <p>Command line local servers run from a terminal window. The associated programming language may need to be installed first.</p>
 
@@ -222,7 +222,7 @@ npm install --save-dev vite
             </ul>
 
 
-            <h3>GUI</h3>
+            <h3 id="local-server-gui">GUI</h3>
 
             <p>GUI local servers run as an application window on your computer, and may have a user interface.</p>
 
@@ -230,7 +230,7 @@ npm install --save-dev vite
               <li>[link:https://greggman.github.io/servez Servez]</li>
             </ul>
 
-            <h3>Code Editor Plugins</h3>
+            <h3 id="local-server-editor-plugins">Code Editor Plugins</h3>
 
             <p>Some code editors have plugins that spawn a simple server on demand.</p>
 
@@ -243,7 +243,7 @@ npm install --save-dev vite
 
           </details>
 
-          <h3>Production</h3>
+          <h3 id="cdn-production">Production</h3>
 
           <p>
             When you're ready to deploy your web application, push the source files to your web hosting provider — no need to build or compile anything. The downside of that tradeoff is that you'll need to be careful to keep the import map updated with any dependencies (and dependencies of dependencies!) that your application requires. If the CDN hosting your dependencies goes down temporarily, your website will stop working too.
@@ -276,7 +276,7 @@ const loader = new GLTFLoader();
             Some excellent third-party projects are available for three.js, too. These need to be installed separately — see <a href="libraries-and-plugins">Libraries and Plugins</a>.
           </p>
 
-          <h2>Next Steps</h2>
+          <h2 id="next-steps">Next Steps</h2>
 
           <p>
             You're now ready to <a href="creating-a-scene.html">create a scene</a>.

--- a/manual/pages/libraries-and-plugins.html
+++ b/manual/pages/libraries-and-plugins.html
@@ -33,7 +33,7 @@
             to be up to date. If you'd like to update this list make a PR!
           </p>
       
-          <h3>Physics</h3>
+          <h3 id="physics">Physics</h3>
       
           <ul>
             <li>[link:https://github.com/lo-th/Oimo.js/ Oimo.js]</li>
@@ -45,7 +45,7 @@
             
           </ul>
       
-          <h3>Postprocessing</h3>
+          <h3 id="postprocessing">Postprocessing</h3>
       
           <p>
             In addition to the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/postprocessing official three.js postprocessing effects],
@@ -56,19 +56,19 @@
             <li>[link:https://github.com/vanruesc/postprocessing postprocessing]</li>
           </ul>
       
-          <h3>Intersection and Raycast Performance</h3>
+          <h3 id="intersection-and-raycast-performance">Intersection and Raycast Performance</h3>
       
           <ul>
             <li>[link:https://github.com/gkjohnson/three-mesh-bvh three-mesh-bvh]</li>
           </ul>
       
-          <h3>Path Tracing</h3>
+          <h3 id="path-tracing">Path Tracing</h3>
           
           <ul>
             <li>[link:https://github.com/gkjohnson/three-gpu-pathtracer three-gpu-pathtracer]</li>
           </ul>
           
-          <h3>File Formats</h3>
+          <h3 id="file-formats">File Formats</h3>
       
           <p>
             In addition to the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/loaders official three.js loaders],
@@ -82,27 +82,27 @@
             <li>[link:https://github.com/IFCjs/web-ifc-three IFC.js]</li>
           </ul>
       
-          <h3>Geometry</h3>
+          <h3 id="geometry">Geometry</h3>
       
           <ul>
             <li>[link:https://github.com/spite/THREE.MeshLine THREE.MeshLine]</li>
           </ul>
       
-          <h3>3D Text and Layout</h3>
+          <h3 id="3d-text-and-layout">3D Text and Layout</h3>
       
           <ul>
             <li>[link:https://github.com/protectwise/troika/tree/master/packages/troika-three-text troika-three-text]</li>
             <li>[link:https://github.com/felixmariotto/three-mesh-ui three-mesh-ui]</li>
           </ul>
       
-          <h3>Particle Systems</h3>
+          <h3 id="particle-systems">Particle Systems</h3>
       
           <ul>
             <li>[link:https://github.com/Alchemist0823/three.quarks three.quarks]</li>
             <li>[link:https://github.com/creativelifeform/three-nebula three-nebula]</li>
           </ul>
       
-          <h3>Inverse Kinematics</h3>
+          <h3 id="inverse-kinematics">Inverse Kinematics</h3>
       
           <ul>
             <li>[link:https://github.com/jsantell/THREE.IK THREE.IK]</li>
@@ -110,7 +110,7 @@
             <li>[link:https://github.com/gkjohnson/closed-chain-ik-js closed-chain-ik]</li>
           </ul>
       
-          <h3>Game AI</h3>
+          <h3 id="game-ai">Game AI</h3>
       
           <ul>
             <li>[link:https://mugen87.github.io/yuka/ yuka]</li>
@@ -118,7 +118,7 @@
             <li>[link:https://github.com/isaac-mason/recast-navigation-js recast-navigation-js]</li>
           </ul>
       
-          <h3>Wrappers and Frameworks</h3>
+          <h3 id="wrappers-and-frameworks">Wrappers and Frameworks</h3>
       
           <ul>
             <li>[link:https://aframe.io/ A-Frame]</li>

--- a/manual/pages/loading-3d-models.html
+++ b/manual/pages/loading-3d-models.html
@@ -42,7 +42,7 @@
             for what to try if things don't go as expected.
           </p>
         
-          <h2>Before we start</h2>
+          <h2 id="before-we-start">Before we start</h2>
         
           <p>
             If you're new to running a local server, begin with
@@ -51,7 +51,7 @@
             correctly.
           </p>
         
-          <h2>Recommended workflow</h2>
+          <h2 id="recommended-workflow">Recommended workflow</h2>
         
           <p>
             Where possible, we recommend using glTF (GL Transmission Format). Both
@@ -92,7 +92,7 @@
             are also available and regularly maintained.
           </p>
         
-          <h2>Loading</h2>
+          <h2 id="loading">Loading</h2>
         
           <p>
             Only a few loaders (e.g. `ObjectLoader`) are included by default with
@@ -123,7 +123,7 @@ loader.load( 'path/to/model.glb', function ( gltf ) {
 } );
 </pre>
         
-          <h2>Troubleshooting</h2>
+          <h2 id="troubleshooting">Troubleshooting</h2>
         
           <p>
             You've spent hours modeling an artisanal masterpiece, you load it into
@@ -162,7 +162,7 @@ loader.load( 'path/to/model.glb', function ( gltf ) {
             </li>
           </ol>
         
-          <h2>Asking for help</h2>
+          <h2 id="asking-for-help">Asking for help</h2>
         
           <p>
             If you've gone through the troubleshooting process above and your model

--- a/manual/pages/materials.html
+++ b/manual/pages/materials.html
@@ -263,7 +263,7 @@ which open up a whole slew of options. Before we cover textures though
 we need to take a break and cover
 <a href="setup.html">setting up your development environment</a></p>
 <div class="threejs_bottombar">
-<h3>material.needsUpdate</h3>
+<h3 id="material-needsupdate">material.needsUpdate</h3>
 <p>
 This topic rarely affects most three.js apps but just as an FYI...
 Three.js applies material settings when a material is used where "used"

--- a/manual/pages/matrix-transformations.html
+++ b/manual/pages/matrix-transformations.html
@@ -31,7 +31,7 @@
             Three.js uses `matrices` to encode 3D transformations---translations (position), rotations, and scaling. Every instance of `Object3D` has a `matrix` which stores that object's position, rotation, and scale. This page describes how to update an object's transformation.
             </p>
         
-            <h2>Convenience properties and `matrixAutoUpdate`</h2>
+            <h2 id="convenience-properties-and-matrixautoupdate">Convenience properties and `matrixAutoUpdate`</h2>
         
             <p>
               There are two ways to update an object's transformation:
@@ -65,7 +65,7 @@ object.matrixAutoUpdate = false;
               </li>
             </ol>
         
-            <h2>Object and world matrices</h2>
+            <h2 id="object-and-world-matrices">Object and world matrices</h2>
             <p>
             An object's  matrix stores the object's transformation <em>relative</em> to the object's parent; to get the object's transformation in <em>world</em> coordinates, you must access the object's world matrix.
             </p>
@@ -76,7 +76,7 @@ object.matrixAutoUpdate = false;
             An object can be transformed via `applyMatrix4()`. Note: Under-the-hood, this method relies on `Matrix4.decompose()`, and not all matrices are decomposable in this way. For example, if an object has a non-uniformly scaled parent, then the object's world matrix may not be decomposable, and this method may not be appropriate.
             </p>
         
-            <h2>Rotation and Quaternion</h2>
+            <h2 id="rotation-and-quaternion">Rotation and Quaternion</h2>
             <p>
             Three.js provides two ways of representing 3D rotations: Euler angles and Quaternions, as well as methods for converting between the two. Euler angles are subject to a problem called "gimbal lock," where certain configurations can lose a degree of freedom (preventing the object from being rotated about one axis). For this reason, object rotations are <em>always</em> stored in the object's quaternion.
             </p>

--- a/manual/pages/physics.html
+++ b/manual/pages/physics.html
@@ -52,13 +52,13 @@
                     application requiring realistic object behavior, such as objects falling, bouncing, or sliding.
                 </p>
 
-                <h2>Integration Approaches</h2>
+                <h2 id="integration-approaches">Integration Approaches</h2>
 
                 <p>
                     There are three main ways to integrate a physics engine into a three.js project:
                 </p>
 
-                <h3>1. Using Three.js Physics Addons</h3>
+                <h3 id="using-threejs-physics-addons">1. Using Three.js Physics Addons</h3>
 
                 <p>
                     Three.js provides wrapper classes for several popular physics engines in the
@@ -81,7 +81,7 @@
                     cases, they offer a very quick way to get started.
                 </p>
 
-                <h4>
+                <h4 id="using-threejs-physics-addons-examples">
                     Examples
                 </h4>
                 <ul>
@@ -90,7 +90,7 @@
                     <li><a href="https://threejs.org/examples/physics_rapier_instancing.html" target="_blank">physics / rapier / instancing</a></li>
                 </ul>
 
-                <h3>2. Using 3rd-Party Physics JS/TS Libraries</h3>
+                <h3 id="using-3rd-party-physics-js-ts-libraries">2. Using 3rd-Party Physics JS/TS Libraries</h3>
 
                 <p>
                     Many physics engines are written directly in JavaScript or TypeScript and are designed to work
@@ -104,7 +104,7 @@
                 </p>
 
 
-                <h4>
+                <h4 id="using-3rd-party-physics-js-ts-libraries-projects">
                     Projects
                 </h4>
                 <ul>
@@ -121,7 +121,7 @@
                     <li><b><a href="https://github.com/enable3d/enable3d" target="_blank">enable3d</a></b>: 3D physics framework for three.js built on top of ammo.js. Under LGPL-3.0 license. Apparently maintained.</li>
                 </ul>
 
-                <h3>3. Importing WASM-based Engines</h3>
+                <h3 id="importing-wasm-based-engines">3. Importing WASM-based Engines</h3>
 
                 <p>
                     For maximum performance, stability, and precision, especially with complex simulations, you can use physics engines written in
@@ -134,7 +134,7 @@
                     to handle the WASM memory management and interaction with the physics API directly.
                 </p>
 
-                <h4>
+                <h4 id="importing-wasm-based-engines-examples">
                     Examples
                 </h4>
                 <ul>
@@ -145,7 +145,7 @@
                     <li><a href="https://threejs.org/examples/physics_ammo_volume.html" target="_blank">physics / ammo / volume</a></li>
                 </ul>
 
-                <h4>
+                <h4 id="importing-wasm-based-engines-projects">
                     Projects
                 </h4>
                 <ul>

--- a/manual/pages/uniform-types.html
+++ b/manual/pages/uniform-types.html
@@ -184,7 +184,7 @@
             containing the components of all vectors or matrices in the array.
           </p>
       
-          <h2>Structured Uniforms</h2>
+          <h2 id="structured-uniforms">Structured Uniforms</h2>
       
           <p>
             Sometimes you want to organize uniforms as `structs` in your shader code.
@@ -210,7 +210,7 @@ struct Data {
 uniform Data data;
 </pre>
       
-          <h2>Structured Uniforms with Arrays</h2>
+          <h2 id="structured-uniforms-with-arrays">Structured Uniforms with Arrays</h2>
       
           <p>
             It's also possible to manage `structs` in arrays. The syntax for this use

--- a/manual/pages/useful-links.html
+++ b/manual/pages/useful-links.html
@@ -37,15 +37,15 @@
             check the browser console for warnings or errors. Also check the relevant docs pages.
           </p>
       
-          <h2>Help forums</h2>
+          <h2 id="help-forums">Help forums</h2>
           <p>
             Three.js officially uses the [link:https://discourse.threejs.org/ forum] and [link:http://stackoverflow.com/tags/three.js/info Stack Overflow] for help requests.
             If you need assistance with something, that's the place to go. Do NOT open an issue on Github for help requests.
           </p>
       
-          <h2>Tutorials and courses</h2>
+          <h2 id="tutorials-and-courses">Tutorials and courses</h2>
       
-          <h3>Getting started with three.js</h3>
+          <h3 id="getting-started-with-threejs">Getting started with three.js</h3>
           <ul>
             <li>
               [link:https://threejs.org/manual/#fundamentals Three.js Fundamentals starting lesson]
@@ -58,7 +58,7 @@
             </li>
           </ul>
       
-          <h3>More extensive / advanced articles and courses</h3>
+          <h3 id="more-extensive-advanced-articles-and-courses">More extensive / advanced articles and courses</h3>
           <ul>
             <li>
               [link:https://threejs-journey.com/ Three Journey] Course by [link:https://bruno-simon.com/ Bruno Simon] - Teaches beginners how to use Three.js step by step
@@ -85,7 +85,7 @@
            </li>
           </ul>
       
-          <h2>News and Updates</h2>
+          <h2 id="news-and-updates">News and Updates</h2>
           <ul>
             <li>
               [link:https://twitter.com/hashtag/threejs Three.js on Twitter]
@@ -98,7 +98,7 @@
             </li>
           </ul>
       
-          <h2>Examples</h2>
+          <h2 id="examples">Examples</h2>
           <ul>
             <li>
               [link:https://github.com/edwinwebb/three-seed/ three-seed] - three.js starter project with ES6 and Webpack
@@ -118,7 +118,7 @@
             </li>
           </ul>
       
-        <h2>Tools</h2>
+        <h2 id="tools">Tools</h2>
         <ul>
           <li>
             [link:https://github.com/tbensky/physgl physgl.org] - JavaScript front-end with wrappers to three.js, to bring WebGL
@@ -143,14 +143,14 @@
           </li>
         </ul>
       
-        <h2>WebGL References</h2>
+        <h2 id="webgl-references">WebGL References</h2>
           <ul>
             <li>
             [link:https://www.khronos.org/files/webgl/webgl-reference-card-1_0.pdf webgl-reference-card.pdf] - Reference of all WebGL and GLSL keywords, terminology, syntax and definitions.
             </li>
           </ul>
       
-        <h2>Old Links</h2>
+        <h2 id="old-links">Old Links</h2>
         <p>
           These links are kept for historical purposes - you may still find them useful, but be warned that
           they may have information relating to very old versions of three.js.

--- a/manual/pages/webgpu-postprocessing.html
+++ b/manual/pages/webgpu-postprocessing.html
@@ -32,7 +32,7 @@
               works and provides some basic guidelines about the usage.
             </p>
 
-            <h2>Overview</h2>
+            <h2 id="overview">Overview</h2>
 
              <p>
               The previous post-processing for `WebGLRenderer` had many conceptual issues. Making use of Multiple Render Targets 
@@ -58,7 +58,7 @@
                Let's find out how to integrate post-processing in three.js applications.
             </p>
 
-            <h2>Basics</h2>
+            <h2 id="basics">Basics</h2>
 
             <p>
               First, please read the instructions in the guide about <a href="webgpurenderer">WebGPURenderer</a> to correctly configure your 
@@ -115,7 +115,7 @@ const scenePass = pass( scene, camera );
 renderPipeline.outputNode = rgbShiftPass;
 </pre>
 
-            <h2>Tone Mapping and Color Spaces</h2>
+            <h2 id="tone-mapping-and-color-spaces">Tone Mapping and Color Spaces</h2>
 
             <p>
             When using post-processing, tone mapping and color space conversion are automatically applied at the end 
@@ -147,7 +147,7 @@ renderPipeline.outputNode = fxaaPass;
             based on your requirements.
           </p>
 
-          <h2>MRT</h2>
+          <h2 id="mrt">MRT</h2>
 
           <p>
             The new post-processing stack has built-in Multiple Render Targets (MRT) support which is crucial for more advanced

--- a/manual/pages/webgpurenderer.html
+++ b/manual/pages/webgpurenderer.html
@@ -32,7 +32,7 @@
               renderer and basic guidelines about the usage.
             </p>
 
-            <h2>Overview</h2>
+            <h2 id="overview">Overview</h2>
 
             <p>
               `WebGPURenderer` is designed to be the modern alternative to the long-standing `WebGLRenderer`.
@@ -65,7 +65,7 @@
 
             Let's find out how to integrate `WebGPURenderer` in three.js applications.
 
-            <h2>Usage</h2>
+            <h2 id="usage">Usage</h2>
 
              <p>
              `WebGPURenderer` has different build files so the way you import three.js changes:
@@ -133,7 +133,7 @@ document.body.appendChild( renderer.domElement );
 +  const renderer = new THREE.WebGPURenderer( { antialias: true, forceWebGL: true } );
 </pre>
 
-            <h2>Migration</h2>
+            <h2 id="migration">Migration</h2>
 
             <p>
               If you want to give `WebGPURenderer` a try, you have to be aware of the following.
@@ -160,7 +160,7 @@ document.body.appendChild( renderer.domElement );
               </li>
             </ul>
 
-            <h2>State of WebGLRenderer</h2>
+            <h2 id="state-of-webglrenderer">State of WebGLRenderer</h2>
 
             <p>Although in the meanwhile a lot of work happens in context of `WebGPURenderer`, the node material and TSL, `WebGLRenderer` is still maintained 
               and the recommended choice for pure WebGL 2 applications. However, keep in mind that there are no plans to add larger new features to 


### PR DESCRIPTION
This follow-up to #34017 adds explicit, stable `id` attributes to every remaining `.lesson-main` heading across the manual.

The change adds 124 anchors across 20 pages, bringing coverage to all 192 content headings. Existing IDs and legacy named anchors are preserved, and repeated headings use contextual IDs where necessary.

There are no heading text, JavaScript, navigation, or permalink UI changes.

### Preview

- [Animation system overview](https://rawcdn.githack.com/zackabrah/three.js/cf67704db54dd5097ce099100c3a6afd496f8acb/manual/index.html#animation-system#overview)
- [`renderer.info.memory` disposal question](https://rawcdn.githack.com/zackabrah/three.js/cf67704db54dd5097ce099100c3a6afd496f8acb/manual/index.html#how-to-dispose-of-objects#renderer-info-memory-after-dispose)
- [Third-party physics projects](https://rawcdn.githack.com/zackabrah/three.js/cf67704db54dd5097ce099100c3a6afd496f8acb/manual/index.html#physics#using-3rd-party-physics-js-ts-libraries-projects)
- [Existing Addons anchor](https://rawcdn.githack.com/zackabrah/three.js/cf67704db54dd5097ce099100c3a6afd496f8acb/manual/index.html#installation#addons)

### Testing

- Confirmed all 192 `.lesson-main` headings have IDs.
- Confirmed there are no duplicate targets, removed existing targets, or newly broken local fragment links.
- Confirmed all `manual/list.json` section routes still resolve.
- Tested new, existing, nested, named-anchor, direct-page, and closed-`details` routes in a browser.

Fixed #23225.
