### PR TITLE
TSL: Preserve array semantics for struct storage buffers

### DIFF
--- a/examples/webgpu_struct_drawindirect.html
+++ b/examples/webgpu_struct_drawindirect.html
@@ -142,21 +142,19 @@
 					offset: 'uint'
 				}, 'DrawBuffer' );
 
-				const drawStorage = storage( drawBuffer, drawBufferStruct, drawBuffer.count );
+				const drawInfo = storage( drawBuffer, drawBufferStruct, drawBuffer.count ).element( 0 );
 
 				computeDrawBuffer = Fn( () => {
 
 					const halfTime = sin( time.mul( 0.5 ) );
 
 					const instanceCount = max( ( pow( halfTime.add( 1 ), 4.0 ) ).mul( instances ), 100 ).toVar( 'instanceCount' );
-					atomicStore( drawStorage.get( 'instanceCount' ), instanceCount );
+					atomicStore( drawInfo.get( 'instanceCount' ), instanceCount );
 			
 				} )().compute( instances );
 
 				computeInitDrawBuffer = Fn( () => {
 
-					const drawInfo = drawStorage;
-			
 					drawInfo.get( 'vertexCount' ).assign( 3 );
 					atomicStore( drawInfo.get( 'instanceCount' ), uint( 0 ) );
 					drawInfo.get( 'firstVertex' ).assign( 0 );

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1177,12 +1177,6 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 			} else if ( type === 'buffer' || type === 'storageBuffer' || type === 'indirectStorageBuffer' ) {
 
-				if ( this.isCustomStruct( node ) ) {
-
-					return name;
-
-				}
-
 				return name + '.value';
 
 			} else {
@@ -2095,21 +2089,6 @@ ${ flowData.code }
 
 	}
 
-	isCustomStruct( nodeUniform ) {
-
-		const attribute = nodeUniform.value;
-		const bufferNode = nodeUniform.node;
-
-		const isAttributeStructType = ( attribute.isBufferAttribute || attribute.isInstancedBufferAttribute ) && bufferNode.structTypeNode !== null;
-
-		const isStructArray =
-			( bufferNode.value && bufferNode.value.array ) &&
-			( typeof bufferNode.value.itemSize === 'number' && bufferNode.value.array.length > bufferNode.value.itemSize );
-
-		return isAttributeStructType && ! isStructArray;
-
-	}
-
 	/**
 	 * Returns the uniforms of the given shader stage as a WGSL string.
 	 *
@@ -2224,18 +2203,10 @@ ${ flowData.code }
 				const bufferCountSnippet = bufferCount > 0 && uniform.type === 'buffer' ? ', ' + bufferCount : '';
 				const bufferAccessMode = bufferNode.isStorageBufferNode ? `storage, ${ this.getStorageAccess( bufferNode, shaderStage ) }` : 'uniform';
 
-				if ( this.isCustomStruct( uniform ) ) {
+				const bufferTypeSnippet = bufferNode.isAtomic ? `atomic<${ bufferType }>` : `${ bufferType }`;
+				const bufferSnippet = `\tvalue : array< ${ bufferTypeSnippet }${ bufferCountSnippet } >`;
 
-					bufferSnippets.push( `@binding( ${ uniformIndexes.binding ++ } ) @group( ${ uniformIndexes.group } ) var<${ bufferAccessMode }> ${ uniform.name } : ${ bufferType };` );
-
-				} else {
-
-					const bufferTypeSnippet = bufferNode.isAtomic ? `atomic<${ bufferType }>` : `${ bufferType }`;
-					const bufferSnippet = `\tvalue : array< ${ bufferTypeSnippet }${ bufferCountSnippet } >`;
-
-					bufferSnippets.push( this._getWGSLStructBinding( uniform.name, bufferSnippet, bufferAccessMode, uniformIndexes.binding ++, uniformIndexes.group ) );
-
-				}
+				bufferSnippets.push( this._getWGSLStructBinding( uniform.name, bufferSnippet, bufferAccessMode, uniformIndexes.binding ++, uniformIndexes.group ) );
 
 			} else {
 

--- a/test/unit/src/renderers/webgpu/WGSLNodeBuilder.tests.js
+++ b/test/unit/src/renderers/webgpu/WGSLNodeBuilder.tests.js
@@ -1,0 +1,49 @@
+import WGSLNodeBuilder from '../../../../../src/renderers/webgpu/nodes/WGSLNodeBuilder.js';
+import StorageBufferNode from '../../../../../src/nodes/accessors/StorageBufferNode.js';
+import StructTypeNode from '../../../../../src/nodes/core/StructTypeNode.js';
+import NodeUniform from '../../../../../src/nodes/core/NodeUniform.js';
+import StorageBufferAttribute from '../../../../../src/renderers/common/StorageBufferAttribute.js';
+
+function buildStructStorageUniform( count ) {
+
+	const attribute = new StorageBufferAttribute( new Float32Array( count * 4 ), 4 );
+	const structType = new StructTypeNode( { test: 'vec4' }, 'TestData' );
+	const storageNode = new StorageBufferNode( attribute, structType );
+	const uniform = new NodeUniform( 'data', 'storageBuffer', storageNode );
+	const builder = new WGSLNodeBuilder( null, { backend: {} } );
+
+	builder.setShaderStage( 'compute' );
+	builder.uniforms.compute.push( uniform );
+	builder.bindingsIndexes[ uniform.groupNode.name ] = { binding: 0, group: 0 };
+
+	return {
+		propertyName: builder.getPropertyName( uniform ),
+		uniforms: builder.getUniforms( 'compute' )
+	};
+
+}
+
+export default QUnit.module( 'Renderers', () => {
+
+	QUnit.module( 'WebGPU', () => {
+
+		QUnit.module( 'WGSLNodeBuilder', () => {
+
+			QUnit.test( 'struct storage buffers preserve array semantics', ( assert ) => {
+
+				for ( const count of [ 1, 2 ] ) {
+
+					const result = buildStructStorageUniform( count );
+
+					assert.strictEqual( result.propertyName, 'data.value', `storage buffer with ${ count } element(s) uses array access` );
+					assert.ok( result.uniforms.includes( '\tvalue : array< TestData >' ), `storage buffer with ${ count } element(s) has an array binding` );
+
+				}
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -266,6 +266,9 @@ import './src/renderers/webgl/WebGLTextures.tests.js';
 import './src/renderers/webgl/WebGLUniforms.tests.js';
 import './src/renderers/webgl/WebGLUtils.tests.js';
 
+//src/renderers/webgpu
+import './src/renderers/webgpu/WGSLNodeBuilder.tests.js';
+
 
 //src/scenes
 import './src/scenes/Fog.tests.js';


### PR DESCRIPTION
Related issue: #33145

**Description**

Struct storage buffers currently change their generated WGSL type based on element count. A one-element buffer is emitted as a direct struct while larger buffers use an array wrapper, so a graph written for array access can fail and the shader interface can change when the buffer grows.

This change keeps struct storage buffers as arrays regardless of their current length. The indirect-draw example now selects its single record explicitly with `.element( 0 )`, and a focused WGSL builder test covers both one- and two-element buffers.

**Testing**

- `npm run test-unit` — 1316 passed, 1 todo
- `npm run test-e2e-webgpu -- webgpu_struct_drawindirect` — 0.0% image diff, 1 screenshot passed
- ESLint on the four changed files
- `npm run build`