### PR TITLE
RenderTarget3D: Fix texture setup.

### DIFF
--- a/src/core/RenderTarget3D.js
+++ b/src/core/RenderTarget3D.js
@@ -31,15 +31,19 @@ class RenderTarget3D extends RenderTarget {
 
 		this.depth = depth;
 
-		/**
-		 * Overwritten with a different texture type.
-		 *
-		 * @type {Data3DTexture}
-		 */
-		this.texture = new Data3DTexture( null, width, height, depth );
-		this._setTextureOptions( options );
+		// overwrite attachments with 3D textures
 
-		this.texture.isRenderTargetTexture = true;
+		for ( let i = 0; i < this.textures.length; i ++ ) {
+
+			const texture = new Data3DTexture( null, width, height, depth );
+			texture.isRenderTargetTexture = true;
+			texture.renderTarget = this;
+
+			this.textures[ i ] = texture;
+
+		}
+
+		this._setTextureOptions( options );
 
 	}
 


### PR DESCRIPTION
Fixed #34116.

**Description**

The PR makes sure `RenderTarget3D` uses instances of `Data3DTexture` for all color attachments, not just for the default one. 
