### PR TITLE
WebGPURenderer: Support shared depth texture between multiple passes

### DIFF
--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -453,7 +453,19 @@ class RenderTarget extends EventDispatcher {
 		this.storeMultisampledDepthBuffer = source.storeMultisampledDepthBuffer;
 		this.storeMultisampledStencilBuffer = source.storeMultisampledStencilBuffer;
 
-		if ( source.depthTexture !== null ) this.depthTexture = source.depthTexture.clone();
+		if ( source.depthTexture !== null ) {
+
+			if ( source.depthTexture.renderTarget === source ) {
+
+				this.depthTexture = source.depthTexture.clone();
+
+			} else {
+
+				this.depthTexture = source.depthTexture;
+
+			}
+
+		}
 
 		this.samples = source.samples;
 		this.multiview = source.multiview;

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -334,8 +334,8 @@ class RenderTarget extends EventDispatcher {
 
 	set depthTexture( current ) {
 
-		if ( this._depthTexture !== null ) this._depthTexture.renderTarget = null;
-		if ( current !== null ) current.renderTarget = this;
+		if ( this._depthTexture !== null && this._depthTexture.renderTarget === this ) this._depthTexture.renderTarget = null;
+		if ( current !== null && current.renderTarget === null ) current.renderTarget = this;
 
 		this._depthTexture = current;
 

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -457,7 +457,10 @@ class RenderTarget extends EventDispatcher {
 
 			if ( source.depthTexture.renderTarget === source ) {
 
-				this.depthTexture = source.depthTexture.clone();
+				const depthTexture = source.depthTexture.clone();
+				depthTexture.renderTarget = null;
+
+				this.depthTexture = depthTexture;
 
 			} else {
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -250,7 +250,7 @@ class PassNode extends TempNode {
 
 		if ( this.scope === PassNode.DEPTH || options.depthBuffer !== false ) {
 
-			depthTexture = new DepthTexture();
+			depthTexture = options.depthTexture || new DepthTexture();
 			depthTexture.isRenderTargetTexture = true;
 			//depthTexture.type = FloatType;
 			depthTexture.name = 'depth';
@@ -288,6 +288,38 @@ class PassNode extends TempNode {
 		 * @default true
 		 */
 		this.opaque = true;
+
+		/**
+		 * Whether the renderer should automatically clear before rendering the pass.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.autoClear = options.autoClear !== undefined ? options.autoClear : true;
+
+		/**
+		 * Whether the color buffer should be cleared.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.autoClearColor = options.autoClearColor !== undefined ? options.autoClearColor : true;
+
+		/**
+		 * Whether the depth buffer should be cleared.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.autoClearDepth = options.autoClearDepth !== undefined ? options.autoClearDepth : true;
+
+		/**
+		 * Whether the stencil buffer should be cleared.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.autoClearStencil = options.autoClearStencil !== undefined ? options.autoClearStencil : true;
 
 		/**
 		 * An optional global context for the pass.
@@ -807,6 +839,9 @@ class PassNode extends TempNode {
 		const currentRenderTarget = renderer.getRenderTarget();
 		const currentMRT = renderer.getMRT();
 		const currentAutoClear = renderer.autoClear;
+		const currentAutoClearColor = renderer.autoClearColor;
+		const currentAutoClearDepth = renderer.autoClearDepth;
+		const currentAutoClearStencil = renderer.autoClearStencil;
 		const currentTransparent = renderer.transparent;
 		const currentOpaque = renderer.opaque;
 		const currentMask = camera.layers.mask;
@@ -836,7 +871,10 @@ class PassNode extends TempNode {
 
 		renderer.setRenderTarget( this.renderTarget );
 		renderer.setMRT( this._mrt );
-		renderer.autoClear = true;
+		renderer.autoClear = this.autoClear;
+		renderer.autoClearColor = this.autoClearColor;
+		renderer.autoClearDepth = this.autoClearDepth;
+		renderer.autoClearStencil = this.autoClearStencil;
 		renderer.transparent = this.transparent;
 		renderer.opaque = this.opaque;
 
@@ -867,6 +905,9 @@ class PassNode extends TempNode {
 		renderer.setRenderTarget( currentRenderTarget );
 		renderer.setMRT( currentMRT );
 		renderer.autoClear = currentAutoClear;
+		renderer.autoClearColor = currentAutoClearColor;
+		renderer.autoClearDepth = currentAutoClearDepth;
+		renderer.autoClearStencil = currentAutoClearStencil;
 		renderer.transparent = currentTransparent;
 		renderer.opaque = currentOpaque;
 		renderer.contextNode = currentContextNode;

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -111,7 +111,7 @@ class Textures extends DataMap {
 
 			textureNeedsUpdate = true;
 
-			if ( depthTexture ) {
+			if ( depthTexture && depthTexture.renderTarget === renderTarget ) {
 
 				depthTexture.needsUpdate = true;
 				depthTexture.image.width = mipWidth;
@@ -134,7 +134,7 @@ class Textures extends DataMap {
 
 			textureNeedsUpdate = true;
 
-			if ( depthTexture ) {
+			if ( depthTexture && depthTexture.renderTarget === renderTarget ) {
 
 				depthTexture.needsUpdate = true;
 
@@ -568,7 +568,7 @@ class Textures extends DataMap {
 
 			}
 
-			if ( depthTexture ) {
+			if ( depthTexture && depthTexture.renderTarget === renderTarget ) {
 
 				this._destroyTexture( depthTexture );
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2208,7 +2208,7 @@ class WebGLBackend extends Backend {
 
 			let samples = renderTarget.samples;
 
-			if ( descriptor.depthTexture !== null && useMultisampledRTT === false ) {
+			if ( descriptor.depthTexture !== null && descriptor.depthTexture.renderTarget !== renderTarget && useMultisampledRTT === false ) {
 
 				if ( samples > 0 ) {
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2192,7 +2192,7 @@ class WebGLBackend extends Backend {
 
 			const renderTarget = descriptor.renderTarget;
 			const renderTargetContextData = this.get( renderTarget );
-			const { samples, depthBuffer, stencilBuffer } = renderTarget;
+			const { depthBuffer, stencilBuffer } = renderTarget;
 
 			const isCube = renderTarget.isCubeRenderTarget === true;
 			const isRenderTarget3D = renderTarget.isRenderTarget3D === true;
@@ -2205,6 +2205,20 @@ class WebGLBackend extends Backend {
 			const multisampledRTTExt = this.extensions.get( 'WEBGL_multisampled_render_to_texture' );
 			const multiviewExt = this.extensions.get( 'OVR_multiview2' );
 			const useMultisampledRTT = this._useMultisampledExtension( renderTarget );
+
+			let samples = renderTarget.samples;
+
+			if ( descriptor.depthTexture !== null && useMultisampledRTT === false ) {
+
+				if ( samples > 0 ) {
+
+					warnOnce( 'WebGLBackend: Shared depth texture is not supported with MSAA when "WEBGL_multisampled_render_to_texture" is unsupported. Falling back to single-sample rendering.' );
+					samples = 0;
+
+				}
+
+			}
+
 			const cacheKey = getCacheKey( descriptor );
 
 			let fb;
@@ -2717,7 +2731,7 @@ class WebGLBackend extends Backend {
 
 			const renderTargetContextData = this.get( renderTarget );
 
-			if ( renderTarget.samples > 0 && this._useMultisampledExtension( renderTarget ) === false ) {
+			if ( renderTarget.samples > 0 && renderTargetContextData.msaaFrameBuffer !== undefined && this._useMultisampledExtension( renderTarget ) === false ) {
 
 				const fb = renderTargetContextData.framebuffers[ renderContext.getCacheKey() ];
 


### PR DESCRIPTION
Closes https://github.com/mrdoob/three.js/issues/33062

**Description**

This PR adds support for sharing a `DepthTexture` between multiple rendering passes/render targets in `WebGPURenderer`.

The idea is for the `DepthTexture` to have a "parent" `renderTarget` that acts as the source and is responsible for resizing and disposal while the `DepthTexture` itself can be shared among other `RenderTargets` without a strong binding.

<img width="1022" height="572" alt="image" src="https://github.com/user-attachments/assets/0ea06a2f-4d34-40d6-b0be-74c94103bb2a" />

----

Simple example, see transparentPass `pass( scene, camera, { depthTexture: opaqueDepthTexture, autoClearDepth: false } )`

```js
// opaque pass

const opaquePass = pass( scene, camera );
opaquePass.transparent = false;

// transparent pass

const opaqueDepthTexture = opaquePass.getTexture( 'depth' );

const transparentPass = pass( scene, camera, { depthTexture: opaqueDepthTexture, autoClearDepth: false } );
transparentPass.opaque = false;

// resolve - render pipeline

renderPipeline = new THREE.RenderPipeline( renderer );
renderPipeline.outputNode = opaquePass.add( transparentPass );
```

----

<details>
<summary>Code for testing</summary>

```js

import * as THREE from 'three/webgpu';
import { pass } from 'three/tsl';

import { Inspector } from 'three/addons/inspector/Inspector.js';

import { UltraHDRLoader } from 'three/addons/loaders/UltraHDRLoader.js';

import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
import { TeapotGeometry } from 'three/addons/geometries/TeapotGeometry.js';

let camera, scene, renderer;
let renderPipeline;
let planesGroup;

init();

function init() {

	const container = document.createElement( 'div' );
	document.body.appendChild( container );

	// scene

	camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.25, 20 );
	camera.position.set( - 1.8, 0.0, 2.7 );

	scene = new THREE.Scene();

	new UltraHDRLoader()
		.setPath( 'textures/equirectangular/' )
		.load( 'royal_esplanade_2k.hdr.jpg', function ( texture ) {

			texture.mapping = THREE.EquirectangularReflectionMapping;

			//scene.background = texture;
			scene.environment = texture;

			// teapot model
			const teapotGeometry = new TeapotGeometry( 0.4, 18 );
			const teapotMaterial = new THREE.MeshStandardMaterial( { color: 0x333333, roughness: 0.2, metalness: 0.8 } );
			const teapot = new THREE.Mesh( teapotGeometry, teapotMaterial );
			teapot.position.y = - 0.15;
			scene.add( teapot );

		} );


	// planes group
	planesGroup = new THREE.Group();
	planesGroup.position.y = - 0.15;
	scene.add( planesGroup );

	const planeGeometry = new THREE.PlaneGeometry( 0.4, 0.4 );
	const planeMaterial = new THREE.MeshStandardMaterial( { color: 0x999999, roughness: 0.5, metalness: 0.5, side: THREE.DoubleSide, transparent: true, opacity: 0.5 } );

	const numPlanes = 6;
	const planesRadius = 1.5;

	for ( let i = 0; i < numPlanes; i ++ ) {

		const angle = ( i / numPlanes ) * Math.PI * 2;

		const pivot = new THREE.Group();
		pivot.rotation.y = angle;
		planesGroup.add( pivot );

		const plane = new THREE.Mesh( planeGeometry, planeMaterial );
		plane.position.z = planesRadius;
		pivot.add( plane );

	}

	// renderer

	renderer = new THREE.WebGPURenderer( /*{ antialias: true }*/ );
	renderer.setPixelRatio( window.devicePixelRatio );
	renderer.setSize( window.innerWidth, window.innerHeight );
	renderer.setAnimationLoop( render );
	renderer.toneMapping = THREE.ACESFilmicToneMapping;
	renderer.inspector = new Inspector();
	container.appendChild( renderer.domElement );

	// opaque pass

	const opaquePass = pass( scene, camera );
	opaquePass.transparent = false;

	// transparent pass

	const opaqueDepthTexture = opaquePass.getTexture( 'depth' );

	const transparentPass = pass( scene, camera, { depthTexture: opaqueDepthTexture, autoClearDepth: false } );
	transparentPass.opaque = false;

	// resolve - render pipeline

	renderPipeline = new THREE.RenderPipeline( renderer );
	renderPipeline.outputNode = opaquePass.add( transparentPass );

	// controls

	const controls = new OrbitControls( camera, renderer.domElement );
	controls.minDistance = 2;
	controls.maxDistance = 10;
	controls.target.set( 0, 0, - 0.2 );
	controls.update();

	window.addEventListener( 'resize', onWindowResize );

}

function onWindowResize() {

	camera.aspect = window.innerWidth / window.innerHeight;
	camera.updateProjectionMatrix();

	renderer.setSize( window.innerWidth, window.innerHeight );

}

//

function render() {

	planesGroup.rotation.y = - performance.now() * 0.0005;

	renderPipeline.render();

}
```
</details>