### PR TITLE
WebGPUAttributeUtils: Fix interleaved buffer handling for integer attributes.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -14,7 +14,7 @@ const typedArraysToVertexFormatPrefix = new Map( [
 	[ Uint8Array, [ 'uint8', 'unorm8' ]],
 	[ Int16Array, [ 'sint16', 'snorm16' ]],
 	[ Uint16Array, [ 'uint16', 'unorm16' ]],
-	[ Int32Array, [ 'sint32', 'snorm32' ]],
+	[ Int32Array, [ 'sint32' ]],
 	[ Uint32Array, [ 'uint32' ]],
 	[ Float32Array, [ 'float32', ]],
 ] );

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -15,7 +15,7 @@ const typedArraysToVertexFormatPrefix = new Map( [
 	[ Int16Array, [ 'sint16', 'snorm16' ]],
 	[ Uint16Array, [ 'uint16', 'unorm16' ]],
 	[ Int32Array, [ 'sint32', 'snorm32' ]],
-	[ Uint32Array, [ 'uint32', 'unorm32' ]],
+	[ Uint32Array, [ 'uint32' ]],
 	[ Float32Array, [ 'float32', ]],
 ] );
 
@@ -82,7 +82,7 @@ class WebGPUAttributeUtils {
 			let array = bufferAttribute.array;
 
 			// patch for INT16 and UINT16
-			if ( attribute.normalized === false ) {
+			if ( attribute.normalized === false && attribute.isInterleavedBufferAttribute === false ) {
 
 				if ( array.constructor === Int16Array || array.constructor === Int8Array ) {
 
@@ -322,7 +322,8 @@ class WebGPUAttributeUtils {
 				}
 
 				// patch for INT16 and UINT16
-				if ( geometryAttribute.normalized === false && ( geometryAttribute.array.constructor === Int16Array || geometryAttribute.array.constructor === Uint16Array ) ) {
+				if ( geometryAttribute.normalized === false && geometryAttribute.isInterleavedBufferAttribute === false &&
+					( geometryAttribute.array.constructor === Int16Array || geometryAttribute.array.constructor === Uint16Array ) ) {
 
 					arrayStride = 4;
 

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -31,9 +31,7 @@ const typedAttributeToVertexFormatPrefix = new Map( [
 
 const typeArraysToVertexFormatPrefixForItemSize1 = new Map( [
 	[ Int32Array, 'sint32' ],
-	[ Int16Array, 'sint32' ], // patch for INT16
 	[ Uint32Array, 'uint32' ],
-	[ Uint16Array, 'uint32' ], // patch for UINT16
 	[ Float32Array, 'float32' ]
 ] );
 
@@ -82,7 +80,7 @@ class WebGPUAttributeUtils {
 			let array = bufferAttribute.array;
 
 			// patch for INT16 and UINT16
-			if ( attribute.normalized === false && attribute.isInterleavedBufferAttribute === false ) {
+			if ( attribute.normalized === false && attribute.isInterleavedBufferAttribute !== true ) {
 
 				if ( array.constructor === Int16Array || array.constructor === Int8Array ) {
 
@@ -318,14 +316,6 @@ class WebGPUAttributeUtils {
 						arrayStride = Math.floor( ( arrayStride + 3 ) / 4 ) * 4;
 
 					}
-
-				}
-
-				// patch for INT16 and UINT16
-				if ( geometryAttribute.normalized === false && geometryAttribute.isInterleavedBufferAttribute === false &&
-					( geometryAttribute.array.constructor === Int16Array || geometryAttribute.array.constructor === Uint16Array ) ) {
-
-					arrayStride = 4;
 
 				}
 


### PR DESCRIPTION
**Description**

Fixes an issue where integer attribute promotion in `WebGPUAttributeUtils`could modify the underlying InterleavedBuffer shared by multiple attributes.

When an interleaved buffer contains both normalized and non-normalizedinteger attributes (e.g. COLOR_0 and JOINTS_0 from `examples/webgpu_loader_gltf.html RecursiveSkeletons model`), promotingUint8Array/Uint16Array data to Uint32Array for one attribute would incorrectly affect other attributes sharing the same buffer.

This change handles interleaved attributes separately during WebGPU buffer creation while preserving the original geometry layout.

And removed the unorm32 format to ensure it throws the appropriate errors.

After the fix:

<img width="280" height="200" alt="image" src="https://github.com/user-attachments/assets/51cdd089-897c-454b-b73d-634aa71e1b77" />
