### PR TITLE
Fix TSL: toVar inside If() triggers false 'already in use' warning

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2280,6 +2280,10 @@ class NodeBuilder {
 		let property = this.getPropertyName( node );
 		let index = 1;
 
+		// If this exact node is already registered under its current name, skip — it's a re-registration, not a conflict.
+
+		if ( declarations[ property ] === node ) return;
+
 		// Automatically renames the property if the name is already in use or reserved.
 
 		while ( ( checkKeywords && this.isReservedKeyword( name ) ) || declarations[ property ] !== undefined ) {


### PR DESCRIPTION
Fixes #33838

When `toVar('name')` is called inside an `If()` block, the build pipeline runs multiple stages (setup → analyze → generate). On each pass, `getVarFromNode()` calls `registerDeclaration()` for the same `VarNode`.

The collision check `declarations[ property ] !== undefined` does not distinguish between a different node with the same name (true conflict) vs the same node being re-registered (false positive). This causes a spurious rename and warning even though the variable is only declared once.

Fix: added an early-exit at the top of `registerDeclaration()` in `NodeBuilder.js` — if the slot already holds the exact same node reference, bail out immediately. No rename, no warning.

- `npm run lint` ✅
- `npm run test-unit` ✅ 1315 pass, 0 fail