### PR TITLE
WebGLXRFallback: Detect WebGPU XR support upfront

### DIFF
--- a/examples/jsm/webxr/WebGLXRFallback.js
+++ b/examples/jsm/webxr/WebGLXRFallback.js
@@ -26,27 +26,13 @@ function setupWebGLXRFallback( renderer, createFallbackRenderer, onFallback = ()
 
 			}
 
-			if ( session !== null && renderer.backend.isWebGPUBackend === true && session.enabledFeatures.includes( 'webgpu' ) === false ) {
+			if ( session !== null && renderer.backend.isWebGPUBackend === true && typeof globalThis.XRGPUBinding === 'undefined' ) {
 
 				return switchToFallbackRenderer( session, renderer );
 
 			}
 
-			try {
-
-				return await setSession( session );
-
-			} catch ( error ) {
-
-				if ( session === null || renderer.backend.isWebGPUBackend !== true ) {
-
-					throw error;
-
-				}
-
-				return switchToFallbackRenderer( session, renderer );
-
-			}
+			return setSession( session );
 
 		};
 


### PR DESCRIPTION
Use the presence of `XRGPUBinding` to decide whether the WebGL fallback is needed. When the API is available, let WebGPU session setup errors propagate instead of silently switching renderers.
We couldn't do this previously on Quest because it always exposed `XRGPUBinding` even when WebGPU for WebXR was disabled.

*This contribution is funded by [Meta](https://meta.com)*
