### PR TITLE
GLTFExporter: Let a ShaderMaterial nominate a stand-in.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -99,6 +99,13 @@ const KHR_mesh_quantization_ExtraAttrTypes = {
  * const data = await exporter.parseAsync( scene, options );
  * ```
  *
+ * A custom shader has no glTF equivalent and cannot be exported. Such a material can nominate a
+ * standard stand-in through `userData.gltfProxyMaterial`, which is written in its place:
+ *
+ * ```js
+ * gemMaterial.userData.gltfProxyMaterial = new THREE.MeshPhysicalMaterial( { transmission: 1, ior: 2.42 } );
+ * ```
+ *
  * @three_import import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
  */
 class GLTFExporter {
@@ -1644,8 +1651,32 @@ class GLTFWriter {
 
 		if ( material.isShaderMaterial ) {
 
-			console.warn( 'GLTFExporter: THREE.ShaderMaterial not supported.' );
-			return null;
+			// A custom shader has no glTF equivalent, so it cannot be described here. Dropping it
+			// leaves the mesh with no material at all, and the writeMaterial plugin hook further
+			// down is never reached from this branch, so there is no way to intervene either.
+			// Instead let the material nominate a standard stand-in to be written in its place:
+			// gems, matcaps and other procedural surfaces then still export the approximation a
+			// glTF viewer was going to show anyway, instead of nothing.
+			const proxy = material.userData.gltfProxyMaterial;
+
+			if ( proxy === undefined ) {
+
+				console.warn( 'THREE.GLTFExporter: THREE.ShaderMaterial not supported. Set userData.gltfProxyMaterial to export a standard material in its place.' );
+				return null;
+
+			}
+
+			if ( proxy.isMaterial !== true || proxy.isShaderMaterial === true ) {
+
+				console.warn( 'THREE.GLTFExporter: userData.gltfProxyMaterial must be a material, and not itself a THREE.ShaderMaterial.' );
+				return null;
+
+			}
+
+			// Cached under the shader material too, so a scene that reuses it writes one material.
+			const proxyIndex = await this.processMaterialAsync( proxy, geometry );
+			cache.materials.set( cacheKey, proxyIndex );
+			return proxyIndex;
 
 		}
 


### PR DESCRIPTION
A custom shader has no glTF equivalent, so the exporter drops it and the mesh comes out with no material at all. There is no way to intervene either: the `writeMaterial` plugin hook sits ~160 lines below the early return, so it is never reached for the one material type that needs it.

```js
if ( material.isShaderMaterial ) {
    console.warn( 'GLTFExporter: THREE.ShaderMaterial not supported.' );
    return null;                                  // <- bails here
}
...
ext.writeMaterial( material, materialDef );       // <- plugin hook, never reached
```

A shader material can now nominate a standard stand-in, which is written in its place:

```js
gemMaterial.userData.gltfProxyMaterial = new THREE.MeshPhysicalMaterial( { transmission: 1, ior: 2.42 } );
```

Gems, matcaps and other procedural surfaces then export the approximation a glTF viewer was going to show anyway, instead of nothing. This matters most for AR: iOS Quick Look and Android Scene Viewer only ever render standard PBR, so the stand-in is the real output — today it just cannot be expressed.

`userData.gltfProxyMaterial` follows the existing `userData.gltfExtensions` convention, and the proxy is exported through the normal material path, so it picks up every extension the exporter already writes.

**Behaviour without the property is unchanged**, down to the warning — which now points at the fix. A proxy that is not a material, or is itself a shader material, is refused with its own warning rather than exported as garbage. The result is cached under the shader material too, so reusing one shader material across meshes still writes a single glTF material.

Verified in a browser against this build — the exported glTF JSON and a full `GLTFExporter` -> `.glb` -> `GLTFLoader` round trip:

```
✅ a bare ShaderMaterial is still dropped — existing behaviour unchanged
✅ and it still warns; the warning now mentions gltfProxyMaterial
✅ a nominated stand-in IS exported, and the mesh is bound to it
✅ ior (2.42), transmission, volume thickness and attenuation all survive
✅ KHR_materials_ior is declared in extensionsUsed
✅ the Material object in userData never leaks into the JSON
✅ one shader material on two meshes still writes ONE material
✅ bad proxies warn and export nothing, rather than throwing
✅ round trip: comes back a MeshPhysicalMaterial, not a broken shader
```