### PR TITLE
Editor: Don't use picker object with skeletons.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -448,10 +448,12 @@ Editor.prototype = {
 				} else if ( object.isSkinnedMesh ) {
 
 					helper = new THREE.SkeletonHelper( object.skeleton.bones[ 0 ] );
+					helper.userData.object = object;
 
 				} else if ( object.isBone === true && object.parent && object.parent.isBone !== true ) {
 
 					helper = new THREE.SkeletonHelper( object );
+					helper.userData.object = object;
 
 				} else {
 
@@ -460,10 +462,14 @@ Editor.prototype = {
 
 				}
 
-				const picker = new THREE.Mesh( geometry, material );
-				picker.name = 'picker';
-				picker.userData.object = object;
-				helper.add( picker );
+				if ( helper.isSkeletonHelper !== true ) {
+
+					const picker = new THREE.Mesh( geometry, material );
+					picker.name = 'picker';
+					picker.userData.object = object;
+					helper.add( picker );
+
+				}
 
 			}
 

--- a/editor/js/Selector.js
+++ b/editor/js/Selector.js
@@ -76,7 +76,7 @@ class Selector {
 
 		this.editor.sceneHelpers.traverseVisible( function ( child ) {
 
-			if ( child.name === 'picker' ) objects.push( child );
+			if ( child.name === 'picker' || child.userData.object !== undefined ) objects.push( child );
 
 		} );
 


### PR DESCRIPTION
Fixed #25859.

**Description**

Makes sure the picker is not used for skeletons since skinned meshes and skeleton helpers can already be properly raycasted. Not using a picker avoids issues like mentioned in #25859 where the picker for a skinned mesh occluded a too large area in the scene.