### PR TITLE
Nodes: Make node buffer binding labels deterministic

### DIFF
--- a/src/renderers/common/nodes/NodeStorageBuffer.js
+++ b/src/renderers/common/nodes/NodeStorageBuffer.js
@@ -20,7 +20,9 @@ class NodeStorageBuffer extends StorageBuffer {
 	 */
 	constructor( nodeUniform, groupNode ) {
 
-		super( 'StorageBuffer_' + _id ++, nodeUniform ? nodeUniform.value : null );
+		const label = nodeUniform && nodeUniform.name ? nodeUniform.name : _id ++;
+
+		super( 'StorageBuffer_' + label, nodeUniform ? nodeUniform.value : null );
 
 		/**
 		 * The node uniform.

--- a/src/renderers/common/nodes/NodeUniformBuffer.js
+++ b/src/renderers/common/nodes/NodeUniformBuffer.js
@@ -20,7 +20,9 @@ class NodeUniformBuffer extends UniformBuffer {
 	 */
 	constructor( nodeUniform, groupNode ) {
 
-		super( 'UniformBuffer_' + _id ++, nodeUniform ? nodeUniform.value : null );
+		const label = nodeUniform && nodeUniform.name ? nodeUniform.name : _id ++;
+
+		super( 'UniformBuffer_' + label, nodeUniform ? nodeUniform.value : null );
 
 		/**
 		 * The uniform buffer node.


### PR DESCRIPTION
Related issue: #32037
Follow-up to: #32247

**Description**

`NodeUniformBuffer` and `NodeStorageBuffer` currently derive their labels from module-global counters. The counter value depends on earlier binding construction, so named buffers can receive different GPU-visible labels across page loads or when multiple renderers share a page.

This change uses the owning node name when one is available, producing stable, meaningful labels such as `StorageBuffer_particlePositions`. Unnamed nodes and null construction continue to use the existing numeric fallback, preserving the current behavior for internal cloning.

These strings are diagnostic labels only: WGSL identifiers still come from the node uniform name, and bind-group caching still uses node IDs. This does not change rendering behavior or the public API.

This makes named bindings easier to inspect in GPU captures and lets tools compare captured binding layouts across sessions without special-casing counter suffixes.

**Testing**

- `npm run lint-core`
- `npm run test-unit` (1,314 passed, 1 todo, 0 failed)


