### PR TITLE
WebGLTextureUtils: Fix 3D/array texture readback in copyTextureToBuffer.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -3214,7 +3214,7 @@ class Renderer {
 	 * @param {number} width - The width of the copy region.
 	 * @param {number} height - The height of the copy region.
 	 * @param {number} [textureIndex=0] - The texture index of a MRT render target.
-	 * @param {number} [faceIndex=0] - The active cube face index.
+	 * @param {number} [faceIndex=0] - The active cube face index, or the layer of a 3D/array render target.
 	 * @return {Promise<TypedArray>} A Promise that resolves when the read has been finished. The resolve provides the read data as a typed array.
 	 */
 	async readRenderTargetPixelsAsync( renderTarget, x, y, width, height, textureIndex = 0, faceIndex = 0 ) {

--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -1246,9 +1246,17 @@ class WebGLTextureUtils {
 
 		backend.state.bindFramebuffer( gl.READ_FRAMEBUFFER, fb );
 
-		const target = texture.isCubeTexture ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + faceIndex : gl.TEXTURE_2D;
+		if ( texture.isArrayTexture || texture.isDataArrayTexture || texture.isData3DTexture ) {
 
-		gl.framebufferTexture2D( gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, target, textureGPU, 0 );
+			gl.framebufferTextureLayer( gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, textureGPU, 0, faceIndex );
+
+		} else {
+
+			const target = texture.isCubeTexture ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + faceIndex : gl.TEXTURE_2D;
+
+			gl.framebufferTexture2D( gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, target, textureGPU, 0 );
+
+		}
 
 		const typedArrayType = this._getTypedArrayType( glType );
 		const bytesPerTexel = this._getBytesPerTexel( glType, glFormat );


### PR DESCRIPTION
Fixed #34118.

**Description**

`readRenderTargetPixelsAsync()` returned all zeros on the WebGL backend when the source was a `RenderTarget3D` or a layered (`depth > 1`) render target, and did so silently — no warning, no error.

`WebGLTextureUtils.copyTextureToBuffer()` only consulted `faceIndex` for cube maps and otherwise built the read framebuffer with `gl.framebufferTexture2D( ..., gl.TEXTURE_2D, ... )`, which is invalid for a 3D or 2D-array texture object. The framebuffer ended up incomplete and `readPixels()` produced zeros. The WebGPU backend already treats `faceIndex` as the copy origin's z ([`WebGPUTextureUtils.js#L796`](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgpu/utils/WebGPUTextureUtils.js#L796)), so the two backends disagreed on the same call.

The PR attaches the requested layer with `gl.framebufferTextureLayer()` for these texture types. That is the same call the renderer's own path already uses for exactly these render targets ([`WebGLBackend.js#L2333`](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgl-fallback/WebGLBackend.js#L2333)), it is core WebGL2 with no extension required, and it covers `TEXTURE_3D` and `TEXTURE_2D_ARRAY` alike. The cube and 2D paths are untouched.

The condition uses `isArrayTexture || isDataArrayTexture || isData3DTexture` rather than only the 3D/data-array pair suggested in the issue. `RenderTarget3D` allocates `Data3DTexture` attachments, but a plain `RenderTarget` created with `depth > 1` gets ordinary `Texture` attachments that carry only `isArrayTexture` (`Texture.js` L359, `RenderTarget.js` L385) — that shape was broken the same way and is fixed here too.

**Verification**

Headless Chrome (ANGLE/Metal), `WebGPURenderer( { forceWebGL: true } )`, rendering a constant into one slice and reading each slice back:

| | `RenderTarget3D` slice 2 | untouched slice 0 | `RenderTarget` depth 3, slice 1 | plain 2D target |
|---|---|---|---|---|
| `dev` | `[0, 0, 0, 0]` | `[0, 0, 0, 0]` | `[0, 0, 0, 0]` | `[255, 55, 0, 255]` |
| this PR | `[255, 55, 0, 255]` | `[0, 0, 0, 0]` | `[255, 55, 0, 255]` | `[255, 55, 0, 255]` |

The written slice now reads back correctly, neighbouring slices stay untouched, and the plain 2D target is unaffected — matching what the reporter's fiddle shows the WebGPU backend producing.

No unit test is included: `test/unit/` never acquires a WebGL2 context (the renderer test modules are empty stubs), so there is no harness in which a backend-level `framebufferTextureLayer` call can be asserted. `npm run lint`, `npm run test-unit` (1314 passing) and `npm run test-unit-addons` are green.

---
🤖 Opened with [Superhuman](https://github.com/gaurav0107/superhuman), an open-source contribution agent.
