### PR TITLE
WebGLBackend: Fix usage of `storeMultisampledDepthBuffer`.

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -958,8 +958,6 @@ class XRManager extends EventDispatcher {
 				storeMultisampledStencilBuffer: false
 			} );
 
-		renderTarget._autoAllocateDepthBuffer = true;
-
 		const material = new MeshBasicMaterial( { color: 0xffffff, side: FrontSide } );
 		material.map = renderTarget.texture;
 		material.map.offset.y = 1;
@@ -1050,8 +1048,6 @@ class XRManager extends EventDispatcher {
 				storeMultisampledDepthBuffer: false,
 				storeMultisampledStencilBuffer: false
 			} );
-
-		renderTarget._autoAllocateDepthBuffer = true;
 
 		const material = new MeshBasicMaterial( { color: 0xffffff, side: BackSide } );
 		material.map = renderTarget.texture;

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2886,7 +2886,7 @@ class WebGLBackend extends Backend {
 
 				}
 
-			} else if ( renderTarget.storeMultisampledDepthBuffer === false && renderTargetContextData.framebuffers ) {
+			} else if ( this._supportsInvalidateFramebuffer === true && ( renderTarget.samples > 0 && renderTarget.storeMultisampledDepthBuffer === false ) && renderTargetContextData.framebuffers ) {
 
 				const fb = renderTargetContextData.framebuffers[ renderContext.getCacheKey() ];
 				state.bindFramebuffer( gl.DRAW_FRAMEBUFFER, fb );

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2886,7 +2886,8 @@ class WebGLBackend extends Backend {
 
 				}
 
-			} else if ( this._supportsInvalidateFramebuffer === true && ( renderTarget.samples > 0 && renderTarget.storeMultisampledDepthBuffer === false ) && renderTargetContextData.framebuffers ) {
+			} else if ( this._supportsInvalidateFramebuffer === true && renderTargetContextData.framebuffers &&
+				( renderTarget._autoAllocateDepthBuffer === true || ( renderTarget.samples > 0 && renderTarget.storeMultisampledDepthBuffer === false ) ) ) {
 
 				const fb = renderTargetContextData.framebuffers[ renderContext.getCacheKey() ];
 				state.bindFramebuffer( gl.DRAW_FRAMEBUFFER, fb );


### PR DESCRIPTION
Related issue: #34120

**Description**

@cabanier I've started reviewing your MSAA PR today and noticed a small existing bug. We must check `_supportsInvalidateFramebuffer` before invalidating the depth in the WebGL backend and only evaluate `storeMultisampledDepthBuffer` in a multisampled context.