### PR TITLE
WebGLRenderer: Optimize readRenderTargetPixels capability checks

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3066,26 +3066,20 @@ class WebGLRenderer {
 
 		};
 
-		function isRenderTargetReadable( renderTarget, textureIndex ) {
+		function getReadableState( texture ) {
 
-			const texture = renderTarget.textures[ textureIndex ];
 			const textureProperties = properties.get( texture );
 
-			if ( textureProperties.__readFormatSupported === undefined || textureProperties.__cachedFormat !== texture.format ) {
+			if ( textureProperties.__readFormat !== texture.format || textureProperties.__readType !== texture.type ) {
 
-				textureProperties.__cachedFormat = texture.format;
-				textureProperties.__readFormatSupported = capabilities.textureFormatReadable( texture.format );
-
-			}
-
-			if ( textureProperties.__readTypeSupported === undefined || textureProperties.__cachedType !== texture.type ) {
-
-				textureProperties.__cachedType = texture.type;
-				textureProperties.__readTypeSupported = capabilities.textureTypeReadable( texture.type );
+				textureProperties.__readFormat = texture.format;
+				textureProperties.__readType = texture.type;
+				textureProperties.__formatReadable = capabilities.textureFormatReadable( texture.format );
+				textureProperties.__typeReadable = capabilities.textureTypeReadable( texture.type );
 
 			}
 
-			return textureProperties.__readFormatSupported && textureProperties.__readTypeSupported;
+			return textureProperties;
 
 		}
 
@@ -3132,9 +3126,18 @@ class WebGLRenderer {
 
 					if ( renderTarget.textures.length > 1 ) _gl.readBuffer( _gl.COLOR_ATTACHMENT0 + textureIndex );
 
-					if ( ! isRenderTargetReadable( renderTarget, textureIndex ) ) {
+					const readableState = getReadableState( texture );
 
-						error( 'WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA/UnsignedByteType or implementation defined format/type.' );
+					if ( readableState.__formatReadable === false ) {
+
+						error( 'WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA or implementation defined format.' );
+						return;
+
+					}
+
+					if ( readableState.__typeReadable === false ) {
+
+						error( 'WebGLRenderer.readRenderTargetPixels: renderTarget is not in UnsignedByteType or implementation defined type.' );
 						return;
 
 					}
@@ -3207,9 +3210,17 @@ class WebGLRenderer {
 
 					if ( renderTarget.textures.length > 1 ) _gl.readBuffer( _gl.COLOR_ATTACHMENT0 + textureIndex );
 
-					if ( ! isRenderTargetReadable( renderTarget, textureIndex ) ) {
+					const readableState = getReadableState( texture );
 
-						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA/UnsignedByteType or implementation defined format/type.' );
+					if ( readableState.__formatReadable === false ) {
+
+						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA or implementation defined format.' );
+
+					}
+
+					if ( readableState.__typeReadable === false ) {
+
+						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in UnsignedByteType or implementation defined type.' );
 
 					}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -3066,6 +3066,29 @@ class WebGLRenderer {
 
 		};
 
+		function isRenderTargetReadable( renderTarget, textureIndex ) {
+
+			const texture = renderTarget.textures[ textureIndex ];
+			const textureProperties = properties.get( texture );
+
+			if ( textureProperties.__readFormatSupported === undefined || textureProperties.__cachedFormat !== texture.format ) {
+
+				textureProperties.__cachedFormat = texture.format;
+				textureProperties.__readFormatSupported = capabilities.textureFormatReadable( texture.format );
+
+			}
+
+			if ( textureProperties.__readTypeSupported === undefined || textureProperties.__cachedType !== texture.type ) {
+
+				textureProperties.__cachedType = texture.type;
+				textureProperties.__readTypeSupported = capabilities.textureTypeReadable( texture.type );
+
+			}
+
+			return textureProperties.__readFormatSupported && textureProperties.__readTypeSupported;
+
+		}
+
 		/**
 		 * Reads the pixel data from the given render target into the given buffer.
 		 *
@@ -3109,16 +3132,9 @@ class WebGLRenderer {
 
 					if ( renderTarget.textures.length > 1 ) _gl.readBuffer( _gl.COLOR_ATTACHMENT0 + textureIndex );
 
-					if ( ! capabilities.textureFormatReadable( textureFormat ) ) {
+					if ( ! isRenderTargetReadable( renderTarget, textureIndex ) ) {
 
-						error( 'WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA or implementation defined format.' );
-						return;
-
-					}
-
-					if ( ! capabilities.textureTypeReadable( textureType ) ) {
-
-						error( 'WebGLRenderer.readRenderTargetPixels: renderTarget is not in UnsignedByteType or implementation defined type.' );
+						error( 'WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA/UnsignedByteType or implementation defined format/type.' );
 						return;
 
 					}
@@ -3191,16 +3207,9 @@ class WebGLRenderer {
 
 					if ( renderTarget.textures.length > 1 ) _gl.readBuffer( _gl.COLOR_ATTACHMENT0 + textureIndex );
 
+					if ( ! isRenderTargetReadable( renderTarget, textureIndex ) ) {
 
-					if ( ! capabilities.textureFormatReadable( textureFormat ) ) {
-
-						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA or implementation defined format.' );
-
-					}
-
-					if ( ! capabilities.textureTypeReadable( textureType ) ) {
-
-						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in UnsignedByteType or implementation defined type.' );
+						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA/UnsignedByteType or implementation defined format/type.' );
 
 					}
 

--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -41,8 +41,8 @@ function WebGLCapabilities( gl, extensions, parameters, utils ) {
 
 		const halfFloatSupportedByExt = ( textureType === HalfFloatType ) && ( extensions.has( 'EXT_color_buffer_half_float' ) || extensions.has( 'EXT_color_buffer_float' ) );
 
-		if ( textureType !== UnsignedByteType && utils.convert( textureType ) !== gl.getParameter( gl.IMPLEMENTATION_COLOR_READ_TYPE ) && // Edge and Chrome Mac < 52 (#9513)
-			textureType !== FloatType && ! halfFloatSupportedByExt ) {
+		if ( textureType !== UnsignedByteType && textureType !== FloatType && ! halfFloatSupportedByExt &&
+			utils.convert( textureType ) !== gl.getParameter( gl.IMPLEMENTATION_COLOR_READ_TYPE ) ) { // Edge and Chrome Mac < 52 (#9513)
 
 			return false;
 


### PR DESCRIPTION
Fixed #34182

**Description**

Caches the results of `textureFormatReadable` and `textureTypeReadable` to avoid `gl.getParameter` on subsequent reads.

Before:
<img width="1624" height="1061" alt="Screenshot 2026-08-07 at 8 36 43 PM" src="https://github.com/user-attachments/assets/f5a5485e-8e32-46e2-9e30-2323d5d7e11e" />

After:
<img width="1624" height="1061" alt="Screenshot 2026-08-07 at 8 46 27 PM" src="https://github.com/user-attachments/assets/ed160402-b71d-4579-b7be-efdd7d0c311c" />
