### PR TITLE
Frustum: Fix intersectsBox() false positives for large boxes

### DIFF
--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -7,6 +7,45 @@ import { Plane } from './Plane.js';
 const _sphere = /*@__PURE__*/ new Sphere();
 const _defaultSpriteCenter = /*@__PURE__*/ new Vector2( 0.5, 0.5 );
 const _vector = /*@__PURE__*/ new Vector3();
+const _v1 = /*@__PURE__*/ new Vector3();
+const _v2 = /*@__PURE__*/ new Vector3();
+const _v3 = /*@__PURE__*/ new Vector3();
+
+function setCornerFromPlanes( target, p1, p2, p3 ) {
+
+	// intersection point of three planes, n * x + constant = 0
+
+	_v1.crossVectors( p2.normal, p3.normal );
+	_v2.crossVectors( p3.normal, p1.normal );
+	_v3.crossVectors( p1.normal, p2.normal );
+
+	const denominator = p1.normal.dot( _v1 );
+
+	// for degenerate plane configurations the result is not finite and the
+	// corner-based rejection in intersectsBox() is skipped implicitly
+
+	return target.copy( _v1 ).multiplyScalar( - p1.constant )
+		.addScaledVector( _v2, - p2.constant )
+		.addScaledVector( _v3, - p3.constant )
+		.divideScalar( denominator );
+
+}
+
+function updateCorners( frustum ) {
+
+	const [ right, left, bottom, top, far, near ] = frustum.planes;
+	const corners = frustum._corners;
+
+	setCornerFromPlanes( corners[ 0 ], left, bottom, near );
+	setCornerFromPlanes( corners[ 1 ], right, bottom, near );
+	setCornerFromPlanes( corners[ 2 ], left, top, near );
+	setCornerFromPlanes( corners[ 3 ], right, top, near );
+	setCornerFromPlanes( corners[ 4 ], left, bottom, far );
+	setCornerFromPlanes( corners[ 5 ], right, bottom, far );
+	setCornerFromPlanes( corners[ 6 ], left, top, far );
+	setCornerFromPlanes( corners[ 7 ], right, top, far );
+
+}
 
 /**
  * Frustums are used to determine what is inside the camera's field of view.
@@ -36,6 +75,12 @@ class Frustum {
 		 */
 		this.planes = [ p0, p1, p2, p3, p4, p5 ];
 
