### PR TITLE
WebGLRenderer: Tighten multi-scattering check.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -54,7 +54,7 @@ vec3 geometryClearcoatNormal = vec3( 0.0 );
 
 #endif
 
-#ifdef STANDARD
+#if defined( STANDARD ) && ( NUM_DIR_LIGHTS > 0 || NUM_POINT_LIGHTS > 0 || NUM_SPOT_LIGHTS > 0 )
 
 	// Multi-scattering energy compensation for direct lighting
 	// Based on "Practical Multiple Scattering Compensation for Microfacet Models"


### PR DESCRIPTION
Related issue: #34046

**Description**

Follow-up of #34046. The PR makes sure `material.multiScatteringCompensation` is only precomputed when direct lights are in the scene. The TSL side does not to be changed since if no direct light is in place, nothing builds `multiScatteringCompensation`.
