### PR TITLE
WebGLBackend: Support OCULUS_multiview

### DIFF
--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -40,7 +40,7 @@ class RenderTarget extends EventDispatcher {
 	 * @property {number} [samples=0] - The MSAA samples count.
 	 * @property {number} [count=1] - Defines the number of color attachments . Must be at least `1`.
 	 * @property {number} [depth=1] - The texture depth.
-	 * @property {boolean} [multiview=false] - Whether this target is used for multiview rendering (WebGL OVR_multiview2 extension).
+	 * @property {boolean} [multiview=false] - Whether this target is used for WebGL multiview rendering.
 	 * @property {boolean} [useArrayDepthTexture=false] - Whether to create the depth texture as an array texture for per-layer depth testing. This is separate from multiview so layered render targets can use array depth without the multiview extension.
 	 */
 

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -405,7 +405,7 @@ class XRManager extends EventDispatcher {
 
 		/**
 		 * Whether the usage of multiview is actually enabled. This flag only evaluates to `true`
-		 * if multiview has been requested by the application and the `OVR_multiview2` is available.
+		 * if multiview has been requested by the application and the backend supports it.
 		 *
 		 * @private
 		 * @type {boolean}
@@ -1275,10 +1275,14 @@ class XRManager extends EventDispatcher {
 					clearOnAccess: false
 				};
 
-				if ( this._useMultiviewIfPossible && renderer.hasFeature( 'OVR_multiview2' ) ) {
+				if ( this._useMultiviewIfPossible && renderer.hasFeature( 'multiview' ) ) {
 
 					projectionlayerInit.textureType = 'texture-array';
 					this._useMultiview = true;
+
+				} else if ( this._useMultiviewIfPossible ) {
+
+					warnOnce( 'XRManager: The active WebGL context does not support the requested multiview configuration. Falling back to stereo rendering.' );
 
 				}
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2151,6 +2151,15 @@ class WebGLBackend extends Backend {
 	 */
 	hasFeature( name ) {
 
+		if ( name === 'multiview' ) {
+
+			const attributes = this.gl.getContextAttributes();
+			const multisampled = attributes !== null && attributes.antialias === true;
+
+			return this.extensions.getMultiviewExtension( multisampled ) !== null;
+
+		}
+
 		const keysMatching = Object.keys( GLFeatureName ).filter( key => GLFeatureName[ key ] === name );
 
 		const extensions = this.extensions;
@@ -2162,6 +2171,41 @@ class WebGLBackend extends Backend {
 		}
 
 		return false;
+
+	}
+
+	/**
+	 * Attaches a texture array to the active framebuffer for multiview rendering.
+	 *
+	 * @private
+	 * @param {number} framebufferTarget - The framebuffer target.
+	 * @param {number} attachment - The framebuffer attachment.
+	 * @param {WebGLTexture} texture - The texture array.
+	 * @param {number} mipLevel - The mip level.
+	 * @param {number} samples - The number of MSAA samples.
+	 * @param {number} baseViewIndex - The first texture-array view.
+	 * @param {number} viewCount - The number of views.
+	 */
+	_attachMultiviewTexture( framebufferTarget, attachment, texture, mipLevel, samples, baseViewIndex, viewCount ) {
+
+		const extension = this.extensions.getMultiviewExtension( samples > 0 );
+
+		if ( extension === null ) {
+
+			error( `WebGLBackend: Multiview framebuffer attachment is not supported with ${samples} samples.` );
+			return;
+
+		}
+
+		if ( samples > 0 ) {
+
+			extension.framebufferTextureMultisampleMultiviewOVR( framebufferTarget, attachment, texture, mipLevel, samples, baseViewIndex, viewCount );
+
+		} else {
+
+			extension.framebufferTextureMultiviewOVR( framebufferTarget, attachment, texture, mipLevel, baseViewIndex, viewCount );
+
+		}
 
 	}
 
@@ -2250,7 +2294,6 @@ class WebGLBackend extends Backend {
 			let msaaFb = renderTargetContextData.msaaFrameBuffer;
 			let depthRenderbuffer = renderTargetContextData.depthRenderbuffer;
 			const multisampledRTTExt = this.extensions.get( 'WEBGL_multisampled_render_to_texture' );
-			const multiviewExt = this.extensions.get( 'OVR_multiview2' );
 			const useMultisampledRTT = this._useMultisampledExtension( renderTarget );
 
 			let samples = renderTarget.samples;
@@ -2323,7 +2366,7 @@ class WebGLBackend extends Backend {
 
 						if ( renderTarget.multiview ) {
 
-							multiviewExt.framebufferTextureMultisampleMultiviewOVR( gl.FRAMEBUFFER, attachment, textureData.textureGPU, 0, samples, 0, 2 );
+							this._attachMultiviewTexture( gl.FRAMEBUFFER, attachment, textureData.textureGPU, 0, samples, 0, 2 );
 
 						} else if ( isRenderTarget3D || isRenderTargetArray ) {
 
@@ -2377,7 +2420,7 @@ class WebGLBackend extends Backend {
 
 						if ( renderTarget.multiview ) {
 
-							multiviewExt.framebufferTextureMultisampleMultiviewOVR( gl.FRAMEBUFFER, depthStyle, textureData.textureGPU, 0, samples, 0, 2 );
+							this._attachMultiviewTexture( gl.FRAMEBUFFER, depthStyle, textureData.textureGPU, 0, samples, 0, 2 );
 
 						} else if ( _hasExternalTextures && useMultisampledRTT ) {
 
@@ -2446,7 +2489,7 @@ class WebGLBackend extends Backend {
 
 					if ( renderTarget.multiview ) {
 
-						multiviewExt.framebufferTextureMultisampleMultiviewOVR( gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, textureData.textureGPU, 0, samples, 0, 2 );
+						this._attachMultiviewTexture( gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, textureData.textureGPU, 0, samples, 0, 2 );
 
 					} else if ( useMultisampledRTT ) {
 
@@ -2474,7 +2517,7 @@ class WebGLBackend extends Backend {
 
 						if ( renderTarget.multiview ) {
 
-							multiviewExt.framebufferTextureMultisampleMultiviewOVR( gl.FRAMEBUFFER, depthStyle, textureData.textureGPU, 0, samples, 0, 2 );
+							this._attachMultiviewTexture( gl.FRAMEBUFFER, depthStyle, textureData.textureGPU, 0, samples, 0, 2 );
 
 						} else if ( useMultisampledRTT ) {
 

--- a/src/renderers/webgl-fallback/utils/WebGLConstants.js
+++ b/src/renderers/webgl-fallback/utils/WebGLConstants.js
@@ -8,6 +8,7 @@ export const GLFeatureName = {
 	'WEBGL_compressed_texture_s3tc': 'texture-compression-s3tc',
 	'EXT_texture_compression_bptc': 'texture-compression-bc',
 	'EXT_disjoint_timer_query_webgl2': 'timestamp-query',
+	'OCULUS_multiview': 'OCULUS_multiview',
 	'OVR_multiview2': 'OVR_multiview2'
 
 };

--- a/src/renderers/webgl-fallback/utils/WebGLExtensions.js
+++ b/src/renderers/webgl-fallback/utils/WebGLExtensions.js
@@ -78,6 +78,42 @@ class WebGLExtensions {
 
 	}
 
+	/**
+	 * Returns a multiview extension that supports the requested sample mode.
+	 *
+	 * `OCULUS_multiview` is checked first since it provides the multisampled
+	 * attachment path used by Meta Quest Browser. `OVR_multiview2` is used as a
+	 * fallback when it exposes the required attachment method.
+	 *
+	 * @param {boolean} [multisampled=false] - Whether multisampled attachment support is required.
+	 * @return {?Object} The multiview extension object.
+	 */
+	getMultiviewExtension( multisampled = false ) {
+
+		const method = multisampled
+			? 'framebufferTextureMultisampleMultiviewOVR'
+			: 'framebufferTextureMultiviewOVR';
+
+		const oculusExtension = this.get( 'OCULUS_multiview' );
+
+		if ( oculusExtension !== null && typeof oculusExtension[ method ] === 'function' ) {
+
+			return oculusExtension;
+
+		}
+
+		const ovrExtension = this.get( 'OVR_multiview2' );
+
+		if ( ovrExtension !== null && typeof ovrExtension[ method ] === 'function' ) {
+
+			return ovrExtension;
+
+		}
+
+		return null;
+
+	}
+
 }
 
 export default WebGLExtensions;

--- a/test/unit/src/renderers/webgl-fallback/WebGLMultiview.tests.js
+++ b/test/unit/src/renderers/webgl-fallback/WebGLMultiview.tests.js
@@ -1,0 +1,201 @@
+import WebGLBackend from '../../../../../src/renderers/webgl-fallback/WebGLBackend.js';
+import WebGLExtensions from '../../../../../src/renderers/webgl-fallback/utils/WebGLExtensions.js';
+
+import { CONSOLE_LEVEL } from '../../../utils/console-wrapper.js';
+
+function createProvider( name, singleSample = true, multisample = false ) {
+
+	const provider = {
+		name,
+		calls: []
+	};
+
+	if ( singleSample ) {
+
+		provider.framebufferTextureMultiviewOVR = function ( ...args ) {
+
+			this.calls.push( { method: 'singleSample', args } );
+
+		};
+
+	}
+
+	if ( multisample ) {
+
+		provider.framebufferTextureMultisampleMultiviewOVR = function ( ...args ) {
+
+			this.calls.push( { method: 'multisample', args } );
+
+		};
+
+	}
+
+	return provider;
+
+}
+
+function createBackend( providers = {}, antialias = false, supportedExtensions = Object.keys( providers ) ) {
+
+	const gl = {
+		getContextAttributes() {
+
+			return { antialias };
+
+		},
+		getExtension( name ) {
+
+			return providers[ name ] || null;
+
+		},
+		getSupportedExtensions() {
+
+			return supportedExtensions;
+
+		}
+	};
+
+	const backend = new WebGLBackend();
+	backend.gl = gl;
+	backend.extensions = new WebGLExtensions( { gl } );
+
+	return backend;
+
+}
+
+export default QUnit.module( 'Renderers', () => {
+
+	QUnit.module( 'WebGLFallback', () => {
+
+		QUnit.module( 'Multiview', () => {
+
+			QUnit.test( 'OCULUS_multiview only', ( assert ) => {
+
+				const oculus = createProvider( 'OCULUS_multiview', true, true );
+				const backend = createBackend( { OCULUS_multiview: oculus } );
+
+				assert.strictEqual( backend.extensions.getMultiviewExtension( false ), oculus, 'uses the Oculus provider for a non-multisampled target' );
+				assert.true( backend.hasFeature( 'multiview' ), 'exposes the backend-neutral multiview feature' );
+				assert.true( backend.hasFeature( 'OCULUS_multiview' ), 'preserves extension-name feature lookup' );
+				assert.false( backend.hasFeature( 'OVR_multiview2' ), 'does not report an unavailable OVR provider' );
+
+			} );
+
+			QUnit.test( 'OVR_multiview2 only', ( assert ) => {
+
+				const ovr = createProvider( 'OVR_multiview2' );
+				const backend = createBackend( { OVR_multiview2: ovr } );
+
+				assert.strictEqual( backend.extensions.getMultiviewExtension( false ), ovr, 'uses the OVR provider for a non-multisampled target' );
+				assert.true( backend.hasFeature( 'multiview' ), 'supports single-sample multiview through OVR' );
+				assert.true( backend.hasFeature( 'OVR_multiview2' ), 'preserves the OVR extension-name feature lookup' );
+				assert.false( backend.hasFeature( 'OCULUS_multiview' ), 'does not report an unavailable Oculus provider' );
+
+			} );
+
+			QUnit.test( 'both providers prefer Oculus', ( assert ) => {
+
+				const oculus = createProvider( 'OCULUS_multiview', true, true );
+				const ovr = createProvider( 'OVR_multiview2' );
+				const backend = createBackend( { OCULUS_multiview: oculus, OVR_multiview2: ovr }, true );
+
+				assert.strictEqual( backend.extensions.getMultiviewExtension( false ), oculus, 'prefers Oculus for single-sample multiview' );
+				assert.strictEqual( backend.extensions.getMultiviewExtension( true ), oculus, 'prefers Oculus for multisampled multiview' );
+				assert.true( backend.hasFeature( 'multiview' ), 'supports multiview for an antialiased context' );
+				assert.true( backend.hasFeature( 'OCULUS_multiview' ), 'preserves the Oculus extension-name feature lookup' );
+				assert.true( backend.hasFeature( 'OVR_multiview2' ), 'preserves the OVR extension-name feature lookup' );
+
+			} );
+
+			QUnit.test( 'provider method fallback', ( assert ) => {
+
+				const oculus = createProvider( 'OCULUS_multiview', false, true );
+				const ovr = createProvider( 'OVR_multiview2' );
+				const backend = createBackend( { OCULUS_multiview: oculus, OVR_multiview2: ovr } );
+
+				assert.strictEqual( backend.extensions.getMultiviewExtension( false ), ovr, 'uses OVR when Oculus lacks the single-sample method' );
+				assert.strictEqual( backend.extensions.getMultiviewExtension( true ), oculus, 'uses Oculus for the available multisampled method' );
+
+			} );
+
+			QUnit.test( 'neither provider', ( assert ) => {
+
+				const backend = createBackend();
+
+				assert.strictEqual( backend.extensions.getMultiviewExtension( false ), null, 'has no single-sample provider' );
+				assert.strictEqual( backend.extensions.getMultiviewExtension( true ), null, 'has no multisampled provider' );
+				assert.false( backend.hasFeature( 'multiview' ), 'does not expose the multiview feature' );
+
+			} );
+
+			QUnit.test( 'missing multisampled method fails safely', ( assert ) => {
+
+				const ovr = createProvider( 'OVR_multiview2' );
+				const backend = createBackend( { OVR_multiview2: ovr }, true );
+
+				assert.strictEqual( backend.extensions.getMultiviewExtension( true ), null, 'rejects a provider without the required method' );
+				assert.false( backend.hasFeature( 'multiview' ), 'disables multiview for the unsupported sample configuration' );
+
+				let exception = null;
+
+				try {
+
+					console.level = CONSOLE_LEVEL.OFF;
+					backend._attachMultiviewTexture( 1, 2, {}, 0, 4, 0, 2 );
+
+				} catch ( error ) {
+
+					exception = error;
+
+				} finally {
+
+					console.level = CONSOLE_LEVEL.DEFAULT;
+
+				}
+
+				assert.strictEqual( exception, null, 'does not attempt an undefined function call' );
+				assert.strictEqual( ovr.calls.length, 0, 'does not call the single-sample method for a multisampled target' );
+
+			} );
+
+			QUnit.test( 'OVR non-multisampled attachment', ( assert ) => {
+
+				const ovr = createProvider( 'OVR_multiview2' );
+				const backend = createBackend( { OVR_multiview2: ovr } );
+				const texture = {};
+
+				backend._attachMultiviewTexture( 1, 2, texture, 3, 0, 4, 2 );
+
+				assert.strictEqual( ovr.calls.length, 1, 'performs one attachment' );
+				assert.strictEqual( ovr.calls[ 0 ].method, 'singleSample', 'uses the non-multisampled entry point' );
+				assert.deepEqual( ovr.calls[ 0 ].args, [ 1, 2, texture, 3, 4, 2 ], 'passes the OVR argument shape' );
+
+			} );
+
+			QUnit.test( 'Oculus multisampled attachment', ( assert ) => {
+
+				const oculus = createProvider( 'OCULUS_multiview', true, true );
+				const backend = createBackend( { OCULUS_multiview: oculus }, true );
+				const texture = {};
+
+				backend._attachMultiviewTexture( 1, 2, texture, 3, 4, 5, 2 );
+
+				assert.strictEqual( oculus.calls.length, 1, 'performs one attachment' );
+				assert.strictEqual( oculus.calls[ 0 ].method, 'multisample', 'uses the multisampled entry point' );
+				assert.deepEqual( oculus.calls[ 0 ].args, [ 1, 2, texture, 3, 4, 5, 2 ], 'passes the Oculus argument shape' );
+
+			} );
+
+			QUnit.test( 'unrelated extension behavior', ( assert ) => {
+
+				const backend = createBackend( {}, false, [ 'WEBGL_multi_draw' ] );
+
+				assert.true( backend.hasFeature( 'WEBGL_multi_draw' ), 'keeps existing feature lookup behavior' );
+				assert.false( backend.hasFeature( 'texture-compression-astc' ), 'keeps unavailable feature behavior' );
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -266,6 +266,9 @@ import './src/renderers/webgl/WebGLTextures.tests.js';
 import './src/renderers/webgl/WebGLUniforms.tests.js';
 import './src/renderers/webgl/WebGLUtils.tests.js';
 
+//src/renderers/webgl-fallback
+import './src/renderers/webgl-fallback/WebGLMultiview.tests.js';
+
 
 //src/scenes
 import './src/scenes/Fog.tests.js';


### PR DESCRIPTION
Closes #20368

**Description**

The common WebGL backend already supports opt-in WebXR multiview through `WebGPURenderer( { forceWebGL: true, multiview: true } )`.

On Meta Quest, the framebuffer provider is exposed as `OCULUS_multiview`, while the shader path continues to use `GL_OVR_multiview2`. The existing feature check only recognized `OVR_multiview2`, so the available Quest provider was not selected.

This change adds provider-aware multiview support to the common WebGL backend.

## Changes

- Recognize `OCULUS_multiview` as a usable multiview provider.
- Preserve support for `OVR_multiview2` and exact provider feature queries.
- Keep multiview opt-in.
- Validate the required attachment method for the active WebGL sample configuration before creating a texture-array XR projection layer.
- Prefer the Oculus provider and fall back to OVR when it exposes the required method.
- Use `framebufferTextureMultiviewOVR()` for single-sample multiview.
- Use `framebufferTextureMultisampleMultiviewOVR()` for multisampled multiview.
- Centralize color/depth attachment and external-texture reattachment.
- Fall back to ordinary stereo when the requested sample configuration is unsupported.
- Keep the existing `GL_OVR_multiview2` shader path unchanged.

The classic `WebGLRenderer` and native WebGPU backend are not changed.

## Quest testing

Tested on:

- Device: Meta Quest 3
- Horizon OS: version 2.6 (build number ending in `.520`)
- Quest Browser: `149.1.0.10.52` (Chromium)

The final branch was retested at feature commit `a19a6eb724bc172b2faad961c89c84669bd98532`, based on Three.js `6dc4966d7f4714bab429671ac12071b74c81775b`.

The controlled test verified:

- multiview off, AA off
- multiview on, AA off
- multiview off, AA on
- multiview on, AA on

Both multiview configurations rendered correctly in both eyes, including multisampled multiview.

A synthetic draw-call-bound scene with 600 separate meshes produced:

| AA | Mode | FPS | Average frame | p95 frame | JS + submission | Draw calls |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| Off | Stereo | 48.0 | 20.81 ms | 23.44 ms | 17.84 ms | 1,273 |
| Off | Multiview | 49.5 | 20.20 ms | 24.24 ms | 17.82 ms | 636 |
| On | Stereo | 43.5 | 22.96 ms | 26.10 ms | 18.79 ms | 1,273 |
| On | Multiview | 48.3 | 20.71 ms | 24.67 ms | 18.31 ms | 636 |

Multiview reduced draw submissions by approximately 50% in both AA modes. With AA disabled, average frame interval improved by approximately 3% and FPS increased by approximately 3%; JavaScript plus submission time was effectively unchanged, while p95 frame interval was approximately 3% higher. With AA enabled, average frame interval improved by approximately 10%, FPS increased by approximately 11%, p95 frame interval improved by approximately 5%, and JavaScript plus submission time improved by approximately 3%.

These measurements are from one deliberately submission-bound test scene; `JS + submission` is a CPU-side measurement, not a GPU timer, and the results are not intended as a general performance guarantee.

## Compatibility testing

Official webgpu_xr_native_layers example running on Meta Quest 3 with PR #34147 (a19a6eb724), using the common WebGL backend with multiview and MSAA enabled.
<img width="2048" height="1152" alt="image" src="https://github.com/user-attachments/assets/5a7a1c6e-f3ef-41a8-ae3f-7958cd225126" />



## Tests

- Added focused WebGL multiview provider and attachment tests.
- `npm test`
- `npm run lint-test`
- `npm run build`
- `git diff --check`

All completed successfully.

## Notes

Multiview remains disabled unless explicitly requested with `multiview: true`.

The implementation does not add multiview support to classic `WebGLRenderer`, and it does not change the existing two-view shader architecture.


## Screenshot from Quest testing
<img width="638" height="341" alt="image" src="https://github.com/user-attachments/assets/2579a25e-6219-4d6a-aa99-62dace63a681" />

