### PR TITLE
Materials: Fix serialization of overwritten default values.

### DIFF
--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -389,6 +389,11 @@ class ShaderMaterial extends Material {
 		data.lights = this.lights;
 		data.clipping = this.clipping;
 
+		// these defaults differ from Material so its toJSON() would omit the opposite value
+
+		data.fog = this.fog;
+		data.forceSinglePass = this.forceSinglePass;
+
 		const extensions = {};
 
 		for ( const key in this.extensions ) {

--- a/src/materials/ShadowMaterial.js
+++ b/src/materials/ShadowMaterial.js
@@ -86,6 +86,18 @@ class ShadowMaterial extends Material {
 
 	}
 
+	toJSON( meta ) {
+
+		const data = super.toJSON( meta );
+
+		// transparent defaults to true here so Material.toJSON() would omit a false value
+
+		data.transparent = this.transparent;
+
+		return data;
+
+	}
+
 }
 
 export { ShadowMaterial };

--- a/src/materials/SpriteMaterial.js
+++ b/src/materials/SpriteMaterial.js
@@ -138,6 +138,18 @@ class SpriteMaterial extends Material {
 
 	}
 
+	toJSON( meta ) {
+
+		const data = super.toJSON( meta );
+
+		// transparent defaults to true here so Material.toJSON() would omit a false value
+
+		data.transparent = this.transparent;
+
+		return data;
+
+	}
+
 }
 
 export { SpriteMaterial };

--- a/test/unit/src/loaders/MaterialLoader.tests.js
+++ b/test/unit/src/loaders/MaterialLoader.tests.js
@@ -1,6 +1,9 @@
 import { MaterialLoader } from '../../../../src/loaders/MaterialLoader.js';
 
 import { Loader } from '../../../../src/loaders/Loader.js';
+import { ShaderMaterial } from '../../../../src/materials/ShaderMaterial.js';
+import { ShadowMaterial } from '../../../../src/materials/ShadowMaterial.js';
+import { SpriteMaterial } from '../../../../src/materials/SpriteMaterial.js';
 
 export default QUnit.module( 'Loaders', () => {
 
@@ -31,6 +34,31 @@ export default QUnit.module( 'Loaders', () => {
 
 			const object = new MaterialLoader();
 			assert.ok( object, 'Can instantiate a MaterialLoader.' );
+
+		} );
+
+		// OTHERS
+		QUnit.test( 'parse - overwritten defaults', ( assert ) => {
+
+			const loader = new MaterialLoader();
+
+			const shaderMaterial = new ShaderMaterial( { fog: true, forceSinglePass: false } );
+			const parsedShaderMaterial = loader.parse( shaderMaterial.toJSON() );
+
+			assert.strictEqual( parsedShaderMaterial.fog, true,
+				'ShaderMaterial.fog survives serialization.' );
+			assert.strictEqual( parsedShaderMaterial.forceSinglePass, false,
+				'ShaderMaterial.forceSinglePass survives serialization.' );
+
+			const shadowMaterial = new ShadowMaterial( { transparent: false } );
+
+			assert.strictEqual( loader.parse( shadowMaterial.toJSON() ).transparent, false,
+				'ShadowMaterial.transparent survives serialization.' );
+
+			const spriteMaterial = new SpriteMaterial( { transparent: false } );
+
+			assert.strictEqual( loader.parse( spriteMaterial.toJSON() ).transparent, false,
+				'SpriteMaterial.transparent survives serialization.' );
 
 		} );
 


### PR DESCRIPTION
Related issue: none

**Description**

`Material.toJSON()` omits properties whose value equals the default defined on `Material`, and `MaterialLoader` restores whatever the material type's constructor sets. That works as long as every material agrees on the default — but four built-in materials deliberately overwrite one, so the *opposite* value is the one that gets dropped:

| material | property | `Material` default | type default |
| --- | --- | --- | --- |
| `ShaderMaterial` / `RawShaderMaterial` | `fog` | `true` | `false` |
| `ShaderMaterial` / `RawShaderMaterial` | `forceSinglePass` | `false` | `true` |
| `ShadowMaterial` | `transparent` | `false` | `true` |
| `SpriteMaterial` | `transparent` | `false` | `true` |

Since e.g. `data.fog` is only written `if ( this.fog === false )`, a `ShaderMaterial` that opts *into* fog serializes nothing, and loading it back turns fog off again — which is exactly the configuration the `ShaderMaterial.fog` docs describe:

```js
const material = new THREE.ShaderMaterial( {
	uniforms: THREE.UniformsUtils.merge( [ THREE.UniformsLib[ 'fog' ], shaderUniforms ] ),
	vertexShader, fragmentShader,
	fog: true
} );
```

Round tripping a scene through `ObjectLoader` before this change:

```js
const scene = new THREE.Scene();
scene.add( new THREE.Mesh( geometry, new THREE.ShaderMaterial( { fog: true, forceSinglePass: false } ) ) );
scene.add( new THREE.Mesh( geometry, new THREE.ShadowMaterial( { transparent: false } ) ) );
scene.add( new THREE.Sprite( new THREE.SpriteMaterial( { transparent: false } ) ) );

const loaded = new THREE.ObjectLoader().parse( scene.toJSON() );
```

```
ShaderMaterial.fog              true  -> false
ShaderMaterial.forceSinglePass  false -> true
ShadowMaterial.transparent      false -> true
SpriteMaterial.transparent      false -> true
```

All four flip back after the fix. The loss is on the serializing side only — `Material.fromJSON()` already reads `fog`, `forceSinglePass` and `transparent`.

**Fix**

Each material that overwrites one of these defaults now writes the property out itself, the way `ShaderMaterial.toJSON()` already does for `lights` and `clipping`. JSON for every other material type is unchanged.

Added a round trip test to `MaterialLoader.tests.js` covering the four cases; it fails on `dev` with all four assertions and passes with the patch. `npm run lint-core` is clean.
