### PR TITLE
speed up mobile.  replace exp with polynomial approx.

### DIFF
--- a/examples/jsm/objects/GaussianSplatMesh.js
+++ b/examples/jsm/objects/GaussianSplatMesh.js
@@ -17,7 +17,6 @@ import {
 	cameraProjectionMatrix,
 	cos,
 	dot,
-	exp,
 	float,
 	highpModelViewMatrix,
 	instanceIndex,
@@ -454,7 +453,16 @@ function createMaterial( buffers, sort ) {
 
 		} );
 
-		return vec4( splatColor.rgb, exp( r2.mul( - 0.5 ) ).mul( splatColor.a ) );
+		// Using a polynomial approximation to avoid stalls on mobile devices per:
+		// https://arxiv.org/html/2603.18707
+		// We use a quadratic rather than their
+		// recommended first-order fit because our discard cutoff above already limits the
+		// domain to r2 <= 4 (tighter than their 1/255-alpha cutoff of r2 <= 11.1); over
+		// this narrower range a constrained linear fit has ~0.14 max error (visibly too
+		// coarse), while this quadratic (Horner form, exact at r2 = 0) has only ~0.021.
+		const falloff = max( float( 1 ).add( r2.mul( float( - 0.4298496 ).add( r2.mul( 0.0547243 ) ) ) ), 0 ).toVar( 'falloff' );
+
+		return vec4( splatColor.rgb, falloff.mul( splatColor.a ) );
 
 	} )();
 


### PR DESCRIPTION
**Description**

I noticed that rendering on mobile can be slow.  I did some research and "exp" is slow on mobile if you do it on every fragment pixel and there is a lot of overlap.  While "exp" is apparently 1 tick, it uses the mobile SFU of which there is only one, while if you use a polynomial approximation, it uses the ALU, of which there are multiple lanes.  This makes the polynomial approximation much faster.

This is covered in this paper: https://arxiv.org/html/2603.18707

You can see the difference by zooming into the lion head so it is full screen on an iPhone 13.

new version: https://rawcdn.githack.com/mrdoob/three.js/eea79bb2cd2a4ed9bf7dd26aa4809f421654bcc4/examples/webgpu_gaussian_splatting.html

old version: https://rawcdn.githack.com/mrdoob/three.js/98fbdb4a5ca8f095554e5ea58b8f58c8cbc35aac/examples/webgpu_gaussian_splatting.html