### PR TITLE
Inspector: Use absolute positioning and add alignment configuration

### DIFF
--- a/examples/jsm/inspector/Inspector.js
+++ b/examples/jsm/inspector/Inspector.js
@@ -135,6 +135,20 @@ class Inspector extends RendererInspector {
 
 	}
 
+	setVisible( value ) {
+
+		this.domElement.style.display = value ? '' : 'none';
+
+		return this;
+
+	}
+
+	getVisible() {
+
+		return this.domElement.style.display !== 'none';
+
+	}
+
 	getSize() {
 
 		return this.profiler.getSize();
@@ -144,6 +158,14 @@ class Inspector extends RendererInspector {
 	setActiveTab( tab ) {
 
 		this.profiler.setActiveTab( tab.id );
+
+		return this;
+
+	}
+
+	setDefaultAlign( horizontal, vertical ) {
+
+		this.profiler.setDefaultAlign( horizontal, vertical );
 
 		return this;
 

--- a/examples/jsm/inspector/Inspector.js
+++ b/examples/jsm/inspector/Inspector.js
@@ -163,9 +163,17 @@ class Inspector extends RendererInspector {
 
 	}
 
-	setDefaultAlign( horizontal, vertical ) {
+	setHorizontalAlign( value ) {
 
-		this.profiler.setDefaultAlign( horizontal, vertical );
+		this.profiler.setHorizontalAlign( value );
+
+		return this;
+
+	}
+
+	setVerticalAlign( value ) {
+
+		this.profiler.setVerticalAlign( value );
 
 		return this;
 

--- a/examples/jsm/inspector/ui/Profiler.js
+++ b/examples/jsm/inspector/ui/Profiler.js
@@ -20,8 +20,8 @@ export class Profiler extends EventDispatcher {
 		this.maxZIndex = 1002; // Track the highest z-index for detached windows (starts at base z-index from CSS)
 		this.nextTabOriginalIndex = 0; // Track the original order of tabs as they are added
 
-		this.defaultHorizontal = 'right'; // 'left' or 'right'
-		this.defaultVertical = 'top';     // 'top' or 'bottom'
+		this.horizontalAlign = 'right'; // 'left' or 'right'
+		this.verticalAlign = 'top';     // 'top' or 'bottom'
 
 		this.setupShell();
 		this.setupResizing();
@@ -2124,11 +2124,21 @@ export class Profiler extends EventDispatcher {
 
 	}
 
-	setDefaultAlign( horizontal, vertical ) {
+	setHorizontalAlign( value ) {
 
-		this.defaultHorizontal = horizontal;
-		this.defaultVertical = vertical;
+		this.horizontalAlign = value;
 		this.updateWidgetPosition();
+
+		return this;
+
+	}
+
+	setVerticalAlign( value ) {
+
+		this.verticalAlign = value;
+		this.updateWidgetPosition();
+
+		return this;
 
 	}
 
@@ -2138,8 +2148,8 @@ export class Profiler extends EventDispatcher {
 		const isMaximized = this.panel.classList.contains( 'maximized' );
 		const isRight = this.position === 'right';
 
-		let horizontal = this.defaultHorizontal; // 'left' or 'right'
-		let vertical = this.defaultVertical;     // 'top' or 'bottom'
+		let horizontal = this.horizontalAlign; // 'left' or 'right'
+		let vertical = this.verticalAlign;     // 'top' or 'bottom'
 
 		if ( isVisible ) {
 
@@ -2147,7 +2157,7 @@ export class Profiler extends EventDispatcher {
 
 				// If panel is open on the right:
 				// Toggle should be on the opposite side of 'right' if default is 'right' to avoid overlapping the panel.
-				if ( this.defaultHorizontal === 'right' ) {
+				if ( this.horizontalAlign === 'right' ) {
 
 					horizontal = 'left';
 
@@ -2159,7 +2169,7 @@ export class Profiler extends EventDispatcher {
 				if ( ! isMaximized ) {
 
 					// If default is bottom, we must move to top to avoid overlapping the panel at the bottom.
-					if ( this.defaultVertical === 'bottom' ) {
+					if ( this.verticalAlign === 'bottom' ) {
 
 						vertical = 'top';
 
@@ -2168,7 +2178,7 @@ export class Profiler extends EventDispatcher {
 				} else {
 
 					// If maximized, move to the opposite vertical position to avoid overlap with header/tabs.
-					vertical = this.defaultVertical === 'top' ? 'bottom' : 'top';
+					vertical = this.verticalAlign === 'top' ? 'bottom' : 'top';
 
 				}
 

--- a/examples/jsm/inspector/ui/Profiler.js
+++ b/examples/jsm/inspector/ui/Profiler.js
@@ -20,10 +20,15 @@ export class Profiler extends EventDispatcher {
 		this.maxZIndex = 1002; // Track the highest z-index for detached windows (starts at base z-index from CSS)
 		this.nextTabOriginalIndex = 0; // Track the original order of tabs as they are added
 
+		this.defaultHorizontal = 'right'; // 'left' or 'right'
+		this.defaultVertical = 'top';     // 'top' or 'bottom'
+
 		this.setupShell();
 		this.setupResizing();
 
 		Style.init( this.domElement );
+
+		this.updateWidgetPosition();
 
 		// Setup window resize listener and update mobile status
 		this.setupWindowResizeListener();
@@ -495,19 +500,21 @@ export class Profiler extends EventDispatcher {
 			// Maximize based on current position
 			if ( this.position === 'bottom' ) {
 
-				this.panel.style.height = '100vh';
+				this.panel.style.height = '100%';
 				this.panel.style.width = '100%';
 
 			} else if ( this.position === 'right' ) {
 
 				this.panel.style.height = '100%';
-				this.panel.style.width = '100vw';
+				this.panel.style.width = '100%';
 
 			}
 
 			this.maximizeBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="8" width="12" height="12" rx="2" ry="2"></rect><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path></svg>';
 
 		}
+
+		this.updateWidgetPosition();
 
 		this.dispatchEvent( { type: 'resize' } );
 
@@ -1691,6 +1698,8 @@ export class Profiler extends EventDispatcher {
 
 		}
 
+		this.updateWidgetPosition();
+
 		this.dispatchEvent( { type: 'resize' } );
 
 		this.saveLayout();
@@ -1723,8 +1732,6 @@ export class Profiler extends EventDispatcher {
 			// Apply right position styles
 			this.panel.classList.remove( 'position-bottom' );
 			this.panel.classList.add( 'position-right' );
-			this.toggleButton.classList.add( 'position-right' );
-			this.miniPanel.classList.add( 'position-right' );
 			this.panel.style.bottom = '';
 			this.panel.style.top = '0';
 			this.panel.style.right = '0';
@@ -1733,7 +1740,7 @@ export class Profiler extends EventDispatcher {
 			// Apply size based on maximized state
 			if ( isMaximized ) {
 
-				this.panel.style.width = '100vw';
+				this.panel.style.width = '100%';
 				this.panel.style.height = '100%';
 
 			} else {
@@ -1753,8 +1760,6 @@ export class Profiler extends EventDispatcher {
 			// Apply bottom position styles
 			this.panel.classList.remove( 'position-right' );
 			this.panel.classList.add( 'position-bottom' );
-			this.toggleButton.classList.remove( 'position-right' );
-			this.miniPanel.classList.remove( 'position-right' );
 			this.panel.style.top = '';
 			this.panel.style.right = '';
 			this.panel.style.bottom = '0';
@@ -1764,7 +1769,7 @@ export class Profiler extends EventDispatcher {
 			if ( isMaximized ) {
 
 				this.panel.style.width = '100%';
-				this.panel.style.height = '100vh';
+				this.panel.style.height = '100%';
 
 			} else {
 
@@ -1774,6 +1779,8 @@ export class Profiler extends EventDispatcher {
 			}
 
 		}
+
+		this.updateWidgetPosition();
 
 		// Re-enable transition after a brief delay
 		setTimeout( () => {
@@ -2114,6 +2121,86 @@ export class Profiler extends EventDispatcher {
 
 		// Update panel size after restoring detached tabs
 		this.updatePanelSize();
+
+	}
+
+	setDefaultAlign( horizontal, vertical ) {
+
+		this.defaultHorizontal = horizontal;
+		this.defaultVertical = vertical;
+		this.updateWidgetPosition();
+
+	}
+
+	updateWidgetPosition() {
+
+		const isVisible = this.panel.classList.contains( 'visible' );
+		const isMaximized = this.panel.classList.contains( 'maximized' );
+		const isRight = this.position === 'right';
+
+		let horizontal = this.defaultHorizontal; // 'left' or 'right'
+		let vertical = this.defaultVertical;     // 'top' or 'bottom'
+
+		if ( isVisible ) {
+
+			if ( isRight ) {
+
+				// If panel is open on the right:
+				// Toggle should be on the opposite side of 'right' if default is 'right' to avoid overlapping the panel.
+				if ( this.defaultHorizontal === 'right' ) {
+
+					horizontal = 'left';
+
+				}
+
+			} else {
+
+				// If panel is open at the bottom:
+				if ( ! isMaximized ) {
+
+					// If default is bottom, we must move to top to avoid overlapping the panel at the bottom.
+					if ( this.defaultVertical === 'bottom' ) {
+
+						vertical = 'top';
+
+					}
+
+				} else {
+
+					// If maximized, move to the opposite vertical position to avoid overlap with header/tabs.
+					vertical = this.defaultVertical === 'top' ? 'bottom' : 'top';
+
+				}
+
+			}
+
+		}
+
+		// Apply horizontal class
+		if ( horizontal === 'left' ) {
+
+			this.toggleButton.classList.add( 'toggle-left' );
+			this.miniPanel.classList.add( 'toggle-left' );
+
+		} else {
+
+			this.toggleButton.classList.remove( 'toggle-left' );
+			this.miniPanel.classList.remove( 'toggle-left' );
+
+		}
+
+		// Apply vertical class
+		if ( vertical === 'bottom' ) {
+
+			this.toggleButton.classList.add( 'toggle-bottom' );
+			this.miniPanel.classList.add( 'toggle-bottom' );
+
+		} else {
+
+			this.toggleButton.classList.remove( 'toggle-bottom' );
+			this.miniPanel.classList.remove( 'toggle-bottom' );
+
+		}
 
 	}
 

--- a/examples/jsm/inspector/ui/Style.js
+++ b/examples/jsm/inspector/ui/Style.js
@@ -20,6 +20,18 @@ export class Style {
 		--color-call: rgba(255, 185, 34, 1);
 		--font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 		--font-mono: 'Courier New', Courier, monospace;
+
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		pointer-events: none;
+		z-index: 1000;
+	}
+
+	:scope * {
+		pointer-events: auto;
 	}
 
 	.profiler-panel, .profiler-toggle, .detached-tab-panel,
@@ -33,7 +45,7 @@ export class Style {
 	}
 
 	.profiler-toggle {
-		position: fixed;
+		position: absolute;
 		top: 15px;
 		right: 15px;
 		background-color: rgba(30, 30, 36, 0.85);
@@ -68,14 +80,14 @@ export class Style {
 		opacity: 0.5;
 	}
 
-	.profiler-toggle.position-right.panel-open {
+	.profiler-toggle.toggle-left {
 		right: auto;
 		left: 15px;
 		border-radius: 6px 12px 12px 6px;
 		flex-direction: row-reverse;
 	}
 
-	.profiler-toggle.position-right.panel-open .builtin-tabs-container {
+	.profiler-toggle.toggle-left .builtin-tabs-container {
 		border-right: none;
 		border-left: 1px solid #262636;
 	}
@@ -227,7 +239,7 @@ export class Style {
 	}
 
 	.profiler-mini-panel {
-		position: fixed;
+		position: absolute;
 		top: 60px;
 		right: 15px;
 		background-color: rgba(30, 30, 36, 0.85);
@@ -252,7 +264,7 @@ export class Style {
 					transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 	}
 
-	.profiler-mini-panel.position-right.panel-open {
+	.profiler-mini-panel.toggle-left {
 		right: auto;
 		left: 15px;
 	}
@@ -263,20 +275,14 @@ export class Style {
 		transform: translateY(0) scale(1);
 	}
 
-	/* Position toggle and mini-panel at the bottom when maximized */
-	:scope:has(.profiler-panel.maximized) .profiler-toggle,
-	:scope.maximized .profiler-toggle {
-		top: auto !important;
-		bottom: 15px !important;
-		z-index: 10005 !important;
+	.profiler-toggle.toggle-bottom {
+		top: auto;
+		bottom: 15px;
 	}
 
-	:scope:has(.profiler-panel.maximized) .profiler-mini-panel,
-	:scope.maximized .profiler-mini-panel {
-		top: auto !important;
-		bottom: 60px !important;
-		max-height: calc(100vh - 120px) !important;
-		z-index: 10006 !important;
+	.profiler-mini-panel.toggle-bottom {
+		top: auto;
+		bottom: 60px;
 	}
 
 	.profiler-mini-panel::-webkit-scrollbar {
@@ -560,7 +566,7 @@ export class Style {
 	}
 
 	.profiler-panel {
-		position: fixed;
+		position: absolute;
 		z-index: 1001 !important;
 		bottom: 0;
 		left: 0;
@@ -589,7 +595,7 @@ export class Style {
 	}
 
 	.profiler-panel.maximized {
-		height: 100vh;
+		height: 100%;
 	}
 
 	/* Position-specific styles */
@@ -1689,7 +1695,7 @@ export class Style {
 	}
 
 	.drag-preview-indicator {
-		position: fixed;
+		position: absolute;
 		background-color: rgba(0, 170, 255, 0.2);
 		border: 2px dashed var(--color-accent);
 		z-index: 999;
@@ -1699,7 +1705,7 @@ export class Style {
 
 	/* Detached Tab Windows */
 	.detached-tab-panel {
-		position: fixed;
+		position: absolute;
 		width: 500px;
 		height: 400px;
 		background: var(--profiler-background);


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/34085

**Description**

- **Positioning limitations:** The use of `position: fixed` forced the inspector layout to be relative to the viewport. Switching to `position: absolute` enables rendering the inspector inside specific parent DOM containers.

- **Programmatic control:** Adding methods to show, hide, and configure the inspector's alignment allows API users to manage the GUI lifecycle and initial layout programmatically.

- **Overlap/Collision issues:** Hardcoded styles caused the toggle button and mini-panel to overlap with the main panel when opened or maximized. Dynamic class computation resolves these conflicts automatically.

- **API Changes (`Inspector.js`)**:
  - Added `setVisible( value )` and `getVisible()` to programmatically toggle inspector visibility.
  - Added `setHorizontalAlign( value )` and `setVerticalAlign( value )`  to configure and retrieve alignment settings.