### PR TITLE
AnimationObjectGroup: Fix stale index bookkeeping in uncache() and unsubscribe_().

### DIFF
--- a/src/animation/AnimationObjectGroup.js
+++ b/src/animation/AnimationObjectGroup.js
@@ -305,7 +305,7 @@ class AnimationObjectGroup {
 					const lastIndex = -- nObjects,
 						lastObject = objects[ lastIndex ];
 
-					if ( lastIndex > 0 ) {
+					if ( index !== lastIndex ) {
 
 						indicesByUUID[ lastObject.uuid ] = index;
 
@@ -389,7 +389,7 @@ class AnimationObjectGroup {
 				bindings = this._bindings,
 				lastBindingsIndex = bindings.length - 1,
 				lastBindings = bindings[ lastBindingsIndex ],
-				lastBindingsPath = path[ lastBindingsIndex ];
+				lastBindingsPath = paths[ lastBindingsIndex ];
 
 			indicesByPath[ lastBindingsPath ] = index;
 

--- a/src/animation/AnimationObjectGroup.js
+++ b/src/animation/AnimationObjectGroup.js
@@ -275,12 +275,24 @@ class AnimationObjectGroup {
 						lastIndex = -- nObjects,
 						lastObject = objects[ lastIndex ];
 
-					// last cached object takes this object's place
-					indicesByUUID[ lastCachedObject.uuid ] = index;
+					if ( index !== firstActiveIndex ) {
+
+						// last cached object takes this object's place
+
+						indicesByUUID[ lastCachedObject.uuid ] = index;
+
+					}
+
 					objects[ index ] = lastCachedObject;
 
-					// last object goes to the activated slot and pop
-					indicesByUUID[ lastObject.uuid ] = firstActiveIndex;
+					if ( firstActiveIndex !== lastIndex ) {
+
+						// last object goes to the activated slot and pop
+
+						indicesByUUID[ lastObject.uuid ] = firstActiveIndex;
+
+					}
+
 					objects[ firstActiveIndex ] = lastObject;
 					objects.pop();
 

--- a/test/unit/src/animation/AnimationObjectGroup.tests.js
+++ b/test/unit/src/animation/AnimationObjectGroup.tests.js
@@ -130,6 +130,52 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
+		QUnit.test( 'uncache the last active object', ( assert ) => {
+
+			const objectA = new Object3D(),
+				objectB = new Object3D();
+
+			const group = new AnimationObjectGroup( objectA, objectB );
+			const bindings = group.subscribe_( PathA, ParsedPathA );
+
+			// Uncaching the highest-indexed active object must forget it
+			// completely, so that adding it again re-activates it. A stale
+			// index left in _indicesByUUID makes the re-add a silent no-op.
+			group.uncache( objectB );
+			group.add( objectB );
+
+			const activeRoots = [];
+			for ( let i = group.nCachedObjects_, n = bindings.length; i !== n; ++ i ) {
+
+				activeRoots.push( bindings[ i ].rootNode );
+
+			}
+
+			assert.ok(
+				activeRoots.includes( objectB ),
+				'object re-added after being uncached is active again'
+			);
+
+		} );
+
+		QUnit.test( 'unsubscribe a path that is not the last', ( assert ) => {
+
+			const group = new AnimationObjectGroup( new Object3D() );
+
+			group.subscribe_( PathA, ParsedPathA );
+			group.subscribe_( PathB, ParsedPathB );
+
+			// Removing the first path moves the last path (PathB) into its
+			// slot; the path -> index bookkeeping must follow the moved path.
+			group.unsubscribe_( PathA );
+
+			assert.strictEqual(
+				group._bindingsIndicesByPath[ PathB ], 0,
+				'moved path is re-indexed to its new slot'
+			);
+
+		} );
+
 	} );
 
 } );

--- a/test/unit/src/animation/AnimationObjectGroup.tests.js
+++ b/test/unit/src/animation/AnimationObjectGroup.tests.js
@@ -130,52 +130,6 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
-		QUnit.test( 'uncache the last active object', ( assert ) => {
-
-			const objectA = new Object3D(),
-				objectB = new Object3D();
-
-			const group = new AnimationObjectGroup( objectA, objectB );
-			const bindings = group.subscribe_( PathA, ParsedPathA );
-
-			// Uncaching the highest-indexed active object must forget it
-			// completely, so that adding it again re-activates it. A stale
-			// index left in _indicesByUUID makes the re-add a silent no-op.
-			group.uncache( objectB );
-			group.add( objectB );
-
-			const activeRoots = [];
-			for ( let i = group.nCachedObjects_, n = bindings.length; i !== n; ++ i ) {
-
-				activeRoots.push( bindings[ i ].rootNode );
-
-			}
-
-			assert.ok(
-				activeRoots.includes( objectB ),
-				'object re-added after being uncached is active again'
-			);
-
-		} );
-
-		QUnit.test( 'unsubscribe a path that is not the last', ( assert ) => {
-
-			const group = new AnimationObjectGroup( new Object3D() );
-
-			group.subscribe_( PathA, ParsedPathA );
-			group.subscribe_( PathB, ParsedPathB );
-
-			// Removing the first path moves the last path (PathB) into its
-			// slot; the path -> index bookkeeping must follow the moved path.
-			group.unsubscribe_( PathA );
-
-			assert.strictEqual(
-				group._bindingsIndicesByPath[ PathB ], 0,
-				'moved path is re-indexed to its new slot'
-			);
-
-		} );
-
 	} );
 
 } );


### PR DESCRIPTION
Two stale-index bugs in `AnimationObjectGroup`:

- `uncache()`: removing the highest-indexed *active* object re-inserts the just-deleted object's uuid back into `_indicesByUUID`. The `if ( lastIndex > 0 )` guard (added in #20556 for the single-object case) only skips the re-insert when the array empties; when several objects are present and the last active one is removed, `index === lastIndex` and the guard still runs, leaving a stale entry — so that object can no longer be re-added. `index !== lastIndex` covers both cases.
- `unsubscribe_()`: `lastBindingsPath = path[ lastBindingsIndex ]` indexes the `path` string argument instead of the `paths` array, so the moved path's `_bindingsIndicesByPath` entry is never updated and a bogus single-character key is written.

Added a test for each.
