### PR TITLE
NodeMaterialObserver: Fix stale render object cache.

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -730,11 +730,18 @@ class NodeMaterialObserver {
 
 		const { renderId } = nodeFrame;
 
+		let force = false;
+
 		if ( this.renderId !== renderId ) {
 
 			this.renderId = renderId;
 
-			return true;
+			// this force has two purposes:
+			//
+			// 1. force the render object to use the equals() code path so its internal cache state gets synched
+			// 2. make sure shared UBOs are updated at least once
+
+			force = true;
 
 		}
 
@@ -742,12 +749,12 @@ class NodeMaterialObserver {
 		const isBundle = renderObject.bundle !== null && renderObject.bundle.static === true && this.getRenderObjectData( renderObject ).version === renderObject.bundle.version;
 
 		if ( isStatic || isBundle )
-			return false;
+			return force;
 
 		const lightsData = this.getLights( renderObject.lightsNode, renderId );
 		const notEqual = this.equals( renderObject, lightsData, renderId ) !== true;
 
-		return notEqual;
+		return ( force || notEqual );
 
 	}
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -732,14 +732,14 @@ class NodeMaterialObserver {
 
 		let force = false;
 
+		// shared UBOs are potentially never updated when objects don't change. Below block
+		// make sure these UBOs are updated at least once.
+
 		if ( this.renderId !== renderId ) {
 
 			this.renderId = renderId;
 
-			// this force has two purposes:
-			//
-			// 1. force the render object to use the equals() code path so its internal cache state gets synched
-			// 2. make sure shared UBOs are updated at least once
+			// no early out here. instead, force the render object to use the equals() code path so its internal cache state gets synched
 
 			force = true;
 


### PR DESCRIPTION
Fixed #34063.

**Description**

The PR makes sure to to fix an edge case in `NodeMaterialObserver.needsRefresh()`. 

The current render ID check forces an early out of the method. That skips however a sync of the internal render object cache which can lead to side effects like reported in #34063.

The PR fixes that and also better documents what the render ID check actually does (without the check, shared UBOs are potentially never updated when objects don't change).