### PR TITLE
Docs: Fix typos and a wrong parameter name in JSDoc comments

### DIFF
--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -2563,7 +2563,7 @@ class ArcballControls extends Controls {
 	 * Rotates camera around its direction axis passing by a given point by a given angle.
 	 *
 	 * @private
-	 * @param {Vector3} point - The point where the rotation axis is passing trough.
+	 * @param {Vector3} point - The point where the rotation axis is passing through.
 	 * @param {number} angle - Angle in radians.
 	 * @returns {Object} The computed transformation matrix.
 	 */

--- a/src/math/FrustumArray.js
+++ b/src/math/FrustumArray.js
@@ -188,7 +188,7 @@ class FrustumArray {
 	/**
 	 * Copies the values of the given frustum array to this instance.
 	 *
-	 * @param {FrustumArray} frustumArray - The frustum array to copy.
+	 * @param {FrustumArray} source - The frustum array to copy.
 	 * @return {FrustumArray} A reference to this frustum array.
 	 */
 	copy( source ) {

--- a/src/nodes/functions/PhongLightingModel.js
+++ b/src/nodes/functions/PhongLightingModel.js
@@ -59,7 +59,7 @@ class PhongLightingModel extends BasicLightingModel {
 	}
 
 	/**
-	 * Implements the direct lighting. The specular portion is optional an can be controlled
+	 * Implements the direct lighting. The specular portion is optional and can be controlled
 	 * with the {@link PhongLightingModel#specular} flag.
 	 *
 	 * @param {Object} lightData - The light data.

--- a/src/renderers/webgl-fallback/utils/WebGLState.js
+++ b/src/renderers/webgl-fallback/utils/WebGLState.js
@@ -1341,7 +1341,7 @@ class WebGLState {
 	/**
 	 * Returns the value for the given parameter.
 	 *
-	 * @param {number} name - The paramter to get the value for.
+	 * @param {number} name - The parameter to get the value for.
 	 * @return {any} The value for the given parameter.
 	 */
 	getParameter( name ) {


### PR DESCRIPTION
Small documentation-only fixes found while reading through the JSDoc comments. No functional changes — all four edits are inside comments.

- `WebGLState.getParameter()`: "paramter" → "parameter".
- `ArcballControls.zRotate()`: "trough" → "through".
- `PhongLightingModel.direct()`: "is optional an can be controlled" → "and".
- `FrustumArray.copy()`: the `@param` was named `frustumArray`, but the actual signature is `copy( source )`, so the generated docs documented a parameter that does not exist. Renamed the tag to match the code. (`Frustum.copy()` is already consistent in this regard.)