### PR TITLE
TSL: Build CodeNode includes as references

### DIFF
--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -102,7 +102,7 @@ class CodeNode extends Node {
 
 		for ( const include of includes ) {
 
-			include.build( builder, 'property' );
+			include.build( builder, 'void' );
 
 		}
 

--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -102,7 +102,6 @@ class CodeNode extends Node {
 
 		for ( const include of includes ) {
 
-			// Build only the include declaration or resource binding.
 			include.build( builder, 'property' );
 
 		}

--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -102,7 +102,8 @@ class CodeNode extends Node {
 
 		for ( const include of includes ) {
 
-			include.build( builder );
+			// Build only the include declaration or resource binding.
+			include.build( builder, 'property' );
 
 		}
 


### PR DESCRIPTION
Fixed #34131

**Description**

`CodeNode` includes represent declarations and resource bindings, but they were built as value expressions.

When a `TextureNode` was used as a native WGSL include, this caused the texture's default sample to be generated, implicitly requiring the geometry's `uv` attribute even though the native function only used the texture binding.

Build includes with the `property` output so resources are declared without being evaluated. This preserves the texture and sampler bindings while avoiding the unused sample and missing-UV warning.