### PR TITLE
Object3D: Add `dispose()`.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1653,6 +1653,27 @@ class Object3D extends EventDispatcher {
 
 	}
 
+	/**
+	 * Frees the GPU-related resources allocated by this instance. Call this
+	 * method whenever this instance is no longer used in your app.
+	 *
+	 * Geometries, materials and textures are potentially shared with other
+	 * 3D objects and must be disposed of separately.
+	 *
+	 * @fires Object3D#dispose
+	 */
+	dispose() {
+
+		/**
+		 * Fires when the 3D object has been disposed of.
+		 *
+		 * @event Object3D#dispose
+		 * @type {Object}
+		 */
+		this.dispatchEvent( { type: 'dispose' } );
+
+	}
+
 }
 
 /**

--- a/src/helpers/ArrowHelper.js
+++ b/src/helpers/ArrowHelper.js
@@ -159,6 +159,8 @@ class ArrowHelper extends Object3D {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.line.geometry.dispose();
 		this.line.material.dispose();
 		this.cone.geometry.dispose();

--- a/src/helpers/AxesHelper.js
+++ b/src/helpers/AxesHelper.js
@@ -85,6 +85,8 @@ class AxesHelper extends LineSegments {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.geometry.dispose();
 		this.material.dispose();
 

--- a/src/helpers/Box3Helper.js
+++ b/src/helpers/Box3Helper.js
@@ -73,6 +73,8 @@ class Box3Helper extends LineSegments {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.geometry.dispose();
 		this.material.dispose();
 

--- a/src/helpers/BoxHelper.js
+++ b/src/helpers/BoxHelper.js
@@ -138,6 +138,8 @@ class BoxHelper extends LineSegments {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.geometry.dispose();
 		this.material.dispose();
 

--- a/src/helpers/CameraHelper.js
+++ b/src/helpers/CameraHelper.js
@@ -314,6 +314,8 @@ class CameraHelper extends LineSegments {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.geometry.dispose();
 		this.material.dispose();
 

--- a/src/helpers/DirectionalLightHelper.js
+++ b/src/helpers/DirectionalLightHelper.js
@@ -103,6 +103,8 @@ class DirectionalLightHelper extends Object3D {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.lightPlane.geometry.dispose();
 		this.lightPlane.material.dispose();
 		this.targetLine.geometry.dispose();

--- a/src/helpers/GridHelper.js
+++ b/src/helpers/GridHelper.js
@@ -71,6 +71,8 @@ class GridHelper extends LineSegments {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.geometry.dispose();
 		this.material.dispose();
 

--- a/src/helpers/HemisphereLightHelper.js
+++ b/src/helpers/HemisphereLightHelper.js
@@ -82,6 +82,8 @@ class HemisphereLightHelper extends Object3D {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.children[ 0 ].geometry.dispose();
 		this.children[ 0 ].material.dispose();
 

--- a/src/helpers/PlaneHelper.js
+++ b/src/helpers/PlaneHelper.js
@@ -84,6 +84,8 @@ class PlaneHelper extends Line {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.geometry.dispose();
 		this.material.dispose();
 		this.children[ 0 ].geometry.dispose();

--- a/src/helpers/PointLightHelper.js
+++ b/src/helpers/PointLightHelper.js
@@ -65,6 +65,8 @@ class PointLightHelper extends Mesh {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.geometry.dispose();
 		this.material.dispose();
 

--- a/src/helpers/PolarGridHelper.js
+++ b/src/helpers/PolarGridHelper.js
@@ -115,6 +115,8 @@ class PolarGridHelper extends LineSegments {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.geometry.dispose();
 		this.material.dispose();
 

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -162,6 +162,8 @@ class SkeletonHelper extends LineSegments {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.geometry.dispose();
 		this.material.dispose();
 

--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -95,6 +95,8 @@ class SpotLightHelper extends Object3D {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.cone.geometry.dispose();
 		this.cone.material.dispose();
 

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -48,16 +48,6 @@ class Light extends Object3D {
 
 	}
 
-	/**
-	 * Frees the GPU-related resources allocated by this instance. Call this
-	 * method whenever this instance is no longer used in your app.
-	 */
-	dispose() {
-
-		this.dispatchEvent( { type: 'dispose' } );
-
-	}
-
 	copy( source, recursive ) {
 
 		super.copy( source, recursive );

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1498,6 +1498,8 @@ class BatchedMesh extends Mesh {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		// Assuming the geometry is not shared with other meshes
 		this.geometry.dispose();
 

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -395,7 +395,7 @@ class InstancedMesh extends Mesh {
 	 */
 	dispose() {
 
-		this.dispatchEvent( { type: 'dispose' } );
+		super.dispose();
 
 		if ( this.morphTexture !== null ) {
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -343,6 +343,19 @@ class RenderObject {
 
 		};
 
+		/**
+		 * An event listener which is executed when `dispose()` is called on
+		 * the 3D object of this render object.
+		 *
+		 * @method
+		 */
+		this.onObjectDispose = () => {
+
+			this.dispose();
+
+		};
+
+		this.object.addEventListener( 'dispose', this.onObjectDispose );
 		this.material.addEventListener( 'dispose', this.onMaterialDispose );
 		this.geometry.addEventListener( 'dispose', this.onGeometryDispose );
 
@@ -957,6 +970,7 @@ class RenderObject {
 	 */
 	dispose() {
 
+		this.object.removeEventListener( 'dispose', this.onObjectDispose );
 		this.material.removeEventListener( 'dispose', this.onMaterialDispose );
 		this.geometry.removeEventListener( 'dispose', this.onGeometryDispose );
 


### PR DESCRIPTION
Fixed #34139.

**Description**

In `WebGPURenderer`, we have started to maintain UBOs and bind groups per object level. It turns out there is no intuitive way to get rid of these object-level entities, see https://github.com/mrdoob/three.js/issues/34139#issuecomment-5128528716. You would have to call `object.material.dispose()` which is unexpected expecially when the material is shared with other objects.

A natural way for fixing this issue is to introduce `Object3D.dispose()`. Note that many concrete 3D object types already have `dispose()` implementations so it makes sense to define it on root level and dispatch the respective `dispose` event. The renderer can then listen to this event and properly dispose render objects.

We can't automatically dispose render objects on scene removal since objects might be added back to the scene after a a period of time. So it's best if the user explicitly states "I don't need this 3D object anymore".