### PR TITLE
PCDLoader: Fix regex to remove comments.

### DIFF
--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -269,7 +269,7 @@ class PCDLoader extends Loader {
 
 			// remove comments
 
-			PCDheader.str = PCDheader.str.replace(/^#.*/gim, '');
+			PCDheader.str = PCDheader.str.replace( /^#.*/gm, '' );
 
 			// parse
 

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -269,7 +269,7 @@ class PCDLoader extends Loader {
 
 			// remove comments
 
-			PCDheader.str = PCDheader.str.replace( /#.*/gi, '' );
+			PCDheader.str = PCDheader.str.replace(/^#.*/gim, '');
 
 			// parse
 


### PR DESCRIPTION
**Description**

old regex matched fields like  "Scalar_field Scalar_field_#2 Scalar_field_#3 x y z" will only left "Scalar_field Scalar_field_" in pcds which cloudcompare can open . 

