### PR TITLE
WebGPURenderer: Enable single-pass rendering in WebXR

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -49,6 +49,32 @@ const _vector4 = /*@__PURE__*/ new Vector4();
 
 const _shadowSide = { [ FrontSide ]: BackSide, [ BackSide ]: FrontSide, [ DoubleSide ]: DoubleSide };
 
+function needsLinearFrameBuffer( object, camera, overrideMaterial = null ) {
+
+	if ( object.visible === false ) return false;
+
+	if ( object.layers.test( camera.layers ) && object.material !== undefined ) {
+
+		const materials = overrideMaterial !== null ? [ overrideMaterial ] : ( Array.isArray( object.material ) ? object.material : [ object.material ] );
+
+		for ( const material of materials ) {
+
+			if ( material.visible === true && ( material.transmission > 0 || material.transmissionNode?.isNode === true || material.backdropNode?.isNode === true ) ) return true;
+
+		}
+
+	}
+
+	for ( const child of object.children ) {
+
+		if ( needsLinearFrameBuffer( child, camera, overrideMaterial ) ) return true;
+
+	}
+
+	return false;
+
+}
+
 /**
  * Base class for renderers.
  */
@@ -1493,7 +1519,40 @@ class Renderer {
 
 		}
 
-		this._renderScene( scene, camera );
+		const inlineOutputContextNode = this.contextNode;
+		const outputRenderTarget = this._outputRenderTarget;
+
+		// Framebuffer-dependent materials must sample the linear scene before the output transform.
+		const useLinearFrameBuffer = outputRenderTarget !== null && this.xr.isPresenting === true && this.isOutputTarget === true &&
+			inlineOutputContextNode.value.outputColorTransform === false && inlineOutputContextNode.node !== null &&
+			needsLinearFrameBuffer( scene, camera, scene.isScene === true ? scene.overrideMaterial : null );
+
+		if ( useLinearFrameBuffer === false ) {
+
+			this._renderScene( scene, camera );
+			return;
+
+		}
+
+		const samples = outputRenderTarget.samples;
+		const depthBuffer = outputRenderTarget.depthBuffer;
+
+		this.contextNode = inlineOutputContextNode.node;
+		outputRenderTarget.samples = 0;
+		outputRenderTarget.depthBuffer = false;
+
+		try {
+
+			this._renderScene( scene, camera );
+
+		} finally {
+
+			if ( this.contextNode === inlineOutputContextNode.node ) this.contextNode = inlineOutputContextNode;
+
+			outputRenderTarget.samples = samples;
+			outputRenderTarget.depthBuffer = depthBuffer;
+
+		}
 
 	}
 
@@ -1552,12 +1611,7 @@ class Renderer {
 	 */
 	_getFrameBufferTarget() {
 
-		const { currentToneMapping, currentColorSpace } = this;
-
-		const useToneMapping = currentToneMapping !== NoToneMapping;
-		const useColorSpace = currentColorSpace !== ColorManagement.workingColorSpace;
-
-		if ( useToneMapping === false && useColorSpace === false ) return null;
+		if ( this.needsFrameBufferTarget === false ) return null;
 
 		const { width, height } = this.getDrawingBufferSize( _drawingBufferSize );
 		const { depth, stencil } = this;
@@ -2603,6 +2657,9 @@ class Renderer {
 	 *
 	 */
 	get needsFrameBufferTarget() {
+
+		// The active material context can apply the output transform inline.
+		if ( this.contextNode.value.outputColorTransform === false ) return false;
 
 		const useToneMapping = this.currentToneMapping !== NoToneMapping;
 		const useColorSpace = this.currentColorSpace !== ColorManagement.workingColorSpace;

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -23,6 +23,40 @@ const _cameraRPos = /*@__PURE__*/ new Vector3();
 
 const _contextNodeLib = /*@__PURE__*/ new WeakMap();
 
+function getInlineOutputContextNode( contextNode ) {
+
+	let outputContextNode = _contextNodeLib.get( contextNode );
+
+	if ( outputContextNode === undefined ) {
+
+		outputContextNode = contextNode.context( {
+			outputColorTransform: false,
+
+			getOutput: ( outputNode, builder ) => {
+
+				const renderer = builder.renderer;
+				const renderTarget = renderer.getRenderTarget();
+
+				if ( renderer.isOutputTarget === true || renderTarget?._hasExternalTextures === true ) {
+
+					return renderOutput( outputNode, renderer.toneMapping, renderer.outputColorSpace );
+
+				}
+
+				return outputNode;
+
+			}
+
+		} );
+
+		_contextNodeLib.set( contextNode, outputContextNode );
+
+	}
+
+	return outputContextNode;
+
+}
+
 /**
  * The XR manager is built on top of the WebXR Device API to
  * manage XR sessions with renderer backends.
@@ -1110,25 +1144,7 @@ class XRManager extends EventDispatcher {
 
 				renderer._setXRLayerSize( layer.renderTarget.width, layer.renderTarget.height );
 
-				contextNode = _contextNodeLib.get( currentContextNode );
-
-				if ( contextNode === undefined ) {
-
-					// Apply ToneMapping and OutputColorSpace directly in the material shader
-
-					contextNode = currentContextNode.context( {
-
-						getOutput: ( outputNode ) => {
-
-							return renderOutput( outputNode, renderer.toneMapping, renderer.outputColorSpace );
-
-						}
-
-					} );
-
-					_contextNodeLib.set( currentContextNode, contextNode );
-
-				}
+				contextNode = getInlineOutputContextNode( currentContextNode );
 
 			} else {
 
@@ -1829,6 +1845,8 @@ function onAnimationFrame( time, frame ) {
 	const backend = renderer.backend;
 
 	const glBaseLayer = this._glBaseLayer;
+	let currentContextNode = null;
+	let inlineOutputContextNode = null;
 
 	const referenceSpace = this.getReferenceSpace();
 	const pose = frame.getViewerPose( referenceSpace );
@@ -1936,6 +1954,16 @@ function onAnimationFrame( time, frame ) {
 
 		renderer.setOutputRenderTarget( this._xrRenderTarget );
 
+		if ( webgpuViewData !== null ) {
+
+			// Inline the output transform so MSAA can resolve directly into the XR texture.
+			currentContextNode = renderer.contextNode;
+			inlineOutputContextNode = getInlineOutputContextNode( currentContextNode );
+
+			renderer.contextNode = inlineOutputContextNode;
+
+		}
+
 		const frameBufferTarget = renderer._getFrameBufferTarget();
 
 		if ( webgpuViewData !== null ) {
@@ -1964,7 +1992,19 @@ function onAnimationFrame( time, frame ) {
 
 	}
 
-	if ( this._currentAnimationLoop ) this._currentAnimationLoop( time, frame );
+	try {
+
+		if ( this._currentAnimationLoop ) this._currentAnimationLoop( time, frame );
+
+	} finally {
+
+		if ( inlineOutputContextNode !== null ) {
+
+			if ( renderer.contextNode === inlineOutputContextNode ) renderer.contextNode = currentContextNode;
+
+		}
+
+	}
 
 	if ( frame.detectedPlanes ) {
 


### PR DESCRIPTION
Apply tone mapping and output color-space conversion inline when rendering native WebGPU XR scenes. This allows multisampled color to resolve directly into XR projection textures without a separate output pass.

Use the linear framebuffer and output path for transmission and backdrop materials, which must sample scene color before output conversion.

*This contribution is funded by [Meta](https://meta.com)*
