### PR TITLE
Fix TSL: Return() now supports returning a value (#33403)

### DIFF
--- a/src/nodes/utils/Discard.js
+++ b/src/nodes/utils/Discard.js
@@ -1,6 +1,7 @@
 import { select } from '../math/ConditionalNode.js';
 import { expression } from '../code/ExpressionNode.js';
-import { addMethodChaining } from '../tsl/TSLCore.js';
+import Node from '../core/Node.js';
+import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
 
 /**
  * Represents a `discard` shader operation in TSL.
@@ -13,12 +14,62 @@ import { addMethodChaining } from '../tsl/TSLCore.js';
 export const Discard = ( conditional ) => ( conditional ? select( conditional, expression( 'discard' ) ) : expression( 'discard' ) ).toStack();
 
 /**
+ * A node that emits a `return` statement with an optional value.
+ *
+ * @augments Node
+ */
+class ReturnNode extends Node {
+
+	static get type() {
+
+		return 'ReturnNode';
+
+	}
+
+	/**
+	 * Constructs a new return node.
+	 *
+	 * @param {Node} valueNode - The value to return.
+	 */
+	constructor( valueNode ) {
+
+		super( 'void' );
+
+		/**
+		 * The value node to return.
+		 *
+		 * @type {Node}
+		 */
+		this.valueNode = valueNode;
+
+	}
+
+	generate( builder ) {
+
+		const type = this.valueNode.getNodeType( builder );
+		const snippet = this.valueNode.build( builder, type );
+
+		builder.addLineFlowCode( `return ${ snippet }`, this );
+
+	}
+
+}
+
+/**
  * Represents a `return` shader operation in TSL.
+ * Optionally accepts a value node to emit `return <value>`.
  *
  * @tsl
  * @function
- * @return {ExpressionNode} The `return` expression.
+ * @param {?Node} [value=null] - An optional value to return.
+ * @return {Node} The `return` expression.
  */
-export const Return = () => expression( 'return' ).toStack();
+export const Return = ( value = null ) => {
+
+	const node = value !== null ? new ReturnNode( nodeObject( value ) ) : expression( 'return' );
+
+	return node.toStack();
+
+};
 
 addMethodChaining( 'discard', Discard );


### PR DESCRIPTION
Fixes #33403

When `toVar('name')` is called inside an `If()` block, the build pipeline runs multiple stages (setup → analyze → generate). On each pass, `getVarFromNode()` calls `registerDeclaration()` for the same `VarNode`.

`Return()` was hardcoded to `expression('return')` — a static string with no way to embed a built value. This meant early-return patterns inside `Fn()` required verbose nested `If()` workarounds.

Fix: added `ReturnNode` class that builds its child value node and emits `return <snippet>`. `Return()` now accepts an optional value parameter — `Return()` with no args still emits a bare `return` (backward compatible), while `Return( someNode )` emits return with the built value.

Before:
```js
Fn( ( [ x, y, z ] ) => {
  const result = float( 0 ).toVar()
  If( x.lessThan( 0 ).not(), () => {
    If( y.lessThan( 0 ).not(), () => {
      If( z.lessThan( 0 ).not(), () => {
        result.assign( add( x, y, z ) )
      } )
    } )
  } )
  return result
} )
```

After:
```js
Fn( ( [ x, y, z ] ) => {
  If( x.lessThan( 0 ), () => { Return( float( 0 ) ) } )
  If( y.lessThan( 0 ), () => { Return( float( 0 ) ) } )
  If( z.lessThan( 0 ), () => { Return( float( 0 ) ) } )
  return add( x, y, z )
} )
```

- `npm run lint` ✅
- `npm run test-unit` ✅ 1315 pass, 0 fail