### PR TITLE
Examples: Refined the `webgl_volume_perlin` with bisection based refinement.

### DIFF
--- a/examples/webgl_volume_perlin.html
+++ b/examples/webgl_volume_perlin.html
@@ -4,31 +4,11 @@
 		<title>three.js webgl2 - volume</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<style>
-			body {
-				margin: 0;
-				background-color: #000;
-				color: #fff;
-				font-family: Monospace, monospace;
-				font-size: 13px;
-				line-height: 24px;
-				overscroll-behavior: none;
-			}
-			#info {
-				position: absolute;
-				top: 0;
-				width: 100%;
-				padding: 10px;
-				box-sizing: border-box;
-				text-align: center;
-				z-index: 1;
-				pointer-events: none;
-			}
-			#info a {
-				color: #ff0;
-				pointer-events: auto;
-			}
-		</style>
+		<meta property="og:title" content="three.js webgl2 - volume">
+		<meta property="og:type" content="website">
+		<meta property="og:url" content="https://threejs.org/examples/webgl_volume_perlin.html">
+		<meta property="og:image" content="https://threejs.org/examples/screenshots/webgl_volume_perlin.jpg">
+		<link type="text/css" rel="stylesheet" href="main.css">		
 	</head>
 
 	<body>
@@ -39,8 +19,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.166.1/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.166.1/examples/jsm/"
+					"three": "../build/three.module.js",
+					"three/addons/": "./jsm/"
 				}
 			}
 		</script>

--- a/examples/webgl_volume_perlin.html
+++ b/examples/webgl_volume_perlin.html
@@ -193,7 +193,7 @@
 									float t1 = t;
 
 									for ( int j = 0; j < REFINEMENT_STEPS; j ++ ) {
-										
+
 										float tm = ( t0 + t1 ) * 0.5;
 
 										float dm = sample1( vOrigin + tm * rayDir + 0.5 );
@@ -201,7 +201,7 @@
 										if ( dm > threshold ) {
 
 											t1 = tm;
-											
+
 										} else {
 
 											t0 = tm;

--- a/examples/webgl_volume_perlin.html
+++ b/examples/webgl_volume_perlin.html
@@ -8,7 +8,7 @@
 		<meta property="og:type" content="website">
 		<meta property="og:url" content="https://threejs.org/examples/webgl_volume_perlin.html">
 		<meta property="og:image" content="https://threejs.org/examples/screenshots/webgl_volume_perlin.jpg">
-		<link type="text/css" rel="stylesheet" href="main.css">		
+		<link type="text/css" rel="stylesheet" href="main.css">
 	</head>
 
 	<body>
@@ -194,20 +194,15 @@
 
 									for ( int j = 0; j < REFINEMENT_STEPS; j ++ ) {
 										
-									  //get the mid point ray parameter
 										float tm = ( t0 + t1 ) * 0.5;
 
-										//get the sample at mid point and check if its above the threshold
 										float dm = sample1( vOrigin + tm * rayDir + 0.5 );
 
-										//if it is, we reduce the higher interval
 										if ( dm > threshold ) {
 
 											t1 = tm;
 											
-										} 
-										//else, we reduce the lower interval	
-										else {
+										} else {
 
 											t0 = tm;
 

--- a/examples/webgl_volume_perlin.html
+++ b/examples/webgl_volume_perlin.html
@@ -4,11 +4,31 @@
 		<title>three.js webgl2 - volume</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<meta property="og:title" content="three.js webgl2 - volume">
-		<meta property="og:type" content="website">
-		<meta property="og:url" content="https://threejs.org/examples/webgl_volume_perlin.html">
-		<meta property="og:image" content="https://threejs.org/examples/screenshots/webgl_volume_perlin.jpg">
-		<link type="text/css" rel="stylesheet" href="main.css">
+		<style>
+			body {
+				margin: 0;
+				background-color: #000;
+				color: #fff;
+				font-family: Monospace, monospace;
+				font-size: 13px;
+				line-height: 24px;
+				overscroll-behavior: none;
+			}
+			#info {
+				position: absolute;
+				top: 0;
+				width: 100%;
+				padding: 10px;
+				box-sizing: border-box;
+				text-align: center;
+				z-index: 1;
+				pointer-events: none;
+			}
+			#info a {
+				color: #ff0;
+				pointer-events: auto;
+			}
+		</style>
 	</head>
 
 	<body>
@@ -19,8 +39,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "../build/three.module.js",
-					"three/addons/": "./jsm/"
+					"three": "https://cdn.jsdelivr.net/npm/three@0.166.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.166.1/examples/jsm/"
 				}
 			}
 		</script>
