### PR TITLE
Renderers: Optimize multi-scattering energy compensation.

### DIFF
--- a/src/nodes/functions/PhysicalLightingModel.js
+++ b/src/nodes/functions/PhysicalLightingModel.js
@@ -473,6 +473,14 @@ class PhysicalLightingModel extends LightingModel {
 		 */
 		this.iridescenceF0Metallic = null;
 
+		/**
+		 * The multi-scattering energy compensation for direct lighting.
+		 *
+		 * @type {?Node}
+		 * @default null
+		 */
+		this.multiScatteringCompensation = null;
+
 	}
 
 	/**
@@ -557,6 +565,18 @@ class PhysicalLightingModel extends LightingModel {
 
 		}
 
+		// Multi-scattering energy compensation for direct lighting
+		// Based on "Practical Multiple Scattering Compensation for Microfacet Models"
+		// https://blog.selfshadow.com/publications/turquin/ms_comp_final.pdf
+		const dotNV = normalView.dot( positionViewDirection ).clamp();
+		const fab = DFGLUT( { roughness, dotNV } );
+
+		// Energy of the single-scattering lobe in a white furnace ( F0 = F90 = 1 )
+		const Ess = fab.x.add( fab.y );
+
+		// Compensate for the energy lost to multiple scattering, tinting the added term by F0 ( equation 16 )
+		this.multiScatteringCompensation = specularColorBlended.mul( Ess.reciprocal().sub( 1.0 ) ).add( 1.0 ).toConst( 'multiScatteringCompensation' );
+
 		super.start( builder );
 
 	}
@@ -639,19 +659,7 @@ class PhysicalLightingModel extends LightingModel {
 
 		}
 
-		// Multi-scattering energy compensation for direct lighting
-		// Based on "Practical Multiple Scattering Compensation for Microfacet Models"
-		// https://blog.selfshadow.com/publications/turquin/ms_comp_final.pdf
-		const dotNV = normalView.dot( positionViewDirection ).clamp();
-		const fab = DFGLUT( { roughness, dotNV } );
-
-		// Energy of the single-scattering lobe in a white furnace ( F0 = F90 = 1 )
-		const Ess = fab.x.add( fab.y );
-
-		// Compensate for the energy lost to multiple scattering, tinting the added term by F0 ( equation 16 )
-		const energyCompensation = specularColorBlended.mul( Ess.reciprocal().sub( 1.0 ) ).add( 1.0 );
-
-		reflectedLight.directSpecular.addAssign( irradiance.mul( specularBRDF ).mul( energyCompensation ) );
+		reflectedLight.directSpecular.addAssign( irradiance.mul( specularBRDF ).mul( this.multiScatteringCompensation ) );
 
 	}
 

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -54,6 +54,23 @@ vec3 geometryClearcoatNormal = vec3( 0.0 );
 
 #endif
 
+#ifdef STANDARD
+
+	// Multi-scattering energy compensation for direct lighting
+	// Based on "Practical Multiple Scattering Compensation for Microfacet Models"
+	// https://blog.selfshadow.com/publications/turquin/ms_comp_final.pdf
+	float dotNVms = saturate( dot( geometryNormal, geometryViewDir ) );
+
+	vec2 fabMs = texture2D( dfgLUT, vec2( material.roughness, dotNVms ) ).rg;
+
+	// Energy of the single-scattering lobe in a white furnace ( F0 = F90 = 1 )
+	float EssMs = fabMs.x + fabMs.y;
+
+	// Compensate for the energy lost to multiple scattering, tinting the added term by F0 ( equation 16 )
+	material.multiScatteringCompensation = 1.0 + material.specularColorBlended * ( 1.0 / EssMs - 1.0 );
+
+#endif
+
 IncidentLight directLight;
 
 #if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -13,6 +13,7 @@ struct PhysicalMaterial {
 	float metalness;
 	float specularF90;
 	float dispersion;
+	vec3 multiScatteringCompensation;
 
 	#ifdef USE_RETROREFLECTIVE
 		float retroreflective;
@@ -527,20 +528,7 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in vec3 geome
 
 	#endif
 
-	// Multi-scattering energy compensation for direct lighting
-	// Based on "Practical Multiple Scattering Compensation for Microfacet Models"
-	// https://blog.selfshadow.com/publications/turquin/ms_comp_final.pdf
-	float dotNV = saturate( dot( geometryNormal, geometryViewDir ) );
-
-	vec2 fab = texture2D( dfgLUT, vec2( material.roughness, dotNV ) ).rg;
-
-	// Energy of the single-scattering lobe in a white furnace ( F0 = F90 = 1 )
-	float Ess = fab.x + fab.y;
-
-	// Compensate for the energy lost to multiple scattering, tinting the added term by F0 ( equation 16 )
-	vec3 energyCompensation = 1.0 + material.specularColorBlended * ( 1.0 / Ess - 1.0 );
-
-	reflectedLight.directSpecular += irradiance * specularBRDF * energyCompensation;
+	reflectedLight.directSpecular += irradiance * specularBRDF * material.multiScatteringCompensation;
 
 	// Light reflected by the specular interface is not available to the diffuse layer ( glTF fresnel_mix )
 	vec3 halfDir = normalize( directLight.direction + geometryViewDir );


### PR DESCRIPTION
Related issue: #33983

**Description**

During a performance analysis of our PBR material, I have noticed an issue with the new multi-scattering energy compensation.

The DFG LUT sampling as well as the computation of the energy conservation term are done per light. That is a waste because the uvs are equal for all lights and no light-specific data are part of this computation. So the energy conservation term is a fragment-constant.

The PR makes sure to compute it once and reuse it for all lights.