### PR TITLE
TSL: Fix angle bug in `hashBlur()`.

### DIFF
--- a/examples/jsm/tsl/display/hashBlur.js
+++ b/examples/jsm/tsl/display/hashBlur.js
@@ -1,4 +1,4 @@
-import { float, Fn, vec2, uv, sin, rand, degrees, cos, Loop, vec4, premultiplyAlpha, unpremultiplyAlpha, convertToTexture, nodeObject } from 'three/tsl';
+import { float, Fn, vec2, uv, sin, rand, TWO_PI, cos, Loop, vec4, premultiplyAlpha, unpremultiplyAlpha, convertToTexture, nodeObject } from 'three/tsl';
 
 /**
  * Applies a hash blur effect to the given texture node.
@@ -41,7 +41,8 @@ export const hashBlur = /*#__PURE__*/ Fn( ( [ textureNode, bluramount = float( 0
 
 	Loop( { start: 0., end: repeats, type: 'float' }, ( { i } ) => {
 
-		const q = vec2( vec2( cos( degrees( i.div( repeats ).mul( 360. ) ) ), sin( degrees( i.div( repeats ).mul( 360. ) ) ) ).mul( rand( vec2( i, targetUV.x.add( targetUV.y ) ) ).add( bluramount ) ) );
+		const angle = i.div( repeats ).mul( TWO_PI ).toConst();
+		const q = vec2( cos( angle ), sin( angle ) ).mul( rand( vec2( i, targetUV.x.add( targetUV.y ) ) ).add( bluramount ) );
 		const uv2 = vec2( targetUV.add( q.mul( bluramount ) ) );
 		blurred_image.addAssign( tap( uv2 ) );
 


### PR DESCRIPTION
Related issue: -

**Description**

While investigating a performance issue, I have noticed `hashBlur()` incorrectly uses `degrees()` to compute angles that should be in radians.

The PR refactors that by computing the angle once in radians via `TWO_PI` and with no further conversion steps.