### PR TITLE
NodeMaterial: Improve scene lighting enabled check

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -994,14 +994,6 @@ class NodeMaterial extends Material {
 
 		const materialLightsNode = [];
 
-		if ( builder.renderer.lighting.enabled === false ) {
-
-			return materialLightsNode;
-
-		}
-
-		//
-
 		const envNode = this.setupEnvironment( builder );
 
 		if ( envNode && envNode.isLightingNode ) {
@@ -1087,9 +1079,10 @@ class NodeMaterial extends Material {
 
 		// OUTGOING LIGHT
 
-		const lights = this.lights === true || this.lightsNode !== null;
+		const sceneLighting = this.lights === true && builder.renderer.lighting.enabled;
+		const lights = sceneLighting || this.lightsNode !== null;
 
-		const materialLightings = this.lights === true ? this.setupMaterialLightings( builder ) : [];
+		const materialLightings = sceneLighting ? this.setupMaterialLightings( builder ) : [];
 		const lightsNode = lights ? ( this.lightsNode || builder.lightsNode ) : null;
 
 		let outgoingLightNode = this.setupOutgoingLight( builder );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/34049

**Description**

This PR refactors the condition for enabling scene lights in `NodeMaterial` to separate default scene-wide lighting from custom material-specific light nodes (`material.lightsNode`).

Previously, if `builder.renderer.lighting.enabled` was `false` (for example, in a G-buffer pass with lighting disabled), `setupMaterialLightings` would return an empty array, but other scene light nodes might still have been checked or mixed. 
By introducing a distinct `sceneLighting` boolean check (`this.lights === true && builder.renderer.lighting.enabled`), we ensure that:
1. Standard scene-wide lights are only evaluated when the renderer's lighting system is enabled.
2. Custom material-specific lights (`this.lightsNode`) can still be evaluated independently if provided, even if the renderer's default lighting is disabled.