+		// the eight corner points of the frustum, derived lazily from the
+		// planes by intersectsBox()
+
+		this._corners = [ new Vector3(), new Vector3(), new Vector3(), new Vector3(), new Vector3(), new Vector3(), new Vector3(), new Vector3() ];
+		this._cornersNeedUpdate = true;
+
 	}
 
 	/**
@@ -60,6 +105,8 @@ class Frustum {
 		planes[ 4 ].copy( p4 );
 		planes[ 5 ].copy( p5 );
 
+		this._cornersNeedUpdate = true;
+
 		return this;
 
 	}
@@ -79,6 +126,8 @@ class Frustum {
 			planes[ i ].copy( frustum.planes[ i ] );
 
 		}
+
+		this._cornersNeedUpdate = true;
 
 		return this;
 
@@ -130,6 +179,8 @@ class Frustum {
 			}
 
 		}
+
+		this._cornersNeedUpdate = true;
 
 		return this;
 
@@ -240,7 +291,36 @@ class Frustum {
 
 		}
 
-		return true;
+		// No frustum plane separates the box, but a large box that crosses
+		// several frustum planes can still lie outside the frustum. If all
+		// eight frustum corners lie beyond one face of the box, the box's
+		// face separates the two (see #27756). Non-finite corners (degenerate
+		// planes) fail every comparison and skip this rejection.
+
+		if ( this._cornersNeedUpdate ) {
+
+			updateCorners( this );
+			this._cornersNeedUpdate = false;
+
+		}
+
+		const corners = this._corners;
+		let outMaxX = 0, outMinX = 0, outMaxY = 0, outMinY = 0, outMaxZ = 0, outMinZ = 0;
+
+		for ( let i = 0; i < 8; i ++ ) {
+
+			const corner = corners[ i ];
+
+			if ( corner.x > box.max.x ) outMaxX ++;
+			if ( corner.x < box.min.x ) outMinX ++;
+			if ( corner.y > box.max.y ) outMaxY ++;
+			if ( corner.y < box.min.y ) outMinY ++;
+			if ( corner.z > box.max.z ) outMaxZ ++;
+			if ( corner.z < box.min.z ) outMinZ ++;
+
+		}
+
+		return outMaxX !== 8 && outMinX !== 8 && outMaxY !== 8 && outMinY !== 8 && outMaxZ !== 8 && outMinZ !== 8;
 
 	}
 

--- a/test/unit/src/math/Frustum.tests.js
+++ b/test/unit/src/math/Frustum.tests.js
@@ -247,6 +247,26 @@ export default QUnit.module( 'Maths', () => {
 			intersects = a.intersectsBox( box );
 			assert.ok( intersects, 'Successful intersection' );
 
+			// large box that crosses several frustum planes while lying fully
+			// outside the frustum must not report a false positive (see #27756).
+			// fov 60, aspect 1, far 10: no frustum point has |x| > 10 * tan( 30 deg )
+
+			const t = Math.tan( Math.PI / 6 );
+			const m2 = new Matrix4().makePerspective( - t, t, t, - t, 1, 10 );
+			const b = new Frustum().setFromProjectionMatrix( m2 );
+
+			const bigBox = new Box3( new Vector3( 6, - 60, - 12 ), new Vector3( 60, 60, 1 ) );
+
+			intersects = b.intersectsBox( bigBox );
+			assert.notOk( intersects, 'No intersection for a large box beyond the side plane' );
+
+			// a box that encloses the entire frustum still intersects
+
+			const hugeBox = new Box3( new Vector3( - 100, - 100, - 100 ), new Vector3( 100, 100, 100 ) );
+
+			intersects = b.intersectsBox( hugeBox );
+			assert.ok( intersects, 'Successful intersection for a box enclosing the frustum' );
+
 		} );
 
 	} );


### PR DESCRIPTION
Fixes #27756.

### Problem

`intersectsBox()` only rejects a box when a *single* frustum plane separates it. A large box that crosses several frustum planes can lie fully outside the frustum with no single plane separating it — the false positive reported in #27756 (and the reason 3DTilesRendererJS grew its own `ExtendedFrustum`).

### Approach

The complementary test from [the article referenced in the issue](https://iquilezles.org/articles/frustumcorrect/): after the existing plane pass, check the frustum's eight corner points against the faces of the AABB — if all eight corners lie beyond one face, the box's face separates the two.

- Corners are derived lazily from the planes themselves (intersection of three planes) the first time `intersectsBox()` needs them, and invalidated by `set()`, `copy()` and `setFromProjectionMatrix()` — so the same code path serves either coordinate system, `reversedDepth`, and manually-built frustums, without adding public API surface. This mirrors what `ExtendedFrustum` does downstream, but without storing anything beyond eight internal `Vector3`s. (Lazy rather than eager on purpose: eager derivation on construction produced non-finite corners for default-constructed frustums, which broke deep-equality comparisons in the `Lights` unit tests.)
- **Soundness**: the frustum is the convex hull of its corners, so if all corners lie beyond one box face, every frustum point does too — the new check can never reject a genuinely intersecting box (a box enclosing the whole frustum still intersects; covered by a new unit test).
- **Degenerate planes** (e.g. a default-constructed `Frustum`) produce non-finite corners, which fail every comparison — the method then behaves exactly as before.
- **Cost**: the corner pass only runs when the plane pass has already passed (the hot rejection path is unchanged), and corner derivation happens once per `set*()` call, not per box test.

### Verification

Reproduced the false positive analytically before fixing: fov 60°/aspect 1/far 10 ⇒ no frustum point has |x| > 10·tan 30° ≈ 5.77; a box spanning x ∈ [6, 60] with large y/z extents passed the old test. With this change it is rejected, while overlapping boxes, enclosed boxes, a frustum-enclosing box, behind-camera boxes, `reversedDepth`, and default-constructed frustums all keep their previous results. Unit tests added for the false-positive case and the enclosing-box case.


Full unit suite run locally after the lazy rework: 1314 passed, 0 failed.
