### PR TITLE
BufferGeometryLoader: Restore usage on deserialized morph attributes

### DIFF
--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -190,6 +190,7 @@ class BufferGeometryLoader extends Loader {
 					}
 
 					if ( attribute.name !== undefined ) bufferAttribute.name = attribute.name;
+					if ( attribute.usage !== undefined ) bufferAttribute.setUsage( attribute.usage );
 					array.push( bufferAttribute );
 
 				}

--- a/test/unit/src/loaders/BufferGeometryLoader.tests.js
+++ b/test/unit/src/loaders/BufferGeometryLoader.tests.js
@@ -52,6 +52,25 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
+		QUnit.test( 'parser - morphAttributes - usage', ( assert ) => {
+
+			const loader = new BufferGeometryLoader();
+			const geometry = new BufferGeometry();
+			const attr = new BufferAttribute( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3 );
+			attr.setUsage( DynamicDrawUsage );
+
+			geometry.morphAttributes.position = [ attr ];
+
+			const geometry2 = loader.parse( geometry.toJSON() );
+
+			assert.strictEqual(
+				geometry2.morphAttributes.position[ 0 ].usage,
+				DynamicDrawUsage,
+				'The usage of a morph attribute is preserved through serialization.'
+			);
+
+		} );
+
 	} );
 
 } );


### PR DESCRIPTION
When parsing a serialized `BufferGeometry`, the main-attribute loop restores each attribute's `usage` hint:

```js
if ( attribute.usage !== undefined ) bufferAttribute.setUsage( attribute.usage );
```

but the sibling morph-attribute loop only restored `name`, silently dropping `usage`. `BufferAttribute.toJSON()` serializes `usage` whenever it differs from `StaticDrawUsage`, so a morph attribute set to `DynamicDrawUsage` was written to JSON but reverted to `StaticDrawUsage` on load.

This adds the same `setUsage` line to the morph-attribute loop so the two paths round-trip identically.

Added a `parser - morphAttributes - usage` unit test. Full unit suite passes (1315 pass / 0 fail).