### PR TITLE
WebGLRenderer: Fix color texture check for `BatchedMesh`.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2415,11 +2415,11 @@ class WebGLRenderer {
 
 					needsProgramChange = true;
 
-				} else if ( object.isBatchedMesh && materialProperties.batchingColor === true && object.colorTexture === null ) {
+				} else if ( object.isBatchedMesh && materialProperties.batchingColor === true && object._colorsTexture === null ) {
 
 					needsProgramChange = true;
 
-				} else if ( object.isBatchedMesh && materialProperties.batchingColor === false && object.colorTexture !== null ) {
+				} else if ( object.isBatchedMesh && materialProperties.batchingColor === false && object._colorsTexture !== null ) {
 
 					needsProgramChange = true;
 


### PR DESCRIPTION
Fixed #34054.

**Description**

The PR makes sure `WebGLRenderer` accesses the correct property name of `BatchedMesh` to check whether a color texture exists or not.

Nothing visual was broken with this bug but colorless instances of `BatchedMesh` set `needsProgramChange` to `true` every frame producing unnecessary overhead. This triggered no shader compilation but just some redundant cache-key computations. So nothing that makes the batch unusable but still something the engine should not do.
