### PR TITLE
Examples: Optimize `hashBlur()` usage in `webgpu_backdrop_area`.

### DIFF
--- a/examples/webgpu_backdrop_area.html
+++ b/examples/webgpu_backdrop_area.html
@@ -90,7 +90,7 @@
 				const depthDistance = viewportLinearDepth.distance( linearDepth() );
 
 				const depthAlphaNode = depthDistance.oneMinus().smoothstep( .90, 2 ).mul( 10 ).saturate();
-				const depthBlurred = hashBlur( viewportSharedTexture(), depthDistance.smoothstep( 0, .6 ).mul( 40 ).clamp().mul( .1 ) );
+				const depthBlurred = hashBlur( viewportSharedTexture(), depthDistance.smoothstep( 0, .6 ).mul( 40 ).clamp().mul( .1 ), { repeats: 25 } );
 
 				const blurredBlur = new THREE.MeshBasicNodeMaterial();
 				blurredBlur.backdropNode = depthBlurred.add( depthAlphaNode.mix( color( 0x003399 ).mul( .3 ), 0 ) );


### PR DESCRIPTION
Related issue: -

**Description**

I've noticed `webgpu_backdrop_area` can be noticeably optimized by lowering the `repeats` value of the  `hashBlur()`. Performance goes up from 32 to 54 FPS without much of a quality difference.

PR: https://rawcdn.githack.com/Mugen87/three.js/f6178a6534a1aee5115bc2be903a7e7b4507bec6/examples/webgpu_backdrop_area.html

Dev: https://rawcdn.githack.com/mrdoob/three.js/a94b0a4a67e1dc1a504bbfbf4b87c60741860a7a/examples/webgpu_backdrop_area.html