### PR TITLE
Examples: Refined the `webgpu_volume_perlin` with bisection based refinement.

### DIFF
--- a/examples/webgpu_volume_perlin.html
+++ b/examples/webgpu_volume_perlin.html
@@ -37,7 +37,7 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { Break, If, vec3, vec4, texture3D, uniform, Fn } from 'three/tsl';
+			import { Break, If, Loop, bool, vec3, vec4, texture3D, uniform, Fn } from 'three/tsl';
 
 			import { RaymarchingBox } from 'three/addons/tsl/utils/Raymarching.js';
 
@@ -45,6 +45,8 @@
 			import { ImprovedNoise } from 'three/addons/math/ImprovedNoise.js';
 
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
+
+			const REFINEMENT_STEPS = 4;
 
 			let renderer, scene, camera;
 			let mesh;
@@ -103,23 +105,73 @@
 
 				// Shader
 
-				const opaqueRaymarchingTexture = Fn( ( { texture, steps, threshold } ) => {
+				const opaqueRaymarchingTexture = Fn( ( { texture, steps, threshold, refine } ) => {
 
 					const finalColor = vec4( 0 ).toVar();
 
+					// Previous sample position along the ray, used to bracket
+					// the iso-surface crossing for bisection refinement.
+
+					const positionPrev = vec3( 0 ).toVar();
+					const hasPrev = bool( false ).toVar();
+
 					RaymarchingBox( steps, ( { positionRay } ) => {
+
+						If( hasPrev.not(), () => {
+
+							// First sample: there is no previous position yet,
+							// so bracket degenerates to the entry point.
+
+							positionPrev.assign( positionRay );
+							hasPrev.assign( true );
+
+						} );
 
 						const mapValue = texture.sample( positionRay.add( 0.5 ) ).r.toVar();
 
 						If( mapValue.greaterThan( threshold ), () => {
 
-							const p = vec3( positionRay ).add( 0.5 );
+							const surfacePos = vec3( positionRay ).toVar();
 
-							finalColor.rgb.assign( texture.normal( p ).mul( 0.5 ).add( positionRay.mul( 1.5 ).add( 0.25 ) ) );
+							If( refine, () => {
+
+								// The surface lies between the previous sample (below
+								// the threshold) and this one (above it). Bisect that
+								// interval to localize the crossing precisely.
+
+								const p0 = vec3( positionPrev ).toVar();
+								const p1 = vec3( positionRay ).toVar();
+
+								Loop( REFINEMENT_STEPS, () => {
+
+									const pm = p0.add( p1 ).mul( 0.5 ).toVar();
+									const dm = texture.sample( pm.add( 0.5 ) ).r.toVar();
+
+									If( dm.greaterThan( threshold ), () => {
+
+										p1.assign( pm );
+
+									} ).Else( () => {
+
+										p0.assign( pm );
+
+									} );
+
+								} );
+
+								surfacePos.assign( p1 );
+
+							} );
+
+							const p = vec3( surfacePos ).add( 0.5 );
+
+							finalColor.rgb.assign( texture.normal( p ).mul( 0.5 ).add( surfacePos.mul( 1.5 ).add( 0.25 ) ) );
 							finalColor.a.assign( 1 );
 							Break();
 
 						} );
+
+						positionPrev.assign( positionRay );
 
 					} );
 
@@ -131,12 +183,14 @@
 
 				const threshold = uniform( 0.6 );
 				const steps = uniform( 200 );
+				const refine = uniform( true );
 
 				const material = new THREE.NodeMaterial();
 				material.colorNode = opaqueRaymarchingTexture( {
 					texture: texture3D( texture, null, 0 ),
 					steps,
-					threshold
+					threshold,
+					refine
 				} );
 				material.side = THREE.BackSide;
 				material.transparent = true;
@@ -149,6 +203,7 @@
 				const gui = renderer.inspector.createParameters( 'Parameters' );
 				gui.add( threshold, 'value', 0, 1, 0.01 ).name( 'threshold' );
 				gui.add( steps, 'value', 0, 300, 1 ).name( 'steps' );
+				gui.add( refine, 'value' ).name( 'refine' );
 
 				window.addEventListener( 'resize', onWindowResize );
 

--- a/examples/webgpu_volume_perlin.html
+++ b/examples/webgpu_volume_perlin.html
@@ -46,7 +46,7 @@
 
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 
-			const REFINEMENT_STEPS = 6;
+			const REFINEMENT_STEPS = 4;
 
 			let renderer, scene, camera;
 			let mesh;

--- a/examples/webgpu_volume_perlin.html
+++ b/examples/webgpu_volume_perlin.html
@@ -46,7 +46,7 @@
 
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 
-			const REFINEMENT_STEPS = 4;
+			const REFINEMENT_STEPS = 6;
 
 			let renderer, scene, camera;
 			let mesh;
@@ -109,43 +109,30 @@
 
 					const finalColor = vec4( 0 ).toVar();
 
-					// Previous sample position along the ray, used to bracket
-					// the iso-surface crossing for bisection refinement.
-
 					const positionPrev = vec3( 0 ).toVar();
 					const hasPrev = bool( false ).toVar();
 
 					RaymarchingBox( steps, ( { positionRay } ) => {
 
-						If( hasPrev.not(), () => {
-
-							// First sample: there is no previous position yet,
-							// so bracket degenerates to the entry point.
-
-							positionPrev.assign( positionRay );
-							hasPrev.assign( true );
-
-						} );
-
 						const mapValue = texture.sample( positionRay.add( 0.5 ) ).r.toVar();
 
 						If( mapValue.greaterThan( threshold ), () => {
 
-							const surfacePos = vec3( positionRay ).toVar();
+							const surfacePos = positionRay.toVar();
 
-							If( refine, () => {
+							If( refine.and( hasPrev ), () => {
 
-								// The surface lies between the previous sample (below
-								// the threshold) and this one (above it). Bisect that
-								// interval to localize the crossing precisely.
+								// The surface lies between the previous sample (below the threshold)
+								// and the current one (above it). Bisect that interval to localize
+								// the crossing precisely.
 
-								const p0 = vec3( positionPrev ).toVar();
-								const p1 = vec3( positionRay ).toVar();
+								const p0 = positionPrev.toVar();
+								const p1 = positionRay.toVar();
 
 								Loop( REFINEMENT_STEPS, () => {
 
-									const pm = p0.add( p1 ).mul( 0.5 ).toVar();
-									const dm = texture.sample( pm.add( 0.5 ) ).r.toVar();
+									const pm = p0.add( p1 ).mul( 0.5 ).toConst();
+									const dm = texture.sample( pm.add( 0.5 ) ).r.toConst();
 
 									If( dm.greaterThan( threshold ), () => {
 
@@ -172,6 +159,7 @@
 						} );
 
 						positionPrev.assign( positionRay );
+						hasPrev.assign( true );
 
 					} );
 


### PR DESCRIPTION
Related issue: #[34087](https://github.com/mrdoob/three.js/issues/34087)

**Description**

Existing webgpu volume perline example code shows sampling artifacts at low raycasting steps as shown below
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/74623b87-e130-4b0f-83c1-710b2f567c8f" />

With bisection based refinement, the quality is improved significantly as shown below:
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/a6ebc93f-a0b9-41d3-89cb-4a7ed13c4946" />