### PR TITLE
WebGPURenderer: Support dynamic swapping of the lighting system

### DIFF
--- a/src/renderers/common/Lighting.js
+++ b/src/renderers/common/Lighting.js
@@ -2,8 +2,6 @@ import { LightsNode } from '../../nodes/Nodes.js';
 
 const _defaultLights = /*@__PURE__*/ new LightsNode();
 
-let _id = 0;
-
 /**
  * This renderer module manages the lights nodes which are unique
  * per scene + camera + lighting combination.
@@ -27,13 +25,6 @@ class Lighting {
 		 * @default true
 		 */
 		this.enabled = true;
-
-		/**
-		 * The ID of this lighting manager.
-		 *
-		 * @type {number}
-		 */
-		this.id = _id ++;
 
 		/**
 		 * A stack of light arrays saved per render via {@link Lighting#beginRender}.

--- a/src/renderers/common/Lighting.js
+++ b/src/renderers/common/Lighting.js
@@ -6,7 +6,7 @@ let _id = 0;
 
 /**
  * This renderer module manages the lights nodes which are unique
- * per scene and camera combination.
+ * per scene + camera + lighting combination.
  *
  * The lights node itself is later configured in the render list
  * with the actual lights from the scene.
@@ -49,7 +49,7 @@ class Lighting {
 		 * @private
 		 * @type {WeakMap<Scene, LightsNode>}
 		 */
-		this._lightsNodeMap = /*@__PURE__*/ new WeakMap();
+		this._lightsNodeMap = new WeakMap();
 
 	}
 

--- a/src/renderers/common/Lighting.js
+++ b/src/renderers/common/Lighting.js
@@ -1,7 +1,8 @@
 import { LightsNode } from '../../nodes/Nodes.js';
 
 const _defaultLights = /*@__PURE__*/ new LightsNode();
-const _weakMap = /*@__PURE__*/ new WeakMap();
+
+let _id = 0;
 
 /**
  * This renderer module manages the lights nodes which are unique
@@ -28,12 +29,27 @@ class Lighting {
 		this.enabled = true;
 
 		/**
+		 * The ID of this lighting manager.
+		 *
+		 * @type {number}
+		 */
+		this.id = _id ++;
+
+		/**
 		 * A stack of light arrays saved per render via {@link Lighting#beginRender}.
 		 *
 		 * @private
 		 * @type {Array<Array<Light>>}
 		 */
 		this._cache = [];
+
+		/**
+		 * A map of lights nodes per scene.
+		 *
+		 * @private
+		 * @type {WeakMap<Scene, LightsNode>}
+		 */
+		this._lightsNodeMap = /*@__PURE__*/ new WeakMap();
 
 	}
 
@@ -60,12 +76,12 @@ class Lighting {
 		// Ignore renderable objects, e.g: Mesh, Sprite, etc.
 		if ( scene.isScene !== true && scene.isGroup !== true ) return _defaultLights;
 
-		let node = _weakMap.get( scene );
+		let node = this._lightsNodeMap.get( scene );
 
 		if ( node === undefined ) {
 
 			node = this.createNode();
-			_weakMap.set( scene, node );
+			this._lightsNodeMap.set( scene, node );
 
 		}
 

--- a/src/renderers/common/RenderLists.js
+++ b/src/renderers/common/RenderLists.js
@@ -13,17 +13,8 @@ class RenderLists {
 
 	/**
 	 * Constructs a render lists management component.
-	 *
-	 * @param {Lighting} lighting - The lighting management component.
 	 */
-	constructor( lighting ) {
-
-		/**
-		 * The lighting management component.
-		 *
-		 * @type {Lighting}
-		 */
-		this.lighting = lighting;
+	constructor() {
 
 		/**
 		 * The internal chain map which holds the render lists.
@@ -56,26 +47,29 @@ class RenderLists {
 	 *
 	 * @param {Scene} scene - The scene.
 	 * @param {Camera} camera - The camera.
+	 * @param {Lighting} lighting - The lighting manager.
 	 * @return {RenderList} The render list.
 	 */
-	get( scene, camera ) {
+	get( scene, camera, lighting ) {
 
 		const lists = this.lists;
 
 		_chainKeys[ 0 ] = scene;
 		_chainKeys[ 1 ] = camera;
+		_chainKeys[ 2 ] = lighting;
 
 		let list = lists.get( _chainKeys );
 
 		if ( list === undefined ) {
 
-			list = new RenderList( this.lighting, scene, camera );
+			list = new RenderList( lighting, scene, camera );
 			lists.set( _chainKeys, list );
 
 		}
 
 		_chainKeys[ 0 ] = null;
 		_chainKeys[ 1 ] = null;
+		_chainKeys[ 2 ] = null;
 
 		//
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -757,7 +757,7 @@ class Renderer {
 				const useFrameBufferTarget = this.needsFrameBufferTarget && this._renderTarget === null;
 				const renderTarget = useFrameBufferTarget ? this._getFrameBufferTarget() : ( this._renderTarget || this._outputRenderTarget );
 
-				const renderList = this._renderLists.get( scene, camera );
+				const renderList = this._renderLists.get( scene, camera, this.lighting );
 				const renderContext = this._renderContexts.get( renderTarget, this._mrt );
 
 				const material = scene.overrideMaterial || object.material;
@@ -831,7 +831,7 @@ class Renderer {
 			this._pipelines = new Pipelines( backend, this._nodes, this.info );
 			this._bindings = new Bindings( backend, this._nodes, this._textures, this._attributes, this._pipelines, this.info );
 			this._objects = new RenderObjects( this, this._nodes, this._geometries, this._pipelines, this._bindings, this.info );
-			this._renderLists = new RenderLists( this.lighting );
+			this._renderLists = new RenderLists();
 			this._bundles = new RenderBundles();
 			this._renderContexts = new RenderContexts( this );
 
@@ -982,7 +982,7 @@ class Renderer {
 		}
 
 		// Use sceneRef for render list to ensure lightsNode matches between compileAsync and render
-		const renderList = this._renderLists.get( sceneRef, camera );
+		const renderList = this._renderLists.get( sceneRef, camera, this.lighting );
 		renderList.begin();
 
 		this._projectObject( scene, camera, 0, renderList, renderContext.clippingContext );
@@ -1708,7 +1708,7 @@ class Renderer {
 
 		this._renderLists.update( nodeFrame.frameId );
 
-		const renderList = this._renderLists.get( scene, camera );
+		const renderList = this._renderLists.get( scene, camera, this.lighting );
 		renderList.begin();
 
 		this._projectObject( scene, camera, 0, renderList, renderContext.clippingContext );
@@ -3235,7 +3235,7 @@ class Renderer {
 
 			// replace render list
 
-			renderList = this._renderLists.get( object, camera );
+			renderList = this._renderLists.get( object, camera, this.lighting );
 
 			const renderBundle = this._bundles.get( object, camera, this._currentRenderContext );
 			const renderBundleData = this.backend.get( renderBundle );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/34049

**Description**

This PR allows the WebGPU/Node renderer to support dynamically swapping `renderer.lighting` (or using rendering passes with different `Lighting` setups for the same scene and camera).

Previously, `RenderLists` cached render lists using a compound key of `[ scene, camera ]`. If different passes rendered the same scene and camera but used different lighting managers (for example, in a deferred shading pipeline where one pass disables lighting and a subsequent resolve pass computes lighting), they would share and overwrite the same `RenderList` and `LightsNode`. 

This led to lighting configuration conflicts and hashing issues.
