### PR TITLE
Examples: Eliminate branch divergence in volume refinement loops.

### DIFF
--- a/examples/webgl_volume_perlin.html
+++ b/examples/webgl_volume_perlin.html
@@ -195,18 +195,11 @@
 									for ( int j = 0; j < REFINEMENT_STEPS; j ++ ) {
 
 										float tm = ( t0 + t1 ) * 0.5;
-
 										float dm = sample1( vOrigin + tm * rayDir + 0.5 );
 
-										if ( dm > threshold ) {
-
-											t1 = tm;
-
-										} else {
-
-											t0 = tm;
-
-										}
+										bool isGreater = dm > threshold;
+										t1 = isGreater ? tm : t1;
+										t0 = isGreater ? t0 : tm;
 
 									}
 

--- a/examples/webgpu_volume_perlin.html
+++ b/examples/webgpu_volume_perlin.html
@@ -37,7 +37,7 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { Break, If, Loop, bool, vec3, vec4, texture3D, uniform, Fn } from 'three/tsl';
+			import { Break, If, Loop, select, int, bool, vec3, vec4, texture3D, uniform, Fn } from 'three/tsl';
 
 			import { RaymarchingBox } from 'three/addons/tsl/utils/Raymarching.js';
 
@@ -134,15 +134,10 @@
 									const pm = p0.add( p1 ).mul( 0.5 ).toConst();
 									const dm = texture.sample( pm.add( 0.5 ) ).r.toConst();
 
-									If( dm.greaterThan( threshold ), () => {
+									const isGreater = dm.greaterThan( threshold );
 
-										p1.assign( pm );
-
-									} ).Else( () => {
-
-										p0.assign( pm );
-
-									} );
+									p1.assign( select( isGreater, pm, p1 ) );
+									p0.assign( select( isGreater, p0, pm ) );
 
 								} );
 
@@ -166,6 +161,7 @@
 					return finalColor;
 
 				} );
+
 
 				//
 

--- a/examples/webgpu_volume_perlin.html
+++ b/examples/webgpu_volume_perlin.html
@@ -136,8 +136,8 @@
 
 									const isGreater = dm.greaterThan( threshold );
 
-									p1.assign( select( isGreater, pm, p1 ) );
-									p0.assign( select( isGreater, p0, pm ) );
+									p1.assign( select( isGreater, pm, p1 ) ).uniformFlow();
+									p0.assign( select( isGreater, p0, pm ) ).uniformFlow();
 
 								} );
 

--- a/examples/webgpu_volume_perlin.html
+++ b/examples/webgpu_volume_perlin.html
@@ -37,7 +37,7 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { Break, If, Loop, select, int, bool, vec3, vec4, texture3D, uniform, Fn } from 'three/tsl';
+			import { Break, If, Loop, select, bool, vec3, vec4, texture3D, uniform, Fn } from 'three/tsl';
 
 			import { RaymarchingBox } from 'three/addons/tsl/utils/Raymarching.js';
 
@@ -161,7 +161,6 @@
 					return finalColor;
 
 				} );
-
 
 				//
 

--- a/examples/webgpu_volume_perlin.html
+++ b/examples/webgpu_volume_perlin.html
@@ -136,8 +136,8 @@
 
 									const isGreater = dm.greaterThan( threshold );
 
-									p1.assign( select( isGreater, pm, p1 ) ).uniformFlow();
-									p0.assign( select( isGreater, p0, pm ) ).uniformFlow();
+									p1.assign( select( isGreater, pm, p1 ).uniformFlow() );
+									p0.assign( select( isGreater, p0, pm ).uniformFlow() );
 
 								} );
 


### PR DESCRIPTION
Replaces the `if/else` control blocks with branchless ternary selections.