### PR TITLE
Mesh, Sprite: Copy the count property in copy()

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -126,6 +126,8 @@ class Mesh extends Object3D {
 		this.material = Array.isArray( source.material ) ? source.material.slice() : source.material;
 		this.geometry = source.geometry;
 
+		this.count = source.count;
+
 		return this;
 
 	}

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -209,6 +209,8 @@ class Sprite extends Object3D {
 
 		this.material = source.material;
 
+		this.count = source.count;
+
 		return this;
 
 	}

--- a/test/unit/src/objects/Mesh.tests.js
+++ b/test/unit/src/objects/Mesh.tests.js
@@ -71,6 +71,16 @@ export default QUnit.module( 'Objects', () => {
 
 		} );
 
+		QUnit.test( 'copy/count', ( assert ) => {
+
+			const mesh = new Mesh();
+			mesh.count = 4;
+
+			const copy = mesh.clone();
+			assert.strictEqual( copy.count, 4, 'The instance count is copied.' );
+
+		} );
+
 		QUnit.todo( 'raycast', ( assert ) => {
 
 			const geometry = new PlaneGeometry();

--- a/test/unit/src/objects/Sprite.tests.js
+++ b/test/unit/src/objects/Sprite.tests.js
@@ -46,6 +46,16 @@ export default QUnit.module( 'Objects', () => {
 
 		} );
 
+		QUnit.test( 'copy/count', ( assert ) => {
+
+			const sprite = new Sprite();
+			sprite.count = 3;
+
+			const copy = sprite.clone();
+			assert.strictEqual( copy.count, 3, 'The instance count is copied.' );
+
+		} );
+
 	} );
 
 } );


### PR DESCRIPTION
`Mesh` and `Sprite` both expose a public `count` property (default `1`) used for instanced rendering with `WebGPURenderer`, but neither `copy()` carries it over — so `clone()` silently resets `count` back to `1`.

`InstancedMesh.copy()` already copies its `count` (`this.count = source.count;`), so the fix just mirrors that in the two base classes.

```js
const mesh = new THREE.Mesh( geometry, material );
mesh.count = 4;
mesh.clone().count; // was 1, now 4
```

Added `copy/count` unit tests for both `Mesh` and `Sprite`. Full unit suite passes (1316 pass / 0 fail).