### PR TITLE
Core: Fix some `copy()` and `toJSON()` implementations.

### DIFF
--- a/src/lights/LightShadow.js
+++ b/src/lights/LightShadow.js
@@ -333,6 +333,7 @@ class LightShadow {
 		if ( this.bias !== 0 ) object.bias = this.bias;
 		if ( this.normalBias !== 0 ) object.normalBias = this.normalBias;
 		if ( this.radius !== 1 ) object.radius = this.radius;
+		if ( this.blurSamples !== 8 ) object.blurSamples = this.blurSamples;
 		if ( this.mapSize.x !== 512 || this.mapSize.y !== 512 ) object.mapSize = this.mapSize.toArray();
 
 		object.camera = this.camera.toJSON( false ).object;

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -70,8 +70,26 @@ class SpotLightShadow extends LightShadow {
 		super.copy( source );
 
 		this.focus = source.focus;
+		this.aspect = source.aspect;
 
 		return this;
+
+	}
+
+	/**
+	 * Serializes the light shadow into JSON.
+	 *
+	 * @return {Object} A JSON object representing the serialized light shadow.
+	 * @see {@link ObjectLoader#parse}
+	 */
+	toJSON() {
+
+		const object = super.toJSON();
+
+		if ( this.focus !== 1 ) object.focus = this.focus;
+		if ( this.aspect !== 1 ) object.aspect = this.aspect;
+
+		return object;
 
 	}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -1162,6 +1162,9 @@ class ObjectLoader extends Loader {
 			if ( data.shadow.bias !== undefined ) object.shadow.bias = data.shadow.bias;
 			if ( data.shadow.normalBias !== undefined ) object.shadow.normalBias = data.shadow.normalBias;
 			if ( data.shadow.radius !== undefined ) object.shadow.radius = data.shadow.radius;
+			if ( data.shadow.blurSamples !== undefined ) object.shadow.blurSamples = data.shadow.blurSamples;
+			if ( data.shadow.focus !== undefined ) object.shadow.focus = data.shadow.focus;
+			if ( data.shadow.aspect !== undefined ) object.shadow.aspect = data.shadow.aspect;
 			if ( data.shadow.mapSize !== undefined ) object.shadow.mapSize.fromArray( data.shadow.mapSize );
 			if ( data.shadow.camera !== undefined ) object.shadow.camera = this.parseObject( data.shadow.camera );
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,6 +1,6 @@
 import { Color } from '../math/Color.js';
 import { EventDispatcher } from '../core/EventDispatcher.js';
-import { FrontSide, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, AlwaysStencilFunc, KeepStencilOp } from '../constants.js';
+import { FrontSide, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, AlwaysStencilFunc, KeepStencilOp, BasicDepthPacking } from '../constants.js';
 import { generateUUID } from '../math/MathUtils.js';
 import { warn } from '../utils.js';
 import { Vector2 } from '../math/Vector2.js';
@@ -822,11 +822,16 @@ class Material extends EventDispatcher {
 		// rotation (SpriteMaterial)
 		if ( this.rotation !== undefined && this.rotation !== 0 ) data.rotation = this.rotation;
 
+		// depthPacking (MeshDepthMaterial)
+		if ( this.depthPacking !== undefined && this.depthPacking !== BasicDepthPacking ) data.depthPacking = this.depthPacking;
+
 		if ( this.polygonOffset === true ) data.polygonOffset = true;
 		if ( this.polygonOffsetFactor !== 0 ) data.polygonOffsetFactor = this.polygonOffsetFactor;
 		if ( this.polygonOffsetUnits !== 0 ) data.polygonOffsetUnits = this.polygonOffsetUnits;
 
 		if ( this.linewidth !== undefined && this.linewidth !== 1 ) data.linewidth = this.linewidth;
+		if ( this.linecap !== undefined && this.linecap !== 'round' ) data.linecap = this.linecap;
+		if ( this.linejoin !== undefined && this.linejoin !== 'round' ) data.linejoin = this.linejoin;
 		if ( this.dashSize !== undefined ) data.dashSize = this.dashSize;
 		if ( this.gapSize !== undefined ) data.gapSize = this.gapSize;
 		if ( this.scale !== undefined ) data.scale = this.scale;
@@ -936,6 +941,7 @@ class Material extends EventDispatcher {
 		if ( json.depthTest !== undefined ) this.depthTest = json.depthTest;
 		if ( json.depthWrite !== undefined ) this.depthWrite = json.depthWrite;
 		if ( json.colorWrite !== undefined ) this.colorWrite = json.colorWrite;
+		if ( json.depthPacking !== undefined ) this.depthPacking = json.depthPacking;
 		if ( json.blendSrc !== undefined ) this.blendSrc = json.blendSrc;
 		if ( json.blendDst !== undefined ) this.blendDst = json.blendDst;
 		if ( json.blendEquation !== undefined ) this.blendEquation = json.blendEquation;
@@ -961,6 +967,8 @@ class Material extends EventDispatcher {
 		if ( json.rotation !== undefined ) this.rotation = json.rotation;
 
 		if ( json.linewidth !== undefined ) this.linewidth = json.linewidth;
+		if ( json.linecap !== undefined ) this.linecap = json.linecap;
+		if ( json.linejoin !== undefined ) this.linejoin = json.linejoin;
 		if ( json.dashSize !== undefined ) this.dashSize = json.dashSize;
 		if ( json.gapSize !== undefined ) this.gapSize = json.gapSize;
 		if ( json.scale !== undefined ) this.scale = json.scale;

--- a/src/renderers/common/Storage3DTexture.js
+++ b/src/renderers/common/Storage3DTexture.js
@@ -75,6 +75,22 @@ class Storage3DTexture extends Texture {
 	}
 
 	/**
+	 * Copies the values of the given texture to this instance.
+	 *
+	 * @param {Storage3DTexture} source - The texture to copy.
+	 * @return {Storage3DTexture} A reference to this instance.
+	 */
+	copy( source ) {
+
+		super.copy( source );
+
+		this.wrapR = source.wrapR;
+
+		return this;
+
+	}
+
+	/**
 	 * Sets the size of the storage 3d texture.
 	 *
 	 * @param {number} width - The new width of the storage texture.

--- a/src/textures/CompressedArrayTexture.js
+++ b/src/textures/CompressedArrayTexture.js
@@ -61,6 +61,22 @@ class CompressedArrayTexture extends CompressedTexture {
 	}
 
 	/**
+	 * Copies the values of the given texture to this instance.
+	 *
+	 * @param {CompressedArrayTexture} source - The texture to copy.
+	 * @return {CompressedArrayTexture} A reference to this instance.
+	 */
+	copy( source ) {
+
+		super.copy( source );
+
+		this.wrapR = source.wrapR;
+
+		return this;
+
+	}
+
+	/**
 	 * Describes that a specific layer of the texture needs to be updated.
 	 * Normally when {@link Texture#needsUpdate} is set to `true`, the
 	 * entire compressed texture array is sent to the GPU. Marking specific

--- a/src/textures/Data3DTexture.js
+++ b/src/textures/Data3DTexture.js
@@ -107,6 +107,22 @@ class Data3DTexture extends Texture {
 
 	}
 
+	/**
+	 * Copies the values of the given texture to this instance.
+	 *
+	 * @param {Data3DTexture} source - The texture to copy.
+	 * @return {Data3DTexture} A reference to this instance.
+	 */
+	copy( source ) {
+
+		super.copy( source );
+
+		this.wrapR = source.wrapR;
+
+		return this;
+
+	}
+
 }
 
 export { Data3DTexture };

--- a/src/textures/DataArrayTexture.js
+++ b/src/textures/DataArrayTexture.js
@@ -106,6 +106,22 @@ class DataArrayTexture extends Texture {
 	}
 
 	/**
+	 * Copies the values of the given texture to this instance.
+	 *
+	 * @param {DataArrayTexture} source - The texture to copy.
+	 * @return {DataArrayTexture} A reference to this instance.
+	 */
+	copy( source ) {
+
+		super.copy( source );
+
+		this.wrapR = source.wrapR;
+
+		return this;
+
+	}
+
+	/**
 	 * Describes that a specific layer of the texture needs to be updated.
 	 * Normally when {@link Texture#needsUpdate} is set to `true`, the
 	 * entire data texture array is sent to the GPU. Marking specific


### PR DESCRIPTION
Related issue: #34082

**Description**

The PR fixes some copy and serialization/deserialization code in the core.

- The texture property `wrapR` is now properly copied.
- Some light shadow properties are properly serialized and copied now.
- Added missing material properties to `toJSON()` and `fromJSON()`.
