### PR TITLE
Nodes: Introduce renderer.nodeBuilderStateProvider for ahead-of-time compiled shaders

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -263,6 +263,18 @@ class Renderer {
 		 */
 		this.lighting = new Lighting();
 
+		/**
+		 * An application-provided source of prebuilt node builder states.
+		 * `getForRender()` and `getForCompute()` receive the `NodeBuilderState`
+		 * constructor so they can hydrate persisted shader artifacts without
+		 * importing renderer internals. Returning `null` or `undefined` falls
+		 * back to the default build path.
+		 *
+		 * @type {?{getForRender: Function, getForCompute: Function}}
+		 * @default null
+		 */
+		this.nodeBuilderStateProvider = null;
+
 		// internals
 
 		/**

--- a/src/renderers/common/nodes/NodeManager.js
+++ b/src/renderers/common/nodes/NodeManager.js
@@ -207,6 +207,24 @@ class NodeManager extends DataMap {
 
 			if ( nodeBuilderState === undefined ) {
 
+				const provider = this.renderer.nodeBuilderStateProvider;
+
+				if ( provider !== null ) {
+
+					const precompiledState = provider.getForRender( renderObject, NodeBuilderState );
+
+					if ( precompiledState !== undefined && precompiledState !== null ) {
+
+						nodeBuilderCache.set( cacheKey, precompiledState );
+						precompiledState.usedTimes ++;
+						renderObjectData.nodeBuilderState = precompiledState;
+
+						return precompiledState;
+
+					}
+
+				}
+
 				const buildNodeBuilder = async () => {
 
 					let nodeBuilder = this._createNodeBuilder( renderObject, renderObject.material );
@@ -456,10 +474,22 @@ class NodeManager extends DataMap {
 
 		if ( nodeBuilderState === undefined || computeData.version !== computeNode.version ) {
 
-			const nodeBuilder = this.backend.createNodeBuilder( computeNode, this.renderer );
-			nodeBuilder.build();
+			const provider = this.renderer.nodeBuilderStateProvider;
 
-			nodeBuilderState = this._createNodeBuilderState( nodeBuilder );
+			if ( provider !== null ) {
+
+				nodeBuilderState = provider.getForCompute( computeNode, NodeBuilderState );
+
+			}
+
+			if ( nodeBuilderState === undefined || nodeBuilderState === null ) {
+
+				const nodeBuilder = this.backend.createNodeBuilder( computeNode, this.renderer );
+				nodeBuilder.build();
+
+				nodeBuilderState = this._createNodeBuilderState( nodeBuilder );
+
+			}
 
 			computeData.nodeBuilderState = nodeBuilderState;
 			computeData.version = computeNode.version;


### PR DESCRIPTION
Related issue: #31674

Follow-up to: #32984

**Description**

Building a TSL material or compute node runs `nodeBuilder.build()` on the render thread. #32984 made `compileAsync()` responsive by yielding during that work, but the complete TSL-to-native-shader build still runs, and first-render and compute paths remain synchronous.

Applications that own a fixed set of TSL materials or compute kernels can solve a narrower case ahead of time: capture the generated WGSL or GLSL and the small amount of binding metadata during development, store that artifact as JSON, then hydrate a fresh renderer-local builder state on a later page load. This skips work that has already been done. Today, that is impossible without patching `three.webgpu.js`, because there is no interception point before `nodeBuilder.build()`.

We use this approach in production. On a fluid-simulation scene with 25 materials and kernels, first-load node-build time drops from 97 ms to 22 ms; the remaining three internal builds are intentionally not captured.

This draft adds one opt-in seam: `renderer.nodeBuilderStateProvider`, defaulting to `null`. On a cache miss, `NodeManager` asks `getForRender( renderObject, NodeBuilderState )` or `getForCompute( computeNode, NodeBuilderState )` for a prebuilt state. Passing the private constructor lets a provider hydrate persisted artifacts into a fresh state without exporting renderer internals. Returning `null` or `undefined` preserves the existing live-build path, cache behavior, and bookkeeping.

**Demo**

[Run the JSFiddle demo](https://jsfiddle.net/8tr4faL2/embedded/result/) ([source](https://jsfiddle.net/8tr4faL2/))

The demo uses an internal shader-capture tool to capture (which will be presented at the Three.js Conference in Paris) one procedural TSL material into a 17 KB JSON artifact containing its WGSL and binding recipes. The toggle creates a fresh renderer in either live or precompiled mode, and remembers the selection for later runs or refreshes. Live mode performs one TSL graph build; precompiled mode fetches the stored artifact, hydrates one fresh `NodeBuilderState`, renders the same procedural image, and reports zero live TSL builds.

Open it in a WebGPU-capable browser, then switch from **Live TSL** to **Precompiled JSON**.
