### PR TITLE
TSL: Add `OnAfterObjectUpdate()`.

### DIFF
--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -411,6 +411,7 @@ export const objectRadius = TSL.objectRadius;
 export const objectScale = TSL.objectScale;
 export const objectViewPosition = TSL.objectViewPosition;
 export const objectWorldMatrix = TSL.objectWorldMatrix;
+export const OnAfterObjectUpdate = TSL.OnAfterObjectUpdate;
 export const OnBeforeObjectUpdate = TSL.OnBeforeObjectUpdate;
 export const OnBeforeMaterialUpdate = TSL.OnBeforeMaterialUpdate;
 export const OnBeforeRenderPipeline = TSL.OnBeforeRenderPipeline;

--- a/src/nodes/accessors/Batch.js
+++ b/src/nodes/accessors/Batch.js
@@ -7,7 +7,7 @@ import { textureSize } from './TextureSizeNode.js';
 import { tangentLocal } from './Tangent.js';
 import { instanceIndex, drawIndex } from '../core/IndexNode.js';
 import { varyingProperty } from '../core/PropertyNode.js';
-import { OnObjectUpdate } from '../utils/EventNode.js';
+import { OnAfterObjectUpdate } from '../utils/EventNode.js';
 import { DataTexture } from '../../textures/DataTexture.js';
 
 const _previousBatchingMatrices = /*@__PURE__*/ new WeakMap();
@@ -140,7 +140,7 @@ export const batch = /*@__PURE__*/ Fn( ( [ batchMesh ], builder ) => {
 
 	if ( builder.needsPreviousData() ) {
 
-		OnObjectUpdate( ( { object } ) => {
+		OnAfterObjectUpdate( ( { object } ) => {
 
 			const previousBatchData = _previousBatchingMatrices.get( object );
 

--- a/src/nodes/accessors/Instance.js
+++ b/src/nodes/accessors/Instance.js
@@ -1,6 +1,6 @@
 
 import { vec3, mat4, Fn } from '../tsl/TSLBase.js';
-import { OnFrameUpdate, OnObjectUpdate } from '../utils/EventNode.js';
+import { OnAfterObjectUpdate, OnFrameUpdate } from '../utils/EventNode.js';
 import { normalLocal, transformNormal } from './Normal.js';
 import { positionLocal, positionPrevious } from './Position.js';
 import { varyingProperty } from '../core/PropertyNode.js';
@@ -210,7 +210,7 @@ export const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder
 
 		const instancedMesh = builder.object;
 
-		OnObjectUpdate( ( { object } ) => {
+		OnAfterObjectUpdate( ( { object } ) => {
 
 			const previousInstanceData = _previousInstanceMatrices.get( object );
 

--- a/src/nodes/utils/EventNode.js
+++ b/src/nodes/utils/EventNode.js
@@ -39,6 +39,10 @@ class EventNode extends Node {
 
 			this.updateType = NodeUpdateType.FRAME;
 
+		} else if ( eventType === EventNode.AFTER_OBJECT ) {
+
+			this.updateAfterType = NodeUpdateType.OBJECT;
+
 		} else if ( eventType === EventNode.BEFORE_OBJECT ) {
 
 			this.updateBeforeType = NodeUpdateType.OBJECT;
@@ -97,11 +101,18 @@ class EventNode extends Node {
 
 	}
 
+	updateAfter( frame ) {
+
+		this.callback( frame );
+
+	}
+
 }
 
 EventNode.OBJECT = 'object';
 EventNode.MATERIAL = 'material';
 EventNode.FRAME = 'frame';
+EventNode.AFTER_OBJECT = 'afterObject';
 EventNode.BEFORE_OBJECT = 'beforeObject';
 EventNode.BEFORE_MATERIAL = 'beforeMaterial';
 EventNode.BEFORE_FRAME = 'beforeFrame';
@@ -148,6 +159,16 @@ export const OnMaterialUpdate = ( callback ) => createEvent( EventNode.MATERIAL,
  * @returns {EventNode}
  */
 export const OnFrameUpdate = ( callback ) => createEvent( EventNode.FRAME, callback );
+
+/**
+ * Creates an event that triggers a function every time an object (Mesh|Sprite) has been rendered.
+ *
+ * The event will be bound to the declared TSL function `Fn()`; it must be declared within a `Fn()` or the JS function call must be inherited from one.
+ *
+ * @param {Function} callback - The callback function.
+ * @returns {EventNode}
+ */
+export const OnAfterObjectUpdate = ( callback ) => createEvent( EventNode.AFTER_OBJECT, callback );
 
 /**
  * Creates an event that triggers a function before an object (Mesh|Sprite) is updated.


### PR DESCRIPTION
Related issue: #34100

**Description**

While testing #34100, I've noticed a related bug. Whenever individual instances of a instanced or batched mesh are animated, velocity is not computed correctly.  Turns out the `OnObjectUpdate()` is not the correct callback for updating the previous data. Similar to `VelocityNode` that manages the previous world matrix of objects, we must update the data _after_ the object has been rendered.

https://github.com/mrdoob/three.js/blob/ad6961f7fcb52cc3eec877faeb26ea11f611165f/src/nodes/accessors/VelocityNode.js#L152-L156