### PR TITLE
Renderer: Use `WeakMap` in `Info`.

### DIFF
--- a/src/renderers/common/Info.js
+++ b/src/renderers/common/Info.js
@@ -139,10 +139,10 @@ class Info {
 		/**
 		 * Map for storing calculated byte sizes of tracked objects.
 		 *
-		 * @type {Map<Object, number>}
+		 * @type {WeakMap<Object, number>}
 		 * @private
 		 */
-		this.memoryMap = new Map();
+		this.memoryMap = new WeakMap();
 
 	}
 
@@ -218,7 +218,7 @@ class Info {
 
 		}
 
-		this.memoryMap.clear();
+		this.memoryMap = new WeakMap();
 
 	}
 


### PR DESCRIPTION
Related issue: #33097

**Description**

I've realized today `Info.memoryMap` can be a `WeakMap` instead of a ordinary `Map`.

All keys are objects, no iteration happens and its size isn't accessed as well.

If something gets out-of-sync, a `WeakMap` won't block the GC from doing its work.