### PR TITLE
This allows the fragment shader to write into buffers

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1251,22 +1251,14 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 */
 	getNodeAccess( node, shaderStage ) {
 
-		if ( shaderStage !== 'compute' ) {
+		// Per the WGSL spec, atomic built-in functions are only allowed in
+		// the fragment and compute stages, not in the vertex stage.
+
+		if ( shaderStage === 'vertex' ) {
 
 			if ( node.isAtomic === true ) {
 
-				// Per the WGSL spec, atomic built-in functions are only allowed in
-				// the fragment and compute stages, not in the vertex stage.
-
-				if ( shaderStage === 'vertex' ) {
-
-					warn( 'WebGPURenderer: Atomic operations are not supported in the vertex stage. They are only available in the fragment and compute stages.' );
-
-					return NodeAccess.READ_ONLY;
-
-				}
-
-				return NodeAccess.READ_WRITE;
+				warn( 'WebGPURenderer: Atomic storage access is not supported in the vertex stage. Falling back to read-only access.' );
 
 			}
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -437,29 +437,15 @@ class WebGPUBindingUtils {
 
 				if ( binding.isStorageBuffer ) {
 
-					if ( binding.visibility & GPUShaderStage.COMPUTE ) {
+					if ( binding.visibility & GPUShaderStage.VERTEX ) {
 
-						if ( binding.access === NodeAccess.READ_WRITE || binding.access === NodeAccess.WRITE_ONLY ) {
-
-							buffer.type = GPUBufferBindingType.Storage;
-
-						} else {
-
-							buffer.type = GPUBufferBindingType.ReadOnlyStorage;
-
-						}
-
-					} else if ( binding.nodeUniform && binding.nodeUniform.isAtomic && ( binding.visibility & GPUShaderStage.FRAGMENT ) ) {
-
-						// Atomic buffers require a read_write storage binding. Per the WGSL
-						// spec this is only valid in the fragment stage (compute is handled
-						// above), so the vertex stage falls back to read-only storage.
-
-						buffer.type = GPUBufferBindingType.Storage;
+						buffer.type = GPUBufferBindingType.ReadOnlyStorage;
 
 					} else {
 
-						buffer.type = GPUBufferBindingType.ReadOnlyStorage;
+						buffer.type = ( binding.access === NodeAccess.READ_WRITE || binding.access === NodeAccess.WRITE_ONLY )
+							? GPUBufferBindingType.Storage
+							: GPUBufferBindingType.ReadOnlyStorage;
 
 					}
 


### PR DESCRIPTION
For my virtual texture system, I calculate the texture tiles in a compute shader. In the fragment shader, I have to select the mipmaps myself. However, the fragment shader, thanks to dpdx and dpdy, can determine which mipmaps are needed much more precisely than would be possible in the compute shader through cumbersome abstraction.

This is also the approach of modern engines, as it avoids independent calculations in compute and fragment shaders that must lead to synchronous results. The fragment shader can then set these tiles itself so that they are loaded.

Since the vertex shader is the exception and the same conditions apply to the compute and fragment shader, I have simplified the conditions somewhat. If these extra conditions are desired for reasons not apparent to me, please correct my PR.