### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_postprocessing_ao.html
+++ b/examples/webgpu_postprocessing_ao.html
@@ -59,7 +59,7 @@
 			const params = {
 				aoType: 'GTAO',
 				samples: 16,
-				radius: 0.5,
+				radius: 0.4,
 				resolutionScale: 0.5,
 				scale: 0.8, // GTAO
 				thickness: 1, // GTAO


### PR DESCRIPTION
Related issue: -

**Description**

Slightly decreases the radius of the AO in `webgpu_postprocessing_ao`. A wider radius decreases performance (fewer taps are cache hits which can be very noticeable performance wise depending on the GPU) and the AO ends up to dominant. The effect should always be subtle.
