### PR TITLE
Sky: Fix FP16 overflow.

### DIFF
--- a/examples/jsm/objects/Sky.js
+++ b/examples/jsm/objects/Sky.js
@@ -273,7 +273,7 @@ Sky.SkyShader = {
 
 			// composition + solar disc
 			float sundisc = clamp( ( cosTheta - sunAngularDiameterCos ) * 50000.0, 0.0, 1.0 ) * showSunDisc;
-			vec3 sundiscColor = ( 760.0 * sundisc ) * min( vSunE * Fex, 80.0 ); // 760 = 19000 * 0.04, capped below the half-float range
+			vec3 sundiscColor = ( 760.0 * sundisc ) * min( vSunE * Fex, 80.0 );
 
 			vec3 texColor = ( Lin + L0 ) * 0.04 + sundiscColor + vec3( 0.0, 0.0003, 0.00075 );
 

--- a/examples/jsm/objects/Sky.js
+++ b/examples/jsm/objects/Sky.js
@@ -25,9 +25,9 @@ import {
  * sky.scale.setScalar( 10000 );
  * scene.add( sky );
  * ```
- * 
+ *
  * It can be useful to hide the sun disc when generating an environment map to avoid artifacts
- * 
+ *
  * ```js
  * // disable before rendering environment map
  * sky.material.uniforms.showSunDisc.value = false;
@@ -272,10 +272,10 @@ Sky.SkyShader = {
 			vec3 L0 = vec3( 0.1 ) * Fex;
 
 			// composition + solar disc
-			float sundisc = smoothstep( sunAngularDiameterCos, sunAngularDiameterCos + 0.00002, cosTheta ) * showSunDisc;
-			L0 += ( vSunE * 19000.0 * Fex ) * sundisc;
+			float sundisc = clamp( ( cosTheta - sunAngularDiameterCos ) * 50000.0, 0.0, 1.0 ) * showSunDisc;
+			vec3 sundiscColor = ( 760.0 * sundisc ) * min( vSunE * Fex, 80.0 ); // 760 = 19000 * 0.04, capped below the half-float range
 
-			vec3 texColor = ( Lin + L0 ) * 0.04 + vec3( 0.0, 0.0003, 0.00075 );
+			vec3 texColor = ( Lin + L0 ) * 0.04 + sundiscColor + vec3( 0.0, 0.0003, 0.00075 );
 
 			// Clouds
 			if ( direction.y > 0.0 && cloudCoverage > 0.0 ) {

--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -280,7 +280,7 @@ class SkyMesh extends Mesh {
 
 			// composition + solar disc
 			const sundisc = clamp( cosTheta.sub( sunAngularDiameterCos ).mul( 50000.0 ), 0.0, 1.0 ).mul( this.showSunDisc );
-			const sundiscColor = min( vSunE.mul( Fex ), 80.0 ).mul( 760.0 ).mul( sundisc ); // 760 = 19000 * 0.04, capped below the half-float range
+			const sundiscColor = min( vSunE.mul( Fex ), 80.0 ).mul( 760.0 ).mul( sundisc );
 
 			const texColor = add( Lin, L0 ).mul( 0.04 ).add( sundiscColor ).add( vec3( 0.0, 0.0003, 0.00075 ) ).toVar();
 

--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -6,7 +6,7 @@ import {
 	NodeMaterial
 } from 'three/webgpu';
 
-import { Fn, float, floor, fract, vec2, vec3, acos, add, mul, clamp, cos, dot, exp, max, mix, modelViewProjection, normalize, positionWorld, pow, smoothstep, sub, varyingProperty, vec4, uniform, cameraPosition, time, If, Loop } from 'three/tsl';
+import { Fn, float, floor, fract, vec2, vec3, acos, add, mul, clamp, cos, dot, exp, max, min, mix, modelViewProjection, normalize, positionWorld, pow, smoothstep, sub, varyingProperty, vec4, uniform, cameraPosition, time, If, Loop } from 'three/tsl';
 
 /**
  * Represents a skydome for scene backgrounds. Based on [A Practical Analytic Model for Daylight](https://www.researchgate.net/publication/220720443_A_Practical_Analytic_Model_for_Daylight)
@@ -27,7 +27,7 @@ import { Fn, float, floor, fract, vec2, vec3, acos, add, mul, clamp, cos, dot, e
  * ```
  *
  * It can be useful to hide the sun disc when generating an environment map to avoid artifacts
- * 
+ *
  * ```js
  * // disable before rendering environment map
  * sky.showSunDisc.value = false;
@@ -279,10 +279,10 @@ class SkyMesh extends Mesh {
 			const L0 = vec3( 0.1 ).mul( Fex );
 
 			// composition + solar disc
-			const sundisc = smoothstep( sunAngularDiameterCos, sunAngularDiameterCos.add( 0.00002 ), cosTheta ).mul( this.showSunDisc );
-			L0.addAssign( vSunE.mul( 19000.0 ).mul( Fex ).mul( sundisc ) );
+			const sundisc = clamp( cosTheta.sub( sunAngularDiameterCos ).mul( 50000.0 ), 0.0, 1.0 ).mul( this.showSunDisc );
+			const sundiscColor = min( vSunE.mul( Fex ), 80.0 ).mul( 760.0 ).mul( sundisc ); // 760 = 19000 * 0.04, capped below the half-float range
 
-			const texColor = add( Lin, L0 ).mul( 0.04 ).add( vec3( 0.0, 0.0003, 0.00075 ) ).toVar();
+			const texColor = add( Lin, L0 ).mul( 0.04 ).add( sundiscColor ).add( vec3( 0.0, 0.0003, 0.00075 ) ).toVar();
 
 			// gradient at a lattice corner; sinless hash so every GPU produces the same clouds
 			const gradient = Fn( ( [ i ] ) => {
@@ -377,7 +377,7 @@ class SkyMesh extends Mesh {
 				const alpha = sub( 1.0, exp( depth.mul( this.cloudDensity ).mul( - 12.0 ) ) ).mul( horizonFade ).toVar();
 
 				// Occlude the sun disc/glow behind opaque cloud
-				texColor.subAssign( L0.mul( 0.04 ).mul( alpha ) );
+				texColor.subAssign( L0.mul( 0.04 ).add( sundiscColor ).mul( alpha ) );
 
 				// Composite through the atmosphere so distant clouds dissolve into haze
 				const cloudAerial = mix( texColor, cloudColor, Fex );


### PR DESCRIPTION
Closes #33114.

**Description**

When #32677 removed the built-in gamma correction in the sky shaders, a regression was introduces which is only visible when the device works with a lower FP16 precision. In this case, the sun disk term exceeds the FP16 range which results in Infinity values and later `NaN`. 

The idea of this PR is to make sure any computations around the sun disk stays in the FP 16 range. The breakage on mobile is now fixed, tested on an affected Android phone.

PR https://rawcdn.githack.com/mrdoob/three.js/fd8faa6c8b981f20e383a591ac9b332c8d3c9ab6/examples/webgl_shaders_ocean.html
Dev: https://rawcdn.githack.com/mrdoob/three.js/a65ee64819b634f2515c437207aa50c49881484a/examples/webgl_shaders_ocean.html