### PR TITLE
TSL: Fix update range clear bug in `Instance`.

### DIFF
--- a/src/nodes/accessors/Instance.js
+++ b/src/nodes/accessors/Instance.js
@@ -177,29 +177,23 @@ export const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder
 
 		OnFrameUpdate( () => {
 
-			if ( interleavedMatrix !== null ) {
+			if ( interleavedMatrix !== null && matrices.version !== interleavedMatrix.version ) {
 
 				interleavedMatrix.clearUpdateRanges();
 				interleavedMatrix.updateRanges.push( ...matrices.updateRanges );
+				matrices.clearUpdateRanges();
 
-				if ( matrices.version !== interleavedMatrix.version ) {
-
-					interleavedMatrix.version = matrices.version;
-
-				}
+				interleavedMatrix.version = matrices.version;
 
 			}
 
-			if ( colors && interleavedColor !== null ) {
+			if ( colors && interleavedColor !== null && colors.version !== interleavedColor.version ) {
 
 				interleavedColor.clearUpdateRanges();
 				interleavedColor.updateRanges.push( ...colors.updateRanges );
+				colors.clearUpdateRanges();
 
-				if ( colors.version !== interleavedColor.version ) {
-
-					interleavedColor.version = colors.version;
-
-				}
+				interleavedColor.version = colors.version;
 
 			}
 

--- a/src/nodes/accessors/Instance.js
+++ b/src/nodes/accessors/Instance.js
@@ -177,17 +177,17 @@ export const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder
 
 		OnFrameUpdate( () => {
 
-			if ( interleavedMatrix !== null && matrices.version !== interleavedMatrix.version ) {
+			if ( interleavedMatrix !== null && interleavedMatrix.version !== matrices.version ) {
 
 				interleavedMatrix.clearUpdateRanges();
 				interleavedMatrix.updateRanges.push( ...matrices.updateRanges );
-				matrices.clearUpdateRanges();
+				matrices.clearUpdateRanges(); // "matrices" as the source is never uploaded directly. clear to avoid update range accumulation
 
 				interleavedMatrix.version = matrices.version;
 
 			}
 
-			if ( colors && interleavedColor !== null && colors.version !== interleavedColor.version ) {
+			if ( colors && interleavedColor !== null && interleavedColor.version !== colors.version ) {
 
 				interleavedColor.clearUpdateRanges();
 				interleavedColor.updateRanges.push( ...colors.updateRanges );


### PR DESCRIPTION
On `WebGPURenderer`, when sending new `updateRanges`, the `Instance.js` node doesn't clear the dirty-region information (it clears the wrapper but not the source), so it accumulates, causing GPU traffic that grows without bound.