### PR TITLE
BatchedMesh: Mark visibility dirty in setGeometryIdAt().

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1203,6 +1203,7 @@ class BatchedMesh extends Mesh {
 		this.validateGeometryId( geometryId );
 
 		this._instanceInfo[ instanceId ].geometryIndex = geometryId;
+		this._visibilityChanged = true;
 
 		return this;
 


### PR DESCRIPTION
`setGeometryIdAt()` updates the instance's geometry index but never sets `_visibilityChanged`, so with `perObjectFrustumCulled = false` and `sortObjects = false` the multi-draw arrays are never rebuilt (`onBeforeRender()` returns early) and the instance keeps drawing its old geometry until some unrelated `setVisibleAt()` call triggers a rebuild.

This sets the flag like `setVisibleAt()` already does.

Repro:

```js
const material = new THREE.MeshNormalMaterial();
const box = new THREE.BoxGeometry( 1, 1, 1 );
const sphere = new THREE.SphereGeometry( 0.75, 16, 8 );

const mesh = new THREE.BatchedMesh( 1, 2048, 8192, material );
mesh.perObjectFrustumCulled = false;
mesh.sortObjects = false;

const boxId = mesh.addGeometry( box );
const sphereId = mesh.addGeometry( sphere );

const instanceId = mesh.addInstance( boxId );
scene.add( mesh );

setTimeout( () => {

	mesh.setGeometryIdAt( instanceId, sphereId );
	// still renders the box

	// uncomment and the sphere appears, since setVisibleAt() sets _visibilityChanged:
	// mesh.setVisibleAt( instanceId, false ); mesh.setVisibleAt( instanceId, true );

}, 1000 );
```
