### PR TITLE
Examples: Make example links clickable in title & info.

### DIFF
--- a/examples/example.css
+++ b/examples/example.css
@@ -28,7 +28,7 @@ a {
 	pointer-events: none;
 }
 
-#info > a {
+#info a {
 	pointer-events: auto;
 }
 
@@ -60,10 +60,6 @@ a {
 	line-height: 20px;
 }
 
-.title-wrapper a {
-	pointer-events: auto;
-}
-
 .title-wrapper > a {
 	font-weight: 600;
 }
@@ -78,7 +74,6 @@ a {
 #info > small a {
 	color: #ff0;
 	text-decoration: none;
-	pointer-events: auto;
 }
 
 #info > small a:hover {

--- a/examples/example.css
+++ b/examples/example.css
@@ -60,6 +60,10 @@ a {
 	line-height: 20px;
 }
 
+.title-wrapper a {
+	pointer-events: auto;
+}
+
 .title-wrapper > a {
 	font-weight: 600;
 }
@@ -74,6 +78,7 @@ a {
 #info > small a {
 	color: #ff0;
 	text-decoration: none;
+	pointer-events: auto;
 }
 
 #info > small a:hover {

--- a/examples/webgpu_gaussian_splatting.html
+++ b/examples/webgpu_gaussian_splatting.html
@@ -24,7 +24,7 @@
 				<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a><span>Gaussian Splatting</span>
 			</div>
 
-			<small id="status">WebGPU TSL Gaussian splat renderer by <a href="https://ben3d.ca">Ben Houston</a>.</small>
+			<small id="status">WebGPU TSL Gaussian splat renderer by <a href="https://ben3d.ca" target="_blank" rel="noopener">Ben Houston</a>.</small>
 			<small id="license"></small>
 		</div>
 


### PR DESCRIPTION
I noticed that in many examples the links in the title & info are not clickable.  I guess interaction with the text was disabled as some point but the links should still be clickable in my opinion - this adds that back.

This example has non-clickable links from current dev:

https://rawcdn.githack.com/mrdoob/three.js/3b7d8368854922c3503f3edcf0e4a43b633edfd4/examples/webgpu_gaussian_splatting.html

And here is the example after this change - links to license, and creators of the splat files are now clickable again:

https://rawcdn.githack.com/mrdoob/three.js/73dde844ffe706940286215157b5ef4fd1deb9f4/examples/webgpu_gaussian_splatting.html