@@ -125,6 +145,9 @@
 
 					uniform float threshold;
 					uniform float steps;
+					uniform bool refine;
+
+					#define REFINEMENT_STEPS 6
 
 					vec2 hitBox( vec3 orig, vec3 dir ) {
 						const vec3 box_min = vec3( - 0.5 );
@@ -180,6 +203,42 @@
 
 							if ( d > threshold ) {
 
+								if ( refine ) {
+
+									// The surface lies between the previous ray parameter i.e. (t - stepSize)
+									// and the current ray parameter (t). Bisect that interval to localize
+									// the crossing precisely.
+
+									float t0 = max( t - stepSize, bounds.x );
+									float t1 = t;
+
+									for ( int j = 0; j < REFINEMENT_STEPS; j ++ ) {
+										
+									  //get the mid point ray parameter
+										float tm = ( t0 + t1 ) * 0.5;
+
+										//get the sample at mid point and check if its above the threshold
+										float dm = sample1( vOrigin + tm * rayDir + 0.5 );
+
+										//if it is, we reduce the higher interval
+										if ( dm > threshold ) {
+
+											t1 = tm;
+											
+										} 
+										//else, we reduce the lower interval	
+										else {
+
+											t0 = tm;
+
+										}
+
+									}
+
+									p = vOrigin + t1 * rayDir;
+
+								}
+
 								color.rgb = normal( p + 0.5 ) * 0.5 + ( p * 1.5 + 0.25 );
 								color.a = 1.;
 								break;
@@ -200,7 +259,8 @@
 						map: { value: texture },
 						cameraPos: { value: new THREE.Vector3() },
 						threshold: { value: 0.6 },
-						steps: { value: 200 }
+						steps: { value: 200 },
+						refine: { value: true }
 					},
 					vertexShader,
 					fragmentShader,
@@ -212,18 +272,20 @@
 
 				//
 
-				const parameters = { threshold: 0.6, steps: 200 };
+				const parameters = { threshold: 0.6, steps: 200, refine: true };
 
 				function update() {
 
 					material.uniforms.threshold.value = parameters.threshold;
 					material.uniforms.steps.value = parameters.steps;
+					material.uniforms.refine.value = parameters.refine;
 
 				}
 
 				const gui = new GUI();
 				gui.add( parameters, 'threshold', 0, 1, 0.01 ).onChange( update );
 				gui.add( parameters, 'steps', 0, 300, 1 ).onChange( update );
+				gui.add( parameters, 'refine' ).onChange( update );
 
 				window.addEventListener( 'resize', onWindowResize );
 


### PR DESCRIPTION
Fixed [#34087](https://github.com/mrdoob/three.js/issues/34087)

**Description**

The current `webgl_volume_perlin.html` example demonstrates iso-surface rendering of a 3D noise volume. The example suffers from sampling artifacts, which are visible as banding. These are quite noticeable when the total number of ray-casting samples is low, as shown below:

<img width="1908" height="928" alt="Iso-surface rendering with visible banding artifacts" src="https://github.com/user-attachments/assets/096ff73a-c31a-4c34-a85b-140f23c1c397" />

We can significantly reduce these artifacts by using bisection-based iso-surface refinement. With the same total number of ray-casting samples, adding bisection-based refinement gives the following output:

<img width="1920" height="918" alt="Iso-surface rendering with bisection refinement, banding eliminated" src="https://github.com/user-attachments/assets/82f6b353-f636-4fdb-9ed0-efa1bb7294ae" />


