### PR TITLE
WebGPUUtils: Refactor `getTextureSampleData()`.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUUtils.js
@@ -111,10 +111,21 @@ class WebGPUUtils {
 
 		} else if ( texture.isDepthTexture && ! texture.renderTarget ) {
 
-			const renderer = this.backend.renderer;
-			const renderTarget = renderer.getRenderTarget();
+			const textureData = this.backend.get( texture );
 
-			samples = renderTarget ? renderTarget.samples : renderer.currentSamples;
+			if ( textureData.texture !== undefined ) {
+
+				// use the effective sample count of the allocated texture
+
+				samples = textureData.texture.sampleCount;
+
+			} else {
+
+				// otherwise use the current samples of the renderer
+
+				samples = this.backend.renderer.currentSamples;
+
+			}
 
 		} else if ( texture.renderTarget ) {
 


### PR DESCRIPTION
Fixed #34081.

**Description**

The PR fixes a regression introduced in `r182` by #32264. The caching itself is not the problem but it exposes an issue when evaluating MSAA samples.

`getTextureSampleData()` runs at different times and it is not guaranteed it operates in the same renderer state. That means it might report different samples values leading to inconsistencies in bindings, shader and textures. The PR resolves this state-dependence by making sure all callers of `getTextureSampleData()` get consistent results by reporting the cached sample count of the allocated texture.