### PR TITLE
GLTFLoader: Fix KHR_texture_transform support when rotation is specified

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2072,6 +2072,27 @@ class GLTFTextureTransformExtension {
 
 		}
 
+		if ( transform.rotation !== undefined ) {
+
+			// glTF's KHR_texture_transform order differs from three.js:
+			// glTF defines the UV transform as T * R * S
+			// three.js defines the UV transform as T * S * R
+			//
+			// To fix this, we need to override the matrix with the value computed per glTF spec
+			// We still set the other fields so that you can inspect/export the resulting object.
+
+			const c = Math.cos( texture.rotation );
+			const s = Math.sin( texture.rotation );
+
+			texture.matrix.set(
+				texture.repeat.x * c, texture.repeat.y * s, texture.offset.x,
+				- texture.repeat.x * s, texture.repeat.y * c, texture.offset.y,
+				0, 0, 1
+			);
+			texture.matrixAutoUpdate = false;
+
+		}
+
 		texture.needsUpdate = true;
 
 		return texture;


### PR DESCRIPTION
glTF uses a different order of texture coordinate transformation compared to three.js: glTF wants T * R * S, three.js uses T * S * R.

three.js's default order is more intuitive: visually, rotation and texture repeat are decoupled using the existing order, whereas in glTF model, scaling UVs results in visual skew of the resulting texture.

To fix this, we override the UV matrix if the rotation is specified; existing fields are preserved for inspection/export.

To reproduce the behavior before/after, the asset attached to the original issue ([ttmtf.zip](https://github.com/user-attachments/files/29974248/ttmtf.zip)) can be opened in three.js editor.

before | after
-----------|---------
<img width="390" height="418" alt="image" src="https://github.com/user-attachments/assets/9eba2cc5-cf00-4050-8dcb-91764d8d6e1f" /> | <img width="390" height="418" alt="image" src="https://github.com/user-attachments/assets/5293f397-047f-4890-8ff7-702e72b46110" />

Fixes #34032.