### PR TITLE
TSL: Fix update of previous instance matrix data.

### DIFF
--- a/src/nodes/accessors/Instance.js
+++ b/src/nodes/accessors/Instance.js
@@ -212,9 +212,16 @@ export const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder
 
 		OnAfterObjectUpdate( ( { object } ) => {
 
-			const previousInstanceData = _previousInstanceMatrices.get( object );
+			const { previousInstanceMatrix } = _previousInstanceMatrices.get( object );
 
-			previousInstanceData.previousInstanceMatrix.array.set( matrices.array );
+			previousInstanceMatrix.array.set( matrices.array );
+			previousInstanceMatrix.needsUpdate = true;
+
+			// handle interleaved path
+
+			const previousInterleavedMatrix = _matrixBuffers.get( previousInstanceMatrix );
+
+			if ( previousInterleavedMatrix !== undefined ) previousInterleavedMatrix.needsUpdate = true;
 
 		} );
 

--- a/src/nodes/accessors/Instance.js
+++ b/src/nodes/accessors/Instance.js
@@ -215,13 +215,13 @@ export const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder
 			const { previousInstanceMatrix } = _previousInstanceMatrices.get( object );
 
 			previousInstanceMatrix.array.set( matrices.array );
-			previousInstanceMatrix.needsUpdate = true;
+			previousInstanceMatrix.version = matrices.version;
 
 			// handle interleaved path
 
 			const previousInterleavedMatrix = _matrixBuffers.get( previousInstanceMatrix );
 
-			if ( previousInterleavedMatrix !== undefined ) previousInterleavedMatrix.needsUpdate = true;
+			if ( previousInterleavedMatrix !== undefined ) previousInterleavedMatrix.version = matrices.version;
 
 		} );
 


### PR DESCRIPTION
Related issue: #34101

**Description**

Follow-up of #34101. It turns out when `Instance.js` uses the non-UBO path for representing the instance matrix data, the update of previous instance matrix data is broken. That's because storage and interleaved attribute data require `needsUpdate` set to `true`/version bump (in the interleaved case the instance of `InstancedInterleavedBuffer`).
