### PR TITLE
Serialize properties that are dropped by toJSON() and copy()

### DIFF
--- a/src/lights/LightShadow.js
+++ b/src/lights/LightShadow.js
@@ -334,6 +334,7 @@ class LightShadow {
 		if ( this.normalBias !== 0 ) object.normalBias = this.normalBias;
 		if ( this.radius !== 1 ) object.radius = this.radius;
 		if ( this.mapSize.x !== 512 || this.mapSize.y !== 512 ) object.mapSize = this.mapSize.toArray();
+		if ( this.blurSamples !== 8 ) object.blurSamples = this.blurSamples;
 
 		object.camera = this.camera.toJSON( false ).object;
 		delete object.camera.matrix;

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -70,8 +70,20 @@ class SpotLightShadow extends LightShadow {
 		super.copy( source );
 
 		this.focus = source.focus;
+		this.aspect = source.aspect;
 
 		return this;
+
+	}
+
+	toJSON() {
+
+		const object = super.toJSON();
+
+		object.focus = this.focus;
+		object.aspect = this.aspect;
+
+		return object;
 
 	}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -741,6 +741,7 @@ class ObjectLoader extends Loader {
 
 					texture.wrapS = parseConstant( data.wrap[ 0 ], TEXTURE_WRAPPING );
 					texture.wrapT = parseConstant( data.wrap[ 1 ], TEXTURE_WRAPPING );
+					if ( data.wrap[ 2 ] !== undefined ) texture.wrapR = parseConstant( data.wrap[ 2 ], TEXTURE_WRAPPING );
 
 				}
 
@@ -1162,6 +1163,9 @@ class ObjectLoader extends Loader {
 			if ( data.shadow.bias !== undefined ) object.shadow.bias = data.shadow.bias;
 			if ( data.shadow.normalBias !== undefined ) object.shadow.normalBias = data.shadow.normalBias;
 			if ( data.shadow.radius !== undefined ) object.shadow.radius = data.shadow.radius;
+			if ( data.shadow.blurSamples !== undefined ) object.shadow.blurSamples = data.shadow.blurSamples;
+			if ( data.shadow.focus !== undefined ) object.shadow.focus = data.shadow.focus;
+			if ( data.shadow.aspect !== undefined ) object.shadow.aspect = data.shadow.aspect;
 			if ( data.shadow.mapSize !== undefined ) object.shadow.mapSize.fromArray( data.shadow.mapSize );
 			if ( data.shadow.camera !== undefined ) object.shadow.camera = this.parseObject( data.shadow.camera );
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -809,6 +809,9 @@ class Material extends EventDispatcher {
 		if ( this.depthTest === false ) data.depthTest = this.depthTest;
 		if ( this.depthWrite === false ) data.depthWrite = this.depthWrite;
 		if ( this.colorWrite === false ) data.colorWrite = this.colorWrite;
+		if ( this.clipIntersection === true ) data.clipIntersection = true;
+		if ( this.clipShadows === true ) data.clipShadows = true;
+		if ( this.depthPacking !== undefined ) data.depthPacking = this.depthPacking;
 
 		if ( this.stencilWriteMask !== 0xff ) data.stencilWriteMask = this.stencilWriteMask;
 		if ( this.stencilFunc !== AlwaysStencilFunc ) data.stencilFunc = this.stencilFunc;
@@ -830,6 +833,8 @@ class Material extends EventDispatcher {
 		if ( this.dashSize !== undefined ) data.dashSize = this.dashSize;
 		if ( this.gapSize !== undefined ) data.gapSize = this.gapSize;
 		if ( this.scale !== undefined ) data.scale = this.scale;
+		if ( this.linecap !== undefined ) data.linecap = this.linecap;
+		if ( this.linejoin !== undefined ) data.linejoin = this.linejoin;
 
 		if ( this.dithering === true ) data.dithering = true;
 
@@ -936,6 +941,11 @@ class Material extends EventDispatcher {
 		if ( json.depthTest !== undefined ) this.depthTest = json.depthTest;
 		if ( json.depthWrite !== undefined ) this.depthWrite = json.depthWrite;
 		if ( json.colorWrite !== undefined ) this.colorWrite = json.colorWrite;
+		if ( json.clipIntersection !== undefined ) this.clipIntersection = json.clipIntersection;
+		if ( json.clipShadows !== undefined ) this.clipShadows = json.clipShadows;
+		if ( json.depthPacking !== undefined ) this.depthPacking = json.depthPacking;
+		if ( json.linecap !== undefined ) this.linecap = json.linecap;
+		if ( json.linejoin !== undefined ) this.linejoin = json.linejoin;
 		if ( json.blendSrc !== undefined ) this.blendSrc = json.blendSrc;
 		if ( json.blendDst !== undefined ) this.blendDst = json.blendDst;
 		if ( json.blendEquation !== undefined ) this.blendEquation = json.blendEquation;

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -483,6 +483,7 @@ class Texture extends EventDispatcher {
 
 		this.wrapS = source.wrapS;
 		this.wrapT = source.wrapT;
+		if ( source.wrapR !== undefined ) this.wrapR = source.wrapR;
 
 		this.magFilter = source.magFilter;
 		this.minFilter = source.minFilter;
@@ -625,6 +626,9 @@ class Texture extends EventDispatcher {
 			unpackAlignment: this.unpackAlignment
 
 		};
+
+		// wrapR only exists on 3D and array textures, so add it to the wrap list when present
+		if ( this.wrapR !== undefined ) output.wrap.push( this.wrapR );
 
 		if ( Object.keys( this.userData ).length > 0 ) output.userData = this.userData;
 

--- a/test/unit/src/lights/SpotLight.tests.js
+++ b/test/unit/src/lights/SpotLight.tests.js
@@ -2,6 +2,7 @@ import { SpotLight } from '../../../../src/lights/SpotLight.js';
 
 import { Light } from '../../../../src/lights/Light.js';
 import { runStdLightTests } from '../../utils/qunit-utils.js';
+import { ObjectLoader } from '../../../../src/loaders/ObjectLoader.js';
 
 export default QUnit.module( 'Lights', () => {
 
@@ -101,6 +102,23 @@ export default QUnit.module( 'Lights', () => {
 		QUnit.test( 'Standard light tests', ( assert ) => {
 
 			runStdLightTests( assert, lights );
+
+		} );
+
+		// SERIALIZATION
+		QUnit.test( 'shadow focus, aspect and blurSamples survive toJSON and clone', ( assert ) => {
+
+			const light = new SpotLight();
+			light.shadow.focus = 0.5;
+			light.shadow.aspect = 2.5;
+			light.shadow.blurSamples = 17;
+
+			const reloaded = new ObjectLoader().parse( light.toJSON() );
+			assert.equal( reloaded.shadow.focus, 0.5, 'focus' );
+			assert.equal( reloaded.shadow.aspect, 2.5, 'aspect' );
+			assert.equal( reloaded.shadow.blurSamples, 17, 'blurSamples' );
+
+			assert.equal( light.clone().shadow.aspect, 2.5, 'aspect survives clone' );
 
 		} );
 

--- a/test/unit/src/materials/LineBasicMaterial.tests.js
+++ b/test/unit/src/materials/LineBasicMaterial.tests.js
@@ -1,6 +1,7 @@
 import { LineBasicMaterial } from '../../../../src/materials/LineBasicMaterial.js';
 
 import { Material } from '../../../../src/materials/Material.js';
+import { MaterialLoader } from '../../../../src/loaders/MaterialLoader.js';
 
 export default QUnit.module( 'Materials', () => {
 
@@ -44,6 +45,23 @@ export default QUnit.module( 'Materials', () => {
 				object.isLineBasicMaterial,
 				'LineBasicMaterial.isLineBasicMaterial should be true'
 			);
+
+		} );
+
+		// SERIALIZATION
+		QUnit.test( 'linecap and linejoin survive toJSON and clone', ( assert ) => {
+
+			const material = new LineBasicMaterial();
+			material.linecap = 'butt';
+			material.linejoin = 'bevel';
+
+			const reloaded = new MaterialLoader().parse( material.toJSON() );
+			assert.equal( reloaded.linecap, 'butt', 'toJSON/fromJSON keeps linecap' );
+			assert.equal( reloaded.linejoin, 'bevel', 'toJSON/fromJSON keeps linejoin' );
+
+			const cloned = material.clone();
+			assert.equal( cloned.linecap, 'butt', 'clone keeps linecap' );
+			assert.equal( cloned.linejoin, 'bevel', 'clone keeps linejoin' );
 
 		} );
 

--- a/test/unit/src/materials/MeshBasicMaterial.tests.js
+++ b/test/unit/src/materials/MeshBasicMaterial.tests.js
@@ -1,6 +1,7 @@
 import { MeshBasicMaterial } from '../../../../src/materials/MeshBasicMaterial.js';
 
 import { Material } from '../../../../src/materials/Material.js';
+import { MaterialLoader } from '../../../../src/loaders/MaterialLoader.js';
 
 export default QUnit.module( 'Materials', () => {
 
@@ -44,6 +45,23 @@ export default QUnit.module( 'Materials', () => {
 				object.isMeshBasicMaterial,
 				'MeshBasicMaterial.isMeshBasicMaterial should be true'
 			);
+
+		} );
+
+		// SERIALIZATION
+		QUnit.test( 'clipIntersection and clipShadows survive toJSON and clone', ( assert ) => {
+
+			const material = new MeshBasicMaterial();
+			material.clipIntersection = true;
+			material.clipShadows = true;
+
+			const reloaded = new MaterialLoader().parse( material.toJSON() );
+			assert.equal( reloaded.clipIntersection, true, 'toJSON/fromJSON keeps clipIntersection' );
+			assert.equal( reloaded.clipShadows, true, 'toJSON/fromJSON keeps clipShadows' );
+
+			const cloned = material.clone();
+			assert.equal( cloned.clipIntersection, true, 'clone keeps clipIntersection' );
+			assert.equal( cloned.clipShadows, true, 'clone keeps clipShadows' );
 
 		} );
 

--- a/test/unit/src/materials/MeshDepthMaterial.tests.js
+++ b/test/unit/src/materials/MeshDepthMaterial.tests.js
@@ -1,6 +1,8 @@
 import { MeshDepthMaterial } from '../../../../src/materials/MeshDepthMaterial.js';
 
 import { Material } from '../../../../src/materials/Material.js';
+import { MaterialLoader } from '../../../../src/loaders/MaterialLoader.js';
+import { RGBADepthPacking } from '../../../../src/constants.js';
 
 export default QUnit.module( 'Materials', () => {
 
@@ -44,6 +46,18 @@ export default QUnit.module( 'Materials', () => {
 				object.isMeshDepthMaterial,
 				'MeshDepthMaterial.isMeshDepthMaterial should be true'
 			);
+
+		} );
+
+		// SERIALIZATION
+		QUnit.test( 'depthPacking survives toJSON and clone', ( assert ) => {
+
+			const material = new MeshDepthMaterial();
+			material.depthPacking = RGBADepthPacking;
+
+			const reloaded = new MaterialLoader().parse( material.toJSON() );
+			assert.equal( reloaded.depthPacking, RGBADepthPacking, 'toJSON/fromJSON keeps depthPacking' );
+			assert.equal( material.clone().depthPacking, RGBADepthPacking, 'clone keeps depthPacking' );
 
 		} );
 

--- a/test/unit/src/textures/Data3DTexture.tests.js
+++ b/test/unit/src/textures/Data3DTexture.tests.js
@@ -1,6 +1,7 @@
 import { Data3DTexture } from '../../../../src/textures/Data3DTexture.js';
 
 import { Texture } from '../../../../src/textures/Texture.js';
+import { RepeatWrapping } from '../../../../src/constants.js';
 
 export default QUnit.module( 'Textures', () => {
 
@@ -33,6 +34,19 @@ export default QUnit.module( 'Textures', () => {
 				object.isData3DTexture,
 				'Data3DTexture.isData3DTexture should be true'
 			);
+
+		} );
+
+		// SERIALIZATION
+		QUnit.test( 'wrapR survives clone and toJSON', ( assert ) => {
+
+			const texture = new Data3DTexture();
+			texture.wrapR = RepeatWrapping;
+
+			assert.equal( texture.clone().wrapR, RepeatWrapping, 'clone keeps wrapR' );
+
+			const json = texture.toJSON( { images: {}, textures: {} } );
+			assert.equal( json.wrap[ 2 ], RepeatWrapping, 'toJSON writes wrapR' );
 
 		} );
 


### PR DESCRIPTION
A handful of settable properties don't survive serialization. If you set one to a non default value and
then clone the object, or run it through `toJSON()` and load it back with `ObjectLoader` /
`MaterialLoader`, it quietly resets to the default. Each is copied by `copy()` but missing from `toJSON()`
(and a couple are missing from `copy()` too).

Properties fixed:

- **Texture**: `wrapR` on `Data3DTexture`, `DataArrayTexture`, `CompressedArrayTexture` (missing from both
  `copy()` and `toJSON()`).
- **Material**: `clipIntersection` and `clipShadows` (base `Material`, so all materials), `depthPacking`
  (`MeshDepthMaterial`), `linecap` and `linejoin` (`LineBasicMaterial`, `LineDashedMaterial`).
- **LightShadow**: `blurSamples`, and `focus` / `aspect` on `SpotLightShadow` (`aspect` was also missing
  from `copy()`).

Each is added to the relevant `toJSON()` / `fromJSON()` / `copy()` and read back in `ObjectLoader`. For
textures, `wrapR` is appended to the existing `wrap` list only when it is present, so 2D textures
serialize exactly as before.

Adds tests that set each property to a non default value and check it survives a clone and a `toJSON()`
then `fromJSON()` round trip.

Related: #11266, #17974. `TorusGeometry.fromJSON` had the same kind of gap and was fixed in #34034.
