### PR TITLE
WebXR: Restore camera properties at session end.

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -239,8 +239,7 @@ class XRManager extends EventDispatcher {
 		this._currentSize = new Vector2();
 
 		/**
-		 * The `fov` and `zoom` of the user camera before the XR session
-		 * has been started. Used to restore the camera when the session ends.
+		 * Holds a reference to the user camera and its current settings.
 		 *
 		 * @private
 		 * @type {?Object}

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -239,6 +239,16 @@ class XRManager extends EventDispatcher {
 		this._currentSize = new Vector2();
 
 		/**
+		 * The `fov` and `zoom` of the user camera before the XR session
+		 * has been started. Used to restore the camera when the session ends.
+		 *
+		 * @private
+		 * @type {?Object}
+		 * @default null
+		 */
+		this._currentCameraSettings = null;
+
+		/**
 		 * The default event listener for handling events inside a XR session.
 		 *
 		 * @private
@@ -1428,6 +1438,12 @@ class XRManager extends EventDispatcher {
 
 		// update user camera and its children
 
+		if ( this._currentCameraSettings === null && camera.isPerspectiveCamera ) {
+
+			this._currentCameraSettings = { camera: camera, fov: camera.fov, zoom: camera.zoom };
+
+		}
+
 		updateUserCamera( camera, cameraXR, parent );
 
 
@@ -1712,6 +1728,18 @@ function onSessionEnd() {
 
 	renderer.setPixelRatio( this._currentPixelRatio );
 	renderer.setSize( this._currentSize.width, this._currentSize.height, false );
+
+	if ( this._currentCameraSettings !== null ) {
+
+		const camera = this._currentCameraSettings.camera;
+
+		camera.fov = this._currentCameraSettings.fov;
+		camera.zoom = this._currentCameraSettings.zoom;
+		camera.updateProjectionMatrix();
+
+		this._currentCameraSettings = null;
+
+	}
 
 	this.dispatchEvent( { type: 'sessionend' } );
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -67,6 +67,7 @@ class WebXRManager extends EventDispatcher {
 
 		const currentSize = new Vector2();
 		let currentPixelRatio = null;
+		let currentCameraSettings = null;
 
 		//
 
@@ -261,6 +262,18 @@ class WebXRManager extends EventDispatcher {
 
 			renderer.setPixelRatio( currentPixelRatio );
 			renderer.setSize( currentSize.width, currentSize.height, false );
+
+			if ( currentCameraSettings !== null ) {
+
+				const camera = currentCameraSettings.camera;
+
+				camera.fov = currentCameraSettings.fov;
+				camera.zoom = currentCameraSettings.zoom;
+				camera.updateProjectionMatrix();
+
+				currentCameraSettings = null;
+
+			}
 
 			scope.dispatchEvent( { type: 'sessionend' } );
 
@@ -782,6 +795,12 @@ class WebXRManager extends EventDispatcher {
 			}
 
 			// update user camera and its children
+
+			if ( currentCameraSettings === null && camera.isPerspectiveCamera ) {
+
+				currentCameraSettings = { camera: camera, fov: camera.fov, zoom: camera.zoom };
+
+			}
 
 			updateUserCamera( camera, cameraXR, parent );
 


### PR DESCRIPTION
Closes #30374.

**Description**

The XR managers keep the user camera in sync with the main camera. Not just on matrix level but also `fov` and `zoom` properties are synced. The PR makes sure at session end, the original `fov` and `zoom` values are restored and the projection matrices are immediately recomputed.

/ping @cabanier 