### PR TITLE
docs: fix broken TSL anchor links for roughnessNode and metalnessNode

### DIFF
--- a/docs/TSL.md
+++ b/docs/TSL.md
@@ -168,7 +168,7 @@ TSL is a Node-based shader abstraction, written in JavaScript. TSL's functions a
   - Build materials by connecting nodes through: [positionWorld](#position), [normalWorld](#normal), [screenUV](#screen), [attribute()](#attributes), etc. 
 More declarative("what") vs. imperative("how").
 - Composition & High-Level Concepts
-  - Work with high-level concepts for Node Material like [colorNode](#basic), [roughnessNode](#standard), [metalnessNode](#standard), [positionNode](#basic), etc. This preserves the integrity of the lighting model while allowing customizations, helping to avoid mistakes from incorrect setups.
+  - Work with high-level concepts for Node Material like [colorNode](#basic), [roughnessNode](#meshstandardnodematerial), [metalnessNode](#meshstandardnodematerial), [positionNode](#basic), etc. This preserves the integrity of the lighting model while allowing customizations, helping to avoid mistakes from incorrect setups.
 - Keeping an eye on software exchange
   - Modern 3D authoring software uses Shader-Graph based material composition to exchange between other software. TSL already has its own MaterialX integration.
 - Easier Migration


### PR DESCRIPTION
In `docs/TSL.md`, `roughnessNode` and `metalnessNode` link to `#standard`, but no heading in the file produces that anchor. Both are documented in the table under `## MeshStandardNodeMaterial` (anchor `#meshstandardnodematerial`).

The neighbouring `[colorNode](#basic)` and `[positionNode](#basic)` links already resolve correctly to the `#### Basic` table, so this points the two broken links to the table that documents them.
