### PR TITLE
TSL: Support primitive values in custom `struct` constructors

### DIFF
--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -488,3 +488,9 @@ export function base64ToArrayBuffer( base64 ) {
 	return Uint8Array.from( atob( base64 ), c => c.charCodeAt( 0 ) ).buffer;
 
 }
+
+export function isArrayAsParameter( params ) {
+
+	return ( params[ 0 ] !== undefined && params[ 0 ] !== null ) && ( params[ 0 ].isNode || Object.getPrototypeOf( params[ 0 ] ) !== Object.prototype );
+
+}

--- a/src/nodes/core/StructNode.js
+++ b/src/nodes/core/StructNode.js
@@ -1,6 +1,7 @@
 import Node from './Node.js';
 import StructTypeNode from './StructTypeNode.js';
-import { nodeProxyConstructor } from '../tsl/TSLCore.js';
+import { nodeObject, nodeProxyConstructor } from '../tsl/TSLCore.js';
+import { isArrayAsParameter } from './NodeUtils.js';
 
 /**
  * StructNode allows to create custom structures with multiple members.
@@ -103,7 +104,7 @@ export const struct = ( membersLayout, name = null ) => {
 
 		if ( params.length > 0 ) {
 
-			if ( params[ 0 ].isNode ) {
+			if ( isArrayAsParameter( params ) ) {
 
 				values = {};
 
@@ -111,7 +112,7 @@ export const struct = ( membersLayout, name = null ) => {
 
 				for ( let i = 0; i < params.length; i ++ ) {
 
-					values[ names[ i ] ] = params[ i ];
+					values[ names[ i ] ] = nodeObject( params[ i ] );
 
 				}
 

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -8,7 +8,7 @@ import FlipNode from '../utils/FlipNode.js';
 import ConstNode from '../core/ConstNode.js';
 import MemberNode from '../utils/MemberNode.js';
 import StackTrace from '../core/StackTrace.js';
-import { getValueFromType, getValueType } from '../core/NodeUtils.js';
+import { getValueFromType, getValueType, isArrayAsParameter } from '../core/NodeUtils.js';
 import { warn, error } from '../../utils.js';
 
 let currentStack = null;
@@ -700,12 +700,6 @@ class ShaderCallNodeInternal extends Node {
 		return result;
 
 	}
-
-}
-
-function isArrayAsParameter( params ) {
-
-	return params[ 0 ] && ( params[ 0 ].isNode || Object.getPrototypeOf( params[ 0 ] ) !== Object.prototype );
 
 }
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/34085

**Description**

This PR fixes an issue where instantiating custom structs in TSL using primitive numeric values (e.g., `CustomColor( 0.0, 0.0, 1.0 )`) was not supported or failed to initialize the struct's fields correctly.

```js
// Define a custom struct type
const CustomColor = struct( { r: 'float', g: 'float', b: 'float' } );

// Fix primitive values passed to a struct
const myColor = CustomColor( 0.0, 0.0, 1.0 );
```