### PR TITLE
Transpiler: Add GLSL preprocessor directives and macro support

### DIFF
--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -1204,7 +1204,8 @@ class GLSLDecoder {
 
 			if ( macros.has( name ) ) {
 
-				const val = macros.get( name );
+				const macro = macros.get( name );
+				const val = macro.body;
 				return val !== '' ? val : '1';
 
 			}
@@ -1231,6 +1232,49 @@ class GLSLDecoder {
 
 	}
 
+	extractMacroArgs( str ) {
+
+		const args = [];
+		let currentArg = '';
+		let parenDepth = 0;
+
+		for ( let i = 0; i < str.length; i ++ ) {
+
+			const char = str[ i ];
+
+			if ( char === '(' || char === '[' || char === '{' ) {
+
+				parenDepth ++;
+				currentArg += char;
+
+			} else if ( char === ')' || char === ']' || char === '}' ) {
+
+				parenDepth --;
+				currentArg += char;
+
+			} else if ( char === ',' && parenDepth === 0 ) {
+
+				args.push( currentArg.trim() );
+				currentArg = '';
+
+			} else {
+
+				currentArg += char;
+
+			}
+
+		}
+
+		if ( currentArg.trim() !== '' || args.length > 0 ) {
+
+			args.push( currentArg.trim() );
+
+		}
+
+		return args;
+
+	}
+
 	expandMacros( line, macros ) {
 
 		if ( macros.size === 0 ) return line;
@@ -1243,16 +1287,73 @@ class GLSLDecoder {
 
 			let changed = false;
 
-			for ( const [ name, value ] of macros ) {
+			for ( const [ name, macro ] of macros ) {
 
-				if ( value === '' ) continue;
+				if ( macro.params !== null ) {
 
-				const regex = new RegExp( `\\b${ name }\\b`, 'g' );
+					const regex = new RegExp( `\\b${ name }\\s*\\(`, 'g' );
+					let match;
 
-				if ( regex.test( result ) ) {
+					while ( ( match = regex.exec( result ) ) !== null ) {
 
-					result = result.replace( regex, value );
-					changed = true;
+						const startIdx = match.index;
+						const parenStartIdx = startIdx + match[ 0 ].length - 1;
+
+						let parenDepth = 1;
+						let parenEndIdx = - 1;
+
+						for ( let i = parenStartIdx + 1; i < result.length; i ++ ) {
+
+							if ( result[ i ] === '(' ) parenDepth ++;
+							else if ( result[ i ] === ')' ) parenDepth --;
+
+							if ( parenDepth === 0 ) {
+
+								parenEndIdx = i;
+								break;
+
+							}
+
+						}
+
+						if ( parenEndIdx !== - 1 ) {
+
+							const rawArgs = result.slice( parenStartIdx + 1, parenEndIdx );
+							const args = this.extractMacroArgs( rawArgs );
+
+							let substitutedBody = macro.body;
+
+							for ( let p = 0; p < macro.params.length; p ++ ) {
+
+								const paramName = macro.params[ p ];
+								const argVal = args[ p ] !== undefined ? args[ p ] : '';
+								const paramRegex = new RegExp( `\\b${ paramName }\\b`, 'g' );
+
+								substitutedBody = substitutedBody.replace( paramRegex, argVal );
+
+							}
+
+							result = result.slice( 0, startIdx ) + substitutedBody + result.slice( parenEndIdx + 1 );
+							changed = true;
+
+							break;
+
+						}
+
+					}
+
+				} else {
+
+					if ( macro.body === '' ) continue;
+
+					const regex = new RegExp( `\\b${ name }\\b`, 'g' );
+
+					if ( regex.test( result ) ) {
+
+						result = result.replace( regex, macro.body );
+						changed = true;
+
+					}
 
 				}
 
@@ -1339,14 +1440,28 @@ class GLSLDecoder {
 
 					if ( isExecuting() ) {
 
-						const match = args.match( /^(\w+)(?:\s+(.*))?$/ );
+						const fnMatch = args.match( /^(\w+)\((.*?)\)\s*(.*)$/ );
 
-						if ( match ) {
+						if ( fnMatch ) {
 
-							const name = match[ 1 ];
-							const value = match[ 2 ] !== undefined ? match[ 2 ].trim() : '';
+							const name = fnMatch[ 1 ];
+							const params = fnMatch[ 2 ].split( ',' ).map( p => p.trim() ).filter( p => p !== '' );
+							const body = fnMatch[ 3 ] !== undefined ? fnMatch[ 3 ].trim() : '';
 
-							macros.set( name, value );
+							macros.set( name, { params, body } );
+
+						} else {
+
+							const objMatch = args.match( /^(\w+)(?:\s+(.*))?$/ );
+
+							if ( objMatch ) {
+
+								const name = objMatch[ 1 ];
+								const value = objMatch[ 2 ] !== undefined ? objMatch[ 2 ].trim() : '';
+
+								macros.set( name, { params: null, body: value } );
+
+							}
 
 						}
 

--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -1190,7 +1190,283 @@ class GLSLDecoder {
 
 	}
 
+	evaluateCondition( expr, macros ) {
+
+		let str = expr;
+
+		str = str.replace( /defined\s*\(\s*(\w+)\s*\)/g, ( _, name ) => macros.has( name ) ? '1' : '0' );
+		str = str.replace( /defined\s+(\w+)/g, ( _, name ) => macros.has( name ) ? '1' : '0' );
+
+		str = str.replace( /\b([A-Za-z_]\w*)\b/g, ( _, name ) => {
+
+			if ( name === 'true' ) return '1';
+			if ( name === 'false' ) return '0';
+
+			if ( macros.has( name ) ) {
+
+				const val = macros.get( name );
+				return val !== '' ? val : '1';
+
+			}
+
+			return '0';
+
+		} );
+
+		try {
+
+			if ( /^[\d\s+\-*/%&|^!=<>~()]+$/.test( str ) ) {
+
+				return Boolean( Function( `"use strict"; return (${ str });` )() );
+
+			}
+
+		} catch ( e ) {
+
+			return false;
+
+		}
+
+		return false;
+
+	}
+
+	expandMacros( line, macros ) {
+
+		if ( macros.size === 0 ) return line;
+
+		let result = line;
+		let passes = 0;
+		const maxPasses = 10;
+
+		while ( passes < maxPasses ) {
+
+			let changed = false;
+
+			for ( const [ name, value ] of macros ) {
+
+				if ( value === '' ) continue;
+
+				const regex = new RegExp( `\\b${ name }\\b`, 'g' );
+
+				if ( regex.test( result ) ) {
+
+					result = result.replace( regex, value );
+					changed = true;
+
+				}
+
+			}
+
+			if ( ! changed ) break;
+
+			passes ++;
+
+		}
+
+		return result;
+
+	}
+
+	preprocess( source ) {
+
+		const macros = new Map();
+		const conditionalStack = [];
+
+		const isExecuting = () => conditionalStack.every( frame => frame.active );
+
+		const lines = source.split( '\n' );
+		const outputLines = [];
+
+		let inBlockComment = false;
+
+		for ( let i = 0; i < lines.length; i ++ ) {
+
+			let line = lines[ i ];
+
+			while ( line.endsWith( '\\' ) && i + 1 < lines.length ) {
+
+				line = line.slice( 0, - 1 ) + ' ' + lines[ i + 1 ];
+				i ++;
+				outputLines.push( '' );
+
+			}
+
+			let trimmedLine = line.trim();
+
+			if ( inBlockComment ) {
+
+				const endCommentIndex = trimmedLine.indexOf( '*/' );
+
+				if ( endCommentIndex !== - 1 ) {
+
+					inBlockComment = false;
+					trimmedLine = trimmedLine.slice( endCommentIndex + 2 ).trim();
+
+				} else {
+
+					outputLines.push( line );
+					continue;
+
+				}
+
+			}
+
+			if ( trimmedLine.startsWith( '/*' ) ) {
+
+				const endCommentIndex = trimmedLine.indexOf( '*/', 2 );
+
+				if ( endCommentIndex === - 1 ) {
+
+					inBlockComment = true;
+					outputLines.push( line );
+					continue;
+
+				}
+
+			}
+
+			const directiveMatch = trimmedLine.match( /^#\s*(\w+)(?:\s+(.*))?$/ );
+
+			if ( directiveMatch ) {
+
+				const directive = directiveMatch[ 1 ];
+				let args = directiveMatch[ 2 ] || '';
+
+				args = args.replace( /\/\/.*$/, '' ).replace( /\/\*.*?\*\//g, '' ).trim();
+
+				if ( directive === 'define' ) {
+
+					if ( isExecuting() ) {
+
+						const match = args.match( /^(\w+)(?:\s+(.*))?$/ );
+
+						if ( match ) {
+
+							const name = match[ 1 ];
+							const value = match[ 2 ] !== undefined ? match[ 2 ].trim() : '';
+
+							macros.set( name, value );
+
+						}
+
+					}
+
+				} else if ( directive === 'undef' ) {
+
+					if ( isExecuting() ) {
+
+						const name = args.trim();
+
+						macros.delete( name );
+
+					}
+
+				} else if ( directive === 'ifdef' ) {
+
+					const name = args.trim();
+					const parentActive = isExecuting();
+					const condition = parentActive && macros.has( name );
+
+					conditionalStack.push( { active: condition, anyBranchExecuted: condition } );
+
+				} else if ( directive === 'ifndef' ) {
+
+					const name = args.trim();
+					const parentActive = isExecuting();
+					const condition = parentActive && ! macros.has( name );
+
+					conditionalStack.push( { active: condition, anyBranchExecuted: condition } );
+
+				} else if ( directive === 'if' ) {
+
+					const parentActive = isExecuting();
+					const condition = parentActive && this.evaluateCondition( args, macros );
+
+					conditionalStack.push( { active: Boolean( condition ), anyBranchExecuted: Boolean( condition ) } );
+
+				} else if ( directive === 'elif' ) {
+
+					if ( conditionalStack.length > 0 ) {
+
+						const currentFrame = conditionalStack[ conditionalStack.length - 1 ];
+						const parentActive = conditionalStack.slice( 0, - 1 ).every( frame => frame.active );
+
+						if ( ! parentActive || currentFrame.anyBranchExecuted ) {
+
+							currentFrame.active = false;
+
+						} else {
+
+							const condition = this.evaluateCondition( args, macros );
+
+							currentFrame.active = Boolean( condition );
+
+							if ( condition ) {
+
+								currentFrame.anyBranchExecuted = true;
+
+							}
+
+						}
+
+					}
+
+				} else if ( directive === 'else' ) {
+
+					if ( conditionalStack.length > 0 ) {
+
+						const currentFrame = conditionalStack[ conditionalStack.length - 1 ];
+						const parentActive = conditionalStack.slice( 0, - 1 ).every( frame => frame.active );
+
+						if ( ! parentActive || currentFrame.anyBranchExecuted ) {
+
+							currentFrame.active = false;
+
+						} else {
+
+							currentFrame.active = true;
+							currentFrame.anyBranchExecuted = true;
+
+						}
+
+					}
+
+				} else if ( directive === 'endif' ) {
+
+					if ( conditionalStack.length > 0 ) {
+
+						conditionalStack.pop();
+
+					}
+
+				}
+
+				outputLines.push( '' );
+
+			} else {
+
+				if ( isExecuting() ) {
+
+					outputLines.push( this.expandMacros( line, macros ) );
+
+				} else {
+
+					outputLines.push( '' );
+
+				}
+
+			}
+
+		}
+
+		return outputLines.join( '\n' );
+
+	}
+
 	parse( source ) {
+
+		source = this.preprocess( source );
 
 		let polyfill = '';
 
@@ -1219,7 +1495,6 @@ class GLSLDecoder {
 		program.structTypes = this.structTypes;
 
 		return program;
-
 
 	}
 


### PR DESCRIPTION
Related issue: N/A

**Description**

This PR adds support for GLSL preprocessor directives to `GLSLDecoder`. Previously, preprocessor directives (such as `#define`, `#ifdef`, `#version 300 es`, or `#include`) were tokenized as regular `#` operator tokens, causing `GLSLDecoder` to throw syntax errors or generate invalid AST nodes.

Example
```glsl
#version 300 es
#extension GL_OES_standard_derivatives : enable

/*
 * Perlin noise
 * https://gist.github.com/patriciogonzalezvivo/670c22f3966e662d2f83
 */

#define PI 3.141592653589793
#define USE_SMOOTH

float rand(vec2 c){
	return fract(sin(dot(c.xy ,vec2(12.9898,78.233))) * 43758.5453);
}

float noise(vec2 p, float freq ){
	float unit = 1./freq;
	vec2 ij = floor(p/unit);
	vec2 xy = mod(p,unit)/unit;
#ifdef USE_SMOOTH
	xy = .5*(1.-cos(PI*xy));
#else
	xy = 3.*xy*xy-2.*xy*xy*xy;
#endif
	float a = rand((ij+vec2(0.,0.)));
	float b = rand((ij+vec2(1.,0.)));
	float c = rand((ij+vec2(0.,1.)));
	float d = rand((ij+vec2(1.,1.)));
	float x1 = mix(a, b, xy.x);
	float x2 = mix(c, d, xy.x);
	return mix(x1, x2, xy.y);
}

float pNoise(vec2 p, int res){
	float persistence = .5;
	float n = 0.;
	float normK = 0.;
	float f = 4.;
	float amp = 1.;
	int iCount = 0;
	for (int i = 0; i<50; i++){
		n+=amp*noise(p, f);
		f*=2.;
		normK+=amp;
		amp*=persistence;
		if (iCount == res) break;
		iCount++;
	}
	float nf = n/normK;
	return nf*nf*nf*nf;
}
```

Macro
```glsl
#define SQR(x) ((x) * (x))
#define MULT(a, b) ((a) * (b))
#define CLAMP01(x) clamp((x), 0.0, 1.0)

float test(float v) {
	float a = SQR(v);
	float b = MULT(v + 1.0, 2.0);
	float c = CLAMP01(b);
	return a + b + c;
}
```
