### PR TITLE
Object3D: Add `intersectsFrustum()`.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1061,6 +1061,17 @@ class Object3D extends EventDispatcher {
 	raycast( /* raycaster, intersects */ ) {}
 
 	/**
+	 * Abstract method to test whether this 3D object intersects the given frustum.
+	 * Renderable 3D objects such as {@link Mesh}, {@link Line} or {@link Points}
+	 * implement this method in order to use frustum culling.
+	 *
+	 * @abstract
+	 * @param {Frustum|FrustumArray} frustum - The frustum to test.
+	 * @return {boolean|undefined} Whether this 3D object intersects the given frustum or not.
+	 */
+	intersectsFrustum( /* frustum */ ) {}
+
+	/**
 	 * Executes the callback on this 3D object and all descendants.
 	 *
 	 * Note: Modifying the scene graph inside the callback is discouraged.

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -152,6 +152,18 @@ class Line extends Object3D {
 	}
 
 	/**
+	 * Returns `true` if this line intersects the given frustum.
+	 *
+	 * @param {Frustum|FrustumArray} frustum - The frustum to test.
+	 * @return {boolean} Whether this line intersects the given frustum or not.
+	 */
+	intersectsFrustum( frustum ) {
+
+		return frustum.intersectsObject( this );
+
+	}
+
+	/**
 	 * Computes intersection points between a casted ray and this line.
 	 *
 	 * @param {Raycaster} raycaster - The raycaster.

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -218,6 +218,18 @@ class Mesh extends Object3D {
 	}
 
 	/**
+	 * Returns `true` if this mesh intersects the given frustum.
+	 *
+	 * @param {Frustum|FrustumArray} frustum - The frustum to test.
+	 * @return {boolean} Whether this mesh intersects the given frustum or not.
+	 */
+	intersectsFrustum( frustum ) {
+
+		return frustum.intersectsObject( this );
+
+	}
+
+	/**
 	 * Computes intersection points between a casted ray and this line.
 	 *
 	 * @param {Raycaster} raycaster - The raycaster.

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -90,6 +90,18 @@ class Points extends Object3D {
 	}
 
 	/**
+	 * Returns `true` if this point cloud intersects the given frustum.
+	 *
+	 * @param {Frustum|FrustumArray} frustum - The frustum to test.
+	 * @return {boolean} Whether this point cloud intersects the given frustum or not.
+	 */
+	intersectsFrustum( frustum ) {
+
+		return frustum.intersectsObject( this );
+
+	}
+
+	/**
 	 * Computes intersection points between a casted ray and this point cloud.
 	 *
 	 * @param {Raycaster} raycaster - The raycaster.

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -121,6 +121,18 @@ class Sprite extends Object3D {
 	}
 
 	/**
+	 * Returns `true` if this sprite intersects the given frustum.
+	 *
+	 * @param {Frustum|FrustumArray} frustum - The frustum to test.
+	 * @return {boolean} Whether this sprite intersects the given frustum or not.
+	 */
+	intersectsFrustum( frustum ) {
+
+		return frustum.intersectsSprite( this );
+
+	}
+
+	/**
 	 * Computes intersection points between a casted ray and this sprite.
 	 *
 	 * @param {Raycaster} raycaster - The raycaster.

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1868,7 +1868,7 @@ class WebGLRenderer {
 
 				} else if ( object.isSprite ) {
 
-					if ( ! object.frustumCulled || _frustum.intersectsSprite( object ) ) {
+					if ( ! object.frustumCulled || object.intersectsFrustum( _frustum ) ) {
 
 						if ( sortObjects ) {
 
@@ -1890,7 +1890,7 @@ class WebGLRenderer {
 
 				} else if ( object.isMesh || object.isLine || object.isPoints ) {
 
-					if ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) {
+					if ( ! object.frustumCulled || object.intersectsFrustum( _frustum ) ) {
 
 						const geometry = objects.update( object );
 						const material = object.material;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -3159,7 +3159,7 @@ class Renderer {
 
 				const frustum = camera.isArrayCamera ? _frustumArray : _frustum;
 
-				if ( ! object.frustumCulled || frustum.intersectsSprite( object ) ) {
+				if ( ! object.frustumCulled || object.intersectsFrustum( frustum ) ) {
 
 					if ( this.sortObjects === true ) {
 
@@ -3185,7 +3185,7 @@ class Renderer {
 
 				const frustum = camera.isArrayCamera ? _frustumArray : _frustum;
 
-				if ( ! object.frustumCulled || frustum.intersectsObject( object ) ) {
+				if ( ! object.frustumCulled || object.intersectsFrustum( frustum ) ) {
 
 					const { geometry, material } = object;
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -512,7 +512,7 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 		if ( visible && ( object.isMesh || object.isLine || object.isPoints ) ) {
 
-			if ( ( object.castShadow || ( object.receiveShadow && type === VSMShadowMap ) ) && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
+			if ( ( object.castShadow || ( object.receiveShadow && type === VSMShadowMap ) ) && ( ! object.frustumCulled || object.intersectsFrustum( _frustum ) ) ) {
 
 				object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
 


### PR DESCRIPTION
Fixed #32606.

**Description**

Currently, both renderers decide what object-frustum intersection test is used for a given 3D object. However, similar to raycasting, this implementation detail actually belongs to the 3D object. Meaning the 3D object decides how it intersects with a given frustum.

The PR introduces the abstract `Object3D.intersectsFrustum()` that is now implemented in `Mesh`, `Line`, `Points` and `Sprite`. The renderers just call `intersectsFrustum()` and don't care about the details anymore.

This design automatically fixes #32606 since apps can now easier customize how frustum intersection is supposed to work for a 3D object. E.g. apps can implement a more expensive but precise check for frustum culling.