### PR TITLE
TrackballControls: Avoid updating `_movePrev` too often.

### DIFF
--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -839,7 +839,6 @@ function onMouseMove( event ) {
 
 	if ( state === _STATE.ROTATE && ! this.noRotate ) {
 
-		this._movePrev.copy( this._moveCurr );
 		this._moveCurr.copy( this._getMouseOnCircle( event.pageX, event.pageY ) );
 
 	} else if ( state === _STATE.ZOOM && ! this.noZoom ) {
@@ -939,7 +938,6 @@ function onTouchMove( event ) {
 	switch ( this._pointers.length ) {
 
 		case 1:
-			this._movePrev.copy( this._moveCurr );
 			this._moveCurr.copy( this._getMouseOnCircle( event.pageX, event.pageY ) );
 			break;
 


### PR DESCRIPTION
Fixed #19101.

**Description**

The PR makes sure `TrackballControls` does not write `_movePrev` per event but per update step. 

Since `_rotateCamera()` already writes `_movePrev` at the correct point in time, we just have to remove the `_movePrev` writes in the event handlers. With this fix, rotation behaves like pan and zoom.
