### PR TITLE
Transpiler: Add `array` support

### DIFF
--- a/examples/jsm/transpiler/AST.js
+++ b/examples/jsm/transpiler/AST.js
@@ -1,4 +1,4 @@
-import { toFloatType } from './TranspilerUtils.js';
+import { toFloatType, isBuiltinType } from './TranspilerUtils.js';
 
 export class ASTNode {
 
@@ -433,6 +433,24 @@ export class FunctionCall extends ASTNode {
 		this.isFunctionCall = true;
 
 		this.initialize();
+
+	}
+
+	getType() {
+
+		if ( isBuiltinType( this.name ) ) {
+
+			return this.name;
+
+		}
+
+		if ( this.linker.reference ) {
+
+			return this.linker.reference.getType();
+
+		}
+
+		return super.getType();
 
 	}
 

--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -281,6 +281,25 @@ class GLSLDecoder {
 
 	}
 
+	getTokenPosition( token ) {
+
+		if ( ! token || token.pos === undefined || ! token.tokenizer || ! token.tokenizer.source ) {
+
+			return '';
+
+		}
+
+		const source = token.tokenizer.source;
+		const textBefore = source.slice( 0, token.pos );
+
+		const lines = textBefore.split( '\n' );
+		const lineNumber = lines.length;
+		const columnNumber = lines[ lines.length - 1 ].length + 1;
+
+		return ` (line ${ lineNumber }, column ${ columnNumber })`;
+
+	}
+
 	getToken( offset = 0 ) {
 
 		return this.tokens[ this.index + offset ];
@@ -481,6 +500,14 @@ class GLSLDecoder {
 
 			return left;
 
+		} else if ( firstToken.str === '{' ) {
+
+			const internalTokens = tokens.slice( 1, tokens.length - 1 );
+
+			const paramsTokens = this.parseFunctionParametersFromTokens( internalTokens );
+
+			return new FunctionCall( 'array', paramsTokens );
+
 		}
 
 		// primitives and accessors
@@ -558,6 +585,20 @@ class GLSLDecoder {
 
 				} else if ( secondToken.str === '[' ) {
 
+					const bracketTokens = this.getTokensUntil( ']', tokens, 1 );
+					const parenToken = tokens[ 1 + bracketTokens.length ];
+
+					if ( parenToken && parenToken.str === '(' ) {
+
+						// array constructor: type[N](args...) or type[](args...)
+						const parenIndex = 1 + bracketTokens.length;
+						const internalTokens = this.getTokensUntil( ')', tokens, parenIndex ).slice( 1, - 1 );
+						const paramsTokens = this.parseFunctionParametersFromTokens( internalTokens );
+
+						return new FunctionCall( 'array', paramsTokens );
+
+					}
+
 					// array accessor
 
 					const elements = this.parseAccessorElementsFromTokens( tokens.slice( 1 ) );
@@ -571,6 +612,8 @@ class GLSLDecoder {
 			return new Accessor( firstToken.str );
 
 		}
+
+		throw new Error( 'THREE.GLSLDecoder: Unexpected token "' + firstToken.str + '"' + this.getTokenPosition( firstToken ) );
 
 	}
 
@@ -606,9 +649,7 @@ class GLSLDecoder {
 
 			} else {
 
-				console.error( 'Unknown accessor expression', token );
-
-				break;
+				throw new Error( 'THREE.GLSLDecoder: Unknown accessor expression token "' + token.str + '"' + this.getTokenPosition( token ) );
 
 			}
 
@@ -623,19 +664,26 @@ class GLSLDecoder {
 		if ( tokens.length === 0 ) return [];
 
 		const expression = this.parseExpressionFromTokens( tokens );
+
+		if ( ! expression ) {
+
+			throw new Error( 'THREE.GLSLDecoder: Invalid parameter expression' + this.getTokenPosition( tokens[ 0 ] ) );
+
+		}
+
 		const params = [];
 
 		let current = expression;
 
-		while ( current.type === ',' ) {
+		while ( current && current.type === ',' ) {
 
-			params.push( current.left );
+			if ( current.left ) params.push( current.left );
 
 			current = current.right;
 
 		}
 
-		params.push( current );
+		if ( current ) params.push( current );
 
 		return params;
 
@@ -711,10 +759,19 @@ class GLSLDecoder {
 		type = type || tokens[ index ++ ].str;
 		const name = tokens[ index ++ ].str;
 
-		const token = tokens[ index ];
+		let token = tokens[ index ];
 
 		let init = null;
 		let next = null;
+
+		if ( token && token.str === '[' ) {
+
+			const bracketTokens = this.getTokensUntil( ']', tokens, index );
+
+			index += bracketTokens.length;
+			token = tokens[ index ];
+
+		}
 
 		if ( token ) {
 

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -372,7 +372,7 @@ class TSLEncoder {
 
 		} else {
 
-			throw new Error( 'THREE.TSLEncoder: Unknown AST node type "' + ( node ? node.constructor.name : node ) + '"' );
+			throw new Error( 'THREE.TSLEncoder: Unknown AST node type "' + node.constructor.name + '"' );
 
 		}
 

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -188,9 +188,13 @@ class TSLEncoder {
 
 			}
 
-			// handle texture lookup function calls in separate branch
+			if ( node.name === 'array' ) {
 
-			if ( textureLookupFunctions.includes( node.name ) ) {
+				this.addImport( 'array' );
+
+				code = `array( [ ${ params.join( ', ' ) } ] )`;
+
+			} else if ( textureLookupFunctions.includes( node.name ) ) {
 
 				code = `${ params[ 0 ] }.sample( ${ params[ 1 ] } )`;
 
@@ -368,11 +372,9 @@ class TSLEncoder {
 
 		} else {
 
-			console.warn( 'Unknown node type', node );
+			throw new Error( 'THREE.TSLEncoder: Unknown AST node type "' + ( node ? node.constructor.name : node ) + '"' );
 
 		}
-
-		if ( ! code ) code = '/* unknown statement */';
 
 		return code;
 
@@ -504,7 +506,7 @@ ${ this.tab }} )`;
 
 		} else if ( node.afterthought.isOperator ) {
 
-			if ( node.afterthought.right.isAccessor || node.afterthought.right.isNumber ) {
+			if ( node.afterthought.right && ( node.afterthought.right.isAccessor || node.afterthought.right.isNumber ) ) {
 
 				updateParam = `, update: ${ this.emitExpression( node.afterthought.right ) }`;
 
@@ -590,10 +592,10 @@ ${ this.tab }} )`;
 		const { initialization, condition, afterthought } = node;
 
 		if ( ( initialization && initialization.isVariableDeclaration && initialization.next === null ) &&
-			( condition && condition.left.isAccessor && condition.left.property === initialization.name ) &&
+			( condition && condition.left && condition.left.isAccessor && condition.left.property === initialization.name ) &&
 			( afterthought && (
-				( afterthought.isUnary && ( initialization.name === afterthought.expression.property ) ) ||
-				( afterthought.isOperator && ( initialization.name === afterthought.left.property ) )
+				( afterthought.isUnary && afterthought.expression && ( initialization.name === afterthought.expression.property ) ) ||
+				( afterthought.isOperator && afterthought.left && ( initialization.name === afterthought.left.property ) )
 			) )
 		) {
 

--- a/examples/jsm/transpiler/WGSLEncoder.js
+++ b/examples/jsm/transpiler/WGSLEncoder.js
@@ -194,6 +194,23 @@ class WGSLEncoder {
 
 				code += `( ${ params } )`;
 
+			} else if ( fnName === 'array' ) {
+
+				const params = node.params.map( p => this.emitExpression( p ) );
+
+				if ( node.params.length > 0 && node.params[ 0 ].getType() ) {
+
+					const elemType = this.getWgslType( node.params[ 0 ].getType() );
+					const count = node.params.length;
+
+					code = `array<${ elemType }, ${ count }>( ${ params.join( ', ' ) } )`;
+
+				} else {
+
+					code = `array( ${ params.join( ', ' ) } )`;
+
+				}
+
 			} else if ( fnName.startsWith( 'texture' ) ) {
 
 				// Handle texture functions separately due to sampler handling
@@ -335,9 +352,7 @@ class WGSLEncoder {
 
 		} else {
 
-			console.warn( 'Unknown node type in WGSL Encoder:', node );
-
-			code = `/* unknown node: ${ node.constructor.name } */`;
+			throw new Error( 'THREE.WGSLEncoder: Unknown AST node type "' + node.constructor.name + '"' );
 
 		}
 
@@ -577,7 +592,15 @@ class WGSLEncoder {
 
 			}
 
-			declarations.push( `${ keyword } ${ current.name }: ${ type }${ valueStr }` );
+			let typeStr = `: ${ type }`;
+
+			if ( current.value && current.value.isFunctionCall && current.value.name === 'array' ) {
+
+				typeStr = '';
+
+			}
+
+			declarations.push( `${ keyword } ${ current.name }${ typeStr }${ valueStr }` );
 
 			current = current.next;
 


### PR DESCRIPTION
Related issue: N/A

**Description**

This PR adds support for GLSL ES 3.0 array constructors and array initializer lists to the Transpiler.

Example
```glsl
#version 300 es
vec3 getGradientColor(int index) {
	vec3 palette[3] = vec3[3](
		vec3(1.0, 0.0, 0.0),
		vec3(0.0, 1.0, 0.0),
		vec3(0.0, 0.0, 1.0)
	);
	if (index == 0) return palette[0];
	if (index == 1) return palette[1];
	return palette[2];
}