### PR TITLE
TSL: Add `batchIndirectIndex`.

### DIFF
--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -77,6 +77,7 @@ export const backgroundBlurriness = TSL.backgroundBlurriness;
 export const backgroundIntensity = TSL.backgroundIntensity;
 export const backgroundRotation = TSL.backgroundRotation;
 export const batch = TSL.batch;
+export const batchIndirectIndex = TSL.batchIndirectIndex;
 export const bentNormalView = TSL.bentNormalView;
 export const billboarding = TSL.billboarding;
 export const bitAnd = TSL.bitAnd;

--- a/src/nodes/accessors/Batch.js
+++ b/src/nodes/accessors/Batch.js
@@ -108,6 +108,13 @@ function getPreviousNode( batchMesh, id ) {
 export const batchColor = /*@__PURE__*/ varyingProperty( 'vec4', 'vBatchColor' );
 
 /**
+ * TSL object representing a varying property for the batch indirect index (instance ID).
+ *
+ * @type {VaryingNode<uint>}
+ */
+export const batchIndirectIndex = /*@__PURE__*/ varyingProperty( 'uint', 'vBatchIndirectId' );
+
+/**
  * TSL function representing the vertex shader batching setup.
  * Applies the batch transformation matrix to positionLocal, normalLocal, and tangentLocal.
  * Also assigns the batch color if a color texture is present.
@@ -121,6 +128,8 @@ export const batch = /*@__PURE__*/ Fn( ( [ batchMesh ], builder ) => {
 	const batchingIdNode = builder.getDrawIndex() === null ? instanceIndex : drawIndex;
 
 	const indirectId = getIndirectIndex( batchMesh._indirectTexture, int( batchingIdNode ) );
+
+	batchIndirectIndex.assign( indirectId );
 
 	const batchingMatrix = createBatchingMatrixNode( batchMesh._matricesTexture, indirectId );
 


### PR DESCRIPTION
Fixed #33477.

**Description**

The PR introduces the TSL object `batchIndirectIndex` that allows access  tot he indirect index of a batched mesh.

@John-D-a-i @MicolaL Would this work for your use cases?