### PR TITLE
ImageBitmapLoader: Fix regression in `load()`.

### DIFF
--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -186,6 +186,8 @@ class ImageBitmapLoader extends Loader {
 
 			scope.manager.itemEnd( url );
 
+			return imageBitmap;
+
 		} ).catch( function ( e ) {
 
 			if ( onError ) onError( e );

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -186,7 +186,7 @@ class ImageBitmapLoader extends Loader {
 
 			scope.manager.itemEnd( url );
 
-			return imageBitmap;
+			return imageBitmap; // see #34150
 
 		} ).catch( function ( e ) {
 

--- a/test/unit/src/loaders/ImageBitmapLoader.tests.js
+++ b/test/unit/src/loaders/ImageBitmapLoader.tests.js
@@ -1,5 +1,6 @@
 import { ImageBitmapLoader } from '../../../../src/loaders/ImageBitmapLoader.js';
 
+import { Cache } from '../../../../src/loaders/Cache.js';
 import { Loader } from '../../../../src/loaders/Loader.js';
 import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
 
@@ -67,6 +68,45 @@ export default QUnit.module( 'Loaders', () => {
 				object.isImageBitmapLoader,
 				'ImageBitmapLoader.isImageBitmapLoader should be true'
 			);
+
+		} );
+
+		QUnit.test( 'load', async ( assert ) => {
+
+			const canvas = document.createElement( 'canvas' );
+			canvas.width = 8;
+			canvas.height = 8;
+
+			const url = canvas.toDataURL( 'image/png' );
+
+			const enabled = Cache.enabled;
+			Cache.enabled = true;
+
+			try {
+
+				// concurrent requests for the same URL share the cached promise
+
+				const [ first, second ] = await Promise.all( [
+					new ImageBitmapLoader().loadAsync( url ),
+					new ImageBitmapLoader().loadAsync( url )
+				] );
+
+				assert.ok(
+					first instanceof ImageBitmap,
+					'The first request resolves with an image bitmap.'
+				);
+
+				assert.ok(
+					second instanceof ImageBitmap,
+					'The second request resolves with an image bitmap.'
+				);
+
+			} finally {
+
+				Cache.remove( `image-bitmap:${url}` );
+				Cache.enabled = enabled;
+
+			}
 
 		} );
 


### PR DESCRIPTION
Fixed #34150.

**Description**

Makes sure the loaded `imageBitmap` is returned inside the promise so duplicate requests resolve to the correct image.
