### PR TITLE
SkinningNode: Add bone texture fallback for large skeletons.

### DIFF
--- a/src/nodes/accessors/Skinning.js
+++ b/src/nodes/accessors/Skinning.js
@@ -1,5 +1,5 @@
 
-import { Fn, add, uniform, mat3 } from '../tsl/TSLBase.js';
+import { Fn, add, uniform, int, ivec2, mat3, mat4 } from '../tsl/TSLBase.js';
 import { attribute } from '../core/AttributeNode.js';
 import { OnObjectUpdate } from '../utils/EventNode.js';
 import { normalLocal } from './Normal.js';
@@ -7,6 +7,7 @@ import { positionLocal, positionPrevious } from './Position.js';
 import { tangentLocal } from './Tangent.js';
 import { reference, referenceBuffer } from './ReferenceNode.js';
 import { buffer } from './BufferNode.js';
+import { texture } from './TextureNode.js';
 import { storage } from './StorageBufferNode.js';
 import { instanceIndex } from '../core/IndexNode.js';
 
@@ -124,6 +125,52 @@ function getPreviousSkinnedPosition( skinnedMesh, bindMatrixNode, bindMatrixInve
 }
 
 /**
+ * Returns an accessor for the skeleton's bone matrices. Small skeletons use a
+ * uniform buffer; when the bone count exceeds the backend's uniform buffer
+ * capacity, the matrices are stored in the skeleton's bone texture instead,
+ * like `WebGLRenderer` does.
+ *
+ * @param {Skeleton} skeleton - The skeleton.
+ * @param {NodeBuilder} builder - The current node builder.
+ * @returns {Object} An accessor exposing `element( index )` like a buffer node.
+ */
+function getBoneMatricesNode( skeleton, builder ) {
+
+	const limit = ( builder.renderer.backend.isWebGPUBackend === true ) ? 1000 : 250; // WebGL 2 ensures only 16KB
+
+	if ( skeleton.bones.length <= limit ) {
+
+		return referenceBuffer( 'skeleton.boneMatrices', 'mat4', skeleton.bones.length );
+
+	}
+
+	if ( skeleton.boneTexture === null ) skeleton.computeBoneTexture();
+
+	const boneTexture = texture( skeleton.boneTexture );
+	const size = skeleton.boneTexture.image.width;
+
+	return {
+
+		element: ( i ) => {
+
+			const j = int( i ).mul( 4 );
+			const y = j.div( size );
+			const x = j.sub( y.mul( size ) );
+
+			return mat4(
+				boneTexture.load( ivec2( x, y ) ),
+				boneTexture.load( ivec2( x.add( 1 ), y ) ),
+				boneTexture.load( ivec2( x.add( 2 ), y ) ),
+				boneTexture.load( ivec2( x.add( 3 ), y ) )
+			);
+
+		}
+
+	};
+
+}
+
+/**
  * TSL function representing the standard skeletal animation vertex shader setup.
  * Transforms positionLocal, normalLocal, and tangentLocal in-place.
  *
@@ -137,7 +184,7 @@ export const skinning = /*@__PURE__*/ Fn( ( [ skinnedMesh ], builder ) => {
 	const skinWeightNode = attribute( 'skinWeight', 'vec4' );
 	const bindMatrixNode = reference( 'bindMatrix', 'mat4' );
 	const bindMatrixInverseNode = reference( 'bindMatrixInverse', 'mat4' );
-	const boneMatricesNode = referenceBuffer( 'skeleton.boneMatrices', 'mat4', skinnedMesh.skeleton.bones.length );
+	const boneMatricesNode = getBoneMatricesNode( skinnedMesh.skeleton, builder );
 
 	OnObjectUpdate( ( { object, frameId } ) => {
 


### PR DESCRIPTION
Related issue: #32597

**Description**

The WebGL 2 backend lowers `skeleton.boneMatrices` to a uniform block, so skinned meshes fail to link once the skeleton exceeds `GL_MAX_UNIFORM_BLOCK_SIZE / 64` bones — 250 at the 16 KB the spec guarantees:

```
Program Info Log: Size of uniform block NodeBuffer_54298 in VERTEX shader exceeds GL_MAX_UNIFORM_BLOCK_SIZE (16384)
```

#32615 fixed the same overflow for `InstanceNode` with a backend-aware capacity check. This applies the same check to skinning: skeletons within capacity keep the uniform buffer, larger ones use `Skeleton.computeBoneTexture()` and fetch matrices with `texelFetch`, like `WebGLRenderer`.

Tested with 312- and 539-bone skeletons (VRM avatars) on the WebGL 2 backend (ANGLE Metal, 16 KB limit) and on WebGPU.
