### PR TITLE
MeshPhysicalMaterial: Fix diffuse Fresnel blend for `retroreflective`.

### DIFF
--- a/src/nodes/functions/PhysicalLightingModel.js
+++ b/src/nodes/functions/PhysicalLightingModel.js
@@ -651,9 +651,7 @@ class PhysicalLightingModel extends LightingModel {
 		// Light reflected by the specular interface is not available to the diffuse layer ( glTF fresnel_mix )
 		const halfDir = lightDirection.add( positionViewDirection ).normalize();
 		const dotVH = positionViewDirection.dot( halfDir ).clamp();
-		const F = F_Schlick( { f0: specularColor, f90: specularF90, dotVH } );
-
-		reflectedLight.directDiffuse.addAssign( irradiance.mul( BRDF_Lambert( { diffuseColor: diffuseContribution } ) ).mul( F.oneMinus() ) );
+		let F = F_Schlick( { f0: specularColor, f90: specularF90, dotVH } );
 
 		let specularBRDF = BRDF_GGX( { lightDirection, f0: specularColorBlended, f90: 1, roughness, f: this.iridescenceFresnel, USE_IRIDESCENCE: this.iridescence, USE_ANISOTROPY: this.anisotropy } );
 
@@ -662,11 +660,17 @@ class PhysicalLightingModel extends LightingModel {
 			// Minimal Retroreflective Microfacet Model:
 			// https://jcgt.org/published/0015/01/04/
 			const retroViewDirection = positionViewDirection.negate().reflect( normalView );
+			const retroHalfDir = lightDirection.add( retroViewDirection ).normalize();
+			const dotRetroVH = retroViewDirection.dot( retroHalfDir ).clamp();
+			const retroF = F_Schlick( { f0: specularColor, f90: specularF90, dotVH: dotRetroVH } );
 			const retroSpecularBRDF = BRDF_GGX( { lightDirection, viewDirection: retroViewDirection, f0: specularColorBlended, f90: 1, roughness, f: this.iridescenceFresnel, USE_IRIDESCENCE: this.iridescence, USE_ANISOTROPY: this.anisotropy } );
 
+			F = mix( F, retroF, retroreflective.clamp() );
 			specularBRDF = mix( specularBRDF, retroSpecularBRDF, retroreflective.clamp() );
 
 		}
+
+		reflectedLight.directDiffuse.addAssign( irradiance.mul( BRDF_Lambert( { diffuseColor: diffuseContribution } ) ).mul( F.oneMinus() ) );
 
 		reflectedLight.directSpecular.addAssign( irradiance.mul( specularBRDF ).mul( this.multiScatteringCompensation ) );
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -533,6 +533,16 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in vec3 geome
 	float dotVH = saturate( dot( geometryViewDir, halfDir ) );
 	vec3 F = F_Schlick( material.specularColor, material.specularF90, dotVH );
 
+	#ifdef USE_RETROREFLECTIVE
+
+		vec3 retroHalfDir = normalize( directLight.direction + retroViewDir );
+		float dotRetroVH = saturate( dot( retroViewDir, retroHalfDir ) );
+		vec3 retroF = F_Schlick( material.specularColor, material.specularF90, dotRetroVH );
+
+		F = mix( F, retroF, saturate( material.retroreflective ) );
+
+	#endif
+
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseContribution ) * ( 1.0 - F );
 }
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33995#issuecomment-4925377415

**Description**

The PR integrates the diffuse Fresnel blend fix of @bhouston so we have a clean, consistent `retroreflective` implementation on `dev`. Whether we want to support IBLs or not can be decided in #33995. But this discussion should not block this bug fix. 
