### PR TITLE
Manual: Slowed down colourshift effect in scenegraph tutorial.

### DIFF
--- a/manual/examples/scenegraph-tank.html
+++ b/manual/examples/scenegraph-tank.html
@@ -275,8 +275,8 @@ function main() {
 		targetBob.position.y = Math.sin( time * 2 ) * 4;
 		targetMesh.rotation.x = time * 7;
 		targetMesh.rotation.y = time * 13;
-		targetMaterial.emissive.setHSL( time * 10 % 1, 1, .25 );
-		targetMaterial.color.setHSL( time * 10 % 1, 1, .25 );
+		targetMaterial.emissive.setHSL( time * 0.3 % 1, 1, .25 );
+		targetMaterial.color.setHSL( time * 0.3 % 1, 1, .25 );
 
 		// move tank
 		const tankTime = time * .05;

--- a/manual/pages/scenegraph.html
+++ b/manual/pages/scenegraph.html
@@ -385,8 +385,8 @@ targetOrbit.rotation.y = time * .27;
 targetBob.position.y = Math.sin(time * 2) * 4;
 targetMesh.rotation.x = time * 7;
 targetMesh.rotation.y = time * 13;
-targetMaterial.emissive.setHSL(time * 10 % 1, 1, .25);
-targetMaterial.color.setHSL(time * 10 % 1, 1, .25);
+targetMaterial.emissive.setHSL(time * 0.3 % 1, 1, .25);
+targetMaterial.color.setHSL(time * 0.3 % 1, 1, .25);
 </pre>
 <p>For the tank there's an <a href="/docs/#api/en/core/Object3D"><code class="notranslate" translate="no">Object3D</code></a> called <code class="notranslate" translate="no">tank</code> which is used to move everything
 below it around. The code uses a <a href="/docs/#api/en/extras/curves/SplineCurve"><code class="notranslate" translate="no">SplineCurve</code></a> which it can ask for positions


### PR DESCRIPTION
**Description**

In the manual page for the Scenegraph (https://threejs.org/manual/#en/scenegraph) there's a tutorial where a tank looks at a rotating, colour-shifting cube. It's a cool effect but, accessibility-wise, rapidly pulsing neon colours that unexpectedly takes up a huge chunk of the screen with no epilepsy warning is... not so good.

This is a microscopically small PR to just slow down that pulsing colour effect so we don't trigger anyone who's photosensitive.

