### PR TITLE
Nodes: Add `renderer.debug.onNodeBuilderCreated` callback

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -735,6 +735,7 @@ class Renderer {
 		 * @property {boolean} checkShaderErrors - Whether shader errors should be checked or not.
 		 * @property {Object} diagnostics - Diagnostics configuration for the shader generation.
 		 * @property {boolean} diagnostics.keywords - Whether declaration names that collide with reserved keywords should be renamed or not.
+		 * @property {?Function} onNodeBuilderCreated - A callback function that is executed after a node builder has been created and before it is built.
 		 * @property {?Function} onShaderError - A callback function that is executed when a shader error happens. Only supported with WebGL 2 right now.
 		 * @property {Function} getShaderAsync - Allows the get the raw shader code for the given scene, camera and 3D object.
 		 */
@@ -749,6 +750,7 @@ class Renderer {
 			diagnostics: {
 				keywords: false
 			},
+			onNodeBuilderCreated: null,
 			onShaderError: null,
 			getShaderAsync: async ( scene, camera, object ) => {
 

--- a/src/renderers/common/nodes/NodeManager.js
+++ b/src/renderers/common/nodes/NodeManager.js
@@ -165,6 +165,10 @@ class NodeManager extends DataMap {
 	_createNodeBuilder( renderObject, material ) {
 
 		const nodeBuilder = this.backend.createNodeBuilder( renderObject.object, this.renderer );
+		const onNodeBuilderCreated = this.renderer.debug.onNodeBuilderCreated;
+
+		if ( onNodeBuilderCreated !== null ) onNodeBuilderCreated( nodeBuilder, renderObject );
+
 		nodeBuilder.scene = renderObject.scene;
 		nodeBuilder.material = material;
 		nodeBuilder.camera = renderObject.camera;
@@ -457,6 +461,10 @@ class NodeManager extends DataMap {
 		if ( nodeBuilderState === undefined || computeData.version !== computeNode.version ) {
 
 			const nodeBuilder = this.backend.createNodeBuilder( computeNode, this.renderer );
+			const onNodeBuilderCreated = this.renderer.debug.onNodeBuilderCreated;
+
+			if ( onNodeBuilderCreated !== null ) onNodeBuilderCreated( nodeBuilder, computeNode );
+
 			nodeBuilder.build();
 
 			nodeBuilderState = this._createNodeBuilderState( nodeBuilder );


### PR DESCRIPTION
Related issue: Close #33311

## Description

Today, the only window into TSL shader builds is `debug.getShaderAsync()`, which works per object and only after the fact. Applications and tools cannot observe builds as they happen, so answering questions like “How many shaders were built this frame?”, “Why did this material rebuild after its cache key changed?”, or “How long did this build take?” currently requires patching the bundle.

This PR adds one callback alongside the existing `debug` members (`onShaderError` and `getShaderAsync`):

- `renderer.debug.onNodeBuilderCreated( nodeBuilder, targetObject )` (default: `null`) runs immediately after `backend.createNodeBuilder()` and before the builder is built. On the render path, `targetObject` is the `RenderObject`; on the compute path, it is the compute node. The shared render site covers synchronous, asynchronous, and deferred builds.

Receiving the builder before the build lets tooling wrap `build()`, measure its duration, inspect the generated code and registered uniforms afterward, count builds per frame, and attribute them to objects or materials.

[Live JSFiddle](https://jsfiddle.net/fLdzxwtv/) — shows each build’s target, duration, and generated shader size. Use “Trigger material rebuild” to observe another build.

When the callback is unset, behavior is unchanged: the default path only gains two guarded calls (~0.1 kB) and no new files. Happy to rename or move it if `debug` is not the right namespace.
