### PR TITLE
WGSLNodeFunction: Add missing WGSL-TSL type entry.

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -50,6 +50,7 @@ const wgslTypeLib = {
 	'mat4x4f': 'mat4',
 
 	'sampler': 'sampler',
+	'sampler_comparison': 'samplerComparison',
 
 	'texture_1d': 'texture',
 


### PR DESCRIPTION
Related issue: #34081

**Description**

While investigating #34081, I've noticed a type entry is missing in `wgslTypeLib`. Without it, `sampler_comparison` parameters end up with an undefined TSL type. It does not fix #34081 but it make sure the type matches the one defined in `NodeBuilder.isReference()`.