### PR TITLE
TorusGeometry: Forward thetaStart and thetaLength in fromJSON().

### DIFF
--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -152,7 +152,7 @@ class TorusGeometry extends BufferGeometry {
 	 */
 	static fromJSON( data ) {
 
-		return new TorusGeometry( data.radius, data.tube, data.radialSegments, data.tubularSegments, data.arc );
+		return new TorusGeometry( data.radius, data.tube, data.radialSegments, data.tubularSegments, data.arc, data.thetaStart, data.thetaLength );
 
 	}
 

--- a/test/unit/src/geometries/TorusGeometry.tests.js
+++ b/test/unit/src/geometries/TorusGeometry.tests.js
@@ -16,6 +16,8 @@ export default QUnit.module( 'Geometries', () => {
 				radialSegments: 30,
 				tubularSegments: 10,
 				arc: 2.0,
+				thetaStart: Math.PI * 0.5,
+				thetaLength: Math.PI
 			};
 
 			geometries = [
@@ -25,6 +27,8 @@ export default QUnit.module( 'Geometries', () => {
 				new TorusGeometry( parameters.radius, parameters.tube, parameters.radialSegments ),
 				new TorusGeometry( parameters.radius, parameters.tube, parameters.radialSegments, parameters.tubularSegments ),
 				new TorusGeometry( parameters.radius, parameters.tube, parameters.radialSegments, parameters.tubularSegments, parameters.arc ),
+				new TorusGeometry( parameters.radius, parameters.tube, parameters.radialSegments, parameters.tubularSegments, parameters.arc, parameters.thetaStart ),
+				new TorusGeometry( parameters.radius, parameters.tube, parameters.radialSegments, parameters.tubularSegments, parameters.arc, parameters.thetaStart, parameters.thetaLength ),
 			];
 
 		} );
@@ -55,19 +59,6 @@ export default QUnit.module( 'Geometries', () => {
 			assert.ok(
 				object.type === 'TorusGeometry',
 				'TorusGeometry.type should be TorusGeometry'
-			);
-
-		} );
-
-		// PUBLIC
-		QUnit.test( 'fromJSON', ( assert ) => {
-
-			const geometry = new TorusGeometry( 1, 0.4, 12, 48, Math.PI, 0.3, 1.1 );
-			const geometry2 = TorusGeometry.fromJSON( geometry.toJSON() );
-
-			assert.deepEqual(
-				geometry2.parameters, geometry.parameters,
-				'fromJSON() restores all parameters, including thetaStart and thetaLength'
 			);
 
 		} );

--- a/test/unit/src/geometries/TorusGeometry.tests.js
+++ b/test/unit/src/geometries/TorusGeometry.tests.js
@@ -59,6 +59,19 @@ export default QUnit.module( 'Geometries', () => {
 
 		} );
 
+		// PUBLIC
+		QUnit.test( 'fromJSON', ( assert ) => {
+
+			const geometry = new TorusGeometry( 1, 0.4, 12, 48, Math.PI, 0.3, 1.1 );
+			const geometry2 = TorusGeometry.fromJSON( geometry.toJSON() );
+
+			assert.deepEqual(
+				geometry2.parameters, geometry.parameters,
+				'fromJSON() restores all parameters, including thetaStart and thetaLength'
+			);
+
+		} );
+
 		// OTHERS
 		QUnit.test( 'Standard geometry tests', ( assert ) => {
 


### PR DESCRIPTION
`TorusGeometry.fromJSON()` stops at `arc`, so it drops the `thetaStart` and `thetaLength` parameters that were added to the constructor in #32760. A partially-swept torus therefore round-trips (`toJSON()` → `fromJSON()`) back into a full torus. The sibling geometries that have these parameters (Circle, Cone, Cylinder, Ring, Sphere) all forward them in their own `fromJSON()`.

Forwarded the two arguments and added a `fromJSON` round-trip test.
