### PR TITLE
Material: Add serialization/deserialization support for clipping planes.

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -4,6 +4,7 @@ import { FrontSide, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlph
 import { generateUUID } from '../math/MathUtils.js';
 import { warn } from '../utils.js';
 import { Vector2 } from '../math/Vector2.js';
+import { Plane } from '../math/Plane.js';
 
 let _materialId = 0;
 
@@ -810,6 +811,15 @@ class Material extends EventDispatcher {
 		if ( this.depthWrite === false ) data.depthWrite = this.depthWrite;
 		if ( this.colorWrite === false ) data.colorWrite = this.colorWrite;
 
+		if ( Array.isArray( this.clippingPlanes ) && this.clippingPlanes.length > 0 ) {
+
+			data.clippingPlanes = this.clippingPlanes.map( plane => plane.toJSON() );
+
+		}
+
+		if ( this.clipIntersection === true ) data.clipIntersection = true;
+		if ( this.clipShadows === true ) data.clipShadows = true;
+
 		if ( this.stencilWriteMask !== 0xff ) data.stencilWriteMask = this.stencilWriteMask;
 		if ( this.stencilFunc !== AlwaysStencilFunc ) data.stencilFunc = this.stencilFunc;
 		if ( this.stencilRef !== 0 ) data.stencilRef = this.stencilRef;
@@ -941,6 +951,9 @@ class Material extends EventDispatcher {
 		if ( json.depthTest !== undefined ) this.depthTest = json.depthTest;
 		if ( json.depthWrite !== undefined ) this.depthWrite = json.depthWrite;
 		if ( json.colorWrite !== undefined ) this.colorWrite = json.colorWrite;
+		if ( json.clippingPlanes !== undefined ) this.clippingPlanes = json.clippingPlanes.map( plane => new Plane().fromJSON( plane ) );
+		if ( json.clipIntersection !== undefined ) this.clipIntersection = json.clipIntersection;
+		if ( json.clipShadows !== undefined ) this.clipShadows = json.clipShadows;
 		if ( json.depthPacking !== undefined ) this.depthPacking = json.depthPacking;
 		if ( json.blendSrc !== undefined ) this.blendSrc = json.blendSrc;
 		if ( json.blendDst !== undefined ) this.blendDst = json.blendDst;

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -363,6 +363,35 @@ class Plane {
 
 	}
 
+	/**
+	 * Returns a serialized structure of the plane.
+	 *
+	 * @return {Object} Serialized structure with fields representing the object state.
+	 */
+	toJSON() {
+
+		return {
+			normal: this.normal.toArray(),
+			constant: this.constant
+		};
+
+	}
+
+	/**
+	 * Sets the plane properties from the given JSON.
+	 *
+	 * @param {Object} json - The serialized json to set the plane from.
+	 * @return {Plane} A reference to this plane.
+	 */
+	fromJSON( json ) {
+
+		this.normal.fromArray( json.normal );
+		this.constant = json.constant;
+
+		return this;
+
+	}
+
 }
 
 export { Plane };


### PR DESCRIPTION
Related issue: #34083

**Description**

The PR makes sure clipping planes on material level can be properly serialized/deserialized. For that `toJSON()` and `fromJSON()` in `Plane` are introduced.
