### PR TITLE
Docs: Resolve reamining TODOs.

### DIFF
--- a/examples/jsm/shaders/DepthLimitedBlurShader.js
+++ b/examples/jsm/shaders/DepthLimitedBlurShader.js
@@ -8,7 +8,10 @@ import {
  */
 
 /**
- * TODO
+ * A separable Gaussian blur shader that limits blurring across depth
+ * discontinuities, stopping when the view-space depth difference to a
+ * neighboring sample exceeds `depthCutoff`. This preserves edges and
+ * avoids bleeding across them.
  *
  * Used by {@link SAOPass}.
  *

--- a/examples/jsm/shaders/ExposureShader.js
+++ b/examples/jsm/shaders/ExposureShader.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * TODO
+ * Exposure shader that scales the image color by an exposure factor.
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/FilmShader.js
+++ b/examples/jsm/shaders/FilmShader.js
@@ -4,7 +4,8 @@
  */
 
 /**
- * TODO
+ * Film grain shader that adds animated noise to the image, with an optional
+ * grayscale conversion.
  *
  * Used by {@link FilmPass}.
  *

--- a/src/nodes/core/UniformGroupNode.js
+++ b/src/nodes/core/UniformGroupNode.js
@@ -50,8 +50,9 @@ class UniformGroupNode extends Node {
 		this.shared = shared;
 
 		/**
-		 * Influences the internal sorting.
-		 * TODO: Add details when this property should be changed.
+		 * The sort key that determines the order of this group relative to other
+		 * uniform groups. Groups with a lower order are placed first. Shared groups
+		 * typically use a lower order so they precede regular per-object groups.
 		 *
 		 * @type {number}
 		 * @default 1

--- a/src/nodes/utils/ReflectorNode.js
+++ b/src/nodes/utils/ReflectorNode.js
@@ -185,10 +185,14 @@ class ReflectorNode extends TextureNode {
 }
 
 /**
- * Holds the actual implementation of the reflector.
+ * Holds the actual implementation of the reflector (virtual cameras, render
+ * targets and the reflection rendering).
  *
- * TODO: Explain why `ReflectorBaseNode`. Originally the entire logic was implemented
- * in `ReflectorNode`, see #29619.
+ * This logic is kept separate from {@link ReflectorNode} because the latter is
+ * a {@link TextureNode} representing a single texture view. A reflector can be
+ * sampled by multiple texture nodes at once - e.g. one for color and one for
+ * depth (see {@link ReflectorNode#getDepthNode}) - which all reference the same
+ * base node so the reflection is rendered only once.
  *
  * @private
  * @augments Node


### PR DESCRIPTION
Related issue: #34027

**Description**

Follow-up of #34027. The PR resolves the remaining TODOs related to missing JSDoc in `src` and `examples/jsm`.