### PR TITLE
NodeManager: Correctly dispose of background mesh.

### DIFF
--- a/src/renderers/common/nodes/NodeManager.js
+++ b/src/renderers/common/nodes/NodeManager.js
@@ -740,6 +740,27 @@ class NodeManager extends DataMap {
 
 		if ( node === undefined || forceUpdate ) {
 
+			if ( node === undefined && object.isTexture === true ) {
+
+				const onTextureDispose = () => {
+
+					object.removeEventListener( 'dispose', onTextureDispose );
+
+					const node = nodeCache.get( object );
+
+					if ( node !== undefined ) {
+
+						nodeCache.delete( object );
+						node.dispose();
+
+					}
+
+				};
+
+				object.addEventListener( 'dispose', onTextureDispose );
+
+			}
+
 			node = callback();
 			nodeCache.set( object, node );
 


### PR DESCRIPTION
Fixed #34103.

**Description**

When a texture is assigned to `Scene.background`, the renderer creates an internal node. This node has a [dispose()](https://github.com/mrdoob/three.js/blob/27e70ddf91e95c40d03bca7b2bac5a212e4c4151/src/renderers/common/Background.js#L135-L144) routine but it only ever executes if the node is maintained on app level via `Scene.backgroundNode` and `node.dispose()` is called manually. 

When the app just assigns a texture and calls `dispose()`, the above node is never removed. Since there is no `Scene.dispose()`, the only way to get rid of internal resources is to couple the texture disposal with the background node disposal. The PR implements that in `NodeManager`.


