### PR TITLE
Inspector: Add Color Grading extension and improve lifecycle API

### DIFF
--- a/examples/jsm/inspector/Extension.js
+++ b/examples/jsm/inspector/Extension.js
@@ -45,7 +45,7 @@ export class Extension extends Tab {
 
 		const data = getItem( this.name );
 
-		if ( data && typeof data === 'object' && Object.keys( data ).length > 0 ) {
+		if ( Object.keys( data ).length > 0 ) {
 
 			this.deserialize( data );
 

--- a/examples/jsm/inspector/Extension.js
+++ b/examples/jsm/inspector/Extension.js
@@ -1,4 +1,5 @@
 import { Tab } from 'three/addons/inspector/ui/Tab.js';
+import { getItem, setItem } from './Inspector.js';
 
 export class Extension extends Tab {
 
@@ -9,5 +10,98 @@ export class Extension extends Tab {
 		this.isExtension = true;
 
 	}
+
+	init( inspector ) {
+
+		super.init( inspector );
+
+		if ( this._handleLayout && this._inspector ) {
+
+			this._inspector.removeEventListener( 'orientationchange', this._handleLayout );
+			this._inspector.removeEventListener( 'layoutchange', this._handleLayout );
+			this._inspector.removeEventListener( 'resize', this._handleLayout );
+			window.removeEventListener( 'resize', this._handleLayout );
+
+		}
+
+		this._inspector = inspector;
+
+		this._handleLayout = ( event ) => {
+
+			this.onOrientationChange( event );
+			this.onLayoutChange( event );
+
+		};
+
+		if ( inspector ) {
+
+			inspector.addEventListener( 'orientationchange', this._handleLayout );
+			inspector.addEventListener( 'layoutchange', this._handleLayout );
+			inspector.addEventListener( 'resize', this._handleLayout );
+
+		}
+
+		window.addEventListener( 'resize', this._handleLayout );
+
+		const data = getItem( this.name );
+
+		if ( data && typeof data === 'object' && Object.keys( data ).length > 0 ) {
+
+			this.deserialize( data );
+
+		}
+
+	}
+
+	serialize() {
+
+		return {};
+
+	}
+
+	deserialize( /* data */ ) {
+
+	}
+
+	save() {
+
+		const data = this.serialize();
+
+		if ( data === null || ( typeof data === 'object' && Object.keys( data ).length === 0 ) ) {
+
+			setItem( this.name, null );
+
+		} else {
+
+			setItem( this.name, data );
+
+		}
+
+	}
+
+	dispose() {
+
+		if ( this._handleLayout ) {
+
+			if ( this._inspector ) {
+
+				this._inspector.removeEventListener( 'orientationchange', this._handleLayout );
+				this._inspector.removeEventListener( 'layoutchange', this._handleLayout );
+				this._inspector.removeEventListener( 'resize', this._handleLayout );
+
+			}
+
+			window.removeEventListener( 'resize', this._handleLayout );
+			this._handleLayout = null;
+
+		}
+
+		this._inspector = null;
+
+	}
+
+	onOrientationChange( /* event */ ) { }
+
+	onLayoutChange( /* event */ ) { }
 
 }

--- a/examples/jsm/inspector/Inspector.js
+++ b/examples/jsm/inspector/Inspector.js
@@ -22,6 +22,8 @@ class Inspector extends RendererInspector {
 
 		const profiler = new Profiler( this );
 		profiler.addEventListener( 'resize', ( e ) => this.dispatchEvent( e ) );
+		profiler.addEventListener( 'orientationchange', ( e ) => this.dispatchEvent( e ) );
+		profiler.addEventListener( 'layoutchange', ( e ) => this.dispatchEvent( e ) );
 
 		const parameters = new Parameters( {
 			builtin: true,
@@ -92,6 +94,12 @@ class Inspector extends RendererInspector {
 	get domElement() {
 
 		return this.profiler.domElement;
+
+	}
+
+	isVertical() {
+
+		return this.profiler ? this.profiler.isVertical() : false;
 
 	}
 
@@ -188,6 +196,8 @@ class Inspector extends RendererInspector {
 	}
 
 	removeTab( tab ) {
+
+		tab.dispose();
 
 		this.profiler.removeTab( tab );
 

--- a/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
+++ b/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
@@ -1331,27 +1331,23 @@ export class ColorGrading extends Extension {
 
 		}
 
-		if ( comp ) {
+		this.componentsMap[ modId ] = comp;
+		this.cardsMap[ modId ] = comp.domElement;
 
-			this.componentsMap[ modId ] = comp;
-			this.cardsMap[ modId ] = comp.domElement;
+		const targetIdx = Math.max( 0, Math.min( this.pipelineOrder.length, insertIndex ) );
+		this.pipelineOrder.splice( targetIdx, 0, modId );
 
-			const targetIdx = Math.max( 0, Math.min( this.pipelineOrder.length, insertIndex ) );
-			this.pipelineOrder.splice( targetIdx, 0, modId );
+		this._setupCardDragAndDrop( comp.domElement, modId );
+		this._renderCardsFlow();
+		this._onParamChange();
 
-			this._setupCardDragAndDrop( comp.domElement, modId );
-			this._renderCardsFlow();
-			this._onParamChange();
+		if ( comp.domElement ) {
 
-			if ( comp.domElement ) {
+			setTimeout( () => {
 
-				setTimeout( () => {
+				comp.domElement.scrollIntoView( { behavior: 'smooth', block: 'nearest', inline: 'center' } );
 
-					comp.domElement.scrollIntoView( { behavior: 'smooth', block: 'nearest', inline: 'center' } );
-
-				}, 50 );
-
-			}
+			}, 50 );
 
 		}
 

--- a/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
+++ b/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
@@ -457,14 +457,13 @@ export class ColorGrading extends Extension {
 				this.pipelineOrder = [ ...DEFAULT_PIPELINE_ORDER ];
 
 				// Remove any custom or duplicated cards if present
-				Object.keys( this.componentsMap ).forEach( modId => {
+				this.componentsMap.forEach( ( comp, modId ) => {
 
 					if ( ! DEFAULT_PIPELINE_ORDER.includes( modId ) ) {
 
-						const comp = this.componentsMap[ modId ];
 						if ( comp && comp.domElement ) comp.domElement.remove();
-						delete this.componentsMap[ modId ];
-						delete this.cardsMap[ modId ];
+						this.componentsMap.delete( modId );
+						this.cardsMap.delete( modId );
 
 					}
 
@@ -474,7 +473,7 @@ export class ColorGrading extends Extension {
 				this._renderCardsFlow();
 
 				// Reset all module components
-				Object.values( this.componentsMap ).forEach( comp => {
+				this.componentsMap.forEach( ( comp ) => {
 
 					if ( comp && typeof comp.reset === 'function' ) {
 
@@ -1443,9 +1442,9 @@ export class ColorGrading extends Extension {
 			e.preventDefault();
 			e.dataTransfer.dropEffect = 'move';
 
-			if ( this._draggedModuleId && this.cardsMap[ this._draggedModuleId ] ) {
+			if ( this._draggedModuleId && this.cardsMap.has( this._draggedModuleId ) ) {
 
-				const draggedCard = this.cardsMap[ this._draggedModuleId ];
+				const draggedCard = this.cardsMap.get( this._draggedModuleId );
 				if ( card === draggedCard ) return;
 
 				const rect = card.getBoundingClientRect();
@@ -1543,7 +1542,7 @@ export class ColorGrading extends Extension {
 		const activeModules = [];
 		for ( let i = 0; i < this.pipelineOrder.length; i ++ ) {
 
-			const mod = this.componentsMap[ this.pipelineOrder[ i ] ];
+			const mod = this.componentsMap.get( this.pipelineOrder[ i ] );
 			if ( mod && mod.enabled ) {
 
 				activeModules.push( mod );
@@ -1587,9 +1586,11 @@ export class ColorGrading extends Extension {
 
 	_getExportFileName( defaultBase = 'My Color Grading' ) {
 
-		if ( this.componentsMap.output && this.componentsMap.output.params && this.componentsMap.output.params.fileName ) {
+		const outputComp = this.componentsMap.get( 'output' );
 
-			return this.componentsMap.output.params.fileName;
+		if ( outputComp && outputComp.params && outputComp.params.fileName ) {
+
+			return outputComp.params.fileName;
 
 		}
 

--- a/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
+++ b/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
@@ -86,7 +86,7 @@ export class ColorGrading extends Extension {
 		this._lutSizeChanged = false;
 		this.activeTab = 'wheels';
 
-		this.componentsMap = new Map();
+		this.modulesMap = new Map();
 		this.cardsMap = new Map();
 
 		// Container Setup matching Inspector tabs
@@ -457,12 +457,12 @@ export class ColorGrading extends Extension {
 				this.pipelineOrder = [ ...DEFAULT_PIPELINE_ORDER ];
 
 				// Remove any custom or duplicated cards if present
-				this.componentsMap.forEach( ( comp, modId ) => {
+				this.modulesMap.forEach( ( comp, modId ) => {
 
 					if ( ! DEFAULT_PIPELINE_ORDER.includes( modId ) ) {
 
 						if ( comp && comp.domElement ) comp.domElement.remove();
-						this.componentsMap.delete( modId );
+						this.modulesMap.delete( modId );
 						this.cardsMap.delete( modId );
 
 					}
@@ -473,7 +473,7 @@ export class ColorGrading extends Extension {
 				this._renderCardsFlow();
 
 				// Reset all module components
-				this.componentsMap.forEach( ( comp ) => {
+				this.modulesMap.forEach( ( comp ) => {
 
 					if ( comp && typeof comp.reset === 'function' ) {
 
@@ -546,7 +546,7 @@ export class ColorGrading extends Extension {
 		const vibranceComp = new VibranceModule( this.params, onParamChange, () => this._removeCard( 'vibrance' ) );
 		const outputComp = new OutputModule( {}, onParamChange );
 
-		this.componentsMap = new Map( [
+		this.modulesMap = new Map( [
 			[ 'renderer', rendererComp ],
 			[ 'whiteBalance', wbComp ],
 			[ 'lift', liftComp ],
@@ -561,7 +561,7 @@ export class ColorGrading extends Extension {
 
 		this.cardsMap = new Map();
 
-		this.componentsMap.forEach( ( comp, id ) => {
+		this.modulesMap.forEach( ( comp, id ) => {
 
 			this.cardsMap.set( id, comp.domElement );
 			this._setupCardDragAndDrop( comp.domElement, id );
@@ -903,7 +903,7 @@ export class ColorGrading extends Extension {
 		// Re-append cards in current pipelineOrder
 		this.pipelineOrder.forEach( ( modId ) => {
 
-			const comp = this.componentsMap.get( modId );
+			const comp = this.modulesMap.get( modId );
 			if ( comp && comp.domElement ) {
 
 				comp.domElement.classList.remove( 'lut-card-moving' );
@@ -1330,7 +1330,7 @@ export class ColorGrading extends Extension {
 
 		}
 
-		this.componentsMap.set( modId, comp );
+		this.modulesMap.set( modId, comp );
 		this.cardsMap.set( modId, comp.domElement );
 
 		const targetIdx = Math.max( 0, Math.min( this.pipelineOrder.length, insertIndex ) );
@@ -1356,11 +1356,11 @@ export class ColorGrading extends Extension {
 
 	_removeCard( modId ) {
 
-		const comp = this.componentsMap.get( modId );
+		const comp = this.modulesMap.get( modId );
 		if ( comp ) {
 
 			if ( comp.domElement ) comp.domElement.remove();
-			this.componentsMap.delete( modId );
+			this.modulesMap.delete( modId );
 			this.cardsMap.delete( modId );
 
 		}
@@ -1542,7 +1542,7 @@ export class ColorGrading extends Extension {
 		const activeModules = [];
 		for ( let i = 0; i < this.pipelineOrder.length; i ++ ) {
 
-			const mod = this.componentsMap.get( this.pipelineOrder[ i ] );
+			const mod = this.modulesMap.get( this.pipelineOrder[ i ] );
 			if ( mod && mod.enabled ) {
 
 				activeModules.push( mod );
@@ -1586,7 +1586,7 @@ export class ColorGrading extends Extension {
 
 	_getExportFileName( defaultBase = 'My Color Grading' ) {
 
-		const outputComp = this.componentsMap.get( 'output' );
+		const outputComp = this.modulesMap.get( 'output' );
 
 		if ( outputComp && outputComp.params && outputComp.params.fileName ) {
 
@@ -1637,7 +1637,7 @@ export class ColorGrading extends Extension {
 		const params = {};
 		const modulesData = {};
 
-		this.componentsMap.forEach( ( comp, id ) => {
+		this.modulesMap.forEach( ( comp, id ) => {
 
 			if ( ! comp ) return;
 
@@ -1752,7 +1752,7 @@ export class ColorGrading extends Extension {
 
 	_applyParamsToModule( modId, params ) {
 
-		const comp = this.componentsMap.get( modId );
+		const comp = this.modulesMap.get( modId );
 		if ( ! comp ) return;
 
 		switch ( modId ) {
@@ -1852,7 +1852,7 @@ export class ColorGrading extends Extension {
 		if ( typeof json.selectedToneMapping === 'number' ) {
 
 			this.selectedToneMapping = json.selectedToneMapping;
-			const rendererComp = this.componentsMap.get( 'renderer' );
+			const rendererComp = this.modulesMap.get( 'renderer' );
 			if ( rendererComp ) {
 
 				rendererComp.fromJSON( { params: { toneMapping: this.selectedToneMapping } } );
@@ -1864,12 +1864,7 @@ export class ColorGrading extends Extension {
 		if ( typeof json.sceneGradingEnabled === 'boolean' ) {
 
 			this.sceneGradingEnabled = json.sceneGradingEnabled;
-			if ( typeof this.updateGradingBtnState === 'function' ) {
-
-				this.updateGradingBtnState();
-
-			}
-
+			this.updateGradingBtnState();
 			this._toggleSceneGrading( this.sceneGradingEnabled );
 
 		}
@@ -1882,12 +1877,12 @@ export class ColorGrading extends Extension {
 
 		if ( json.modules && typeof json.modules === 'object' ) {
 
-			this.componentsMap.forEach( ( comp, id ) => {
+			this.modulesMap.forEach( ( comp, id ) => {
 
 				if ( id !== 'renderer' && id !== 'output' && ! this.pipelineOrder.includes( id ) ) {
 
 					if ( comp.domElement ) comp.domElement.remove();
-					this.componentsMap.delete( id );
+					this.modulesMap.delete( id );
 					this.cardsMap.delete( id );
 
 				}
@@ -1899,16 +1894,16 @@ export class ColorGrading extends Extension {
 				const mData = json.modules[ id ];
 				if ( id === 'renderer' ) {
 
-					const rendererComp = this.componentsMap.get( 'renderer' );
+					const rendererComp = this.modulesMap.get( 'renderer' );
 					if ( rendererComp ) {
 
 						rendererComp.fromJSON( { params: mData.params } );
 
 					}
 
-				} else if ( this.componentsMap.has( id ) ) {
+				} else if ( this.modulesMap.has( id ) ) {
 
-					this.componentsMap.get( id ).fromJSON( { params: mData.params } );
+					this.modulesMap.get( id ).fromJSON( { params: mData.params } );
 
 				} else {
 
@@ -1921,7 +1916,7 @@ export class ColorGrading extends Extension {
 							( removeId ) => this._removeCard( removeId )
 						);
 
-						this.componentsMap.set( id, comp );
+						this.modulesMap.set( id, comp );
 						this.cardsMap.set( id, comp.domElement );
 						this._setupCardDragAndDrop( comp.domElement, id );
 
@@ -1979,12 +1974,12 @@ export class ColorGrading extends Extension {
 			}
 
 			// Remove cards not used by this preset (except renderer)
-			this.componentsMap.forEach( ( comp, id ) => {
+			this.modulesMap.forEach( ( comp, id ) => {
 
 				if ( id !== 'renderer' && id !== 'output' && ! targetOrder.includes( id ) ) {
 
 					if ( comp && comp.domElement ) comp.domElement.remove();
-					this.componentsMap.delete( id );
+					this.modulesMap.delete( id );
 					this.cardsMap.delete( id );
 
 				}
@@ -1996,7 +1991,7 @@ export class ColorGrading extends Extension {
 
 				if ( modId === 'renderer' ) {
 
-					const rendererComp = this.componentsMap.get( 'renderer' );
+					const rendererComp = this.modulesMap.get( 'renderer' );
 					if ( rendererComp && ( params.rendererToneMapping !== undefined || params.rendererExposure !== undefined ) ) {
 
 						const toneMapping = params.rendererToneMapping !== undefined ? params.rendererToneMapping : rendererComp.params.toneMapping;
@@ -2005,7 +2000,7 @@ export class ColorGrading extends Extension {
 
 					}
 
-				} else if ( this.componentsMap.has( modId ) ) {
+				} else if ( this.modulesMap.has( modId ) ) {
 
 					this._applyParamsToModule( modId, params );
 
@@ -2024,7 +2019,7 @@ export class ColorGrading extends Extension {
 				Object.keys( params.importedCubes ).forEach( modId => {
 
 					const cubeData = params.importedCubes[ modId ];
-					const comp = this.componentsMap.get( modId );
+					const comp = this.modulesMap.get( modId );
 
 					if ( ! comp ) {
 
@@ -2035,7 +2030,7 @@ export class ColorGrading extends Extension {
 							( removeId ) => this._removeCard( removeId )
 						);
 
-						this.componentsMap.set( modId, newComp );
+						this.modulesMap.set( modId, newComp );
 						this.cardsMap.set( modId, newComp.domElement );
 						this._setupCardDragAndDrop( newComp.domElement, modId );
 
@@ -2115,8 +2110,8 @@ export class ColorGrading extends Extension {
 			( removeId ) => this._removeCard( removeId )
 		);
 
-		this.componentsMap[ modId ] = comp;
-		this.cardsMap[ modId ] = comp.domElement;
+		this.modulesMap.set( modId, comp );
+		this.cardsMap.set( modId, comp.domElement );
 
 		return comp.domElement;
 
@@ -2178,8 +2173,8 @@ export class ColorGrading extends Extension {
 						( removeId ) => this._removeCard( removeId )
 					);
 
-					this.componentsMap[ modId ] = comp;
-					this.cardsMap[ modId ] = comp.domElement;
+					this.modulesMap.set( modId, comp );
+					this.cardsMap.set( modId, comp.domElement );
 
 					const targetIdx = ( typeof insertIndex === 'number' ) ? Math.max( 0, Math.min( this.pipelineOrder.length, insertIndex ) ) : this.pipelineOrder.length;
 					this.pipelineOrder.splice( targetIdx, 0, modId );
@@ -2226,7 +2221,7 @@ export class ColorGrading extends Extension {
 		super.init( inspector );
 
 		const renderer = inspector.getRenderer();
-		const rendererComp = this.componentsMap.get( 'renderer' );
+		const rendererComp = this.modulesMap.get( 'renderer' );
 
 		if ( renderer && rendererComp ) {
 
@@ -2293,10 +2288,7 @@ export class ColorGrading extends Extension {
 
 	_getRenderPipeline( renderer ) {
 
-		return ( this.options && ( this.options.renderPipeline || this.options.pipeline ) ) ||
-			this.renderPipeline ||
-			( this.inspector && ( this.inspector.renderPipeline || this.inspector.pipeline ) ) ||
-			_rendererPipelines.get( renderer );
+		return _rendererPipelines.get( renderer );
 
 	}
 
@@ -2355,11 +2347,9 @@ export class ColorGrading extends Extension {
 		}
 
 		const renderer = this.inspector.getRenderer();
-		if ( ! renderer ) return;
+		let renderPipeline = _rendererPipelines.get( renderer );
 
-		let renderPipeline = this._getRenderPipeline( renderer );
-
-		const primaryPass = this.inspector.getPrimaryPass ? this.inspector.getPrimaryPass() : this.inspector.primaryPass;
+		const primaryPass = this.inspector.getPrimaryPass();
 		const scene = primaryPass ? primaryPass.scene : null;
 		const camera = primaryPass ? primaryPass.camera : null;
 
@@ -2420,9 +2410,10 @@ export class ColorGrading extends Extension {
 			if ( renderer.toneMapping !== undefined ) {
 
 				this.selectedToneMapping = renderer.toneMapping;
-				if ( this.componentsMap.renderer ) {
+				const rendererComp = this.modulesMap.get( 'renderer' );
+				if ( rendererComp ) {
 
-					this.componentsMap.renderer.fromJSON( { params: { toneMapping: this.selectedToneMapping } } );
+					rendererComp.fromJSON( { params: { toneMapping: this.selectedToneMapping } } );
 
 				}
 
@@ -2455,8 +2446,8 @@ export class ColorGrading extends Extension {
 
 	_removeLiveGrading() {
 
-		const renderer = this.inspector ? this.inspector.getRenderer() : null;
-		const renderPipeline = this._getRenderPipeline( renderer ) || this._createdPipeline;
+		const renderer = this.inspector.getRenderer();
+		const renderPipeline = _rendererPipelines.get( renderer );
 
 		if ( this._originalPipelineSettings ) {
 
@@ -2532,7 +2523,7 @@ export class ColorGrading extends Extension {
 
 		}
 
-		this.componentsMap.clear();
+		this.modulesMap.clear();
 		this.cardsMap.clear();
 
 		super.dispose();

--- a/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
+++ b/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
@@ -1978,14 +1978,13 @@ export class ColorGrading extends Extension {
 			}
 
 			// Remove cards not used by this preset (except renderer)
-			Object.keys( this.componentsMap ).forEach( id => {
+			this.componentsMap.forEach( ( comp, id ) => {
 
-				if ( id !== 'renderer' && ! targetOrder.includes( id ) ) {
+				if ( id !== 'renderer' && id !== 'output' && ! targetOrder.includes( id ) ) {
 
-					const comp = this.componentsMap[ id ];
 					if ( comp && comp.domElement ) comp.domElement.remove();
-					delete this.componentsMap[ id ];
-					delete this.cardsMap[ id ];
+					this.componentsMap.delete( id );
+					this.cardsMap.delete( id );
 
 				}
 
@@ -1996,15 +1995,16 @@ export class ColorGrading extends Extension {
 
 				if ( modId === 'renderer' ) {
 
-					if ( this.componentsMap.renderer && ( params.rendererToneMapping !== undefined || params.rendererExposure !== undefined ) ) {
+					const rendererComp = this.componentsMap.get( 'renderer' );
+					if ( rendererComp && ( params.rendererToneMapping !== undefined || params.rendererExposure !== undefined ) ) {
 
-						const toneMapping = params.rendererToneMapping !== undefined ? params.rendererToneMapping : this.componentsMap.renderer.params.toneMapping;
-						const exposure = params.rendererExposure !== undefined ? params.rendererExposure : this.componentsMap.renderer.params.exposure;
-						this.componentsMap.renderer.fromJSON( { params: { toneMapping, exposure } } );
+						const toneMapping = params.rendererToneMapping !== undefined ? params.rendererToneMapping : rendererComp.params.toneMapping;
+						const exposure = params.rendererExposure !== undefined ? params.rendererExposure : rendererComp.params.exposure;
+						rendererComp.fromJSON( { params: { toneMapping, exposure } } );
 
 					}
 
-				} else if ( this.componentsMap[ modId ] ) {
+				} else if ( this.componentsMap.has( modId ) ) {
 
 					this._applyParamsToModule( modId, params );
 
@@ -2023,22 +2023,24 @@ export class ColorGrading extends Extension {
 				Object.keys( params.importedCubes ).forEach( modId => {
 
 					const cubeData = params.importedCubes[ modId ];
-					if ( ! this.componentsMap[ modId ] ) {
+					const comp = this.componentsMap.get( modId );
 
-						const comp = new ImportedCubeModule(
+					if ( ! comp ) {
+
+						const newComp = new ImportedCubeModule(
 							modId,
 							cubeData,
 							() => this._onParamChange(),
 							( removeId ) => this._removeCard( removeId )
 						);
 
-						this.componentsMap[ modId ] = comp;
-						this.cardsMap[ modId ] = comp.domElement;
-						this._setupCardDragAndDrop( comp.domElement, modId );
+						this.componentsMap.set( modId, newComp );
+						this.cardsMap.set( modId, newComp.domElement );
+						this._setupCardDragAndDrop( newComp.domElement, modId );
 
 					} else {
 
-						this.componentsMap[ modId ].fromJSON( { params: cubeData } );
+						comp.fromJSON( { params: cubeData } );
 
 					}
 

--- a/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
+++ b/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
@@ -1,0 +1,2543 @@
+import { Extension } from 'three/addons/inspector/Extension.js';
+import {
+	createDefaultParams,
+	LUT_PRESETS,
+	exportCubeFormat,
+	exportLUTCanvas,
+	parseCubeFormat
+} from './LUTMath.js';
+import {
+	Data3DTexture,
+	LinearFilter,
+	RGBAFormat,
+	FloatType,
+	NoToneMapping,
+	RenderPipeline
+} from 'three/webgpu';
+import { pass, texture3D, renderOutput } from 'three/tsl';
+import { lut3D } from 'three/addons/tsl/display/Lut3DNode.js';
+
+import { LUT3DStyle } from './LUT3DStyle.js';
+
+// Module imports
+import { WhiteBalanceModule } from './modules/WhiteBalanceModule.js';
+import { ExposureModule } from './modules/ExposureModule.js';
+import { BrightnessModule } from './modules/BrightnessModule.js';
+import { HueModule } from './modules/HueModule.js';
+import { ColorWheelModule } from './modules/ColorWheelModule.js';
+import { CurvesModule } from './modules/CurvesModule.js';
+import { ContrastModule } from './modules/ContrastModule.js';
+import { SaturationModule } from './modules/SaturationModule.js';
+import { VibranceModule } from './modules/VibranceModule.js';
+import { ImportedCubeModule } from './modules/ImportedCubeModule.js';
+import { RendererModule } from './modules/RendererModule.js';
+import { OutputModule } from './modules/OutputModule.js';
+
+const _rendererPipelines = new WeakMap();
+
+const _origRender = RenderPipeline.prototype.render;
+
+if ( _origRender && ! _origRender._lut3dHooked ) {
+
+	RenderPipeline.prototype.render = function ( ...args ) {
+
+		if ( this.renderer ) {
+
+			_rendererPipelines.set( this.renderer, this );
+
+		}
+
+		return _origRender.apply( this, args );
+
+	};
+
+	RenderPipeline.prototype.render._lut3dHooked = true;
+
+}
+
+const DEFAULT_PIPELINE_ORDER = [
+	'renderer',
+	'whiteBalance',
+	'lift',
+	'gammaBal',
+	'gain',
+	'offset',
+	'curves',
+	'saturation',
+	'vibrance',
+	'output'
+];
+
+export class ColorGrading extends Extension {
+
+	constructor( options = {} ) {
+
+		super( 'Color Grading', options );
+
+		LUT3DStyle.init();
+
+		this.params = createDefaultParams();
+		this.lutSize = 32;
+		this.lutTexture = null;
+		this.lutPassNode = null;
+		this.sceneGradingEnabled = false;
+		this.selectedToneMapping = NoToneMapping;
+		this._lutNeedsUpdate = true;
+		this._lutSizeChanged = false;
+		this.activeTab = 'wheels';
+
+		this.componentsMap = {};
+		this.cardsMap = {};
+
+		// Container Setup matching Inspector tabs
+		this.content.style.overflow = 'hidden';
+		this.content.style.display = 'flex';
+		this.content.style.flexDirection = 'column';
+		this.content.style.height = '100%';
+		this.content.style.background = 'transparent';
+
+		this._buildHeader();
+		this._buildMainView();
+
+	}
+
+	_createSvgIcon( svgPath, width = 13, height = 13, strokeWidth = 2 ) {
+
+		const ns = 'http://www.w3.org/2000/svg';
+		const svg = document.createElementNS( ns, 'svg' );
+		svg.setAttribute( 'width', String( width ) );
+		svg.setAttribute( 'height', String( height ) );
+		svg.setAttribute( 'viewBox', '0 0 24 24' );
+		svg.setAttribute( 'fill', 'none' );
+		svg.setAttribute( 'stroke', 'currentColor' );
+		svg.setAttribute( 'stroke-width', String( strokeWidth ) );
+		svg.setAttribute( 'stroke-linecap', 'round' );
+		svg.setAttribute( 'stroke-linejoin', 'round' );
+		svg.style.display = 'block';
+		svg.innerHTML = svgPath;
+		return svg;
+
+	}
+
+	_buildHeader() {
+
+		// All controls consolidated into sleek Control Dock inside lut-container
+
+	}
+
+	_buildMainView() {
+
+		this.viewContainer = document.createElement( 'div' );
+		this.viewContainer.className = this.sceneGradingEnabled ? 'lut-container is-live-active' : 'lut-container';
+
+		// Glass Control Dock Container at top of lut-container
+		const dock = document.createElement( 'div' );
+		dock.className = 'lut-dock-container';
+		this.dockContainer = dock;
+
+		// 1. LEFT GROUP: Grid Size
+		const leftGroup = document.createElement( 'div' );
+		leftGroup.className = 'lut-dock-group';
+
+		const sizeLabel = document.createElement( 'span' );
+		sizeLabel.className = 'lut-dock-label';
+		sizeLabel.textContent = 'Grid';
+
+		const sizeSelect = document.createElement( 'select' );
+		sizeSelect.className = 'lut-dock-select';
+		this.lutSizeSelect = sizeSelect;
+
+		const sizes = [ 16, 32, 64 ];
+		sizes.forEach( size => {
+
+			const opt = document.createElement( 'option' );
+			opt.value = size;
+			opt.textContent = `${size}³`;
+			if ( size === this.lutSize ) opt.selected = true;
+			sizeSelect.appendChild( opt );
+
+		} );
+
+		sizeSelect.onchange = ( e ) => {
+
+			this.lutSize = parseInt( e.target.value, 10 );
+			this._lutSizeChanged = true;
+			this._onParamChange();
+
+		};
+
+		leftGroup.appendChild( sizeLabel );
+		leftGroup.appendChild( sizeSelect );
+
+		// 2. CENTER GROUP: Live Preview Button
+		const centerGroup = document.createElement( 'div' );
+		centerGroup.className = 'lut-dock-group';
+
+		const gradingBtn = document.createElement( 'button' );
+		gradingBtn.className = 'lut-dock-btn';
+		gradingBtn.title = 'Toggle Realtime Scene Color Grading';
+		this.gradingBtn = gradingBtn;
+
+		const updateGradingBtnState = () => {
+
+			gradingBtn.innerHTML = '';
+			const eyeIcon = this._createSvgIcon( '<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>', 13, 13 );
+			const lbl = document.createElement( 'span' );
+
+			if ( this.sceneGradingEnabled ) {
+
+				if ( this.viewContainer ) this.viewContainer.classList.add( 'is-live-active' );
+				gradingBtn.className = 'lut-dock-btn active';
+				lbl.textContent = 'Live Preview';
+				lbl.className = 'lut-dock-text';
+
+			} else {
+
+				if ( this.viewContainer ) this.viewContainer.classList.remove( 'is-live-active' );
+				gradingBtn.className = 'lut-dock-btn';
+				lbl.textContent = 'Live Preview';
+				lbl.className = 'lut-dock-text';
+
+			}
+
+			gradingBtn.appendChild( eyeIcon );
+			gradingBtn.appendChild( lbl );
+			this._updateRendererCardState();
+
+		};
+
+		this.updateGradingBtnState = updateGradingBtnState;
+
+		gradingBtn.onclick = () => {
+
+			this.sceneGradingEnabled = ! this.sceneGradingEnabled;
+			updateGradingBtnState();
+			this._toggleSceneGrading( this.sceneGradingEnabled );
+
+		};
+
+		updateGradingBtnState();
+		centerGroup.appendChild( gradingBtn );
+
+		// Active context menu tracker
+		let activeContextMenu = null;
+
+		const closeContextMenu = () => {
+
+			if ( activeContextMenu ) {
+
+				activeContextMenu.remove();
+				activeContextMenu = null;
+
+			}
+
+		};
+
+		window.addEventListener( 'pointerdown', ( e ) => {
+
+			if ( activeContextMenu && ! activeContextMenu.contains( e.target ) ) {
+
+				closeContextMenu();
+
+			}
+
+		} );
+
+		const showContextMenu = ( parentNode, items, isSubmenu = false ) => {
+
+			if ( ! isSubmenu ) closeContextMenu();
+
+			const menu = document.createElement( 'div' );
+			menu.className = isSubmenu ? 'lut-context-menu lut-submenu' : 'lut-context-menu';
+
+			let activeSubmenu = null;
+
+			const closeActiveSubmenu = () => {
+
+				if ( activeSubmenu ) {
+
+					activeSubmenu.remove();
+					activeSubmenu = null;
+
+				}
+
+			};
+
+			items.forEach( item => {
+
+				if ( item.divider ) {
+
+					const div = document.createElement( 'div' );
+					div.className = 'lut-menu-divider';
+					menu.appendChild( div );
+					return;
+
+				}
+
+				const row = document.createElement( 'div' );
+				row.className = 'lut-menu-item';
+
+				if ( item.iconPath ) {
+
+					const icon = this._createSvgIcon( item.iconPath, 13, 13 );
+					row.appendChild( icon );
+
+				}
+
+				const label = document.createElement( 'span' );
+				label.textContent = item.label;
+				label.style.flex = '1';
+				row.appendChild( label );
+
+				if ( item.submenu ) {
+
+					const arrow = document.createElement( 'span' );
+					arrow.textContent = '▸';
+					arrow.style.cssText = 'font-size: 10px; opacity: 0.6; margin-left: 6px;';
+					row.appendChild( arrow );
+
+					row.style.position = 'relative';
+
+					const toggleSubmenu = ( e ) => {
+
+						e.stopPropagation();
+						if ( activeSubmenu ) {
+
+							closeActiveSubmenu();
+
+						} else {
+
+							activeSubmenu = showContextMenu( row, item.submenu, true );
+
+						}
+
+					};
+
+					row.onmouseenter = () => {
+
+						closeActiveSubmenu();
+						activeSubmenu = showContextMenu( row, item.submenu, true );
+
+					};
+
+					row.onclick = toggleSubmenu;
+
+				} else if ( item.action ) {
+
+					row.onmouseenter = () => closeActiveSubmenu();
+
+					row.onclick = ( e ) => {
+
+						e.stopPropagation();
+						closeContextMenu();
+						item.action();
+
+					};
+
+				}
+
+				menu.appendChild( row );
+
+			} );
+
+			if ( ! isSubmenu ) {
+
+				parentNode.style.position = 'relative';
+				activeContextMenu = menu;
+
+			}
+
+			parentNode.appendChild( menu );
+			return menu;
+
+		};
+
+		// 3. RIGHT GROUP: Action Buttons with Context Menus
+		const rightGroup = document.createElement( 'div' );
+		rightGroup.className = 'lut-dock-group';
+
+		const createDockBtn = ( title, text, svgPath, onClick ) => {
+
+			const btn = document.createElement( 'button' );
+			btn.className = text ? 'lut-dock-btn' : 'lut-dock-btn lut-dock-icon-btn';
+			btn.title = title;
+
+			if ( svgPath ) {
+
+				const icon = this._createSvgIcon( svgPath, 13, 13 );
+				btn.appendChild( icon );
+
+			}
+
+			if ( text ) {
+
+				const txt = document.createElement( 'span' );
+				txt.textContent = text;
+				btn.appendChild( txt );
+
+			}
+
+			btn.onclick = onClick;
+			return btn;
+
+		};
+
+		const importBtn = createDockBtn(
+			'Import (.CUBE / JSON / Presets)',
+			'▾',
+			'<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>',
+			( e ) => {
+
+				e.stopPropagation();
+
+				const presetItems = Object.keys( LUT_PRESETS ).map( presetName => ( {
+					label: presetName,
+					iconPath: '<path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>',
+					action: () => this.load( { params: LUT_PRESETS[ presetName ] } )
+				} ) );
+
+				showContextMenu( importBtn, [
+					{
+						label: 'Load JSON',
+						iconPath: '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>',
+						action: () => this._importJsonFile()
+					},
+					{
+						label: 'Import Adobe .CUBE',
+						iconPath: '<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/>',
+						action: () => this._importCubeFile()
+					},
+					{ divider: true },
+					{
+						label: 'Presets',
+						iconPath: '<path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>',
+						submenu: presetItems
+					}
+				] );
+
+			}
+		);
+
+		const exportBtn = createDockBtn(
+			'Export (.CUBE / PNG / JSON)',
+			'▾',
+			'<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>',
+			( e ) => {
+
+				e.stopPropagation();
+				showContextMenu( exportBtn, [
+					{
+						label: 'Export JSON',
+						iconPath: '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>',
+						action: () => this._exportJsonFile()
+					},
+					{ divider: true },
+					{
+						label: 'Export .CUBE (3D LUT)',
+						iconPath: '<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="7.5 4.21 12 6.81 16.5 4.21"/>',
+						action: () => this._exportCubeFile()
+					},
+					{
+						label: 'Export PNG (2D LUT)',
+						iconPath: '<rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/>',
+						action: () => this._exportPngFile()
+					}
+				] );
+
+			}
+		);
+
+		const resetBtn = createDockBtn(
+			'Reset',
+			null,
+			'<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>',
+			() => {
+
+				// Reset component pipeline order to default
+				this.pipelineOrder = [ ...DEFAULT_PIPELINE_ORDER ];
+
+				// Remove any custom or duplicated cards if present
+				Object.keys( this.componentsMap ).forEach( modId => {
+
+					if ( ! DEFAULT_PIPELINE_ORDER.includes( modId ) ) {
+
+						const comp = this.componentsMap[ modId ];
+						if ( comp && comp.domElement ) comp.domElement.remove();
+						delete this.componentsMap[ modId ];
+						delete this.cardsMap[ modId ];
+
+					}
+
+				} );
+
+				// Re-render pipeline cards flow
+				this._renderCardsFlow();
+
+				// Reset all module components
+				Object.values( this.componentsMap ).forEach( comp => {
+
+					if ( comp && typeof comp.reset === 'function' ) {
+
+						comp.reset();
+
+					}
+
+				} );
+
+				// Reset all color grading parameters to neutral default
+				this.load( { params: LUT_PRESETS[ 'Neutral (Default)' ] } );
+
+			}
+		);
+
+		rightGroup.appendChild( importBtn );
+		rightGroup.appendChild( exportBtn );
+		rightGroup.appendChild( resetBtn );
+
+		dock.appendChild( leftGroup );
+		dock.appendChild( centerGroup );
+		dock.appendChild( rightGroup );
+
+		this.viewContainer.appendChild( dock );
+
+		const panel = document.createElement( 'div' );
+		panel.className = 'lut-panel';
+
+		// Single Unified Horizontal Flow Cards Row
+		this.cardsRow = document.createElement( 'div' );
+		this.cardsRow.className = 'lut-cards-row';
+
+		// Default calculation pipeline sequence
+		this.pipelineOrder = [ ...DEFAULT_PIPELINE_ORDER ];
+
+		// Initialize Module instances
+		const onParamChange = () => this._onParamChange();
+
+		const rendererComp = new RendererModule(
+			{ toneMapping: this.selectedToneMapping, exposure: 1.0 },
+			onParamChange,
+			( comp ) => {
+
+				this.selectedToneMapping = comp.params.toneMapping;
+				if ( this.sceneGradingEnabled ) {
+
+					const renderer = this.inspector ? this.inspector.getRenderer() : null;
+					if ( renderer ) {
+
+						renderer.toneMappingExposure = comp.params.exposure;
+
+					}
+
+					this._applyLiveGrading();
+
+				}
+
+			}
+		);
+
+		const wbComp = new WhiteBalanceModule( this.params, onParamChange, () => this._removeCard( 'whiteBalance' ) );
+
+		const liftComp = new ColorWheelModule( 'lift', 'Shadows', this.params.lift, onParamChange, () => this._removeCard( 'lift' ) );
+		const gammaBalComp = new ColorWheelModule( 'gammaBal', 'Midtones', this.params.gammaBal, onParamChange, () => this._removeCard( 'gammaBal' ) );
+		const gainComp = new ColorWheelModule( 'gain', 'Highlights', this.params.gain, onParamChange, () => this._removeCard( 'gain' ) );
+		const offsetComp = new ColorWheelModule( 'offset', 'Offset', this.params.offset || { r: 0, g: 0, b: 0 }, onParamChange, () => this._removeCard( 'offset' ) );
+
+		const curvesComp = new CurvesModule( this.params.curves, onParamChange, () => this._removeCard( 'curves' ) );
+		const satComp = new SaturationModule( this.params, onParamChange, () => this._removeCard( 'saturation' ) );
+		const vibranceComp = new VibranceModule( this.params, onParamChange, () => this._removeCard( 'vibrance' ) );
+		const outputComp = new OutputModule( {}, onParamChange );
+
+		this.componentsMap = {
+			renderer: rendererComp,
+			whiteBalance: wbComp,
+			lift: liftComp,
+			gammaBal: gammaBalComp,
+			gain: gainComp,
+			offset: offsetComp,
+			curves: curvesComp,
+			saturation: satComp,
+			vibrance: vibranceComp,
+			output: outputComp
+		};
+
+		// Map DOM elements for cards setup
+		Object.keys( this.componentsMap ).forEach( id => {
+
+			const comp = this.componentsMap[ id ];
+			this.cardsMap[ id ] = comp.domElement;
+			this._setupCardDragAndDrop( comp.domElement, id );
+
+		} );
+
+		// Render initial flow of cards separated by connector lines
+		this._renderCardsFlow();
+
+		// Enable mouse wheel horizontal scrolling & background drag-to-pan
+		this._setupPanAndWheelScroll( panel, this.cardsRow );
+
+		if ( typeof ResizeObserver !== 'undefined' ) {
+
+			this._cardsResizeObserver = new ResizeObserver( () => this._updateCardsRowAlignment() );
+			this._cardsResizeObserver.observe( this.cardsRow );
+
+		}
+
+		this._windowResizeHandler = () => this._updateCardsRowAlignment();
+		window.addEventListener( 'resize', this._windowResizeHandler );
+
+		panel.appendChild( this.cardsRow );
+		this.viewContainer.appendChild( panel );
+		this.content.appendChild( this.viewContainer );
+
+	}
+
+	_isVerticalMode() {
+
+		if ( ! this.cardsRow ) return false;
+		const panelEl = this.content ? this.content.closest( '.profiler-panel' ) : null;
+		return this.cardsRow.classList.contains( 'is-vertical' ) ||
+			( this.viewContainer && this.viewContainer.classList.contains( 'is-vertical' ) ) ||
+			( panelEl && ( panelEl.classList.contains( 'position-left' ) || panelEl.classList.contains( 'position-right' ) ) );
+
+	}
+
+	_updateCardsRowAlignment() {
+
+		if ( ! this.cardsRow ) return;
+
+		requestAnimationFrame( () => {
+
+			if ( ! this.cardsRow ) return;
+
+			const isVert = this._isVerticalMode();
+
+			if ( isVert ) {
+
+				const hasVertOverflow = this.cardsRow.scrollHeight > ( this.cardsRow.clientHeight + 2 );
+
+				if ( hasVertOverflow ) {
+
+					this.cardsRow.style.setProperty( 'justify-content', 'flex-start', 'important' );
+
+				} else {
+
+					this.cardsRow.style.setProperty( 'justify-content', 'center', 'important' );
+
+				}
+
+				this.cardsRow.style.setProperty( 'align-items', 'center', 'important' );
+
+			} else {
+
+				const hasOverflow = this.cardsRow.scrollWidth > ( this.cardsRow.clientWidth + 2 );
+
+				if ( hasOverflow ) {
+
+					this.cardsRow.style.setProperty( 'justify-content', 'flex-start', 'important' );
+
+				} else {
+
+					this.cardsRow.style.setProperty( 'justify-content', 'center', 'important' );
+
+				}
+
+				this.cardsRow.style.setProperty( 'align-items', 'center', 'important' );
+
+			}
+
+		} );
+
+	}
+
+	_setupPanAndWheelScroll( container, cardsRow ) {
+
+		if ( ! cardsRow || ! container ) return;
+
+		let targetScroll = 0;
+		let isAnimating = false;
+
+		const isVerticalMode = () => this._isVerticalMode();
+
+		const updateSmoothScroll = () => {
+
+			const isVert = isVerticalMode();
+			const current = isVert ? cardsRow.scrollTop : cardsRow.scrollLeft;
+			const diff = targetScroll - current;
+
+			if ( Math.abs( diff ) > 0.5 ) {
+
+				if ( isVert ) {
+
+					cardsRow.scrollTop += diff * 0.18;
+
+				} else {
+
+					cardsRow.scrollLeft += diff * 0.18;
+
+				}
+
+				requestAnimationFrame( updateSmoothScroll );
+
+			} else {
+
+				if ( isVert ) {
+
+					cardsRow.scrollTop = targetScroll;
+
+				} else {
+
+					cardsRow.scrollLeft = targetScroll;
+
+				}
+
+				isAnimating = false;
+
+			}
+
+		};
+
+		cardsRow.addEventListener( 'wheel', ( e ) => {
+
+			if ( isVerticalMode() ) {
+
+				return; // Native vertical scrolling in vertical mode
+
+			}
+
+			if ( e.deltaY !== 0 ) {
+
+				e.preventDefault();
+
+				const maxScroll = cardsRow.scrollWidth - cardsRow.clientWidth;
+				if ( ! isAnimating ) {
+
+					targetScroll = cardsRow.scrollLeft;
+
+				}
+
+				targetScroll = Math.max( 0, Math.min( maxScroll, targetScroll + e.deltaY * 1.2 ) );
+
+				if ( ! isAnimating ) {
+
+					isAnimating = true;
+					requestAnimationFrame( updateSmoothScroll );
+
+				}
+
+			}
+
+		}, { passive: false } );
+
+		let isPanning = false;
+		let startPos = 0;
+		let scrollStart = 0;
+		let lastPos = 0;
+		let lastTime = 0;
+		let velocity = 0;
+		let momentumRafId = null;
+
+		const startPan = ( e ) => {
+
+			if ( e.pointerType === 'touch' ) return;
+			if ( e.target.closest( '.lut-card' ) || e.target.closest( '.lut-dock-container' ) ) return;
+
+			if ( momentumRafId ) {
+
+				cancelAnimationFrame( momentumRafId );
+				momentumRafId = null;
+
+			}
+
+			isPanning = true;
+			cardsRow.classList.add( 'is-panning' );
+			container.classList.add( 'is-panning' );
+
+			const isVert = isVerticalMode();
+			const currentPos = isVert ? ( e.pageY - cardsRow.offsetTop ) : ( e.pageX - cardsRow.offsetLeft );
+
+			startPos = currentPos;
+			lastPos = currentPos;
+			lastTime = performance.now();
+			velocity = 0;
+			scrollStart = isVert ? cardsRow.scrollTop : cardsRow.scrollLeft;
+			targetScroll = scrollStart;
+
+		};
+
+		const movePan = ( e ) => {
+
+			if ( ! isPanning ) return;
+			e.preventDefault();
+
+			const isVert = isVerticalMode();
+			const currentPos = isVert ? ( e.pageY - cardsRow.offsetTop ) : ( e.pageX - cardsRow.offsetLeft );
+			const currentTime = performance.now();
+
+			const deltaPos = currentPos - lastPos;
+			const deltaTime = Math.max( 1, currentTime - lastTime );
+
+			const instantVelocity = deltaPos / deltaTime;
+			velocity = 0.5 * velocity + 0.5 * instantVelocity;
+
+			lastPos = currentPos;
+			lastTime = currentTime;
+
+			const walk = currentPos - startPos;
+
+			if ( isVert ) {
+
+				cardsRow.scrollTop = scrollStart - walk;
+				targetScroll = cardsRow.scrollTop;
+
+			} else {
+
+				cardsRow.scrollLeft = scrollStart - walk;
+				targetScroll = cardsRow.scrollLeft;
+
+			}
+
+		};
+
+		const endPan = () => {
+
+			if ( ! isPanning ) return;
+
+			isPanning = false;
+			cardsRow.classList.remove( 'is-panning' );
+			container.classList.remove( 'is-panning' );
+
+			const isVert = isVerticalMode();
+
+			// Apply smooth momentum deceleration physics
+			let currentVelocity = velocity;
+
+			const animateMomentum = () => {
+
+				if ( Math.abs( currentVelocity ) < 0.02 ) return;
+
+				const maxScroll = isVert ? ( cardsRow.scrollHeight - cardsRow.clientHeight ) : ( cardsRow.scrollWidth - cardsRow.clientWidth );
+
+				if ( isVert ) {
+
+					cardsRow.scrollTop = Math.max( 0, Math.min( maxScroll, cardsRow.scrollTop - currentVelocity * 16 ) );
+
+				} else {
+
+					cardsRow.scrollLeft = Math.max( 0, Math.min( maxScroll, cardsRow.scrollLeft - currentVelocity * 16 ) );
+
+				}
+
+				currentVelocity *= 0.94; // Friction factor
+
+				if ( Math.abs( currentVelocity ) >= 0.02 ) {
+
+					momentumRafId = requestAnimationFrame( animateMomentum );
+
+				}
+
+			};
+
+			momentumRafId = requestAnimationFrame( animateMomentum );
+
+		};
+
+		cardsRow.addEventListener( 'pointerdown', startPan );
+		window.addEventListener( 'pointermove', movePan );
+		window.addEventListener( 'pointerup', endPan );
+
+	}
+
+	_renderCardsFlow() {
+
+		if ( ! this.cardsRow ) return;
+
+		// Remove cards no longer in pipelineOrder
+		const existingCards = Array.from( this.cardsRow.children );
+		existingCards.forEach( child => {
+
+			const modId = child.getAttribute( 'data-module-id' );
+			if ( modId && ! this.pipelineOrder.includes( modId ) ) {
+
+				child.remove();
+
+			}
+
+		} );
+
+		// Clean old connectors
+		const connectors = this.cardsRow.querySelectorAll( '.lut-flow-connector' );
+		connectors.forEach( c => c.remove() );
+
+		// Guarantee Renderer at start (0) and Output at end (last)
+		if ( ! this.pipelineOrder.includes( 'renderer' ) ) {
+
+			this.pipelineOrder.unshift( 'renderer' );
+
+		} else {
+
+			const rIdx = this.pipelineOrder.indexOf( 'renderer' );
+			if ( rIdx !== 0 ) {
+
+				this.pipelineOrder.splice( rIdx, 1 );
+				this.pipelineOrder.unshift( 'renderer' );
+
+			}
+
+		}
+
+		if ( ! this.pipelineOrder.includes( 'output' ) ) {
+
+			this.pipelineOrder.push( 'output' );
+
+		} else {
+
+			const oIdx = this.pipelineOrder.indexOf( 'output' );
+			if ( oIdx !== this.pipelineOrder.length - 1 ) {
+
+				this.pipelineOrder.splice( oIdx, 1 );
+				this.pipelineOrder.push( 'output' );
+
+			}
+
+		}
+
+		// Re-append cards in current pipelineOrder
+		this.pipelineOrder.forEach( ( modId ) => {
+
+			const comp = this.componentsMap[ modId ];
+			if ( comp && comp.domElement ) {
+
+				comp.domElement.classList.remove( 'lut-card-moving' );
+				this.cardsRow.appendChild( comp.domElement );
+
+			}
+
+		} );
+
+		this._updateLiveFlowConnectors();
+		this._updateRendererCardState();
+		this._updateCardsRowAlignment();
+
+	}
+
+	_updateLiveFlowConnectors() {
+
+		if ( ! this.cardsRow ) return;
+
+		const oldConnectors = this.cardsRow.querySelectorAll( '.lut-flow-connector' );
+		oldConnectors.forEach( c => c.remove() );
+
+		const items = Array.from( this.cardsRow.children ).filter( el =>
+			el.classList.contains( 'lut-card' )
+		);
+
+		const createConnector = ( insertIndex, titleTip ) => {
+
+			const connector = document.createElement( 'div' );
+			connector.className = 'lut-flow-connector';
+			connector.title = titleTip;
+
+			const addBtn = document.createElement( 'button' );
+			addBtn.className = 'lut-connector-add-btn';
+			addBtn.appendChild( this._createSvgIcon( '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>', 12, 12, 2.5 ) );
+			addBtn.title = 'Add Card Here';
+			addBtn.onclick = ( e ) => {
+
+				e.stopPropagation();
+				this._openAddCardModal( insertIndex );
+
+			};
+
+			connector.appendChild( addBtn );
+			return connector;
+
+		};
+
+		for ( let i = 0; i < items.length - 1; i ++ ) {
+
+			const current = items[ i ];
+			const next = items[ i + 1 ];
+
+			const idA = current.getAttribute( 'data-module-id' ) || 'Origin';
+			const idB = next.getAttribute( 'data-module-id' ) || 'Target';
+
+			const connector = createConnector( i + 1, `Insert Card between ${idA} ➔ ${idB}` );
+			this.cardsRow.insertBefore( connector, next );
+
+		}
+
+	}
+
+	_openAddCardModal( insertIndex ) {
+
+		this._closeAddCardModal();
+
+		const overlay = document.createElement( 'div' );
+		overlay.className = 'lut-modal-overlay';
+		this._activeModalOverlay = overlay;
+
+		const content = document.createElement( 'div' );
+		content.className = 'lut-modal-content';
+
+		// Header
+		const header = document.createElement( 'div' );
+		header.className = 'lut-modal-header';
+
+		const title = document.createElement( 'div' );
+		title.className = 'lut-modal-title';
+		title.appendChild( this._createSvgIcon( '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>', 14, 14, 2.5 ) );
+
+		const titleTxt = document.createElement( 'span' );
+		titleTxt.textContent = 'Add to Pipeline';
+		title.appendChild( titleTxt );
+
+		const closeBtn = document.createElement( 'button' );
+		closeBtn.className = 'lut-modal-close-btn';
+		closeBtn.appendChild( this._createSvgIcon( '<line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>', 12, 12, 2.5 ) );
+		closeBtn.title = 'Close';
+		closeBtn.onclick = () => this._closeAddCardModal();
+
+		header.appendChild( title );
+		header.appendChild( closeBtn );
+		content.appendChild( header );
+
+		// Filter Input Search Bar
+		const filterBox = document.createElement( 'div' );
+		filterBox.className = 'lut-modal-filter-box';
+
+		const filterIcon = document.createElement( 'span' );
+		filterIcon.className = 'lut-modal-filter-icon';
+		filterIcon.appendChild( this._createSvgIcon( '<circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>', 13, 13, 2 ) );
+
+		const filterInput = document.createElement( 'input' );
+		filterInput.type = 'text';
+		filterInput.className = 'lut-modal-filter-input';
+		filterInput.placeholder = 'Filter...';
+
+		filterBox.appendChild( filterIcon );
+		filterBox.appendChild( filterInput );
+		content.appendChild( filterBox );
+
+		// Options Grid
+		const grid = document.createElement( 'div' );
+		grid.className = 'lut-modal-grid';
+
+		const emptyMsg = document.createElement( 'div' );
+		emptyMsg.className = 'lut-modal-empty-msg';
+		emptyMsg.textContent = 'No cards match your filter';
+		emptyMsg.style.display = 'none';
+
+		const cardOptions = [
+			{
+				type: 'whiteBalance',
+				name: 'White Balance',
+				iconSvg: '<path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/>'
+			},
+			{
+				type: 'exposure',
+				name: 'Exposure',
+				iconSvg: '<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'
+			},
+			{
+				type: 'brightness',
+				name: 'Brightness',
+				iconSvg: '<circle cx="12" cy="12" r="9"/><path d="M12 3v18a9 9 0 0 0 0-18z"/>'
+			},
+			{
+				type: 'hue',
+				name: 'Hue Shift',
+				iconSvg: '<circle cx="12" cy="12" r="9"/><path d="M12 3a9 9 0 0 1 9 9h-9V3z"/>'
+			},
+			{
+				type: 'lift',
+				name: 'Shadows (Lift)',
+				iconSvg: '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>'
+			},
+			{
+				type: 'gammaBal',
+				name: 'Midtones (Gamma)',
+				iconSvg: '<circle cx="12" cy="12" r="10"/><path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor"/>'
+			},
+			{
+				type: 'gain',
+				name: 'Highlights (Gain)',
+				iconSvg: '<circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="4"/>'
+			},
+			{
+				type: 'offset',
+				name: 'Offset',
+				iconSvg: '<circle cx="12" cy="12" r="10"/><line x1="22" y1="12" x2="18" y2="12"/><line x1="6" y1="12" x2="2" y2="12"/><line x1="12" y1="6" x2="12" y2="2"/><line x1="12" y1="22" x2="12" y2="18"/>'
+			},
+			{
+				type: 'curves',
+				name: 'Curves',
+				iconSvg: '<path d="M3 3v18h18"/><path d="M19 9l-5 5-4-4-3 3"/>'
+			},
+			{
+				type: 'contrast',
+				name: 'Contrast & Pivot',
+				iconSvg: '<circle cx="12" cy="12" r="10"/><path d="M12 2v20a10 10 0 0 0 0-20z"/>'
+			},
+			{
+				type: 'saturation',
+				name: 'Saturation',
+				iconSvg: '<path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z"/>'
+			},
+			{
+				type: 'vibrance',
+				name: 'Vibrance',
+				iconSvg: '<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>'
+			},
+			{
+				type: 'importedCube',
+				name: 'Import .CUBE',
+				iconSvg: '<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/>'
+			}
+		];
+
+		const optionElements = [];
+
+		cardOptions.forEach( opt => {
+
+			const item = document.createElement( 'div' );
+			item.className = 'lut-modal-option';
+
+			const icon = document.createElement( 'div' );
+			icon.className = 'lut-modal-option-icon';
+			icon.appendChild( this._createSvgIcon( opt.iconSvg, 20, 20, 2 ) );
+
+			const optTitle = document.createElement( 'div' );
+			optTitle.className = 'lut-modal-option-title';
+			optTitle.textContent = opt.name;
+
+			item.appendChild( icon );
+			item.appendChild( optTitle );
+
+			const selectAction = () => {
+
+				this._closeAddCardModal();
+				if ( opt.type === 'importedCube' ) {
+
+					this._importCubeFileAt( insertIndex );
+
+				} else {
+
+					this._addCardAt( opt.type, insertIndex );
+
+				}
+
+			};
+
+			item.onclick = selectAction;
+
+			grid.appendChild( item );
+			optionElements.push( { el: item, name: opt.name.toLowerCase(), select: selectAction } );
+
+		} );
+
+		grid.appendChild( emptyMsg );
+
+		const updateFocusState = ( query, visibleCount ) => {
+
+			let singleVisibleObj = null;
+			if ( query.length > 0 && visibleCount === 1 ) {
+
+				singleVisibleObj = optionElements.find( obj => obj.el.style.display !== 'none' );
+
+			}
+
+			optionElements.forEach( obj => {
+
+				if ( singleVisibleObj && obj === singleVisibleObj ) {
+
+					obj.el.classList.add( 'is-focused' );
+
+				} else {
+
+					obj.el.classList.remove( 'is-focused' );
+
+				}
+
+			} );
+
+		};
+
+		filterInput.oninput = () => {
+
+			const query = filterInput.value.trim().toLowerCase();
+			let visibleCount = 0;
+
+			optionElements.forEach( obj => {
+
+				const matches = ! query || obj.name.includes( query );
+				obj.el.style.display = matches ? 'flex' : 'none';
+				if ( matches ) visibleCount ++;
+
+			} );
+
+			emptyMsg.style.display = visibleCount === 0 ? 'block' : 'none';
+
+			if ( visibleCount === 1 ) {
+
+				grid.style.justifyContent = 'center';
+				grid.style.alignContent = 'center';
+				grid.style.gridTemplateColumns = 'minmax(120px, 150px)';
+
+			} else {
+
+				grid.style.justifyContent = 'start';
+				grid.style.alignContent = 'start';
+				grid.style.gridTemplateColumns = 'repeat(auto-fill, minmax(120px, 1fr))';
+
+			}
+
+			updateFocusState( query, visibleCount );
+
+		};
+
+		updateFocusState( '', optionElements.length );
+
+		const handleKeyDown = ( e ) => {
+
+			if ( e.key === 'Escape' || e.code === 'Escape' || e.keyCode === 27 ) {
+
+				e.preventDefault();
+				e.stopImmediatePropagation();
+				this._closeAddCardModal();
+
+			} else if ( e.key === 'Enter' || e.code === 'Enter' || e.keyCode === 13 ) {
+
+				e.preventDefault();
+				e.stopImmediatePropagation();
+				const visibleItem = optionElements.find( obj => obj.el.style.display !== 'none' );
+				if ( visibleItem ) {
+
+					visibleItem.select();
+
+				}
+
+			}
+
+		};
+
+		window.addEventListener( 'keydown', handleKeyDown, true );
+		this._modalKeyDownHandler = handleKeyDown;
+
+		content.appendChild( grid );
+		overlay.appendChild( content );
+
+		setTimeout( () => filterInput.focus(), 50 );
+
+		overlay.onclick = ( e ) => {
+
+			if ( e.target === overlay ) {
+
+				this._closeAddCardModal();
+
+			}
+
+		};
+
+		if ( this.viewContainer ) {
+
+			this.viewContainer.appendChild( overlay );
+
+		}
+
+	}
+
+	_closeAddCardModal() {
+
+		if ( this._modalKeyDownHandler ) {
+
+			window.removeEventListener( 'keydown', this._modalKeyDownHandler, true );
+			this._modalKeyDownHandler = null;
+
+		}
+
+		if ( this._activeModalOverlay ) {
+
+			this._activeModalOverlay.remove();
+			this._activeModalOverlay = null;
+
+		}
+
+	}
+
+	_addCardAt( type, insertIndex, initialParams = {}, customId = null ) {
+
+		const modId = customId || ( `${type}_${Date.now()}_${Math.floor( Math.random() * 1000 )}` );
+
+		const onParamChange = () => this._onParamChange();
+		const onRemove = () => this._removeCard( modId );
+
+		let comp = null;
+
+		switch ( type ) {
+
+			case 'whiteBalance':
+				comp = new WhiteBalanceModule( initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'exposure':
+			case 'exposureHue':
+				comp = new ExposureModule( initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'brightness':
+				comp = new BrightnessModule( initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'hue':
+				comp = new HueModule( initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'lift':
+				comp = new ColorWheelModule( 'lift', 'Shadows', initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'gammaBal':
+				comp = new ColorWheelModule( 'gammaBal', 'Midtones', initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'gain':
+				comp = new ColorWheelModule( 'gain', 'Highlights', initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'offset':
+				comp = new ColorWheelModule( 'offset', 'Offset', initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'curves':
+				comp = new CurvesModule( initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'contrast':
+				comp = new ContrastModule( initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'saturation':
+				comp = new SaturationModule( initialParams, onParamChange, onRemove, modId );
+				break;
+
+			case 'vibrance':
+			case 'satVibrance':
+				comp = new VibranceModule( initialParams, onParamChange, onRemove, modId );
+				break;
+
+			default:
+				console.warn( `Unknown card module type: ${type}` );
+				return null;
+
+		}
+
+		if ( comp ) {
+
+			this.componentsMap[ modId ] = comp;
+			this.cardsMap[ modId ] = comp.domElement;
+
+			const targetIdx = Math.max( 0, Math.min( this.pipelineOrder.length, insertIndex ) );
+			this.pipelineOrder.splice( targetIdx, 0, modId );
+
+			this._setupCardDragAndDrop( comp.domElement, modId );
+			this._renderCardsFlow();
+			this._onParamChange();
+
+			if ( comp.domElement ) {
+
+				setTimeout( () => {
+
+					comp.domElement.scrollIntoView( { behavior: 'smooth', block: 'nearest', inline: 'center' } );
+
+				}, 50 );
+
+			}
+
+		}
+
+		return comp;
+
+	}
+
+	_removeCard( modId ) {
+
+		const comp = this.componentsMap[ modId ];
+		if ( comp ) {
+
+			if ( comp.domElement ) comp.domElement.remove();
+			delete this.componentsMap[ modId ];
+			delete this.cardsMap[ modId ];
+
+		}
+
+		const idx = this.pipelineOrder.indexOf( modId );
+		if ( idx !== - 1 ) {
+
+			this.pipelineOrder.splice( idx, 1 );
+
+		}
+
+		this._renderCardsFlow();
+		this._onParamChange();
+
+	}
+
+	_setupCardDragAndDrop( card, moduleId ) {
+
+		card.setAttribute( 'data-module-id', moduleId );
+
+		const header = card.querySelector( '.lut-card-header' );
+
+		if ( header ) {
+
+			header.draggable = true;
+
+			if ( ! header.querySelector( '.lut-card-drag-handle' ) ) {
+
+				const dragHandle = document.createElement( 'div' );
+				dragHandle.className = 'lut-card-drag-handle';
+				header.insertBefore( dragHandle, header.firstChild );
+
+			}
+
+			header.ondragstart = ( e ) => {
+
+				e.dataTransfer.setData( 'text/plain', moduleId );
+				e.dataTransfer.effectAllowed = 'move';
+				card.classList.add( 'lut-card-moving' );
+				this._draggedModuleId = moduleId;
+
+				this._updateLiveFlowConnectors();
+
+			};
+
+			header.ondragend = () => {
+
+				card.classList.remove( 'lut-card-moving' );
+				this._draggedModuleId = null;
+
+				const newOrder = [];
+				const childCards = this.cardsRow.querySelectorAll( '.lut-card' );
+				childCards.forEach( childCard => {
+
+					const id = childCard.getAttribute( 'data-module-id' );
+					if ( id && ! newOrder.includes( id ) ) {
+
+						newOrder.push( id );
+
+					}
+
+				} );
+
+				if ( newOrder.length > 0 ) {
+
+					this.pipelineOrder = newOrder;
+
+				}
+
+				this._renderCardsFlow();
+				this._onParamChange();
+
+			};
+
+		}
+
+		card.ondragover = ( e ) => {
+
+			e.preventDefault();
+			e.dataTransfer.dropEffect = 'move';
+
+			if ( this._draggedModuleId && this.cardsMap[ this._draggedModuleId ] ) {
+
+				const draggedCard = this.cardsMap[ this._draggedModuleId ];
+				if ( card === draggedCard ) return;
+
+				const rect = card.getBoundingClientRect();
+				const midX = rect.left + rect.width / 2;
+
+				let changed = false;
+
+				if ( e.clientX < midX ) {
+
+					if ( card.previousSibling !== draggedCard ) {
+
+						this.cardsRow.insertBefore( draggedCard, card );
+						changed = true;
+
+					}
+
+				} else {
+
+					if ( card.nextSibling !== draggedCard ) {
+
+						this.cardsRow.insertBefore( draggedCard, card.nextSibling );
+						changed = true;
+
+					}
+
+				}
+
+				if ( changed ) {
+
+					this._updateLiveFlowConnectors();
+
+				}
+
+			}
+
+		};
+
+		card.ondrop = ( e ) => {
+
+			e.preventDefault();
+
+		};
+
+	}
+
+	_updateRendererCardState() {
+
+		if ( ! this.cardsRow ) return;
+
+		const cards = this.cardsRow.querySelectorAll( '.lut-card' );
+		cards.forEach( card => {
+
+			if ( this.sceneGradingEnabled ) {
+
+				card.style.opacity = '1';
+				card.style.pointerEvents = 'auto';
+
+			} else {
+
+				card.style.opacity = '0.4';
+				card.style.pointerEvents = 'none';
+
+			}
+
+		} );
+
+	}
+
+	_onParamChange() {
+
+		this._lutNeedsUpdate = true;
+
+		if ( this.sceneGradingEnabled ) {
+
+			this._applyLiveGrading();
+
+		}
+
+		this.save();
+
+	}
+
+	generate3DLUTData( size = this.lutSize, buffer = null ) {
+
+		if ( buffer === null ) {
+
+			buffer = new Float32Array( size * size * size * 4 );
+
+		}
+
+		let idx = 0;
+		const norm = 1.0 / ( size - 1 );
+		const _pixel = [ 0, 0, 0 ];
+
+		const activeModules = [];
+		for ( let i = 0; i < this.pipelineOrder.length; i ++ ) {
+
+			const mod = this.componentsMap[ this.pipelineOrder[ i ] ];
+			if ( mod && mod.enabled ) {
+
+				activeModules.push( mod );
+
+			}
+
+		}
+
+		const numModules = activeModules.length;
+
+		for ( let b = 0; b < size; b ++ ) {
+
+			for ( let g = 0; g < size; g ++ ) {
+
+				for ( let r = 0; r < size; r ++ ) {
+
+					_pixel[ 0 ] = r * norm;
+					_pixel[ 1 ] = g * norm;
+					_pixel[ 2 ] = b * norm;
+
+					for ( let m = 0; m < numModules; m ++ ) {
+
+						activeModules[ m ].applyPixel( _pixel[ 0 ], _pixel[ 1 ], _pixel[ 2 ], _pixel );
+
+					}
+
+					buffer[ idx ++ ] = _pixel[ 0 ];
+					buffer[ idx ++ ] = _pixel[ 1 ];
+					buffer[ idx ++ ] = _pixel[ 2 ];
+					buffer[ idx ++ ] = 1.0;
+
+				}
+
+			}
+
+		}
+
+		return buffer;
+
+	}
+
+	_getExportFileName( defaultBase = 'My Color Grading' ) {
+
+		if ( this.componentsMap.output && this.componentsMap.output.params && this.componentsMap.output.params.fileName ) {
+
+			return this.componentsMap.output.params.fileName;
+
+		}
+
+		return defaultBase;
+
+	}
+
+	_exportCubeFile() {
+
+		const baseName = this._getExportFileName();
+		const buffer = this.generate3DLUTData( this.lutSize );
+		const cubeContent = exportCubeFormat( buffer, this.lutSize, baseName );
+		const blob = new Blob( [ cubeContent ], { type: 'text/plain' } );
+		const url = URL.createObjectURL( blob );
+
+		const a = document.createElement( 'a' );
+		a.href = url;
+		a.download = `${baseName}_${this.lutSize}x${this.lutSize}.cube`;
+		a.click();
+		URL.revokeObjectURL( url );
+
+	}
+
+	_exportPngFile() {
+
+		const baseName = this._getExportFileName();
+		const buffer = this.generate3DLUTData( this.lutSize );
+		const canvas = exportLUTCanvas( buffer, this.lutSize );
+		canvas.toBlob( ( blob ) => {
+
+			const url = URL.createObjectURL( blob );
+			const a = document.createElement( 'a' );
+			a.href = url;
+			a.download = `${baseName}_${this.lutSize}x${this.lutSize}.png`;
+			a.click();
+			URL.revokeObjectURL( url );
+
+		} );
+
+	}
+
+	toJSON() {
+
+		const params = {};
+		const modulesData = {};
+
+		Object.keys( this.componentsMap ).forEach( id => {
+
+			const comp = this.componentsMap[ id ];
+			if ( ! comp ) return;
+
+			let modType = 'whiteBalance';
+			let mode = null;
+
+			if ( comp.mode ) {
+
+				modType = 'colorWheel';
+				mode = comp.mode;
+
+			} else if ( id.startsWith( 'importedCube_' ) ) {
+
+				modType = 'importedCube';
+
+			} else if ( id.startsWith( 'whiteBalance' ) ) {
+
+				modType = 'whiteBalance';
+
+			} else if ( id.startsWith( 'exposure' ) ) {
+
+				modType = 'exposure';
+
+			} else if ( id.startsWith( 'brightness' ) ) {
+
+				modType = 'brightness';
+
+			} else if ( id.startsWith( 'hue' ) ) {
+
+				modType = 'hue';
+
+			} else if ( id.startsWith( 'curves' ) ) {
+
+				modType = 'curves';
+
+			} else if ( id.startsWith( 'contrast' ) ) {
+
+				modType = 'contrast';
+
+			} else if ( id.startsWith( 'saturation' ) ) {
+
+				modType = 'saturation';
+
+			} else if ( id.startsWith( 'vibrance' ) ) {
+
+				modType = 'vibrance';
+
+			} else if ( id === 'renderer' ) {
+
+				modType = 'renderer';
+
+			} else if ( id === 'output' ) {
+
+				modType = 'output';
+
+			}
+
+			modulesData[ id ] = {
+				type: modType,
+				mode: mode,
+				params: JSON.parse( JSON.stringify( comp.params ) )
+			};
+
+			if ( id === 'lift' || id === 'gammaBal' || id === 'gain' || id === 'offset' ) {
+
+				params[ id ] = JSON.parse( JSON.stringify( comp.params ) );
+
+			} else if ( id === 'curves' ) {
+
+				params.curves = JSON.parse( JSON.stringify( comp.params.curves ) );
+
+			} else if ( id.startsWith( 'importedCube_' ) ) {
+
+				if ( ! params.importedCubes ) params.importedCubes = {};
+				params.importedCubes[ id ] = JSON.parse( JSON.stringify( comp.params ) );
+
+			} else if ( id !== 'renderer' && ! id.includes( '_' ) ) {
+
+				Object.assign( params, JSON.parse( JSON.stringify( comp.params ) ) );
+
+			}
+
+		} );
+
+		return {
+			version: 2,
+			lutSize: this.lutSize,
+			selectedToneMapping: this.selectedToneMapping,
+			sceneGradingEnabled: this.sceneGradingEnabled,
+			pipelineOrder: [ ...this.pipelineOrder ],
+			modules: modulesData,
+			params: params
+		};
+
+	}
+
+	serialize() {
+
+		return this.toJSON();
+
+	}
+
+	deserialize( data ) {
+
+		if ( data ) {
+
+			this.load( data );
+
+		}
+
+	}
+
+	_applyParamsToModule( modId, params ) {
+
+		const comp = this.componentsMap[ modId ];
+		if ( ! comp ) return;
+
+		switch ( modId ) {
+
+			case 'whiteBalance':
+				comp.fromJSON( { params: { temperature: params.temperature ?? 0, tint: params.tint ?? 0 } } );
+				break;
+
+			case 'exposure':
+				comp.fromJSON( { params: { exposure: params.exposure ?? 0 } } );
+				break;
+
+			case 'brightness':
+				comp.fromJSON( { params: { brightness: params.brightness ?? 0 } } );
+				break;
+
+			case 'hue':
+				comp.fromJSON( { params: { hueShift: params.hueShift ?? 0 } } );
+				break;
+
+			case 'lift':
+				if ( params.lift ) comp.fromJSON( { params: params.lift } );
+				else comp.reset();
+				break;
+
+			case 'gammaBal':
+				if ( params.gammaBal ) comp.fromJSON( { params: params.gammaBal } );
+				else comp.reset();
+				break;
+
+			case 'gain':
+				if ( params.gain ) comp.fromJSON( { params: params.gain } );
+				else comp.reset();
+				break;
+
+			case 'offset':
+				if ( params.offset ) comp.fromJSON( { params: params.offset } );
+				else comp.reset();
+				break;
+
+			case 'curves':
+				if ( params.curves ) comp.fromJSON( { params: { curves: params.curves } } );
+				else comp.reset();
+				break;
+
+			case 'contrast':
+				comp.fromJSON( { params: { contrast: params.contrast ?? 1.0, contrastPivot: params.contrastPivot ?? 0.5 } } );
+				break;
+
+			case 'saturation':
+				comp.fromJSON( { params: { saturation: params.saturation ?? 1.0 } } );
+				break;
+
+			case 'vibrance':
+				comp.fromJSON( { params: { vibrance: params.vibrance ?? 0 } } );
+				break;
+
+		}
+
+	}
+
+	load( data ) {
+
+		if ( ! data ) return;
+
+		let json = data;
+		if ( typeof json === 'string' ) {
+
+			try {
+
+				json = JSON.parse( json );
+
+			} catch ( err ) {
+
+				console.error( 'ColorGrading.load: Invalid JSON data', err );
+				return;
+
+			}
+
+		}
+
+		if ( typeof json !== 'object' || json === null ) return;
+
+		const params = json.params ? json.params : ( json.temperature !== undefined || json.contrast !== undefined || json.curves !== undefined ? json : null );
+
+		if ( typeof json.lutSize === 'number' ) {
+
+			this.lutSize = json.lutSize;
+			if ( this.lutSizeSelect ) {
+
+				this.lutSizeSelect.value = String( this.lutSize );
+
+			}
+
+		}
+
+		if ( typeof json.selectedToneMapping === 'number' ) {
+
+			this.selectedToneMapping = json.selectedToneMapping;
+			if ( this.componentsMap.renderer ) {
+
+				this.componentsMap.renderer.fromJSON( { params: { toneMapping: this.selectedToneMapping } } );
+
+			}
+
+		}
+
+		if ( typeof json.sceneGradingEnabled === 'boolean' ) {
+
+			this.sceneGradingEnabled = json.sceneGradingEnabled;
+			if ( typeof this.updateGradingBtnState === 'function' ) {
+
+				this.updateGradingBtnState();
+
+			}
+
+			this._toggleSceneGrading( this.sceneGradingEnabled );
+
+		}
+
+		if ( Array.isArray( json.pipelineOrder ) && json.pipelineOrder.length > 0 ) {
+
+			this.pipelineOrder = [ ...json.pipelineOrder ];
+
+		}
+
+		if ( json.modules && typeof json.modules === 'object' ) {
+
+			Object.keys( this.componentsMap ).forEach( id => {
+
+				if ( id !== 'renderer' && ! json.modules[ id ] ) {
+
+					const comp = this.componentsMap[ id ];
+					if ( comp && comp.domElement ) comp.domElement.remove();
+					delete this.componentsMap[ id ];
+					delete this.cardsMap[ id ];
+
+				}
+
+			} );
+
+			Object.keys( json.modules ).forEach( id => {
+
+				const mData = json.modules[ id ];
+				if ( id === 'renderer' ) {
+
+					if ( this.componentsMap.renderer ) {
+
+						this.componentsMap.renderer.fromJSON( { params: mData.params } );
+
+					}
+
+				} else if ( this.componentsMap[ id ] ) {
+
+					this.componentsMap[ id ].fromJSON( { params: mData.params } );
+
+				} else {
+
+					if ( mData.type === 'importedCube' ) {
+
+						const comp = new ImportedCubeModule(
+							id,
+							mData.params,
+							() => this._onParamChange(),
+							( removeId ) => this._removeCard( removeId )
+						);
+
+						this.componentsMap[ id ] = comp;
+						this.cardsMap[ id ] = comp.domElement;
+						this._setupCardDragAndDrop( comp.domElement, id );
+
+					} else {
+
+						const targetType = mData.mode || mData.type;
+						this._addCardAt( targetType, this.pipelineOrder.length, mData.params, id );
+
+					}
+
+				}
+
+			} );
+
+		} else if ( params ) {
+
+			const isWBActive = ( params.temperature !== undefined && params.temperature !== 0 ) || ( params.tint !== undefined && params.tint !== 0 );
+			const isExpActive = params.exposure !== undefined && params.exposure !== 0;
+			const isBrightActive = params.brightness !== undefined && params.brightness !== 0;
+			const isHueActive = params.hueShift !== undefined && params.hueShift !== 0;
+			const isLiftActive = params.lift && ( params.lift.r !== 0 || params.lift.g !== 0 || params.lift.b !== 0 );
+			const isGammaActive = params.gammaBal && ( params.gammaBal.r !== 0 || params.gammaBal.g !== 0 || params.gammaBal.b !== 0 );
+			const isGainActive = params.gain && ( params.gain.r !== 0 || params.gain.g !== 0 || params.gain.b !== 0 );
+			const isOffsetActive = params.offset && ( params.offset.r !== 0 || params.offset.g !== 0 || params.offset.b !== 0 );
+			const isCurvesActive = params.curves && Array.isArray( params.curves.rgb ) && ( params.curves.rgb.length > 2 || params.curves.rgb.some( p => p.x !== p.y ) || ( params.curves.red && params.curves.red.some( p => p.x !== p.y ) ) || ( params.curves.blue && params.curves.blue.some( p => p.x !== p.y ) ) );
+			const isContrastActive = params.contrast !== undefined && params.contrast !== 1.0;
+			const isSatActive = params.saturation !== undefined && params.saturation !== 1.0;
+			const isVibActive = params.vibrance !== undefined && params.vibrance !== 0;
+
+			const isAllNeutral = ! isWBActive && ! isExpActive && ! isBrightActive && ! isHueActive && ! isLiftActive && ! isGammaActive && ! isGainActive && ! isOffsetActive && ! isCurvesActive && ! isContrastActive && ! isSatActive && ! isVibActive;
+
+			let targetOrder = [];
+
+			if ( isAllNeutral ) {
+
+				targetOrder = [ ...DEFAULT_PIPELINE_ORDER ];
+
+			} else {
+
+				targetOrder = [ 'renderer' ];
+				if ( isWBActive ) targetOrder.push( 'whiteBalance' );
+				if ( isExpActive ) targetOrder.push( 'exposure' );
+				if ( isBrightActive ) targetOrder.push( 'brightness' );
+				if ( isHueActive ) targetOrder.push( 'hue' );
+				if ( isLiftActive ) targetOrder.push( 'lift' );
+				if ( isGammaActive ) targetOrder.push( 'gammaBal' );
+				if ( isGainActive ) targetOrder.push( 'gain' );
+				if ( isOffsetActive ) targetOrder.push( 'offset' );
+				if ( isCurvesActive ) targetOrder.push( 'curves' );
+				if ( isContrastActive ) targetOrder.push( 'contrast' );
+				if ( isSatActive ) targetOrder.push( 'saturation' );
+				if ( isVibActive ) targetOrder.push( 'vibrance' );
+				targetOrder.push( 'output' );
+
+			}
+
+			// Remove cards not used by this preset (except renderer)
+			Object.keys( this.componentsMap ).forEach( id => {
+
+				if ( id !== 'renderer' && ! targetOrder.includes( id ) ) {
+
+					const comp = this.componentsMap[ id ];
+					if ( comp && comp.domElement ) comp.domElement.remove();
+					delete this.componentsMap[ id ];
+					delete this.cardsMap[ id ];
+
+				}
+
+			} );
+
+			// Ensure target cards exist and update their values
+			targetOrder.forEach( ( modId ) => {
+
+				if ( modId === 'renderer' ) {
+
+					if ( this.componentsMap.renderer && ( params.rendererToneMapping !== undefined || params.rendererExposure !== undefined ) ) {
+
+						const toneMapping = params.rendererToneMapping !== undefined ? params.rendererToneMapping : this.componentsMap.renderer.params.toneMapping;
+						const exposure = params.rendererExposure !== undefined ? params.rendererExposure : this.componentsMap.renderer.params.exposure;
+						this.componentsMap.renderer.fromJSON( { params: { toneMapping, exposure } } );
+
+					}
+
+				} else if ( this.componentsMap[ modId ] ) {
+
+					this._applyParamsToModule( modId, params );
+
+				} else {
+
+					this._addCardAt( modId, targetOrder.length, params, modId );
+
+				}
+
+			} );
+
+			this.pipelineOrder = targetOrder;
+
+			if ( params.importedCubes ) {
+
+				Object.keys( params.importedCubes ).forEach( modId => {
+
+					const cubeData = params.importedCubes[ modId ];
+					if ( ! this.componentsMap[ modId ] ) {
+
+						const comp = new ImportedCubeModule(
+							modId,
+							cubeData,
+							() => this._onParamChange(),
+							( removeId ) => this._removeCard( removeId )
+						);
+
+						this.componentsMap[ modId ] = comp;
+						this.cardsMap[ modId ] = comp.domElement;
+						this._setupCardDragAndDrop( comp.domElement, modId );
+
+					} else {
+
+						this.componentsMap[ modId ].fromJSON( { params: cubeData } );
+
+					}
+
+				} );
+
+			}
+
+		}
+
+		this._renderCardsFlow();
+		this._onParamChange();
+
+	}
+
+	_exportJsonFile() {
+
+		const baseName = this._getExportFileName();
+		const configStr = JSON.stringify( this.toJSON(), null, 2 );
+		const blob = new Blob( [ configStr ], { type: 'application/json' } );
+		const url = URL.createObjectURL( blob );
+		const link = document.createElement( 'a' );
+		link.href = url;
+		link.download = `${baseName}.json`;
+		link.click();
+		URL.revokeObjectURL( url );
+
+	}
+
+	_importJsonFile() {
+
+		const fileInput = document.createElement( 'input' );
+		fileInput.type = 'file';
+		fileInput.accept = '.json';
+
+		fileInput.onchange = ( e ) => {
+
+			const file = e.target.files[ 0 ];
+			if ( ! file ) return;
+
+			const reader = new FileReader();
+			reader.onload = ( evt ) => {
+
+				try {
+
+					const json = JSON.parse( evt.target.result );
+					this.load( json );
+
+				} catch ( err ) {
+
+					alert( 'Error reading JSON config file: ' + err.message );
+
+				}
+
+			};
+
+			reader.readAsText( file );
+
+		};
+
+		fileInput.click();
+
+	}
+
+	_createImportedCubeCard( modId ) {
+
+		const cubeInfo = this.params.importedCubes ? this.params.importedCubes[ modId ] : null;
+		const comp = new ImportedCubeModule(
+			modId,
+			cubeInfo || {},
+			() => this._onParamChange(),
+			( removeId ) => this._removeCard( removeId )
+		);
+
+		this.componentsMap[ modId ] = comp;
+		this.cardsMap[ modId ] = comp.domElement;
+
+		return comp.domElement;
+
+	}
+
+	_removeImportedCubeCard( modId ) {
+
+		this._removeCard( modId );
+
+	}
+
+	_importCubeFileAt( insertIndex ) {
+
+		const fileInput = document.createElement( 'input' );
+		fileInput.type = 'file';
+		fileInput.accept = '.cube';
+
+		fileInput.onchange = ( e ) => {
+
+			const file = e.target.files[ 0 ];
+			if ( ! file ) return;
+
+			const reader = new FileReader();
+			reader.onload = ( evt ) => {
+
+				try {
+
+					const text = evt.target.result;
+					const parsed = parseCubeFormat( text );
+					const cubeData = parsed.dataLines || parsed.data;
+					if ( ! cubeData || cubeData.length === 0 ) {
+
+						alert( 'Invalid or empty .CUBE file.' );
+						return;
+
+					}
+
+					const modId = 'importedCube_' + Date.now() + '_' + Math.floor( Math.random() * 1000 );
+
+					const fileNameNoExt = file.name.replace( /\.cube$/i, '' );
+					const parsedTitle = parsed.title ? parsed.title.trim() : '';
+					const isGenericTitle = ! parsedTitle ||
+						parsedTitle.toLowerCase() === 'untitled' ||
+						parsedTitle.toLowerCase() === 'imported lut';
+
+					const titleName = isGenericTitle ? fileNameNoExt : parsedTitle;
+
+					const cubeInfo = {
+						title: titleName,
+						size: parsed.size || 32,
+						dataLines: cubeData,
+						weight: 1.0
+					};
+
+					const comp = new ImportedCubeModule(
+						modId,
+						cubeInfo,
+						() => this._onParamChange(),
+						( removeId ) => this._removeCard( removeId )
+					);
+
+					this.componentsMap[ modId ] = comp;
+					this.cardsMap[ modId ] = comp.domElement;
+
+					const targetIdx = ( typeof insertIndex === 'number' ) ? Math.max( 0, Math.min( this.pipelineOrder.length, insertIndex ) ) : this.pipelineOrder.length;
+					this.pipelineOrder.splice( targetIdx, 0, modId );
+
+					this._setupCardDragAndDrop( comp.domElement, modId );
+
+					this._renderCardsFlow();
+					this._onParamChange();
+
+					if ( comp.domElement ) {
+
+						setTimeout( () => {
+
+							comp.domElement.scrollIntoView( { behavior: 'smooth', block: 'nearest', inline: 'center' } );
+
+						}, 50 );
+
+					}
+
+				} catch ( err ) {
+
+					alert( 'Error reading .CUBE file: ' + err.message );
+
+				}
+
+			};
+
+			reader.readAsText( file );
+
+		};
+
+		fileInput.click();
+
+	}
+
+	_importCubeFile() {
+
+		this._importCubeFileAt( 1 );
+
+	}
+
+	init( inspector ) {
+
+		super.init( inspector );
+
+		const renderer = inspector.getRenderer();
+		const rendererComp = this.componentsMap.renderer;
+
+		if ( renderer && rendererComp ) {
+
+			const defaultTM = ( renderer.toneMapping !== undefined ) ? renderer.toneMapping : NoToneMapping;
+			const defaultExp = ( renderer.toneMappingExposure !== undefined ) ? renderer.toneMappingExposure : 1.0;
+
+			rendererComp.defaultToneMapping = defaultTM;
+			rendererComp.defaultExposure = defaultExp;
+			rendererComp.params.toneMapping = defaultTM;
+			rendererComp.params.exposure = defaultExp;
+			rendererComp.updateUI();
+
+		}
+
+		this.onOrientationChange();
+		this.onLayoutChange();
+
+	}
+
+	setActive( isActive ) {
+
+		super.setActive( isActive );
+
+		if ( isActive ) {
+
+			this.onOrientationChange();
+			this.onLayoutChange();
+
+		}
+
+	}
+
+	onOrientationChange( event ) {
+
+		const isVert = this.inspector.isVertical() ||
+			( event && event.isVertical ) ||
+			( this.content.clientWidth < 550 );
+
+		this.viewContainer.classList.toggle( 'is-vertical', isVert );
+		this.cardsRow.classList.toggle( 'is-vertical', isVert );
+
+		this.onLayoutChange();
+
+	}
+
+	onLayoutChange() {
+
+		const width = this.content.clientWidth;
+		this.dockContainer.classList.toggle( 'is-compact', width > 0 && width < 400 );
+
+	}
+
+	update( inspector ) {
+
+		super.update( inspector );
+
+		if ( this.sceneGradingEnabled && ( this._lutNeedsUpdate || this._lutSizeChanged ) ) {
+
+			this._updateLiveGrading( inspector );
+
+		}
+
+	}
+
+	_getRenderPipeline( renderer ) {
+
+		return ( this.options && ( this.options.renderPipeline || this.options.pipeline ) ) ||
+			this.renderPipeline ||
+			( this.inspector && ( this.inspector.renderPipeline || this.inspector.pipeline ) ) ||
+			_rendererPipelines.get( renderer );
+
+	}
+
+	_toggleSceneGrading( enable ) {
+
+		this.sceneGradingEnabled = enable;
+
+		if ( enable ) {
+
+			this._lutNeedsUpdate = true;
+
+			this._applyLiveGrading();
+
+		} else {
+
+			this._removeLiveGrading();
+
+		}
+
+	}
+
+	_updateLiveGrading( /* inspector */ ) {
+
+		if ( this.sceneGradingEnabled ) {
+
+			this._applyLiveGrading();
+
+		}
+
+	}
+
+	_applyLiveGrading() {
+
+		if ( ! this.lutTexture || this._lutSizeChanged || this._lutNeedsUpdate ) {
+
+			const buffer = ( this.lutTexture && this.lutTexture.image && ! this._lutSizeChanged ) ? this.lutTexture.image.data : null;
+			const data = this.generate3DLUTData( this.lutSize, buffer );
+
+			if ( ! this.lutTexture || this._lutSizeChanged ) {
+
+				if ( this.lutTexture ) this.lutTexture.dispose();
+
+				this.lutTexture = new Data3DTexture( data, this.lutSize, this.lutSize, this.lutSize );
+				this.lutTexture.format = RGBAFormat;
+				this.lutTexture.type = FloatType;
+				this.lutTexture.minFilter = LinearFilter;
+				this.lutTexture.magFilter = LinearFilter;
+				this.lutTexture.unpackAlignment = 1;
+				this._lutSizeChanged = false;
+
+			}
+
+			this.lutTexture.needsUpdate = true;
+			this._lutNeedsUpdate = false;
+
+		}
+
+		const renderer = this.inspector.getRenderer();
+		if ( ! renderer ) return;
+
+		let renderPipeline = this._getRenderPipeline( renderer );
+
+		const primaryPass = this.inspector.getPrimaryPass ? this.inspector.getPrimaryPass() : this.inspector.primaryPass;
+		const scene = primaryPass ? primaryPass.scene : null;
+		const camera = primaryPass ? primaryPass.camera : null;
+
+		if ( ! renderPipeline && scene && camera ) {
+
+			this._createdPipeline = new RenderPipeline( renderer, pass( scene, camera ) );
+			renderPipeline = this._createdPipeline;
+			_rendererPipelines.set( renderer, renderPipeline );
+
+		}
+
+		if ( ! renderPipeline ) return;
+
+		if ( this._createdPipeline && ! this._origRendererRender ) {
+
+			this._origRendererRender = renderer.render;
+			let isRendering = false;
+
+			renderer.render = ( sceneArg, cameraArg, ...rest ) => {
+
+				if ( this.sceneGradingEnabled && ! isRendering ) {
+
+					const activePipeline = _rendererPipelines.get( renderer );
+
+					if ( activePipeline ) {
+
+						isRendering = true;
+
+						try {
+
+							activePipeline.render();
+							return;
+
+						} finally {
+
+							isRendering = false;
+
+						}
+
+					}
+
+				}
+
+				return this._origRendererRender.call( renderer, sceneArg, cameraArg, ...rest );
+
+			};
+
+		}
+
+		if ( ! this._originalPipelineSettings ) {
+
+			this._originalPipelineSettings = {
+				outputNode: renderPipeline.outputNode,
+				outputColorTransform: renderPipeline.outputColorTransform,
+				rendererToneMapping: renderer.toneMapping
+			};
+
+			if ( renderer.toneMapping !== undefined ) {
+
+				this.selectedToneMapping = renderer.toneMapping;
+				if ( this.componentsMap.renderer ) {
+
+					this.componentsMap.renderer.fromJSON( { params: { toneMapping: this.selectedToneMapping } } );
+
+				}
+
+			}
+
+		}
+
+		renderer.toneMapping = this.selectedToneMapping;
+		renderPipeline.outputColorTransform = false;
+
+		let inputNode = this._originalPipelineSettings.outputNode;
+
+		if ( ! inputNode && scene && camera ) {
+
+			inputNode = pass( scene, camera );
+
+		}
+
+		if ( inputNode ) {
+
+			const outputPass = renderOutput( inputNode, this.selectedToneMapping );
+			this.lutPassNode = lut3D( outputPass, texture3D( this.lutTexture ), this.lutSize, 1.0 );
+
+			renderPipeline.outputNode = this.lutPassNode;
+			renderPipeline.needsUpdate = true;
+
+		}
+
+	}
+
+	_removeLiveGrading() {
+
+		const renderer = this.inspector ? this.inspector.getRenderer() : null;
+		const renderPipeline = this._getRenderPipeline( renderer ) || this._createdPipeline;
+
+		if ( this._originalPipelineSettings ) {
+
+			if ( renderPipeline ) {
+
+				renderPipeline.outputNode = this._originalPipelineSettings.outputNode;
+				renderPipeline.outputColorTransform = this._originalPipelineSettings.outputColorTransform;
+				renderPipeline.needsUpdate = true;
+
+			}
+
+			if ( renderer && this._originalPipelineSettings.rendererToneMapping !== undefined ) {
+
+				renderer.toneMapping = this._originalPipelineSettings.rendererToneMapping;
+
+			}
+
+			this._originalPipelineSettings = null;
+
+		}
+
+		if ( renderer && this._origRendererRender ) {
+
+			renderer.render = this._origRendererRender;
+			this._origRendererRender = null;
+
+		}
+
+		if ( this._createdPipeline ) {
+
+			if ( renderer ) {
+
+				_rendererPipelines.delete( renderer );
+
+			}
+
+			if ( typeof this._createdPipeline.dispose === 'function' ) {
+
+				this._createdPipeline.dispose();
+
+			}
+
+			this._createdPipeline = null;
+
+		}
+
+		this.lutPassNode = null;
+
+		if ( this.lutTexture ) {
+
+			this.lutTexture.dispose();
+			this.lutTexture = null;
+
+		}
+
+	}
+
+	dispose() {
+
+		this._removeLiveGrading();
+
+		if ( this._cardsResizeObserver ) {
+
+			this._cardsResizeObserver.disconnect();
+			this._cardsResizeObserver = null;
+
+		}
+
+		if ( this._windowResizeHandler ) {
+
+			window.removeEventListener( 'resize', this._windowResizeHandler );
+			this._windowResizeHandler = null;
+
+		}
+
+		this.componentsMap = {};
+		this.cardsMap = {};
+
+		super.dispose();
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
+++ b/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
@@ -213,6 +213,7 @@ export class ColorGrading extends Extension {
 			this.sceneGradingEnabled = ! this.sceneGradingEnabled;
 			updateGradingBtnState();
 			this._toggleSceneGrading( this.sceneGradingEnabled );
+			this.save();
 
 		};
 
@@ -530,6 +531,8 @@ export class ColorGrading extends Extension {
 					this._applyLiveGrading();
 
 				}
+
+				this.save();
 
 			}
 		);

--- a/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
+++ b/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
@@ -2484,12 +2484,7 @@ export class ColorGrading extends Extension {
 
 			}
 
-			if ( typeof this._createdPipeline.dispose === 'function' ) {
-
-				this._createdPipeline.dispose();
-
-			}
-
+			this._createdPipeline.dispose();
 			this._createdPipeline = null;
 
 		}

--- a/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
+++ b/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
@@ -1384,59 +1384,87 @@ export class ColorGrading extends Extension {
 
 		card.setAttribute( 'data-module-id', moduleId );
 
+		const comp = this.modulesMap.get( moduleId );
+		const isDraggable = comp ? comp.dragAndDrop !== false : true;
+
+		if ( ! isDraggable ) {
+
+			card.classList.add( 'lut-card-nodrag' );
+
+		}
+
 		const header = card.querySelector( '.lut-card-header' );
 
 		if ( header ) {
 
-			header.draggable = true;
+			if ( isDraggable ) {
 
-			if ( ! header.querySelector( '.lut-card-drag-handle' ) ) {
+				header.draggable = true;
 
-				const dragHandle = document.createElement( 'div' );
-				dragHandle.className = 'lut-card-drag-handle';
-				header.insertBefore( dragHandle, header.firstChild );
+				if ( ! header.querySelector( '.lut-card-drag-handle' ) ) {
 
-			}
-
-			header.ondragstart = ( e ) => {
-
-				e.dataTransfer.setData( 'text/plain', moduleId );
-				e.dataTransfer.effectAllowed = 'move';
-				card.classList.add( 'lut-card-moving' );
-				this._draggedModuleId = moduleId;
-
-				this._updateLiveFlowConnectors();
-
-			};
-
-			header.ondragend = () => {
-
-				card.classList.remove( 'lut-card-moving' );
-				this._draggedModuleId = null;
-
-				const newOrder = [];
-				const childCards = this.cardsRow.querySelectorAll( '.lut-card' );
-				childCards.forEach( childCard => {
-
-					const id = childCard.getAttribute( 'data-module-id' );
-					if ( id && ! newOrder.includes( id ) ) {
-
-						newOrder.push( id );
-
-					}
-
-				} );
-
-				if ( newOrder.length > 0 ) {
-
-					this.pipelineOrder = newOrder;
+					const dragHandle = document.createElement( 'div' );
+					dragHandle.className = 'lut-card-drag-handle';
+					header.insertBefore( dragHandle, header.firstChild );
 
 				}
 
-				this._renderCardsFlow();
-				this._onParamChange();
+				header.ondragstart = ( e ) => {
 
-			};
+					e.dataTransfer.setData( 'text/plain', moduleId );
+					e.dataTransfer.effectAllowed = 'move';
+
+					const rect = card.getBoundingClientRect();
+					const xOffset = e.clientX - rect.left;
+					const yOffset = e.clientY - rect.top;
+					e.dataTransfer.setDragImage( card, xOffset, yOffset );
+
+					this._draggedModuleId = moduleId;
+
+					setTimeout( () => {
+
+						card.classList.add( 'lut-card-moving' );
+
+					}, 0 );
+
+					this._updateLiveFlowConnectors();
+
+				};
+
+				header.ondragend = () => {
+
+					card.classList.remove( 'lut-card-moving' );
+					this._draggedModuleId = null;
+
+					const newOrder = [];
+					const childCards = this.cardsRow.querySelectorAll( '.lut-card' );
+					childCards.forEach( childCard => {
+
+						const id = childCard.getAttribute( 'data-module-id' );
+						if ( id && ! newOrder.includes( id ) ) {
+
+							newOrder.push( id );
+
+						}
+
+					} );
+
+					if ( newOrder.length > 0 ) {
+
+						this.pipelineOrder = newOrder;
+
+					}
+
+					this._renderCardsFlow();
+					this._onParamChange();
+
+				};
+
+			} else {
+
+				header.draggable = false;
+
+			}
 
 		}
 
@@ -1450,26 +1478,82 @@ export class ColorGrading extends Extension {
 				const draggedCard = this.cardsMap.get( this._draggedModuleId );
 				if ( card === draggedCard ) return;
 
+				const targetComp = this.modulesMap.get( moduleId );
+				if ( targetComp && targetComp.dragAndDrop === false ) return;
+
+				const draggedComp = this.modulesMap.get( this._draggedModuleId );
+				if ( draggedComp && draggedComp.dragAndDrop === false ) return;
+
 				const rect = card.getBoundingClientRect();
-				const midX = rect.left + rect.width / 2;
+				const isVert = this._isVerticalMode();
+
+				const childCards = Array.from( this.cardsRow.querySelectorAll( '.lut-card' ) );
+				const draggedIndex = childCards.indexOf( draggedCard );
+				const targetIndex = childCards.indexOf( card );
 
 				let changed = false;
 
-				if ( e.clientX < midX ) {
+				if ( isVert ) {
 
-					if ( card.previousSibling !== draggedCard ) {
+					const relativeY = ( e.clientY - rect.top ) / rect.height;
 
-						this.cardsRow.insertBefore( draggedCard, card );
-						changed = true;
+					if ( draggedIndex < targetIndex ) {
+
+						if ( relativeY > 0.05 ) {
+
+							if ( card.nextSibling !== draggedCard ) {
+
+								this.cardsRow.insertBefore( draggedCard, card.nextSibling );
+								changed = true;
+
+							}
+
+						}
+
+					} else {
+
+						if ( relativeY < 0.95 ) {
+
+							if ( card.previousSibling !== draggedCard ) {
+
+								this.cardsRow.insertBefore( draggedCard, card );
+								changed = true;
+
+							}
+
+						}
 
 					}
 
 				} else {
 
-					if ( card.nextSibling !== draggedCard ) {
+					const relativeX = ( e.clientX - rect.left ) / rect.width;
 
-						this.cardsRow.insertBefore( draggedCard, card.nextSibling );
-						changed = true;
+					if ( draggedIndex < targetIndex ) {
+
+						if ( relativeX > 0.05 ) {
+
+							if ( card.nextSibling !== draggedCard ) {
+
+								this.cardsRow.insertBefore( draggedCard, card.nextSibling );
+								changed = true;
+
+							}
+
+						}
+
+					} else {
+
+						if ( relativeX < 0.95 ) {
+
+							if ( card.previousSibling !== draggedCard ) {
+
+								this.cardsRow.insertBefore( draggedCard, card );
+								changed = true;
+
+							}
+
+						}
 
 					}
 

--- a/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
+++ b/examples/jsm/inspector/extensions/color-grading/ColorGrading.js
@@ -86,8 +86,8 @@ export class ColorGrading extends Extension {
 		this._lutSizeChanged = false;
 		this.activeTab = 'wheels';
 
-		this.componentsMap = {};
-		this.cardsMap = {};
+		this.componentsMap = new Map();
+		this.cardsMap = new Map();
 
 		// Container Setup matching Inspector tabs
 		this.content.style.overflow = 'hidden';
@@ -547,24 +547,24 @@ export class ColorGrading extends Extension {
 		const vibranceComp = new VibranceModule( this.params, onParamChange, () => this._removeCard( 'vibrance' ) );
 		const outputComp = new OutputModule( {}, onParamChange );
 
-		this.componentsMap = {
-			renderer: rendererComp,
-			whiteBalance: wbComp,
-			lift: liftComp,
-			gammaBal: gammaBalComp,
-			gain: gainComp,
-			offset: offsetComp,
-			curves: curvesComp,
-			saturation: satComp,
-			vibrance: vibranceComp,
-			output: outputComp
-		};
+		this.componentsMap = new Map( [
+			[ 'renderer', rendererComp ],
+			[ 'whiteBalance', wbComp ],
+			[ 'lift', liftComp ],
+			[ 'gammaBal', gammaBalComp ],
+			[ 'gain', gainComp ],
+			[ 'offset', offsetComp ],
+			[ 'curves', curvesComp ],
+			[ 'saturation', satComp ],
+			[ 'vibrance', vibranceComp ],
+			[ 'output', outputComp ]
+		] );
 
-		// Map DOM elements for cards setup
-		Object.keys( this.componentsMap ).forEach( id => {
+		this.cardsMap = new Map();
 
-			const comp = this.componentsMap[ id ];
-			this.cardsMap[ id ] = comp.domElement;
+		this.componentsMap.forEach( ( comp, id ) => {
+
+			this.cardsMap.set( id, comp.domElement );
 			this._setupCardDragAndDrop( comp.domElement, id );
 
 		} );
@@ -904,7 +904,7 @@ export class ColorGrading extends Extension {
 		// Re-append cards in current pipelineOrder
 		this.pipelineOrder.forEach( ( modId ) => {
 
-			const comp = this.componentsMap[ modId ];
+			const comp = this.componentsMap.get( modId );
 			if ( comp && comp.domElement ) {
 
 				comp.domElement.classList.remove( 'lut-card-moving' );
@@ -1331,8 +1331,8 @@ export class ColorGrading extends Extension {
 
 		}
 
-		this.componentsMap[ modId ] = comp;
-		this.cardsMap[ modId ] = comp.domElement;
+		this.componentsMap.set( modId, comp );
+		this.cardsMap.set( modId, comp.domElement );
 
 		const targetIdx = Math.max( 0, Math.min( this.pipelineOrder.length, insertIndex ) );
 		this.pipelineOrder.splice( targetIdx, 0, modId );
@@ -1357,12 +1357,12 @@ export class ColorGrading extends Extension {
 
 	_removeCard( modId ) {
 
-		const comp = this.componentsMap[ modId ];
+		const comp = this.componentsMap.get( modId );
 		if ( comp ) {
 
 			if ( comp.domElement ) comp.domElement.remove();
-			delete this.componentsMap[ modId ];
-			delete this.cardsMap[ modId ];
+			this.componentsMap.delete( modId );
+			this.cardsMap.delete( modId );
 
 		}
 
@@ -1636,9 +1636,8 @@ export class ColorGrading extends Extension {
 		const params = {};
 		const modulesData = {};
 
-		Object.keys( this.componentsMap ).forEach( id => {
+		this.componentsMap.forEach( ( comp, id ) => {
 
-			const comp = this.componentsMap[ id ];
 			if ( ! comp ) return;
 
 			let modType = 'whiteBalance';
@@ -1752,7 +1751,7 @@ export class ColorGrading extends Extension {
 
 	_applyParamsToModule( modId, params ) {
 
-		const comp = this.componentsMap[ modId ];
+		const comp = this.componentsMap.get( modId );
 		if ( ! comp ) return;
 
 		switch ( modId ) {
@@ -1852,9 +1851,10 @@ export class ColorGrading extends Extension {
 		if ( typeof json.selectedToneMapping === 'number' ) {
 
 			this.selectedToneMapping = json.selectedToneMapping;
-			if ( this.componentsMap.renderer ) {
+			const rendererComp = this.componentsMap.get( 'renderer' );
+			if ( rendererComp ) {
 
-				this.componentsMap.renderer.fromJSON( { params: { toneMapping: this.selectedToneMapping } } );
+				rendererComp.fromJSON( { params: { toneMapping: this.selectedToneMapping } } );
 
 			}
 
@@ -1881,14 +1881,13 @@ export class ColorGrading extends Extension {
 
 		if ( json.modules && typeof json.modules === 'object' ) {
 
-			Object.keys( this.componentsMap ).forEach( id => {
+			this.componentsMap.forEach( ( comp, id ) => {
 
-				if ( id !== 'renderer' && ! json.modules[ id ] ) {
+				if ( id !== 'renderer' && id !== 'output' && ! this.pipelineOrder.includes( id ) ) {
 
-					const comp = this.componentsMap[ id ];
-					if ( comp && comp.domElement ) comp.domElement.remove();
-					delete this.componentsMap[ id ];
-					delete this.cardsMap[ id ];
+					if ( comp.domElement ) comp.domElement.remove();
+					this.componentsMap.delete( id );
+					this.cardsMap.delete( id );
 
 				}
 
@@ -1899,15 +1898,16 @@ export class ColorGrading extends Extension {
 				const mData = json.modules[ id ];
 				if ( id === 'renderer' ) {
 
-					if ( this.componentsMap.renderer ) {
+					const rendererComp = this.componentsMap.get( 'renderer' );
+					if ( rendererComp ) {
 
-						this.componentsMap.renderer.fromJSON( { params: mData.params } );
+						rendererComp.fromJSON( { params: mData.params } );
 
 					}
 
-				} else if ( this.componentsMap[ id ] ) {
+				} else if ( this.componentsMap.has( id ) ) {
 
-					this.componentsMap[ id ].fromJSON( { params: mData.params } );
+					this.componentsMap.get( id ).fromJSON( { params: mData.params } );
 
 				} else {
 
@@ -1920,8 +1920,8 @@ export class ColorGrading extends Extension {
 							( removeId ) => this._removeCard( removeId )
 						);
 
-						this.componentsMap[ id ] = comp;
-						this.cardsMap[ id ] = comp.domElement;
+						this.componentsMap.set( id, comp );
+						this.cardsMap.set( id, comp.domElement );
 						this._setupCardDragAndDrop( comp.domElement, id );
 
 					} else {
@@ -2223,7 +2223,7 @@ export class ColorGrading extends Extension {
 		super.init( inspector );
 
 		const renderer = inspector.getRenderer();
-		const rendererComp = this.componentsMap.renderer;
+		const rendererComp = this.componentsMap.get( 'renderer' );
 
 		if ( renderer && rendererComp ) {
 
@@ -2529,8 +2529,8 @@ export class ColorGrading extends Extension {
 
 		}
 
-		this.componentsMap = {};
-		this.cardsMap = {};
+		this.componentsMap.clear();
+		this.cardsMap.clear();
 
 		super.dispose();
 

--- a/examples/jsm/inspector/extensions/color-grading/ColorWheel.js
+++ b/examples/jsm/inspector/extensions/color-grading/ColorWheel.js
@@ -1,0 +1,352 @@
+/**
+ * ColorWheel.js - DaVinci Resolve style interactive Color Wheel control widget
+ */
+
+export class ColorWheel {
+
+	constructor( title, initialValues = { r: 0, g: 0, b: 0 }, onChange, onRemove = null ) {
+
+		this.title = title;
+		this.values = { r: initialValues.r || 0, g: initialValues.g || 0, b: initialValues.b || 0 };
+		this.onChange = onChange;
+		this.onRemove = onRemove;
+
+		this.domElement = document.createElement( 'div' );
+		this.domElement.className = 'lut-card';
+
+		this._buildUI();
+		this._initEvents();
+
+		// Deferred initial draw
+		requestAnimationFrame( () => this.draw() );
+
+	}
+
+	_buildUI() {
+
+		// Header title + reset + remove
+		const header = document.createElement( 'div' );
+		header.className = 'lut-card-header';
+
+		const _createSvgIcon = ( svgPath, width = 11, height = 11, strokeWidth = 2.5 ) => {
+
+			const ns = 'http://www.w3.org/2000/svg';
+			const svg = document.createElementNS( ns, 'svg' );
+			svg.setAttribute( 'width', String( width ) );
+			svg.setAttribute( 'height', String( height ) );
+			svg.setAttribute( 'viewBox', '0 0 24 24' );
+			svg.setAttribute( 'fill', 'none' );
+			svg.setAttribute( 'stroke', 'currentColor' );
+			svg.setAttribute( 'stroke-width', String( strokeWidth ) );
+			svg.setAttribute( 'stroke-linecap', 'round' );
+			svg.setAttribute( 'stroke-linejoin', 'round' );
+			svg.style.display = 'block';
+			svg.innerHTML = svgPath;
+			return svg;
+
+		};
+
+		// Left Drag Handle + Reset Button
+		const dragHandle = document.createElement( 'div' );
+		dragHandle.className = 'lut-card-drag-handle';
+
+		const resetBtn = document.createElement( 'button' );
+		resetBtn.className = 'card-reset-btn lut-card-reset-btn';
+		resetBtn.appendChild( _createSvgIcon( '<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>', 13, 13, 2.5 ) );
+		resetBtn.title = 'Reset Wheel';
+		resetBtn.onclick = ( e ) => {
+
+			e.stopPropagation();
+			this.setValues( 0, 0, 0 );
+			if ( typeof this.onChange === 'function' ) this.onChange( this.values );
+
+		};
+
+		dragHandle.appendChild( resetBtn );
+		header.appendChild( dragHandle );
+
+		const titleLabel = document.createElement( 'span' );
+		titleLabel.className = 'lut-card-title';
+		titleLabel.textContent = this.title;
+		header.appendChild( titleLabel );
+
+		// Right Remove Button (where reset button was)
+		if ( this.onRemove ) {
+
+			const removeBtn = document.createElement( 'button' );
+			removeBtn.className = 'lut-card-remove-btn';
+			removeBtn.appendChild( _createSvgIcon( '<line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>', 13, 13, 2.5 ) );
+			removeBtn.title = 'Remove Wheel Card';
+			removeBtn.onclick = ( e ) => {
+
+				e.stopPropagation();
+				this.onRemove();
+
+			};
+
+			header.appendChild( removeBtn );
+
+		}
+
+		this.domElement.appendChild( header );
+
+		// Wheel Canvas
+		this.canvas = document.createElement( 'canvas' );
+		this.canvas.width = 110;
+		this.canvas.height = 110;
+		this.canvas.className = 'lut-wheel-canvas';
+		this.ctx = this.canvas.getContext( '2d' );
+		this.domElement.appendChild( this.canvas );
+
+		// Master Y (Luminance) Slider directly below canvas wheel
+		const ySlider = document.createElement( 'input' );
+		ySlider.type = 'range';
+		ySlider.className = 'inspector-slider';
+		ySlider.style.cssText = 'width: 100%; margin: 4px 0 2px 0 !important;';
+		ySlider.min = '-0.5';
+		ySlider.max = '0.5';
+		ySlider.step = '0.01';
+		ySlider.value = ( this.values && typeof this.values.y === 'number' ) ? this.values.y : 0;
+		this.ySlider = ySlider;
+
+		ySlider.oninput = () => {
+
+			const val = parseFloat( ySlider.value );
+			if ( this.inputs.y ) this.inputs.y.value = val.toFixed( 2 );
+			this.values.y = val;
+			if ( typeof this.onChange === 'function' ) this.onChange( this.values );
+
+		};
+
+		this.domElement.appendChild( ySlider );
+
+		// Bottom Inputs Row (Y, R, G, B)
+		const inputsRow = document.createElement( 'div' );
+		inputsRow.className = 'lut-wheel-inputs-row';
+
+		this.inputs = {};
+
+		[
+			{ key: 'y', label: 'Y' },
+			{ key: 'r', label: 'R' },
+			{ key: 'g', label: 'G' },
+			{ key: 'b', label: 'B' }
+		].forEach( ch => {
+
+			const box = document.createElement( 'div' );
+			box.className = 'lut-wheel-input-box';
+
+			const input = document.createElement( 'input' );
+			input.type = 'number';
+			input.step = '0.01';
+			input.min = '-0.5';
+			input.max = '0.5';
+			const valNum = ( this.values && typeof this.values[ ch.key ] === 'number' ) ? this.values[ ch.key ] : 0;
+			input.value = valNum.toFixed( 2 );
+			input.className = `lut-rgb-input lut-rgb-input-${ch.key}`;
+
+			input.onchange = () => {
+
+				const val = Math.max( - 0.5, Math.min( 0.5, parseFloat( input.value ) || 0 ) );
+				this.values[ ch.key ] = val;
+				input.value = val.toFixed( 2 );
+				if ( ch.key === 'y' && this.ySlider ) {
+
+					this.ySlider.value = val;
+
+				} else {
+
+					this.draw();
+
+				}
+
+				if ( typeof this.onChange === 'function' ) this.onChange( this.values );
+
+			};
+
+			this.inputs[ ch.key ] = input;
+			box.appendChild( input );
+			inputsRow.appendChild( box );
+
+		} );
+
+		this.domElement.appendChild( inputsRow );
+
+	}
+
+	setValues( r, g, b, y = undefined ) {
+
+		this.values.r = r;
+		this.values.g = g;
+		this.values.b = b;
+
+		if ( y !== undefined ) {
+
+			this.values.y = y;
+			if ( this.inputs.y ) this.inputs.y.value = y.toFixed( 2 );
+			if ( this.ySlider ) this.ySlider.value = y;
+
+		}
+
+		if ( this.inputs.r ) this.inputs.r.value = r.toFixed( 2 );
+		if ( this.inputs.g ) this.inputs.g.value = g.toFixed( 2 );
+		if ( this.inputs.b ) this.inputs.b.value = b.toFixed( 2 );
+
+		this.draw();
+
+	}
+
+	draw() {
+
+		if ( ! this.ctx ) return;
+
+		const ctx = this.ctx;
+		const w = this.canvas.width;
+		const h = this.canvas.height;
+		const cx = w / 2;
+		const cy = h / 2;
+		const outerR = w / 2 - 2;
+		const innerR = outerR - 12;
+
+		ctx.clearRect( 0, 0, w, h );
+
+		// 1. Draw outer hue spectrum ring
+		for ( let angle = 0; angle < 360; angle += 2 ) {
+
+			const startAngle = ( angle - 1 ) * Math.PI / 180;
+			const endAngle = ( angle + 2 ) * Math.PI / 180;
+
+			ctx.beginPath();
+			ctx.arc( cx, cy, outerR, startAngle, endAngle );
+			ctx.arc( cx, cy, innerR, endAngle, startAngle, true );
+			ctx.closePath();
+
+			ctx.fillStyle = `hsl(${angle}, 100%, 50%)`;
+			ctx.fill();
+
+		}
+
+		// 2. Inner disc background
+		ctx.beginPath();
+		ctx.arc( cx, cy, innerR - 1, 0, Math.PI * 2 );
+		ctx.fillStyle = '#101014';
+		ctx.fill();
+		ctx.strokeStyle = '#2a2a36';
+		ctx.lineWidth = 1;
+		ctx.stroke();
+
+		// 3. Crosshairs
+		ctx.strokeStyle = '#252530';
+		ctx.lineWidth = 1;
+		ctx.beginPath();
+		ctx.moveTo( cx - innerR + 4, cy );
+		ctx.lineTo( cx + innerR - 4, cy );
+		ctx.moveTo( cx, cy - innerR + 4 );
+		ctx.lineTo( cx, cy + innerR - 4 );
+		ctx.stroke();
+
+		// 4. Calculate handle position from RGB offset values
+		// R at 0 rad (right), G at 2.094 rad (120 deg down-left), B at 4.188 rad (240 deg up-left)
+		const rx = this.values.r;
+		const gx = this.values.g;
+		const bx = this.values.b;
+
+		// Convert RGB balance to 2D displacement vector (Canvas space: X right, Y down)
+		const vx = rx - 0.5 * gx - 0.5 * bx;
+		const vy = 0.866025 * ( gx - bx );
+
+		const maxDist = innerR - 6;
+		const hx = cx + Math.max( - maxDist, Math.min( maxDist, vx * maxDist * 2 ) );
+		const hy = cy + Math.max( - maxDist, Math.min( maxDist, vy * maxDist * 2 ) );
+
+		// 5. Draw handle
+		ctx.beginPath();
+		ctx.arc( hx, hy, 5, 0, Math.PI * 2 );
+		ctx.fillStyle = '#ffffff';
+		ctx.fill();
+		ctx.strokeStyle = '#00aaff';
+		ctx.lineWidth = 2;
+		ctx.stroke();
+
+	}
+
+	_initEvents() {
+
+		let isDragging = false;
+
+		const handlePointer = ( e ) => {
+
+			const rect = this.canvas.getBoundingClientRect();
+			const clientX = e.touches ? e.touches[ 0 ].clientX : e.clientX;
+			const clientY = e.touches ? e.touches[ 0 ].clientY : e.clientY;
+
+			const cx = rect.width / 2;
+			const cy = rect.height / 2;
+			const dx = ( clientX - rect.left ) - cx;
+			const dy = ( clientY - rect.top ) - cy;
+
+			const innerR = ( rect.width / 2 ) - 14;
+			const dist = Math.sqrt( dx * dx + dy * dy );
+			const clampedDist = Math.min( dist, innerR );
+			const normDist = clampedDist / innerR;
+
+			let angle = Math.atan2( dy, dx );
+			if ( angle < 0 ) angle += Math.PI * 2;
+
+			// Convert polar position to RGB balance offsets (-0.5 .. 0.5)
+			const magnitude = normDist * 0.5;
+
+			// Project angle onto R (0 deg), G (120 deg), B (240 deg)
+			const rVal = Math.cos( angle ) * magnitude;
+			const gVal = Math.cos( angle - 2.094395 ) * magnitude;
+			const bVal = Math.cos( angle - 4.18879 ) * magnitude;
+
+			this.setValues( rVal, gVal, bVal );
+
+			if ( typeof this.onChange === 'function' ) {
+
+				this.onChange( this.values );
+
+			}
+
+		};
+
+		this.canvas.addEventListener( 'pointerdown', ( e ) => {
+
+			isDragging = true;
+			this.canvas.setPointerCapture( e.pointerId );
+			handlePointer( e );
+
+		} );
+
+		this.canvas.addEventListener( 'pointermove', ( e ) => {
+
+			if ( isDragging ) {
+
+				handlePointer( e );
+
+			}
+
+		} );
+
+		const stopDrag = ( e ) => {
+
+			if ( isDragging ) {
+
+				isDragging = false;
+				try {
+
+					this.canvas.releasePointerCapture( e.pointerId );
+
+				} catch ( _err ) { /* ignore */ }
+
+			}
+
+		};
+
+		this.canvas.addEventListener( 'pointerup', stopDrag );
+		this.canvas.addEventListener( 'pointercancel', stopDrag );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/CurveEditor.js
+++ b/examples/jsm/inspector/extensions/color-grading/CurveEditor.js
@@ -1,0 +1,599 @@
+import { evaluateSpline } from './LUTMath.js';
+
+export class CurveEditor {
+
+	constructor( options = {} ) {
+
+		this.curves = options.curves || {
+			rgb: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			red: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			green: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			blue: [ { x: 0, y: 0 }, { x: 1, y: 1 } ]
+		};
+
+		this.activeChannel = options.activeChannel || 'rgb';
+		this.onChange = options.onChange || null;
+
+		this.selectedIndex = - 1;
+		this.isDragging = false;
+		this.pointRadius = 4;
+
+		this.domElement = document.createElement( 'div' );
+		this.domElement.className = 'curve-editor-container';
+		this.domElement.style.cssText = 'display: flex; flex-direction: column; gap: 4px; width: 100%; user-select: none; background: transparent; border: none; padding: 0; box-sizing: border-box;';
+
+		this._buildUI();
+		this._initEvents();
+
+		if ( typeof ResizeObserver !== 'undefined' ) {
+
+			const ro = new ResizeObserver( () => this._onResize() );
+			ro.observe( this.domElement );
+
+		}
+
+		requestAnimationFrame( () => {
+
+			this._onResize();
+
+		} );
+
+	}
+
+	_buildUI() {
+
+		// Header toolbar (Channel selector)
+		const toolbar = document.createElement( 'div' );
+		toolbar.style.cssText = 'display: flex; justify-content: center; align-items: center; width: 100%; gap: 4px;';
+
+		// Channel selector tabs
+		const channelGroup = document.createElement( 'div' );
+		channelGroup.style.cssText = 'display: flex; gap: 3px; background: #0a0a0f; padding: 2px; border-radius: 4px; border: 1px solid #222230;';
+
+		const channels = [
+			{ id: 'rgb', label: 'RGB', color: '#e0e0e0' },
+			{ id: 'red', label: 'R', color: '#ff4d4d' },
+			{ id: 'green', label: 'G', color: '#4dff4d' },
+			{ id: 'blue', label: 'B', color: '#4d88ff' }
+		];
+
+		this.channelBtns = {};
+
+		channels.forEach( ch => {
+
+			const btn = document.createElement( 'button' );
+			btn.textContent = ch.label;
+			btn.style.cssText = `padding: 2px 8px; font-size: 11px; font-weight: 700; border-radius: 3px; border: 1px solid transparent; cursor: pointer; color: ${ch.color}; background: transparent; transition: all 0.15s;`;
+			btn.onclick = () => this.setChannel( ch.id );
+
+			this.channelBtns[ ch.id ] = btn;
+			channelGroup.appendChild( btn );
+
+		} );
+
+		toolbar.appendChild( channelGroup );
+		this.domElement.appendChild( toolbar );
+
+		// Canvas Container
+		this.canvasContainer = document.createElement( 'div' );
+		this.canvasContainer.style.cssText = 'width: 100%; height: 130px; position: relative; background: #0c0c12; border-radius: 6px; overflow: hidden;';
+
+		this.canvas = document.createElement( 'canvas' );
+		this.canvas.setAttribute( 'tabindex', '0' );
+		this.canvas.style.cssText = 'width: 100%; height: 100%; display: block; cursor: crosshair; touch-action: none; outline: none;';
+		this.ctx = this.canvas.getContext( '2d' );
+
+		this.canvasContainer.appendChild( this.canvas );
+		this.domElement.appendChild( this.canvasContainer );
+
+		this.setChannel( this.activeChannel );
+
+	}
+
+	_onResize() {
+
+		if ( ! this.canvasContainer || ! this.canvas ) return;
+
+		const rect = this.canvasContainer.getBoundingClientRect();
+		if ( rect.width === 0 || rect.height === 0 ) return;
+
+		const dpr = window.devicePixelRatio || 1;
+		const newW = Math.round( rect.width * dpr );
+		const newH = Math.round( rect.height * dpr );
+
+		if ( this.canvas.width !== newW || this.canvas.height !== newH ) {
+
+			this.canvas.width = newW;
+			this.canvas.height = newH;
+			this.render();
+
+		}
+
+	}
+
+	setChannel( channelId ) {
+
+		this.activeChannel = channelId;
+		this.selectedIndex = - 1;
+
+		Object.keys( this.channelBtns ).forEach( id => {
+
+			const btn = this.channelBtns[ id ];
+			if ( id === channelId ) {
+
+				btn.style.background = 'rgba(255, 255, 255, 0.12)';
+				btn.style.borderColor = 'rgba(74, 74, 90, 0.6)';
+
+			} else {
+
+				btn.style.background = 'transparent';
+				btn.style.borderColor = 'transparent';
+
+			}
+
+		} );
+
+		this.render();
+
+	}
+
+	setCurves( curves ) {
+
+		if ( curves.rgb ) this.curves.rgb = curves.rgb.map( p => ( { ...p } ) );
+		if ( curves.red ) this.curves.red = curves.red.map( p => ( { ...p } ) );
+		if ( curves.green ) this.curves.green = curves.green.map( p => ( { ...p } ) );
+		if ( curves.blue ) this.curves.blue = curves.blue.map( p => ( { ...p } ) );
+
+		this.selectedIndex = - 1;
+		this.render();
+
+	}
+
+	getCurves() {
+
+		return {
+			rgb: this.curves.rgb.map( p => ( { ...p } ) ),
+			red: this.curves.red.map( p => ( { ...p } ) ),
+			green: this.curves.green.map( p => ( { ...p } ) ),
+			blue: this.curves.blue.map( p => ( { ...p } ) )
+		};
+
+	}
+
+	_getChannelColor( channelId = this.activeChannel ) {
+
+		switch ( channelId ) {
+
+			case 'red': return '#ff3344';
+			case 'green': return '#22dd55';
+			case 'blue': return '#3388ff';
+			default: return '#e0e0e0';
+
+		}
+
+	}
+
+	_normToCanvas( point ) {
+
+		const padL = 28;
+		const padR = 10;
+		const padT = 10;
+		const padB = 16;
+
+		const w = this.canvas.width - padL - padR;
+		const h = this.canvas.height - padT - padB;
+
+		return {
+			x: padL + point.x * w,
+			y: padT + ( 1 - point.y ) * h
+		};
+
+	}
+
+	_canvasToNorm( px, py ) {
+
+		const padL = 28;
+		const padR = 10;
+		const padT = 10;
+		const padB = 16;
+
+		const w = this.canvas.width - padL - padR;
+		const h = this.canvas.height - padT - padB;
+
+		return {
+			x: Math.max( 0, Math.min( 1, ( px - padL ) / w ) ),
+			y: Math.max( 0, Math.min( 1, 1 - ( py - padT ) / h ) )
+		};
+
+	}
+
+	_initEvents() {
+
+		const getPointerPos = ( e ) => {
+
+			const rect = this.canvas.getBoundingClientRect();
+			const clientX = e.touches ? e.touches[ 0 ].clientX : e.clientX;
+			const clientY = e.touches ? e.touches[ 0 ].clientY : e.clientY;
+
+			const scaleX = this.canvas.width / rect.width;
+			const scaleY = this.canvas.height / rect.height;
+
+			return {
+				x: ( clientX - rect.left ) * scaleX,
+				y: ( clientY - rect.top ) * scaleY
+			};
+
+		};
+
+		const findPointIndex = ( cPos ) => {
+
+			const pts = this.curves[ this.activeChannel ];
+			const dpr = window.devicePixelRatio || 1;
+			const hitRadius = 16 * dpr;
+
+			let closestIdx = - 1;
+			let minDist = hitRadius;
+
+			for ( let i = 0; i < pts.length; i ++ ) {
+
+				const ptPos = this._normToCanvas( pts[ i ] );
+				const dx = cPos.x - ptPos.x;
+				const dy = cPos.y - ptPos.y;
+				const dist = Math.sqrt( dx * dx + dy * dy );
+
+				if ( dist <= minDist ) {
+
+					minDist = dist;
+					closestIdx = i;
+
+				}
+
+			}
+
+			return closestIdx;
+
+		};
+
+		const onDown = ( e ) => {
+
+			e.preventDefault();
+			if ( this.canvas && typeof this.canvas.focus === 'function' ) {
+
+				this.canvas.focus();
+
+			}
+
+			const pos = getPointerPos( e );
+			const idx = findPointIndex( pos );
+			const pts = this.curves[ this.activeChannel ];
+
+			// Store snapshot for ESC cancel/revert
+			this._dragStartSnapshot = JSON.parse( JSON.stringify( this.curves ) );
+
+			if ( idx !== - 1 ) {
+
+				this.selectedIndex = idx;
+				this.isDragging = true;
+
+			} else {
+
+				// Single click on empty canvas area adds a new point and selects it
+				const norm = this._canvasToNorm( pos.x, pos.y );
+				pts.push( norm );
+				pts.sort( ( a, b ) => a.x - b.x );
+				this.selectedIndex = pts.findIndex( p => p === norm );
+				this.isDragging = true;
+				this.notifyChange();
+
+			}
+
+			this.render();
+
+		};
+
+		const onMove = ( e ) => {
+
+			if ( ! this.isDragging || this.selectedIndex === - 1 ) return;
+
+			e.preventDefault();
+			const pos = getPointerPos( e );
+			const norm = this._canvasToNorm( pos.x, pos.y );
+			const pts = this.curves[ this.activeChannel ];
+
+			if ( this.selectedIndex === 0 ) {
+
+				pts[ 0 ].y = norm.y;
+
+			} else if ( this.selectedIndex === pts.length - 1 ) {
+
+				pts[ pts.length - 1 ].y = norm.y;
+
+			} else {
+
+				pts[ this.selectedIndex ].x = norm.x;
+				pts[ this.selectedIndex ].y = norm.y;
+				pts.sort( ( a, b ) => a.x - b.x );
+				this.selectedIndex = pts.findIndex( p => p.x === norm.x && p.y === norm.y );
+
+			}
+
+			this.render();
+			this.notifyChange();
+
+		};
+
+		const onUp = () => {
+
+			if ( this.isDragging ) {
+
+				this.isDragging = false;
+
+			}
+
+		};
+
+		const onDblClick = ( e ) => {
+
+			const pos = getPointerPos( e );
+			const idx = findPointIndex( pos );
+			const pts = this.curves[ this.activeChannel ];
+
+			if ( idx > 0 && idx < pts.length - 1 ) {
+
+				// Double click on point deletes it
+				pts.splice( idx, 1 );
+				this.selectedIndex = - 1;
+				this.render();
+				this.notifyChange();
+
+			}
+
+		};
+
+		const onOutsidePointer = ( e ) => {
+
+			if ( this.domElement && ! this.domElement.contains( e.target ) ) {
+
+				if ( this.selectedIndex !== - 1 ) {
+
+					this.selectedIndex = - 1;
+					this.render();
+
+				}
+
+			}
+
+		};
+
+		const onKeyDown = ( e ) => {
+
+			const key = e.key;
+			const isCanvasFocused = document.activeElement === this.canvas || ( this.domElement && this.domElement.contains( document.activeElement ) );
+			const hasSelection = this.selectedIndex !== - 1 || this.isDragging || !! this._dragStartSnapshot;
+
+			if ( ! isCanvasFocused && ! hasSelection ) return;
+
+			const pts = this.curves[ this.activeChannel ];
+
+			if ( key === 'Delete' || key === 'Backspace' || key === 'Del' ) {
+
+				if ( this.selectedIndex > 0 && this.selectedIndex < pts.length - 1 ) {
+
+					e.preventDefault();
+					e.stopPropagation();
+					pts.splice( this.selectedIndex, 1 );
+					this.selectedIndex = - 1;
+					this.isDragging = false;
+					this._dragStartSnapshot = null;
+					this.render();
+					this.notifyChange();
+
+				}
+
+			} else if ( key === 'Escape' || key === 'Esc' ) {
+
+				if ( this._dragStartSnapshot ) {
+
+					e.preventDefault();
+					e.stopPropagation();
+					this.curves = JSON.parse( JSON.stringify( this._dragStartSnapshot ) );
+					this.selectedIndex = - 1;
+					this.isDragging = false;
+					this._dragStartSnapshot = null;
+					this.render();
+					this.notifyChange();
+
+				} else if ( this.selectedIndex !== - 1 ) {
+
+					e.preventDefault();
+					e.stopPropagation();
+					this.selectedIndex = - 1;
+					this.isDragging = false;
+					this.render();
+
+				}
+
+			}
+
+		};
+
+		this.canvas.addEventListener( 'pointerdown', onDown );
+		this.canvas.addEventListener( 'keydown', onKeyDown );
+		window.addEventListener( 'pointermove', onMove );
+		window.addEventListener( 'pointerup', onUp );
+		window.addEventListener( 'pointerdown', onOutsidePointer );
+		window.addEventListener( 'keydown', onKeyDown );
+		this.canvas.addEventListener( 'dblclick', onDblClick );
+
+	}
+
+	notifyChange() {
+
+		if ( typeof this.onChange === 'function' ) {
+
+			this.onChange( this.getCurves() );
+
+		}
+
+	}
+
+	render() {
+
+		if ( ! this.canvas || ! this.ctx ) return;
+
+		const ctx = this.ctx;
+		const w = this.canvas.width;
+		const h = this.canvas.height;
+
+		const padL = 28;
+		const padR = 10;
+		const padT = 10;
+		const padB = 16;
+
+		const graphW = w - padL - padR;
+		const graphH = h - padT - padB;
+
+		// 1. Dark Background Fill
+		ctx.fillStyle = '#0a0a0e';
+		ctx.fillRect( 0, 0, w, h );
+
+		// 2. Normalized Axis Labels (1.0, 0.5, 0.0)
+		ctx.fillStyle = '#66667a';
+		ctx.font = '9px monospace';
+		ctx.textAlign = 'left';
+		ctx.fillText( '1.0', 4, padT + 6 );
+		ctx.fillText( '0.5', 4, padT + graphH / 2 + 3 );
+		ctx.fillText( '0.0', 4, padT + graphH - 1 );
+
+		// 3. Fine Grid Mesh Lines (8x8)
+		ctx.strokeStyle = '#1a1a24';
+		ctx.lineWidth = 1;
+
+		const gridDivs = 8;
+		for ( let i = 0; i <= gridDivs; i ++ ) {
+
+			const gx = padL + ( i / gridDivs ) * graphW;
+			const gy = padT + ( i / gridDivs ) * graphH;
+
+			ctx.beginPath();
+			ctx.moveTo( gx, padT );
+			ctx.lineTo( gx, padT + graphH );
+			ctx.stroke();
+
+			ctx.beginPath();
+			ctx.moveTo( padL, gy );
+			ctx.lineTo( padL + graphW, gy );
+			ctx.stroke();
+
+		}
+
+		// 4. Diagonal Reference Line (y = x)
+		ctx.strokeStyle = '#2d2d3c';
+		ctx.setLineDash( [ 3, 3 ] );
+		ctx.beginPath();
+		ctx.moveTo( padL, padT + graphH );
+		ctx.lineTo( padL + graphW, padT );
+		ctx.stroke();
+		ctx.setLineDash( [] );
+
+		// 5. Theme Gray Border Frame
+		ctx.strokeStyle = 'rgba(74, 74, 90, 0.5)';
+		ctx.lineWidth = 1;
+		ctx.strokeRect( padL, padT, graphW, graphH );
+
+		// 6. Draw Inactive Channel Curves & Points (VSDC Overlay Style)
+		const otherChannels = [ 'rgb', 'red', 'green', 'blue' ].filter( c => c !== this.activeChannel );
+		otherChannels.forEach( ch => {
+
+			const pts = this.curves[ ch ];
+			const color = this._getChannelColor( ch );
+
+			ctx.strokeStyle = color;
+			ctx.globalAlpha = 0.5;
+			ctx.lineWidth = 1.2;
+
+			ctx.beginPath();
+			for ( let px = 0; px <= graphW; px += 2 ) {
+
+				const normX = px / graphW;
+				const normY = evaluateSpline( normX, pts );
+				const canvasY = padT + ( 1 - normY ) * graphH;
+
+				if ( px === 0 ) ctx.moveTo( padL + px, canvasY );
+				else ctx.lineTo( padL + px, canvasY );
+
+			}
+
+			ctx.stroke();
+
+			// Inactive channel control points
+			pts.forEach( pt => {
+
+				const cPos = this._normToCanvas( pt );
+				ctx.fillStyle = color;
+				ctx.beginPath();
+				ctx.arc( cPos.x, cPos.y, 2.5, 0, Math.PI * 2 );
+				ctx.fill();
+				ctx.strokeStyle = '#0a0a0e';
+				ctx.lineWidth = 1;
+				ctx.stroke();
+
+			} );
+
+		} );
+
+		ctx.globalAlpha = 1.0;
+
+		// 7. Draw Active Channel Curve (Thin & Crisp, No Glow)
+		const activePts = this.curves[ this.activeChannel ];
+		const activeColor = this._getChannelColor( this.activeChannel );
+
+		ctx.strokeStyle = activeColor;
+		ctx.lineWidth = 1.5;
+
+		ctx.beginPath();
+		for ( let px = 0; px <= graphW; px += 2 ) {
+
+			const normX = px / graphW;
+			const normY = evaluateSpline( normX, activePts );
+			const canvasY = padT + ( 1 - normY ) * graphH;
+
+			if ( px === 0 ) ctx.moveTo( padL + px, canvasY );
+			else ctx.lineTo( padL + px, canvasY );
+
+		}
+
+		ctx.stroke();
+
+		// 8. Draw Active Channel Control Points (Elegant Dots)
+		activePts.forEach( ( pt, idx ) => {
+
+			const cPos = this._normToCanvas( pt );
+			const isSelected = idx === this.selectedIndex;
+
+			// Draw outer halo ring if selected
+			if ( isSelected ) {
+
+				ctx.beginPath();
+				ctx.arc( cPos.x, cPos.y, 5.5, 0, Math.PI * 2 );
+				ctx.strokeStyle = '#00aaff';
+				ctx.lineWidth = 1.0;
+				ctx.stroke();
+
+			}
+
+			// Point body - uniform clean size
+			ctx.fillStyle = activeColor;
+			ctx.beginPath();
+			ctx.arc( cPos.x, cPos.y, 3.2, 0, Math.PI * 2 );
+			ctx.fill();
+
+			ctx.strokeStyle = isSelected ? '#ffffff' : '#0a0a0e';
+			ctx.lineWidth = 1.2;
+			ctx.stroke();
+
+		} );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/LUT3DStyle.js
+++ b/examples/jsm/inspector/extensions/color-grading/LUT3DStyle.js
@@ -137,7 +137,7 @@ export class LUT3DStyle {
 		color: var(--color-accent, #00aaff) !important;
 	}
 
-	.lut-dock-btn:active {
+	.lut-dock-btn:active:not(:has(.lut-context-menu)) {
 		transform: scale(0.95);
 	}
 
@@ -202,6 +202,10 @@ export class LUT3DStyle {
 	.lut-menu-item:hover {
 		background: rgba(0, 170, 255, 0.15);
 		color: var(--color-accent, #00aaff);
+	}
+
+	.lut-menu-item:active:not(:has(.lut-context-menu)) {
+		transform: scale(0.98);
 	}
 
 	.lut-menu-item svg {
@@ -354,7 +358,7 @@ export class LUT3DStyle {
 		background: rgba(30, 30, 36, 0.85) !important;
 		border: 1px solid rgba(74, 74, 90, 0.4) !important;
 		border-radius: 8px !important;
-		padding: 6px 10px 8px 10px !important;
+		padding: 1px 10px 8px 10px !important;
 		width: 175px !important;
 		min-width: 175px !important;
 		max-width: 175px !important;
@@ -443,8 +447,7 @@ export class LUT3DStyle {
 		justify-content: center !important;
 		position: relative !important;
 		width: 100% !important;
-		min-height: 24px !important;
-		height: 24px !important;
+		min-height: 28px !important;
 		margin-bottom: 6px !important;
 		padding: 0 20px !important;
 		border-bottom: 1px solid rgba(74, 74, 90, 0.3) !important;
@@ -456,7 +459,7 @@ export class LUT3DStyle {
 		left: 4px !important;
 		top: 0px !important;
 		bottom: 0px !important;
-		margin: -4px 0 0 0 !important;
+		margin: 0 !important;
 		height: 100% !important;
 		display: flex !important;
 		align-items: center !important;
@@ -468,7 +471,7 @@ export class LUT3DStyle {
 		right: 4px !important;
 		top: 0px !important;
 		bottom: 0px !important;
-		margin: -4px 0 0 0 !important;
+		margin: 0 !important;
 		height: 100% !important;
 		display: flex !important;
 		align-items: center !important;
@@ -501,8 +504,7 @@ export class LUT3DStyle {
 		font-weight: 600 !important;
 		color: var(--text-primary, #e0e0e0) !important;
 		letter-spacing: 0.3px !important;
-		line-height: 23px !important;
-		margin: -6px 0 0 0 !important;
+		margin: 0 !important;
 		padding: 0 !important;
 		white-space: nowrap !important;
 		overflow: hidden !important;
@@ -516,8 +518,8 @@ export class LUT3DStyle {
 		cursor: pointer !important;
 		padding: 0 !important;
 		margin: 0 !important;
-		width: 18px !important;
-		height: 18px !important;
+		width: 20px !important;
+		height: 100% !important;
 		display: flex !important;
 		align-items: center !important;
 		justify-content: center !important;
@@ -528,7 +530,7 @@ export class LUT3DStyle {
 	.lut-card-reset-btn:hover, .lut-container .card-reset-btn:hover {
 		color: var(--color-accent, #00aaff) !important;
 		opacity: 1 !important;
-		transform: rotate(-45deg);
+		transform: scale(1.1);
 	}
 
 	/* Flow Connector Nodes between Cards */
@@ -957,7 +959,7 @@ export class LUT3DStyle {
 	.lut-card-remove-btn:hover {
 		color: var(--color-accent, #00aaff) !important;
 		opacity: 1 !important;
-		transform: scale(1.2);
+		transform: scale(1.1);
 	}
 
 	/* Add Card Modal Window Overlay */

--- a/examples/jsm/inspector/extensions/color-grading/LUT3DStyle.js
+++ b/examples/jsm/inspector/extensions/color-grading/LUT3DStyle.js
@@ -446,7 +446,7 @@ export class LUT3DStyle {
 		align-items: center !important;
 		justify-content: center !important;
 		position: relative !important;
-		width: 100% !important;
+		width: calc(100% + 16px) !important;
 		min-height: 28px !important;
 		margin-bottom: 6px !important;
 		padding: 0 20px !important;

--- a/examples/jsm/inspector/extensions/color-grading/LUT3DStyle.js
+++ b/examples/jsm/inspector/extensions/color-grading/LUT3DStyle.js
@@ -584,8 +584,12 @@ export class LUT3DStyle {
 		cursor: grabbing !important;
 	}
 
+	.lut-card-nodrag .lut-card-header {
+		cursor: default !important;
+	}
+
 	.lut-card.lut-card-moving {
-		opacity: 0.85 !important;
+		opacity: 0.2 !important;
 		border: 1px solid var(--color-accent, #00aaff) !important;
 		box-shadow: 0 4px 16px rgba(0, 170, 255, 0.3) !important;
 		z-index: 10;

--- a/examples/jsm/inspector/extensions/color-grading/LUT3DStyle.js
+++ b/examples/jsm/inspector/extensions/color-grading/LUT3DStyle.js
@@ -1,0 +1,1177 @@
+/**
+ * LUT3DStyle.js - Unified CSS stylesheet module for 3D LUT Generator extension
+ */
+
+export class LUT3DStyle {
+
+	static init() {
+
+		if ( document.getElementById( 'lut3d-generator-style' ) ) return;
+
+		const style = document.createElement( 'style' );
+		style.id = 'lut3d-generator-style';
+		style.textContent = /* css */`
+@scope (.lut-container) {
+
+	:scope {
+		position: relative !important;
+		flex-grow: 1;
+		height: 100%;
+		overflow-y: auto;
+		overflow-x: hidden;
+		padding: 8px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		box-sizing: border-box;
+
+		/* Ultra-Subtle Transparent Blueprint / Checkerboard Grid Background */
+		background-color: transparent;
+		background-image:
+			linear-gradient(45deg, rgba(255, 255, 255, 0.008) 25%, transparent 25%),
+			linear-gradient(-45deg, rgba(255, 255, 255, 0.008) 25%, transparent 25%),
+			linear-gradient(45deg, transparent 75%, rgba(255, 255, 255, 0.008) 75%),
+			linear-gradient(-45deg, transparent 75%, rgba(255, 255, 255, 0.008) 75%),
+			linear-gradient(rgba(0, 170, 255, 0.015) 1px, transparent 1px),
+			linear-gradient(90deg, rgba(0, 170, 255, 0.015) 1px, transparent 1px);
+		background-size: 24px 24px, 24px 24px, 24px 24px, 24px 24px, 12px 12px, 12px 12px;
+		background-position: 0 0, 0 12px, 12px -12px, -12px 0px, -1px -1px, -1px -1px;
+	}
+
+	.lut-toolbar {
+		display: none !important;
+	}
+
+	/* Ultra-Premium Floating Glass Control Dock inside lut-container */
+	.lut-dock-container {
+		position: absolute !important;
+		top: 12px !important;
+		left: 50% !important;
+		transform: translateX(-50%) !important;
+		display: flex !important;
+		align-items: center !important;
+		justify-content: space-between !important;
+		padding: 6px 14px !important;
+		background: rgba(22, 22, 28, 0.85) !important;
+		backdrop-filter: blur(12px) !important;
+		border: 1px solid rgba(74, 74, 90, 0.4) !important;
+		border-radius: 8px !important;
+		box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4) !important;
+		z-index: 100 !important;
+		gap: 12px !important;
+		user-select: none !important;
+		box-sizing: border-box !important;
+		width: calc(100% - 32px) !important;
+		max-width: 960px !important;
+	}
+
+	.lut-dock-container.is-compact .lut-dock-label,
+	.lut-dock-container.is-compact .lut-dock-text {
+		display: none !important;
+	}
+
+	.lut-dock-group {
+		display: flex !important;
+		align-items: center !important;
+		gap: 6px !important;
+		flex-wrap: wrap !important;
+	}
+
+	.lut-dock-label {
+		font-family: var(--font-family, sans-serif);
+		font-size: 11px;
+		font-weight: 500;
+		color: var(--text-secondary, #9a9aab);
+		white-space: nowrap;
+	}
+
+	.lut-dock-select {
+		height: 24px;
+		padding: 0 4px;
+		font-family: var(--font-family, sans-serif);
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--text-primary, #e0e0e0);
+		background: transparent !important;
+		border: none !important;
+		outline: none;
+		cursor: pointer;
+		transition: color 0.15s;
+	}
+
+	.lut-dock-select option,
+	.lut-container select option {
+		background-color: #1e1e24;
+		color: #e0e0e0;
+	}
+
+	.lut-dock-select:hover {
+		color: var(--color-accent, #00aaff);
+	}
+
+	.lut-dock-btn {
+		height: 24px;
+		padding: 0 6px;
+		font-family: var(--font-family, sans-serif);
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--text-primary, #e0e0e0);
+		background: transparent !important;
+		border: none !important;
+		outline: none;
+		cursor: pointer;
+		transition: color 0.15s ease, opacity 0.15s ease;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 4px;
+		white-space: nowrap;
+	}
+
+	.lut-dock-btn.lut-dock-icon-btn {
+		width: 20px !important;
+		padding: 0 !important;
+	}
+
+	.lut-dock-btn:hover {
+		color: var(--color-accent, #00aaff) !important;
+	}
+
+	.lut-dock-btn:active {
+		transform: scale(0.95);
+	}
+
+	.lut-dock-btn.active {
+		color: var(--color-accent, #00aaff) !important;
+		text-shadow: 0 0 8px rgba(0, 170, 255, 0.6);
+	}
+
+	/* Glass Context Menu Popover */
+	.lut-context-menu {
+		position: absolute;
+		top: calc(100% + 4px);
+		right: 0;
+		background: rgba(22, 22, 28, 0.95);
+		border: 1px solid rgba(74, 74, 90, 0.5);
+		border-radius: 6px;
+		box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5), 0 0 10px rgba(0, 170, 255, 0.2);
+		padding: 4px;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		z-index: 100;
+		min-width: 165px;
+		backdrop-filter: blur(12px);
+		animation: lutMenuFadeIn 0.15s ease-out;
+		text-align: left !important;
+	}
+
+	.lut-submenu {
+		top: -4px !important;
+		left: calc(100% + 4px) !important;
+		right: auto !important;
+		min-width: 155px !important;
+	}
+
+	@keyframes lutMenuFadeIn {
+		from { opacity: 0; transform: translateY(-4px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+
+	.lut-menu-item {
+		display: flex !important;
+		align-items: center !important;
+		justify-content: flex-start !important;
+		text-align: left !important;
+		gap: 8px;
+		padding: 6px 10px;
+		font-family: var(--font-family, sans-serif);
+		font-size: 11px;
+		font-weight: 500;
+		color: var(--text-primary, #e0e0e0);
+		border-radius: 4px;
+		cursor: pointer;
+		transition: background 0.12s, color 0.12s;
+		white-space: nowrap;
+	}
+
+	.lut-menu-item span {
+		text-align: left !important;
+	}
+
+	.lut-menu-item:hover {
+		background: rgba(0, 170, 255, 0.15);
+		color: var(--color-accent, #00aaff);
+	}
+
+	.lut-menu-item svg {
+		color: var(--text-secondary, #9a9aab);
+		transition: color 0.12s;
+		flex-shrink: 0;
+	}
+
+	.lut-menu-item:hover svg {
+		color: var(--color-accent, #00aaff);
+	}
+
+	.lut-menu-divider {
+		height: 1px;
+		background: rgba(74, 74, 90, 0.4);
+		margin: 2px 0;
+	}
+
+	.lut-toolbar-group {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.lut-toolbar-center {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		display: flex;
+		gap: 2px;
+		background: rgba(30, 30, 36, 0.6);
+		padding: 2px;
+		border-radius: 6px;
+		border: 1px solid var(--profiler-border, rgba(74, 74, 90, 0.4));
+	}
+
+	.lut-toolbar-label {
+		font-size: 11px;
+		color: var(--text-secondary, #9a9aab);
+	}
+
+	.lut-panel {
+		display: flex;
+		flex-direction: column;
+		justify-content: stretch;
+		align-items: stretch;
+		width: 100%;
+		height: 100%;
+		min-height: 100%;
+		flex-grow: 1;
+		box-sizing: border-box;
+		position: relative;
+	}
+
+	.lut-container, .lut-cards-row {
+		cursor: grab;
+	}
+
+	.lut-container.is-panning, .lut-cards-row.is-panning {
+		cursor: grabbing !important;
+		user-select: none !important;
+	}
+
+	.lut-cards-row {
+		display: flex !important;
+		flex-direction: row !important;
+		justify-content: center !important;
+		align-items: center !important;
+		align-content: center !important;
+		gap: 12px !important;
+		flex-wrap: nowrap !important;
+		overflow-x: auto !important;
+		overflow-y: hidden !important;
+		padding: 50px 32px 10px 32px !important;
+		background: transparent !important;
+		border: none !important;
+		width: 100% !important;
+		height: 100% !important;
+		flex-grow: 1 !important;
+		box-sizing: border-box !important;
+		margin: 0 !important;
+		touch-action: pan-x pan-y !important;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: thin;
+		scrollbar-color: var(--profiler-border, rgba(74, 74, 90, 0.6)) transparent;
+	}
+
+	.lut-cards-row > .lut-card:first-child {
+		margin-left: 24px !important;
+	}
+
+	.lut-cards-row > .lut-card:last-child {
+		margin-right: 24px !important;
+	}
+
+	.lut-cards-row::-webkit-scrollbar,
+	.lut-wheels-row::-webkit-scrollbar,
+	.lut-modules-row::-webkit-scrollbar,
+	.lut-container::-webkit-scrollbar {
+		width: 5px;
+		height: 5px;
+	}
+
+	.lut-cards-row::-webkit-scrollbar-track,
+	.lut-wheels-row::-webkit-scrollbar-track,
+	.lut-modules-row::-webkit-scrollbar-track,
+	.lut-container::-webkit-scrollbar-track {
+		background: rgba(0, 0, 0, 0.2);
+		border-radius: 3px;
+	}
+
+	.lut-cards-row::-webkit-scrollbar-thumb,
+	.lut-wheels-row::-webkit-scrollbar-thumb,
+	.lut-modules-row::-webkit-scrollbar-thumb,
+	.lut-container::-webkit-scrollbar-thumb {
+		background: var(--profiler-border, rgba(74, 74, 90, 0.6));
+		border-radius: 3px;
+	}
+
+	.lut-cards-row::-webkit-scrollbar-thumb:hover,
+	.lut-wheels-row::-webkit-scrollbar-thumb:hover,
+	.lut-modules-row::-webkit-scrollbar-thumb:hover,
+	.lut-container::-webkit-scrollbar-thumb:hover {
+		background: var(--color-accent, #00aaff);
+	}
+
+	.lut-wheels-row, .lut-modules-row {
+		display: flex !important;
+		flex-direction: row !important;
+		justify-content: flex-start !important;
+		align-items: stretch !important;
+		gap: 12px !important;
+		flex-wrap: nowrap !important;
+		overflow-x: auto !important;
+		overflow-y: hidden !important;
+		padding: 6px 4px !important;
+		background: transparent !important;
+		border: none !important;
+		width: 100% !important;
+		box-sizing: border-box !important;
+	}
+
+	/* Modular Cards - Standard Unified Card Specification */
+	.lut-card, .mini-module-card {
+		display: flex !important;
+		flex-direction: column !important;
+		justify-content: space-between !important;
+		align-items: center !important;
+		background: rgba(30, 30, 36, 0.85) !important;
+		border: 1px solid rgba(74, 74, 90, 0.4) !important;
+		border-radius: 8px !important;
+		padding: 6px 10px 8px 10px !important;
+		width: 175px !important;
+		min-width: 175px !important;
+		max-width: 175px !important;
+		flex-shrink: 0 !important;
+		flex-grow: 0 !important;
+		user-select: none !important;
+		box-sizing: border-box !important;
+		gap: 6px !important;
+		backdrop-filter: blur(8px) !important;
+		transition: opacity 0.2s, border-color 0.25s ease, box-shadow 0.25s ease !important;
+	}
+
+	/* Subtle Blue Glow when Hovered, Focused or Edited */
+	.lut-card:hover,
+	.lut-card:focus-within,
+	.lut-card.lut-card-active {
+		border-color: rgba(0, 170, 255, 0.6) !important;
+		box-shadow: 0 0 14px rgba(0, 170, 255, 0.3), 0 0 2px rgba(0, 170, 255, 0.6) !important;
+	}
+
+	.lut-card.curves-card,
+	.lut-card.preview-card {
+		width: 225px !important;
+		min-width: 225px !important;
+		max-width: 225px !important;
+	}
+
+	/* Renderer (Start Node) & Output (End Node) Cards Glowing Highlights */
+	.lut-card.renderer-card {
+		border: 1px solid rgba(0, 170, 255, 0.6) !important;
+		box-shadow: 0 0 12px rgba(0, 170, 255, 0.25), inset 0 0 8px rgba(0, 170, 255, 0.1) !important;
+	}
+
+	.lut-card.output-card {
+		border: 1px solid rgba(0, 220, 180, 0.6) !important;
+		box-shadow: 0 0 12px rgba(0, 220, 180, 0.25), inset 0 0 8px rgba(0, 220, 180, 0.1) !important;
+	}
+
+	.lut-card.renderer-card .lut-card-title {
+		color: #00aaff !important;
+	}
+
+	.lut-card.output-card .lut-card-title {
+		color: #00dcb4 !important;
+	}
+
+	.lut-output-info {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 6px 4px;
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	.lut-output-line {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		font-size: 11px;
+		line-height: 16px;
+	}
+
+	.lut-output-label {
+		color: var(--text-secondary, #9a9aab);
+		font-weight: 500;
+	}
+
+	.lut-output-val {
+		color: var(--text-primary, #e0e0e0);
+		font-weight: 600;
+	}
+
+	.lut-output-badge {
+		background: rgba(0, 220, 180, 0.2);
+		border: 1px solid rgba(0, 220, 180, 0.5);
+		color: #00dcb4;
+		padding: 1px 6px;
+		border-radius: 4px;
+		font-size: 10px;
+	}
+
+	.lut-card-header {
+		display: flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+		position: relative !important;
+		width: 100% !important;
+		min-height: 24px !important;
+		height: 24px !important;
+		margin-bottom: 6px !important;
+		padding: 0 20px !important;
+		border-bottom: 1px solid rgba(74, 74, 90, 0.3) !important;
+		box-sizing: border-box !important;
+	}
+
+	.lut-card-drag-handle {
+		position: absolute !important;
+		left: 4px !important;
+		top: 0px !important;
+		bottom: 0px !important;
+		margin: -4px 0 0 0 !important;
+		height: 100% !important;
+		display: flex !important;
+		align-items: center !important;
+		z-index: 5 !important;
+	}
+
+	.lut-card-remove-btn {
+		position: absolute !important;
+		right: 4px !important;
+		top: 0px !important;
+		bottom: 0px !important;
+		margin: -4px 0 0 0 !important;
+		height: 100% !important;
+		display: flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+		background: transparent !important;
+		border: none !important;
+		color: var(--text-secondary, #9a9aab) !important;
+		cursor: pointer !important;
+		padding: 0 !important;
+		width: 18px !important;
+		opacity: 0.6;
+		z-index: 5 !important;
+		transition: color 0.15s, opacity 0.15s !important;
+	}
+
+	.lut-card-remove-btn:hover {
+		color: var(--color-accent, #00aaff) !important;
+		opacity: 1 !important;
+	}
+
+	.lut-card-title {
+		display: flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+		width: 100% !important;
+		height: 100% !important;
+		text-align: center !important;
+		font-family: var(--font-family, sans-serif) !important;
+		font-size: 11px !important;
+		font-weight: 600 !important;
+		color: var(--text-primary, #e0e0e0) !important;
+		letter-spacing: 0.3px !important;
+		line-height: 23px !important;
+		margin: -6px 0 0 0 !important;
+		padding: 0 !important;
+		white-space: nowrap !important;
+		overflow: hidden !important;
+		text-overflow: ellipsis !important;
+	}
+
+	.lut-card-reset-btn, .lut-container .card-reset-btn {
+		background: transparent !important;
+		border: none !important;
+		color: var(--text-secondary, #9a9aab) !important;
+		cursor: pointer !important;
+		padding: 0 !important;
+		margin: 0 !important;
+		width: 18px !important;
+		height: 18px !important;
+		display: flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+		opacity: 0.6;
+		transition: color 0.15s, opacity 0.15s, transform 0.15s !important;
+	}
+
+	.lut-card-reset-btn:hover, .lut-container .card-reset-btn:hover {
+		color: var(--color-accent, #00aaff) !important;
+		opacity: 1 !important;
+		transform: rotate(-45deg);
+	}
+
+	/* Flow Connector Nodes between Cards */
+	.lut-flow-connector {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 12px;
+		min-width: 12px;
+		height: 100%;
+		position: relative;
+		flex-shrink: 0;
+		user-select: none;
+		pointer-events: none;
+	}
+
+	.lut-flow-connector::before {
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: -6px;
+		right: -6px;
+		height: 2px;
+		background: repeating-linear-gradient(90deg, rgba(74, 74, 90, 0.4) 0px, rgba(74, 74, 90, 0.4) 3px, transparent 3px, transparent 6px);
+		transform: translateY(-50%);
+	}
+
+	@keyframes lutDashMarch {
+		0% { background-position: 0 0; }
+		100% { background-position: 12px 0; }
+	}
+
+	:scope.is-live-active .lut-flow-connector::before {
+		background: repeating-linear-gradient(90deg, #00aaff 0px, #00aaff 4px, transparent 4px, transparent 8px);
+		background-size: 12px 100%;
+		animation: lutDashMarch 0.5s linear infinite;
+		box-shadow: 0 0 8px rgba(0, 170, 255, 0.6);
+	}
+
+	/* Drag & Drop Moving Card State */
+	.lut-card {
+		cursor: default;
+		transition: transform 0.15s ease, opacity 0.15s ease;
+	}
+
+	.lut-card-header {
+		cursor: grab !important;
+	}
+
+	.lut-card-header:active {
+		cursor: grabbing !important;
+	}
+
+	.lut-card.lut-card-moving {
+		opacity: 0.85 !important;
+		border: 1px solid var(--color-accent, #00aaff) !important;
+		box-shadow: 0 4px 16px rgba(0, 170, 255, 0.3) !important;
+		z-index: 10;
+	}
+
+	/* Controls, Inputs & Sliders */
+	.lut-param-box {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+		width: 100%;
+	}
+
+	.lut-param-top {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		width: 100%;
+		gap: 6px;
+	}
+
+	.lut-param-label {
+		font-family: var(--font-family, sans-serif);
+		font-size: 11px;
+		color: var(--text-secondary, #9a9aab);
+		font-weight: 500;
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.lut-select, .lut-container select, .lut-toolbar select {
+		height: 22px;
+		font-family: var(--font-family, sans-serif);
+		font-size: 11px;
+		background: transparent !important;
+		border: none !important;
+		color: var(--text-primary, #e0e0e0);
+		padding: 0 4px;
+		outline: none;
+		cursor: pointer;
+		flex-shrink: 1;
+		min-width: 40px;
+	}
+
+	.lut-select-compact {
+		height: 20px;
+		font-size: 10.5px;
+		max-width: 92px;
+		min-width: 40px;
+		padding: 0 2px;
+		flex-shrink: 1;
+	}
+
+	/* Slider Controls inside Cards */
+	.lut-card input[type="range"].inspector-slider,
+	.lut-container input[type="range"].inspector-slider {
+		-webkit-appearance: none;
+		appearance: none;
+		width: 100%;
+		height: 6px !important;
+		background: rgba(0, 0, 0, 0.4) !important;
+		border-radius: 3px !important;
+		border: 1px solid rgba(74, 74, 90, 0.5) !important;
+		outline: none !important;
+		margin: 6px 0 !important;
+		padding: 0 !important;
+	}
+
+	.lut-card input[type="range"].inspector-slider::-webkit-slider-thumb,
+	.lut-container input[type="range"].inspector-slider::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		appearance: none;
+		width: 13px !important;
+		height: 13px !important;
+		background: var(--profiler-background, #1e1e24) !important;
+		border: 1.5px solid var(--color-accent, #00aaff) !important;
+		border-radius: 3px !important;
+		cursor: pointer !important;
+		margin-top: -0.5px !important;
+	}
+
+	.lut-card input[type="range"].inspector-slider::-moz-range-thumb,
+	.lut-container input[type="range"].inspector-slider::-moz-range-thumb {
+		width: 13px !important;
+		height: 13px !important;
+		background: var(--profiler-background, #1e1e24) !important;
+		border: 1.5px solid var(--color-accent, #00aaff) !important;
+		border-radius: 3px !important;
+		cursor: pointer !important;
+	}
+
+	.lut-card input[type="range"].inspector-slider::-moz-range-track,
+	.lut-container input[type="range"].inspector-slider::-moz-range-track {
+		width: 100%;
+		height: 6px !important;
+		background: rgba(0, 0, 0, 0.4) !important;
+		border-radius: 3px !important;
+		border: 1px solid rgba(74, 74, 90, 0.5) !important;
+	}
+
+	.lut-num-input {
+		width: 52px;
+		min-width: 36px;
+		flex-shrink: 1;
+		background: transparent;
+		border: none !important;
+		color: var(--text-primary, #e0e0e0);
+		font-family: var(--font-mono, monospace);
+		font-size: 11px;
+		font-weight: 600;
+		text-align: right !important;
+		outline: none;
+		padding: 0 2px;
+		transition: color 0.15s;
+	}
+
+	.lut-num-input:focus {
+		color: var(--color-accent, #00aaff);
+	}
+
+	.lut-rgb-input {
+		width: 100%;
+		background: transparent;
+		border: none;
+		color: var(--text-primary, #e0e0e0);
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		font-weight: 600;
+		text-align: center !important;
+		border-radius: 0 !important;
+		outline: none;
+		padding: 2px 2px 2px 0;
+		transition: border-color 0.15s;
+	}
+
+	.lut-rgb-input:focus {
+		border-bottom-color: var(--color-accent, #00aaff) !important;
+	}
+
+	.lut-rgb-input-y { border-bottom: 1px solid #aaaaaa; }
+	.lut-rgb-input-r { border-bottom: 1px solid #ff4d4d; }
+	.lut-rgb-input-g { border-bottom: 1px solid #4dff4d; }
+	.lut-rgb-input-b { border-bottom: 1px solid #4d88ff; }
+
+	.lut-wheel-canvas {
+		width: 110px;
+		height: 110px;
+		cursor: crosshair;
+		touch-action: none;
+		border-radius: 50%;
+		margin-bottom: 5px;
+	}
+
+	.lut-wheel-inputs-row {
+		display: flex;
+		gap: 3px;
+		width: 100%;
+		margin-top: 4px;
+		justify-content: space-between;
+	}
+
+	.lut-wheel-input-box {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		flex: 1;
+		min-width: 0;
+	}
+
+	/* Preview Tab UI */
+	.lut-preview-box {
+		background: rgba(30, 30, 36, 0.85);
+		padding: 10px;
+		border-radius: 8px;
+		border: 1px solid rgba(74, 74, 90, 0.4);
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		backdrop-filter: blur(8px);
+	}
+
+	.lut-preview-title {
+		font-size: 11px;
+		font-weight: 700;
+		color: #e0e0e0;
+		border-bottom: 1px solid #2a2a36;
+		padding-bottom: 4px;
+	}
+
+	.lut-preview-canvas {
+		width: 100%;
+		height: 56px;
+		min-height: 56px;
+		border-radius: 4px;
+		border: 1px solid #2a2a36;
+		background: #000;
+		image-rendering: pixelated;
+	}
+
+	.lut-btn-group {
+		display: flex;
+		gap: 8px;
+	}
+
+	/* Vertical Mode Layout */
+	.profiler-panel.position-left .lut-container,
+	.profiler-panel.position-right .lut-container,
+	.lut-container.is-vertical {
+		overflow-y: auto !important;
+		overflow-x: hidden !important;
+	}
+
+	.profiler-panel.position-left .lut-panel,
+	.profiler-panel.position-right .lut-panel,
+	.lut-panel.is-vertical {
+		height: auto !important;
+		min-height: 100% !important;
+	}
+
+	.profiler-panel.position-left .lut-cards-row,
+	.profiler-panel.position-right .lut-cards-row,
+	.lut-container.is-vertical .lut-cards-row,
+	.lut-cards-row.is-vertical {
+		flex-direction: column !important;
+		justify-content: flex-start !important;
+		align-items: center !important;
+		overflow-x: hidden !important;
+		overflow-y: auto !important;
+		padding: 56px 12px 24px 12px !important;
+		gap: 12px !important;
+		width: 100% !important;
+		height: 100% !important;
+	}
+
+	.profiler-panel.position-left .lut-cards-row > .lut-card,
+	.profiler-panel.position-right .lut-cards-row > .lut-card,
+	.lut-container.is-vertical .lut-cards-row > .lut-card,
+	.lut-cards-row.is-vertical > .lut-card {
+		flex-shrink: 0 !important;
+	}
+
+	.profiler-panel.position-left .lut-cards-row > .lut-card:first-child,
+	.profiler-panel.position-right .lut-cards-row > .lut-card:first-child,
+	.lut-container.is-vertical .lut-cards-row > .lut-card:first-child,
+	.lut-cards-row.is-vertical > .lut-card:first-child {
+		margin-left: 0 !important;
+		margin-top: 0 !important;
+	}
+
+	.profiler-panel.position-left .lut-cards-row > .lut-card:last-child,
+	.profiler-panel.position-right .lut-cards-row > .lut-card:last-child,
+	.lut-container.is-vertical .lut-cards-row > .lut-card:last-child,
+	.lut-cards-row.is-vertical > .lut-card:last-child {
+		margin-right: 0 !important;
+		margin-bottom: 24px !important;
+	}
+
+
+
+	@keyframes lutDashMarchVertical {
+		0% { background-position: 0 0; }
+		100% { background-position: 0 12px; }
+	}
+
+	.profiler-panel.position-left .lut-flow-connector,
+	.profiler-panel.position-right .lut-flow-connector,
+	.lut-container.is-vertical .lut-flow-connector,
+	.lut-cards-row.is-vertical .lut-flow-connector {
+		width: 100% !important;
+		min-width: 0 !important;
+		height: 16px !important;
+		min-height: 16px !important;
+		margin: 2px 0 !important;
+	}
+
+	.profiler-panel.position-left .lut-flow-connector::before,
+	.profiler-panel.position-right .lut-flow-connector::before,
+	.lut-container.is-vertical .lut-flow-connector::before,
+	.lut-cards-row.is-vertical .lut-flow-connector::before {
+		top: -6px !important;
+		bottom: -6px !important;
+		left: 50% !important;
+		right: auto !important;
+		width: 2px !important;
+		height: auto !important;
+		background-image: repeating-linear-gradient(180deg, rgba(74, 74, 90, 0.4) 0px, rgba(74, 74, 90, 0.4) 3px, transparent 3px, transparent 6px) !important;
+		transform: translateX(-50%) !important;
+	}
+
+	:scope.is-live-active.is-vertical .lut-flow-connector::before,
+	:scope.is-live-active .lut-cards-row.is-vertical .lut-flow-connector::before {
+		background-image: repeating-linear-gradient(180deg, #00aaff 0px, #00aaff 4px, transparent 4px, transparent 8px) !important;
+		background-size: 100% 12px !important;
+		animation: lutDashMarchVertical 0.5s linear infinite !important;
+		box-shadow: 0 0 8px rgba(0, 170, 255, 0.6) !important;
+	}
+
+	/* Interactive Add Card Connector [+] Button */
+	.lut-flow-connector {
+		pointer-events: auto !important;
+		width: 24px !important;
+		min-width: 24px !important;
+		z-index: 5;
+	}
+
+	.lut-connector-add-btn {
+		width: 20px;
+		height: 20px;
+		border-radius: 6px;
+		background: rgba(22, 22, 28, 0.95);
+		border: 1px solid rgba(74, 74, 90, 0.7);
+		color: var(--text-secondary, #9a9aab);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		z-index: 6;
+		transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275), background 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s;
+		padding: 0;
+		outline: none;
+		user-select: none;
+	}
+
+	:scope.is-live-active .lut-connector-add-btn {
+		border-color: var(--color-accent, #00aaff);
+		color: var(--color-accent, #00aaff);
+	}
+
+	.lut-connector-add-btn svg {
+		width: 12px;
+		height: 12px;
+		display: block;
+	}
+
+	.lut-connector-add-btn:hover {
+		transform: scale(1.15);
+		background: #00aaff !important;
+		border-color: #00aaff !important;
+		color: #ffffff !important;
+		box-shadow: 0 0 6px rgba(0, 170, 255, 0.4);
+	}
+
+	.lut-connector-add-btn:active {
+		transform: scale(1.05);
+	}
+
+	/* Header Card Close Button at top-right (where reset button was) */
+	.lut-card-remove-btn {
+		position: absolute !important;
+		right: 4px !important;
+		top: 0px !important;
+		bottom: 0px !important;
+		margin: auto 0 !important;
+		width: 20px !important;
+		height: 100% !important;
+		font-size: 11px !important;
+		line-height: 23px !important;
+		display: flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+		background: transparent !important;
+		border: none !important;
+		color: var(--text-secondary, #9a9aab) !important;
+		cursor: pointer !important;
+		padding: 0 !important;
+		z-index: 5;
+		opacity: 0.6;
+		transition: color 0.15s, opacity 0.15s, transform 0.15s !important;
+	}
+
+	.lut-card-remove-btn:hover {
+		color: var(--color-accent, #00aaff) !important;
+		opacity: 1 !important;
+		transform: scale(1.2);
+	}
+
+	/* Add Card Modal Window Overlay */
+	.lut-modal-overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background: rgba(10, 10, 14, 0.75);
+		backdrop-filter: blur(8px);
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		animation: lutModalFadeIn 0.2s ease-out;
+		padding: 16px;
+		box-sizing: border-box;
+	}
+
+	@keyframes lutModalFadeIn {
+		from { opacity: 0; transform: scale(0.97); }
+		to { opacity: 1; transform: scale(1); }
+	}
+
+	.lut-modal-content {
+		background: rgba(22, 22, 28, 0.95);
+		border: 1px solid rgba(74, 74, 90, 0.6);
+		border-radius: 12px;
+		box-shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
+		width: 480px;
+		max-width: 92%;
+		height: 70% !important;
+		max-height: 70% !important;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		padding: 16px 20px;
+		box-sizing: border-box;
+		backdrop-filter: blur(16px);
+		user-select: none;
+	}
+
+	.lut-modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		border-bottom: 1px solid rgba(74, 74, 90, 0.4);
+		padding-bottom: 10px;
+		flex-shrink: 0;
+	}
+
+	.lut-modal-title {
+		font-family: var(--font-family, sans-serif);
+		font-size: 14px;
+		font-weight: 700;
+		color: var(--text-primary, #ffffff);
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.lut-modal-close-btn {
+		background: transparent;
+		border: none;
+		color: var(--text-secondary, #9a9aab);
+		font-size: 16px;
+		cursor: pointer;
+		padding: 4px;
+		border-radius: 4px;
+		transition: color 0.15s, background 0.15s;
+	}
+
+	.lut-modal-close-btn:hover {
+		color: #ffffff;
+	}
+
+	.lut-modal-filter-box {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		background: rgba(30, 30, 38, 0.9);
+		border: 1px solid rgba(74, 74, 90, 0.5);
+		border-radius: 8px;
+		padding: 7px 12px;
+		transition: border-color 0.15s, box-shadow 0.15s;
+		flex-shrink: 0;
+	}
+
+	.lut-modal-filter-box:focus-within {
+		border-color: #00aaff;
+		box-shadow: 0 0 6px rgba(0, 170, 255, 0.25);
+	}
+
+	.lut-modal-filter-icon {
+		color: var(--text-secondary, #9a9aab);
+		font-size: 13px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+	}
+
+	.lut-modal-filter-input {
+		background: transparent !important;
+		border: none !important;
+		outline: none !important;
+		color: var(--text-primary, #ffffff) !important;
+		font-family: var(--font-family, sans-serif) !important;
+		font-size: 12px !important;
+		width: 100% !important;
+		padding: 0 !important;
+		margin: 0 !important;
+	}
+
+	.lut-modal-filter-input::placeholder {
+		color: var(--text-secondary, #6c6c7d) !important;
+	}
+
+	.lut-modal-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+		gap: 10px;
+		overflow-y: auto;
+		padding-right: 4px;
+		flex: 1 !important;
+		min-height: 0 !important;
+		align-content: start;
+		scrollbar-width: thin;
+		scrollbar-color: var(--profiler-border, rgba(74, 74, 90, 0.6)) transparent;
+	}
+
+	.lut-modal-grid::-webkit-scrollbar {
+		width: 4px;
+		height: 4px;
+	}
+
+	.lut-modal-grid::-webkit-scrollbar-track {
+		background: rgba(0, 0, 0, 0.2);
+		border-radius: 2px;
+	}
+
+	.lut-modal-grid::-webkit-scrollbar-thumb {
+		background: var(--profiler-border, rgba(74, 74, 90, 0.6));
+		border-radius: 2px;
+	}
+
+	.lut-modal-grid::-webkit-scrollbar-thumb:hover {
+		background: var(--color-accent, #00aaff);
+	}
+
+	.lut-modal-empty-msg {
+		text-align: center;
+		font-family: var(--font-family, sans-serif);
+		font-size: 12px;
+		color: var(--text-secondary, #9a9aab);
+		padding: 24px 12px;
+		grid-column: 1 / -1;
+	}
+
+	.lut-modal-option {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		gap: 8px;
+		background: rgba(30, 30, 38, 0.85);
+		border: 1px solid transparent;
+		border-radius: 10px;
+		padding: 14px 8px;
+		cursor: pointer;
+		box-sizing: border-box;
+		transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+	}
+
+	.lut-modal-option:hover,
+	.lut-modal-option.is-focused {
+		border-color: var(--color-accent, #00aaff);
+		box-shadow: 0 0 10px rgba(0, 170, 255, 0.2);
+	}
+
+	.lut-modal-option-icon {
+		width: 28px;
+		height: 28px;
+		background: transparent !important;
+		color: #d0d0dc;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		transition: color 0.15s;
+	}
+
+	.lut-modal-option:hover .lut-modal-option-icon,
+	.lut-modal-option.is-focused .lut-modal-option-icon {
+		color: var(--color-accent, #00aaff);
+	}
+
+	.lut-modal-option-title {
+		font-family: var(--font-family, sans-serif);
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--text-primary, #e0e0e0);
+		text-align: center;
+		line-height: 1.3;
+		word-break: break-word;
+	}
+
+}
+`;
+
+		document.head.appendChild( style );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/LUTMath.js
+++ b/examples/jsm/inspector/extensions/color-grading/LUTMath.js
@@ -241,7 +241,7 @@ export function applyColorTransform( r, g, b, params, pipelineOrder = null ) {
 
 				}
 
-				if ( params.brightness && params.brightness !== 0 ) {
+				if ( params.brightness ) {
 
 					cr += params.brightness;
 					cg += params.brightness;
@@ -249,7 +249,7 @@ export function applyColorTransform( r, g, b, params, pipelineOrder = null ) {
 
 				}
 
-				if ( params.hueShift && params.hueShift !== 0 ) {
+				if ( params.hueShift ) {
 
 					const [ origH, s, v ] = rgbToHsv( Math.max( 0, cr ), Math.max( 0, cg ), Math.max( 0, cb ) );
 					let h = ( origH + params.hueShift / 360 ) % 1;

--- a/examples/jsm/inspector/extensions/color-grading/LUTMath.js
+++ b/examples/jsm/inspector/extensions/color-grading/LUTMath.js
@@ -1,0 +1,788 @@
+/**
+ * LUTMath.js - Mathematical operations for LUT 3D Generator
+ */
+
+import { REVISION } from 'three';
+
+// Monotone cubic spline evaluation for curve points
+export function evaluateSpline( t, points ) {
+
+	if ( ! points || points.length === 0 ) return t;
+	if ( points.length === 1 ) return points[ 0 ].y;
+
+	const pts = points;
+
+	if ( t <= pts[ 0 ].x ) return pts[ 0 ].y;
+	if ( t >= pts[ pts.length - 1 ].x ) return pts[ pts.length - 1 ].y;
+
+	// Find segment
+	let i = 0;
+	while ( i < pts.length - 1 && pts[ i + 1 ].x < t ) {
+
+		i ++;
+
+	}
+
+	const p0 = pts[ i ];
+	const p1 = pts[ i + 1 ];
+	const h = p1.x - p0.x;
+
+	if ( h <= 0.00001 ) return p0.y;
+
+	// Secants
+	const d = ( p1.y - p0.y ) / h;
+
+	// Tangents computation (Fritsch-Carlson monotone cubic Hermite)
+	let m0 = d;
+	let m1 = d;
+
+	if ( i > 0 ) {
+
+		const prevD = ( p0.y - pts[ i - 1 ].y ) / ( p0.x - pts[ i - 1 ].x );
+		m0 = 0.5 * ( prevD + d );
+
+	}
+
+	if ( i < pts.length - 2 ) {
+
+		const nextD = ( pts[ i + 2 ].y - p1.y ) / ( pts[ i + 2 ].x - p1.x );
+		m1 = 0.5 * ( d + nextD );
+
+	}
+
+	// Hermite basis
+	const localT = ( t - p0.x ) / h;
+	const t2 = localT * localT;
+	const t3 = t2 * localT;
+
+	const h00 = 2 * t3 - 3 * t2 + 1;
+	const h10 = t3 - 2 * t2 + localT;
+	const h01 = - 2 * t3 + 3 * t2;
+	const h11 = t3 - t2;
+
+	const val = h00 * p0.y + h10 * h * m0 + h01 * p1.y + h11 * h * m1;
+
+	return Math.max( 0, Math.min( 1, val ) );
+
+}
+
+// RGB to HSV conversion
+export function rgbToHsv( r, g, b ) {
+
+	const max = Math.max( r, g, b );
+	const min = Math.min( r, g, b );
+	const d = max - min;
+	let h = 0;
+	const s = max === 0 ? 0 : d / max;
+	const v = max;
+
+	if ( max !== min ) {
+
+		switch ( max ) {
+
+			case r: h = ( g - b ) / d + ( g < b ? 6 : 0 ); break;
+			case g: h = ( b - r ) / d + 2; break;
+			case b: h = ( r - g ) / d + 4; break;
+
+		}
+
+		h /= 6;
+
+	}
+
+	return [ h, s, v ];
+
+}
+
+// HSV to RGB conversion
+export function hsvToRgb( h, s, v ) {
+
+	let r = 0, g = 0, b = 0;
+
+	const i = Math.floor( h * 6 );
+	const f = h * 6 - i;
+	const p = v * ( 1 - s );
+	const q = v * ( 1 - f * s );
+	const t = v * ( 1 - ( 1 - f ) * s );
+
+	switch ( i % 6 ) {
+
+		case 0: r = v; g = t; b = p; break;
+		case 1: r = q; g = v; b = p; break;
+		case 2: r = p; g = v; b = t; break;
+		case 3: r = p; g = q; b = v; break;
+		case 4: r = t; g = p; b = v; break;
+		case 5: r = v; g = p; b = q; break;
+
+	}
+
+	return [ r, g, b ];
+
+}
+
+// Main color transformation pipeline
+// Trilinear 3D LUT sampling for imported .CUBE datasets
+export function sample3DLUT( r, g, b, size, dataLines ) {
+
+	const nr = Math.max( 0, Math.min( 1, r ) );
+	const ng = Math.max( 0, Math.min( 1, g ) );
+	const nb = Math.max( 0, Math.min( 1, b ) );
+
+	const rx = nr * ( size - 1 );
+	const gy = ng * ( size - 1 );
+	const bz = nb * ( size - 1 );
+
+	const x0 = Math.floor( rx );
+	const x1 = Math.min( size - 1, x0 + 1 );
+	const y0 = Math.floor( gy );
+	const y1 = Math.min( size - 1, y0 + 1 );
+	const z0 = Math.floor( bz );
+	const z1 = Math.min( size - 1, z0 + 1 );
+
+	const fx = rx - x0;
+	const fy = gy - y0;
+	const fz = bz - z0;
+
+	const getVal = ( x, y, z ) => {
+
+		const index = z * size * size + y * size + x;
+		return dataLines[ index ] || [ x / ( size - 1 ), y / ( size - 1 ), z / ( size - 1 ) ];
+
+	};
+
+	const c000 = getVal( x0, y0, z0 );
+	const c100 = getVal( x1, y0, z0 );
+	const c010 = getVal( x0, y1, z0 );
+	const c110 = getVal( x1, y0, z0 );
+	const c001 = getVal( x0, y0, z1 );
+	const c101 = getVal( x1, y0, z1 );
+	const c011 = getVal( x0, y1, z1 );
+	const c111 = getVal( x1, y1, z1 );
+
+	const trilinear = ( ch ) => {
+
+		const c00 = c000[ ch ] * ( 1 - fx ) + c100[ ch ] * fx;
+		const c01 = c001[ ch ] * ( 1 - fx ) + c101[ ch ] * fx;
+		const c10 = c010[ ch ] * ( 1 - fx ) + c110[ ch ] * fx;
+		const c11 = c011[ ch ] * ( 1 - fx ) + c111[ ch ] * fx;
+
+		const c0 = c00 * ( 1 - fy ) + c10 * fy;
+		const c1 = c01 * ( 1 - fy ) + c11 * fy;
+
+		return c0 * ( 1 - fz ) + c1 * fz;
+
+	};
+
+	return [ trilinear( 0 ), trilinear( 1 ), trilinear( 2 ) ];
+
+}
+
+export function applyColorTransform( r, g, b, params, pipelineOrder = null ) {
+
+	let cr = r;
+	let cg = g;
+	let cb = b;
+
+	const order = pipelineOrder || [
+		'whiteBalance',
+		'exposureHue',
+		'lift',
+		'gammaBal',
+		'gain',
+		'offset',
+		'contrast',
+		'satVibrance'
+	];
+
+	for ( let i = 0; i < order.length; i ++ ) {
+
+		const step = order[ i ];
+
+		if ( step.startsWith( 'importedCube_' ) && params.importedCubes && params.importedCubes[ step ] ) {
+
+			const cubeInfo = params.importedCubes[ step ];
+			const cubeData = cubeInfo.dataLines || cubeInfo.data;
+			if ( cubeData && cubeData.length > 0 ) {
+
+				const [ lr, lg, lb ] = sample3DLUT( cr, cg, cb, cubeInfo.size, cubeData );
+				const weight = cubeInfo.weight !== undefined ? cubeInfo.weight : 1.0;
+				cr = cr * ( 1 - weight ) + lr * weight;
+				cg = cg * ( 1 - weight ) + lg * weight;
+				cb = cb * ( 1 - weight ) + lb * weight;
+
+			}
+
+			continue;
+
+		}
+
+		switch ( step ) {
+
+			case 'whiteBalance':
+				if ( params.temperature !== 0 || params.tint !== 0 ) {
+
+					const temp = params.temperature / 100;
+					const tint = params.tint / 100;
+					cr += temp * 0.1;
+					cb -= temp * 0.1;
+					cg -= tint * 0.1;
+
+				}
+
+				break;
+
+			case 'exposureHue':
+				if ( params.exposure !== 0 ) {
+
+					const factor = Math.pow( 2, params.exposure );
+					cr *= factor;
+					cg *= factor;
+					cb *= factor;
+
+				}
+
+				if ( params.brightness && params.brightness !== 0 ) {
+
+					cr += params.brightness;
+					cg += params.brightness;
+					cb += params.brightness;
+
+				}
+
+				if ( params.hueShift && params.hueShift !== 0 ) {
+
+					const [ origH, s, v ] = rgbToHsv( Math.max( 0, cr ), Math.max( 0, cg ), Math.max( 0, cb ) );
+					let h = ( origH + params.hueShift / 360 ) % 1;
+					if ( h < 0 ) h += 1;
+					const [ nr, ng, nb ] = hsvToRgb( h, s, v );
+					cr = nr; cg = ng; cb = nb;
+
+				}
+
+				break;
+
+			case 'lift':
+				if ( params.lift ) {
+
+					const ly = params.lift.y || 0;
+					const lr = params.lift.r + ly;
+					const lg = params.lift.g + ly;
+					const lb = params.lift.b + ly;
+
+					cr += lr * ( 1 - Math.max( 0, Math.min( 1, cr ) ) );
+					cg += lg * ( 1 - Math.max( 0, Math.min( 1, cg ) ) );
+					cb += lb * ( 1 - Math.max( 0, Math.min( 1, cb ) ) );
+
+				}
+
+				break;
+
+			case 'gammaBal':
+				if ( params.gammaBal ) {
+
+					const gy = params.gammaBal.y || 0;
+					const gr = Math.pow( 2.0, - ( params.gammaBal.r + gy ) );
+					const gg = Math.pow( 2.0, - ( params.gammaBal.g + gy ) );
+					const gb = Math.pow( 2.0, - ( params.gammaBal.b + gy ) );
+
+					cr = cr > 0 ? Math.pow( cr, gr ) : cr;
+					cg = cg > 0 ? Math.pow( cg, gg ) : cg;
+					cb = cb > 0 ? Math.pow( cb, gb ) : cb;
+
+				}
+
+				break;
+
+			case 'gain':
+				if ( params.gain ) {
+
+					const gy = params.gain.y || 0;
+					const sr = Math.max( 0, 1.0 + ( params.gain.r + gy ) );
+					const sg = Math.max( 0, 1.0 + ( params.gain.g + gy ) );
+					const sb = Math.max( 0, 1.0 + ( params.gain.b + gy ) );
+
+					cr *= sr;
+					cg *= sg;
+					cb *= sb;
+
+				}
+
+				break;
+
+			case 'offset':
+				if ( params.offset ) {
+
+					const oy = params.offset.y || 0;
+					cr += params.offset.r + oy;
+					cg += params.offset.g + oy;
+					cb += params.offset.b + oy;
+
+				}
+
+				break;
+
+			case 'contrast':
+				if ( params.contrast !== 1 ) {
+
+					const pivot = params.contrastPivot !== undefined ? params.contrastPivot : 0.5;
+					const c = params.contrast;
+					cr = pivot + ( cr - pivot ) * c;
+					cg = pivot + ( cg - pivot ) * c;
+					cb = pivot + ( cb - pivot ) * c;
+
+				}
+
+				break;
+
+			case 'satVibrance':
+				if ( params.saturation !== 1 || params.vibrance !== 0 ) {
+
+					const [ h, origS, origV ] = rgbToHsv( Math.max( 0, cr ), Math.max( 0, cg ), Math.max( 0, cb ) );
+					let s = origS;
+
+					if ( params.saturation !== 1 ) {
+
+						s *= params.saturation;
+
+					}
+
+					if ( params.vibrance !== 0 ) {
+
+						const vib = params.vibrance;
+						if ( vib > 0 ) {
+
+							s += ( 1 - s ) * vib * 0.5;
+
+						} else {
+
+							s += s * vib * 0.5;
+
+						}
+
+					}
+
+					s = Math.max( 0, Math.min( 1, s ) );
+					const v = Math.max( 0, Math.min( 1, origV ) );
+					const [ nr, ng, nb ] = hsvToRgb( h, s, v );
+					cr = nr; cg = ng; cb = nb;
+
+				}
+
+				break;
+
+		}
+
+	}
+
+	// Gamma Evaluation
+	if ( params.gamma !== 1 && params.gamma > 0 ) {
+
+		const invGamma = 1 / params.gamma;
+		cr = Math.pow( Math.max( 0, cr ), invGamma );
+		cg = Math.pow( Math.max( 0, cg ), invGamma );
+		cb = Math.pow( Math.max( 0, cb ), invGamma );
+
+	}
+
+	// Clamp to non-negative before Channel Mixer operations
+	cr = Math.max( 0, cr );
+	cg = Math.max( 0, cg );
+	cb = Math.max( 0, cb );
+
+	// Channel Mixer
+	if ( params.channelMixer ) {
+
+		const cm = params.channelMixer;
+		const nr = cr * cm.red.r + cg * cm.red.g + cb * cm.red.b;
+		const ng = cr * cm.green.r + cg * cm.green.g + cb * cm.green.b;
+		const nb = cr * cm.blue.r + cg * cm.blue.g + cb * cm.blue.b;
+
+		cr = nr;
+		cg = ng;
+		cb = nb;
+
+	}
+
+	// Clamp before curves evaluation (0..1)
+	cr = Math.max( 0, Math.min( 1, cr ) );
+	cg = Math.max( 0, Math.min( 1, cg ) );
+	cb = Math.max( 0, Math.min( 1, cb ) );
+
+	// Curves Evaluation
+	if ( params.curves ) {
+
+		// RGB / Master curve
+		if ( params.curves.rgb && params.curves.rgb.length > 0 ) {
+
+			cr = evaluateSpline( cr, params.curves.rgb );
+			cg = evaluateSpline( cg, params.curves.rgb );
+			cb = evaluateSpline( cb, params.curves.rgb );
+
+		}
+
+		// Individual Red, Green, Blue curves
+		if ( params.curves.red && params.curves.red.length > 0 ) {
+
+			cr = evaluateSpline( cr, params.curves.red );
+
+		}
+
+		if ( params.curves.green && params.curves.green.length > 0 ) {
+
+			cg = evaluateSpline( cg, params.curves.green );
+
+		}
+
+		if ( params.curves.blue && params.curves.blue.length > 0 ) {
+
+			cb = evaluateSpline( cb, params.curves.blue );
+
+		}
+
+	}
+
+	// Final clamp (0..1)
+	return [
+		Math.max( 0, Math.min( 1, cr ) ),
+		Math.max( 0, Math.min( 1, cg ) ),
+		Math.max( 0, Math.min( 1, cb ) )
+	];
+
+}
+
+// Generate 3D LUT Float32Array
+export function generate3DLUTData( params, size = 32, buffer = null, pipelineOrder = null ) {
+
+	if ( buffer === null ) {
+
+		buffer = new Float32Array( size * size * size * 4 );
+
+	}
+
+	let idx = 0;
+
+	for ( let b = 0; b < size; b ++ ) {
+
+		for ( let g = 0; g < size; g ++ ) {
+
+			for ( let r = 0; r < size; r ++ ) {
+
+				const nr = r / ( size - 1 );
+				const ng = g / ( size - 1 );
+				const nb = b / ( size - 1 );
+
+				const [ tr, tg, tb ] = applyColorTransform( nr, ng, nb, params, pipelineOrder );
+
+				buffer[ idx ++ ] = tr;
+				buffer[ idx ++ ] = tg;
+				buffer[ idx ++ ] = tb;
+				buffer[ idx ++ ] = 1.0; // Alpha
+
+			}
+
+		}
+
+	}
+
+	return buffer;
+
+}
+
+// Export Adobe .CUBE file format
+export function exportCubeFormat( paramsOrBuffer, size = 32, title = 'LUT 3D Generator', pipelineOrder = null ) {
+
+	let output = `#Created by: Three.js ${REVISION} - Color Grading\n`;
+	output += `TITLE "${title}"\n`;
+	output += `LUT_3D_SIZE ${size}\n\n`;
+
+	if ( paramsOrBuffer instanceof Float32Array ) {
+
+		const buffer = paramsOrBuffer;
+		for ( let i = 0; i < buffer.length; i += 4 ) {
+
+			output += `${buffer[ i ].toFixed( 6 )} ${buffer[ i + 1 ].toFixed( 6 )} ${buffer[ i + 2 ].toFixed( 6 )}\n`;
+
+		}
+
+	} else {
+
+		const params = paramsOrBuffer;
+
+		for ( let b = 0; b < size; b ++ ) {
+
+			for ( let g = 0; g < size; g ++ ) {
+
+				for ( let r = 0; r < size; r ++ ) {
+
+					const nr = r / ( size - 1 );
+					const ng = g / ( size - 1 );
+					const nb = b / ( size - 1 );
+
+					const [ tr, tg, tb ] = applyColorTransform( nr, ng, nb, params, pipelineOrder );
+
+					output += `${tr.toFixed( 6 )} ${tg.toFixed( 6 )} ${tb.toFixed( 6 )}\n`;
+
+				}
+
+			}
+
+		}
+
+	}
+
+	return output;
+
+}
+
+// Parse .CUBE file text into data grid
+export function parseCubeFormat( text ) {
+
+	const lines = text.split( /\r?\n/ );
+	let size = 0;
+	let title = 'Imported LUT';
+	const dataLines = [];
+
+	for ( const line of lines ) {
+
+		const trimmed = line.trim();
+		if ( ! trimmed || trimmed.startsWith( '#' ) ) continue;
+
+		const upper = trimmed.toUpperCase();
+		if ( upper.startsWith( 'TITLE' ) ) {
+
+			const match = trimmed.match( /TITLE\s+"?([^"]+)"?/i );
+			if ( match ) title = match[ 1 ];
+
+		} else if ( upper.startsWith( 'LUT_3D_SIZE' ) ) {
+
+			const parts = trimmed.split( /\s+/ );
+			size = parseInt( parts[ 1 ], 10 );
+
+		} else if ( upper.startsWith( 'LUT_1D_SIZE' ) || upper.startsWith( 'DOMAIN_MIN' ) || upper.startsWith( 'DOMAIN_MAX' ) ) {
+
+			continue;
+
+		} else {
+
+			const parts = trimmed.split( /\s+/ ).map( Number );
+			if ( parts.length >= 3 && ! isNaN( parts[ 0 ] ) && ! isNaN( parts[ 1 ] ) && ! isNaN( parts[ 2 ] ) ) {
+
+				dataLines.push( [ parts[ 0 ], parts[ 1 ], parts[ 2 ] ] );
+
+			}
+
+		}
+
+	}
+
+	if ( size === 0 && dataLines.length > 0 ) {
+
+		size = Math.round( Math.cbrt( dataLines.length ) );
+
+	}
+
+	return {
+		title,
+		size,
+		data: dataLines,
+		dataLines: dataLines
+	};
+
+}
+
+// Export 2D LUT Canvas for LUTImageLoader (PNG export)
+export function exportLUTCanvas( paramsOrBuffer, size = 32, pipelineOrder = null ) {
+
+	const canvas = document.createElement( 'canvas' );
+	const width = size * size;
+	const height = size;
+	canvas.width = width;
+	canvas.height = height;
+
+	const ctx = canvas.getContext( '2d' );
+	const imgData = ctx.createImageData( width, height );
+	const data = imgData.data;
+
+	if ( paramsOrBuffer instanceof Float32Array ) {
+
+		const buffer = paramsOrBuffer;
+		let idx = 0;
+
+		for ( let b = 0; b < size; b ++ ) {
+
+			for ( let g = 0; g < size; g ++ ) {
+
+				for ( let r = 0; r < size; r ++ ) {
+
+					const tr = buffer[ idx ++ ];
+					const tg = buffer[ idx ++ ];
+					const tb = buffer[ idx ++ ];
+					idx ++; // skip alpha
+
+					const x = b * size + r;
+					const y = g;
+					const pxIdx = ( y * width + x ) * 4;
+
+					data[ pxIdx ] = Math.round( Math.max( 0, Math.min( 1, tr ) ) * 255 );
+					data[ pxIdx + 1 ] = Math.round( Math.max( 0, Math.min( 1, tg ) ) * 255 );
+					data[ pxIdx + 2 ] = Math.round( Math.max( 0, Math.min( 1, tb ) ) * 255 );
+					data[ pxIdx + 3 ] = 255;
+
+				}
+
+			}
+
+		}
+
+	} else {
+
+		const params = paramsOrBuffer;
+
+		for ( let b = 0; b < size; b ++ ) {
+
+			for ( let g = 0; g < size; g ++ ) {
+
+				for ( let r = 0; r < size; r ++ ) {
+
+					const nr = r / ( size - 1 );
+					const ng = g / ( size - 1 );
+					const nb = b / ( size - 1 );
+
+					const [ tr, tg, tb ] = applyColorTransform( nr, ng, nb, params, pipelineOrder );
+
+					const x = b * size + r;
+					const y = g;
+					const idx = ( y * width + x ) * 4;
+
+					data[ idx ] = Math.round( tr * 255 );
+					data[ idx + 1 ] = Math.round( tg * 255 );
+					data[ idx + 2 ] = Math.round( tb * 255 );
+					data[ idx + 3 ] = 255;
+
+				}
+
+			}
+
+		}
+
+	}
+
+	ctx.putImageData( imgData, 0, 0 );
+	return canvas;
+
+}
+
+
+
+// Default Parameter Object factory
+export function createDefaultParams() {
+
+	return {
+		exposure: 0,
+		brightness: 0,
+		contrast: 1.0,
+		contrastPivot: 0.5,
+		gamma: 1.0,
+		saturation: 1.0,
+		vibrance: 0,
+		temperature: 0,
+		tint: 0,
+		hueShift: 0,
+		lift: { r: 0, g: 0, b: 0, y: 0 },
+		gammaBal: { r: 0, g: 0, b: 0, y: 0 },
+		gain: { r: 0, g: 0, b: 0, y: 0 },
+		offset: { r: 0, g: 0, b: 0, y: 0 },
+		channelMixer: {
+			red: { r: 1, g: 0, b: 0 },
+			green: { r: 0, g: 1, b: 0 },
+			blue: { r: 0, g: 0, b: 1 }
+		},
+		curves: {
+			rgb: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			red: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			green: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			blue: [ { x: 0, y: 0 }, { x: 1, y: 1 } ]
+		}
+	};
+
+}
+
+// Presets Collection
+export const LUT_PRESETS = {
+
+	'Neutral (Default)': createDefaultParams(),
+
+	'Cinematic Teal & Orange': {
+		...createDefaultParams(),
+		contrast: 1.15,
+		temperature: 15,
+		lift: { r: - 0.05, g: 0.02, b: 0.08 },
+		gain: { r: 0.08, g: 0.03, b: - 0.05 },
+		curves: {
+			rgb: [ { x: 0, y: 0 }, { x: 0.25, y: 0.2 }, { x: 0.75, y: 0.82 }, { x: 1, y: 1 } ],
+			red: [ { x: 0, y: 0 }, { x: 0.5, y: 0.48 }, { x: 1, y: 1 } ],
+			green: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			blue: [ { x: 0, y: 0 }, { x: 0.5, y: 0.54 }, { x: 1, y: 1 } ]
+		}
+	},
+
+	'Vintage Warm Film': {
+		...createDefaultParams(),
+		exposure: 0.1,
+		contrast: 0.92,
+		saturation: 0.85,
+		temperature: 25,
+		tint: 5,
+		lift: { r: 0.04, g: 0.02, b: - 0.02 },
+		gain: { r: 0.06, g: 0.04, b: - 0.04 },
+		curves: {
+			rgb: [ { x: 0, y: 0.05 }, { x: 0.5, y: 0.5 }, { x: 1, y: 0.95 } ],
+			red: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			green: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			blue: [ { x: 0, y: 0.06 }, { x: 1, y: 0.9 } ]
+		}
+	},
+
+	'Cold Sci-Fi Blue': {
+		...createDefaultParams(),
+		contrast: 1.2,
+		temperature: - 35,
+		tint: - 10,
+		lift: { r: - 0.04, g: - 0.01, b: 0.06 },
+		gain: { r: - 0.06, g: 0.02, b: 0.1 },
+		curves: {
+			rgb: [ { x: 0, y: 0 }, { x: 0.3, y: 0.22 }, { x: 0.7, y: 0.78 }, { x: 1, y: 1 } ],
+			red: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			green: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			blue: [ { x: 0, y: 0 }, { x: 1, y: 1 } ]
+		}
+	},
+
+	'Cyberpunk Neon': {
+		...createDefaultParams(),
+		contrast: 1.25,
+		saturation: 1.3,
+		vibrance: 0.4,
+		lift: { r: 0.06, g: - 0.04, b: 0.12 },
+		gain: { r: 0.1, g: - 0.02, b: 0.08 },
+		curves: {
+			rgb: [ { x: 0, y: 0 }, { x: 0.2, y: 0.15 }, { x: 0.8, y: 0.88 }, { x: 1, y: 1 } ],
+			red: [ { x: 0, y: 0 }, { x: 0.5, y: 0.55 }, { x: 1, y: 1 } ],
+			green: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			blue: [ { x: 0, y: 0.05 }, { x: 0.5, y: 0.6 }, { x: 1, y: 1 } ]
+		}
+	},
+
+	'High Contrast B&W': {
+		...createDefaultParams(),
+		contrast: 1.35,
+		saturation: 0.0,
+		curves: {
+			rgb: [ { x: 0, y: 0 }, { x: 0.25, y: 0.15 }, { x: 0.75, y: 0.88 }, { x: 1, y: 1 } ],
+			red: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			green: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			blue: [ { x: 0, y: 0 }, { x: 1, y: 1 } ]
+		}
+	}
+
+};

--- a/examples/jsm/inspector/extensions/color-grading/modules/BrightnessModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/BrightnessModule.js
@@ -1,0 +1,72 @@
+import { Module } from './Module.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class BrightnessModule extends Module {
+
+	constructor( params = {}, onChange = null, onRemove = null, id = 'brightness' ) {
+
+		super( id, 'Brightness', {
+			brightness: params.brightness ?? 0
+		} );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset(), onRemove ) );
+
+		this.brightnessControl = this.createSliderControl( {
+			key: 'brightness',
+			label: 'Brightness',
+			min: - 1,
+			max: 1,
+			step: 0.02,
+			def: 0
+		} );
+
+		card.appendChild( this.brightnessControl );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		let cr = r;
+		let cg = g;
+		let cb = b;
+
+		const { brightness } = this.params;
+
+		if ( brightness !== 0 ) {
+
+			cr += brightness;
+			cg += brightness;
+			cb += brightness;
+
+		}
+
+		target[ 0 ] = cr;
+		target[ 1 ] = cg;
+		target[ 2 ] = cb;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.brightness = 0;
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.brightnessControl._setValue( this.params.brightness );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/ColorWheelModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/ColorWheelModule.js
@@ -1,0 +1,112 @@
+import { Module } from './Module.js';
+import { ColorWheel } from '../ColorWheel.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class ColorWheelModule extends Module {
+
+	constructor( mode, title, initialParams = {}, onChange = null, onRemove = null, id = null ) {
+
+		const defaultWheelParams = { r: 0, g: 0, b: 0, y: 0 };
+		const mergedParams = Object.assign( {}, defaultWheelParams, initialParams );
+
+		super( id || mode, title, mergedParams );
+
+		this.mode = mode; // 'lift', 'gammaBal', 'gain', 'offset'
+		this.onChange = onChange;
+		this.onRemove = onRemove;
+
+		this.wheel = new ColorWheel( this.name, this.params, ( updatedVal ) => {
+
+			Object.assign( this.params, updatedVal );
+			this.onParamChange();
+
+		}, onRemove );
+
+		this.domElement = this.wheel.domElement;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		const { r: pr, g: pg, b: pb, y: py } = this.params;
+
+		switch ( this.mode ) {
+
+			case 'lift': {
+
+				const lr = pr + py;
+				const lg = pg + py;
+				const lb = pb + py;
+
+				target[ 0 ] = r + lr * ( 1 - Math.max( 0, Math.min( 1, r ) ) );
+				target[ 1 ] = g + lg * ( 1 - Math.max( 0, Math.min( 1, g ) ) );
+				target[ 2 ] = b + lb * ( 1 - Math.max( 0, Math.min( 1, b ) ) );
+				return target;
+
+			}
+
+			case 'gammaBal': {
+
+				const gr = Math.pow( 2.0, - ( pr + py ) );
+				const gg = Math.pow( 2.0, - ( pg + py ) );
+				const gb = Math.pow( 2.0, - ( pb + py ) );
+
+				target[ 0 ] = r > 0 ? Math.pow( r, gr ) : r;
+				target[ 1 ] = g > 0 ? Math.pow( g, gg ) : g;
+				target[ 2 ] = b > 0 ? Math.pow( b, gb ) : b;
+				return target;
+
+			}
+
+			case 'gain': {
+
+				const sr = Math.max( 0, 1.0 + pr + py );
+				const sg = Math.max( 0, 1.0 + pg + py );
+				const sb = Math.max( 0, 1.0 + pb + py );
+
+				target[ 0 ] = r * sr;
+				target[ 1 ] = g * sg;
+				target[ 2 ] = b * sb;
+				return target;
+
+			}
+
+			case 'offset': {
+
+				target[ 0 ] = r + pr + py;
+				target[ 1 ] = g + pg + py;
+				target[ 2 ] = b + pb + py;
+				return target;
+
+			}
+
+			default:
+				target[ 0 ] = r;
+				target[ 1 ] = g;
+				target[ 2 ] = b;
+				return target;
+
+		}
+
+	}
+
+	reset() {
+
+		this.params.r = 0;
+		this.params.g = 0;
+		this.params.b = 0;
+		this.params.y = 0;
+
+		this.wheel.setValues( 0, 0, 0, 0 );
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.wheel.setValues( this.params.r, this.params.g, this.params.b, this.params.y );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/ContrastModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/ContrastModule.js
@@ -1,0 +1,82 @@
+import { Module } from './Module.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class ContrastModule extends Module {
+
+	constructor( params = {}, onChange = null, onRemove = null, id = 'contrast' ) {
+
+		super( id, 'Contrast & Pivot', {
+			contrast: params.contrast ?? 1.0,
+			contrastPivot: params.contrastPivot ?? 0.5
+		} );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset(), onRemove ) );
+
+		this.contrastControl = this.createSliderControl( {
+			key: 'contrast',
+			label: 'Contrast',
+			min: 0.2,
+			max: 2.0,
+			step: 0.01,
+			def: 1.0
+		} );
+
+		this.pivotControl = this.createSliderControl( {
+			key: 'contrastPivot',
+			label: 'Pivot',
+			min: 0.1,
+			max: 0.9,
+			step: 0.01,
+			def: 0.5
+		} );
+
+		card.appendChild( this.contrastControl );
+		card.appendChild( this.pivotControl );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		const { contrast, contrastPivot } = this.params;
+
+		if ( contrast === 1.0 ) {
+
+			target[ 0 ] = r;
+			target[ 1 ] = g;
+			target[ 2 ] = b;
+			return target;
+
+		}
+
+		target[ 0 ] = contrastPivot + ( r - contrastPivot ) * contrast;
+		target[ 1 ] = contrastPivot + ( g - contrastPivot ) * contrast;
+		target[ 2 ] = contrastPivot + ( b - contrastPivot ) * contrast;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.contrast = 1.0;
+		this.params.contrastPivot = 0.5;
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.contrastControl._setValue( this.params.contrast );
+		this.pivotControl._setValue( this.params.contrastPivot );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/CurvesModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/CurvesModule.js
@@ -1,0 +1,109 @@
+import { Module } from './Module.js';
+import { CurveEditor } from '../CurveEditor.js';
+import { evaluateSpline } from '../LUTMath.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class CurvesModule extends Module {
+
+	constructor( params = {}, onChange = null, onRemove = null, id = 'curves' ) {
+
+		const defaultCurves = {
+			rgb: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			red: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			green: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			blue: [ { x: 0, y: 0 }, { x: 1, y: 1 } ]
+		};
+
+		const initialCurves = params.curves ? params.curves : ( params.rgb ? params : defaultCurves );
+
+		super( id, 'Curves', { curves: JSON.parse( JSON.stringify( initialCurves ) ) } );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card curves-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset(), onRemove ) );
+
+		this.curveEditor = new CurveEditor( {
+			curves: this.params.curves,
+			onChange: ( updatedCurves ) => {
+
+				this.params.curves = updatedCurves;
+				this.onParamChange();
+
+			}
+		} );
+
+		card.appendChild( this.curveEditor.domElement );
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		let cr = Math.max( 0, Math.min( 1, r ) );
+		let cg = Math.max( 0, Math.min( 1, g ) );
+		let cb = Math.max( 0, Math.min( 1, b ) );
+
+		const { rgb, red, green, blue } = this.params.curves;
+
+		if ( rgb && rgb.length > 0 ) {
+
+			cr = evaluateSpline( cr, rgb );
+			cg = evaluateSpline( cg, rgb );
+			cb = evaluateSpline( cb, rgb );
+
+		}
+
+		if ( red && red.length > 0 ) {
+
+			cr = evaluateSpline( cr, red );
+
+		}
+
+		if ( green && green.length > 0 ) {
+
+			cg = evaluateSpline( cg, green );
+
+		}
+
+		if ( blue && blue.length > 0 ) {
+
+			cb = evaluateSpline( cb, blue );
+
+		}
+
+		target[ 0 ] = Math.max( 0, Math.min( 1, cr ) );
+		target[ 1 ] = Math.max( 0, Math.min( 1, cg ) );
+		target[ 2 ] = Math.max( 0, Math.min( 1, cb ) );
+		return target;
+
+	}
+
+	reset() {
+
+		const defaultCurves = {
+			rgb: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			red: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			green: [ { x: 0, y: 0 }, { x: 1, y: 1 } ],
+			blue: [ { x: 0, y: 0 }, { x: 1, y: 1 } ]
+		};
+
+		this.params.curves = JSON.parse( JSON.stringify( defaultCurves ) );
+
+		this.curveEditor.curves = this.params.curves;
+		this.curveEditor.render();
+
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.curveEditor.setCurves( this.params.curves );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/ExposureHueModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/ExposureHueModule.js
@@ -1,0 +1,110 @@
+import { Module } from './Module.js';
+import { rgbToHsv, hsvToRgb } from '../LUTMath.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class ExposureHueModule extends Module {
+
+	constructor( params = {}, onChange = null, onRemove = null, id = 'exposureHue' ) {
+
+		super( id, 'Exposure & Hue', {
+			exposure: params.exposure ?? 0,
+			brightness: params.brightness ?? 0,
+			hueShift: params.hueShift ?? 0
+		} );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset(), onRemove ) );
+
+		this.exposureControl = this.createSliderControl( {
+			key: 'exposure',
+			label: 'Exposure',
+			min: - 3,
+			max: 3,
+			step: 0.05,
+			def: 0
+		} );
+
+		this.hueShiftControl = this.createSliderControl( {
+			key: 'hueShift',
+			label: 'Hue (°)',
+			min: - 180,
+			max: 180,
+			step: 1,
+			def: 0
+		} );
+
+		card.appendChild( this.exposureControl );
+		card.appendChild( this.hueShiftControl );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		let cr = r;
+		let cg = g;
+		let cb = b;
+
+		const { exposure, brightness, hueShift } = this.params;
+
+		if ( exposure !== 0 ) {
+
+			const factor = Math.pow( 2, exposure );
+			cr *= factor;
+			cg *= factor;
+			cb *= factor;
+
+		}
+
+		if ( brightness !== 0 ) {
+
+			cr += brightness;
+			cg += brightness;
+			cb += brightness;
+
+		}
+
+		if ( hueShift !== 0 ) {
+
+			const [ origH, s, v ] = rgbToHsv( Math.max( 0, cr ), Math.max( 0, cg ), Math.max( 0, cb ) );
+			let h = ( origH + hueShift / 360 ) % 1;
+			if ( h < 0 ) h += 1;
+
+			const [ nr, ng, nb ] = hsvToRgb( h, s, v );
+			cr = nr;
+			cg = ng;
+			cb = nb;
+
+		}
+
+		target[ 0 ] = cr;
+		target[ 1 ] = cg;
+		target[ 2 ] = cb;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.exposure = 0;
+		this.params.brightness = 0;
+		this.params.hueShift = 0;
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.exposureControl._setValue( this.params.exposure );
+		this.hueShiftControl._setValue( this.params.hueShift );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/ExposureModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/ExposureModule.js
@@ -1,0 +1,73 @@
+import { Module } from './Module.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class ExposureModule extends Module {
+
+	constructor( params = {}, onChange = null, onRemove = null, id = 'exposure' ) {
+
+		super( id, 'Exposure', {
+			exposure: params.exposure ?? 0
+		} );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset(), onRemove ) );
+
+		this.exposureControl = this.createSliderControl( {
+			key: 'exposure',
+			label: 'Exposure',
+			min: - 3,
+			max: 3,
+			step: 0.05,
+			def: 0
+		} );
+
+		card.appendChild( this.exposureControl );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		let cr = r;
+		let cg = g;
+		let cb = b;
+
+		const { exposure } = this.params;
+
+		if ( exposure !== 0 ) {
+
+			const factor = Math.pow( 2, exposure );
+			cr *= factor;
+			cg *= factor;
+			cb *= factor;
+
+		}
+
+		target[ 0 ] = cr;
+		target[ 1 ] = cg;
+		target[ 2 ] = cb;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.exposure = 0;
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.exposureControl._setValue( this.params.exposure );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/HueModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/HueModule.js
@@ -1,0 +1,78 @@
+import { Module } from './Module.js';
+import { rgbToHsv, hsvToRgb } from '../LUTMath.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class HueModule extends Module {
+
+	constructor( params = {}, onChange = null, onRemove = null, id = 'hue' ) {
+
+		super( id, 'Hue Shift', {
+			hueShift: params.hueShift ?? 0
+		} );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset(), onRemove ) );
+
+		this.hueShiftControl = this.createSliderControl( {
+			key: 'hueShift',
+			label: 'Hue (°)',
+			min: - 180,
+			max: 180,
+			step: 1,
+			def: 0
+		} );
+
+		card.appendChild( this.hueShiftControl );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		let cr = r;
+		let cg = g;
+		let cb = b;
+
+		const { hueShift } = this.params;
+
+		if ( hueShift !== 0 ) {
+
+			const [ origH, s, v ] = rgbToHsv( Math.max( 0, cr ), Math.max( 0, cg ), Math.max( 0, cb ) );
+			let h = ( origH + hueShift / 360 ) % 1;
+			if ( h < 0 ) h += 1;
+
+			const [ nr, ng, nb ] = hsvToRgb( h, s, v );
+			cr = nr;
+			cg = ng;
+			cb = nb;
+
+		}
+
+		target[ 0 ] = cr;
+		target[ 1 ] = cg;
+		target[ 2 ] = cb;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.hueShift = 0;
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.hueShiftControl._setValue( this.params.hueShift );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/ImportedCubeModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/ImportedCubeModule.js
@@ -1,0 +1,89 @@
+import { Module } from './Module.js';
+import { sample3DLUT } from '../LUTMath.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class ImportedCubeModule extends Module {
+
+	constructor( id, cubeInfo = {}, onChange = null, onRemove = null ) {
+
+		super( id, cubeInfo.title || 'Imported LUT', {
+			title: cubeInfo.title || 'Imported LUT',
+			size: cubeInfo.size ?? 32,
+			dataLines: cubeInfo.dataLines || cubeInfo.data || [],
+			weight: cubeInfo.weight ?? 1.0
+		} );
+
+		this.onChange = onChange;
+		this.onRemove = onRemove;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card lut-imported-cube-card';
+
+		card.appendChild( this.createCardHeader(
+			this.name,
+			() => this.reset(),
+			this.onRemove ? () => this.onRemove( this.id ) : null
+		) );
+
+		const body = document.createElement( 'div' );
+		body.style.cssText = 'display: flex; flex-direction: column; gap: 8px; width: 100%;';
+
+		const infoLabel = document.createElement( 'div' );
+		infoLabel.style.cssText = 'font-size: 10px; color: var(--text-secondary, #9a9aab); text-align: center; font-weight: 500;';
+		infoLabel.textContent = `3D LUT Size: ${this.params.size}³`;
+		body.appendChild( infoLabel );
+
+		this.weightControl = this.createSliderControl( {
+			key: 'weight',
+			label: 'Mix Weight',
+			min: 0,
+			max: 1.0,
+			step: 0.01,
+			def: 1.0
+		} );
+
+		body.appendChild( this.weightControl );
+		card.appendChild( body );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		const { dataLines, size, weight } = this.params;
+
+		if ( dataLines.length === 0 ) {
+
+			target[ 0 ] = r;
+			target[ 1 ] = g;
+			target[ 2 ] = b;
+			return target;
+
+		}
+
+		const [ lr, lg, lb ] = sample3DLUT( r, g, b, size, dataLines );
+
+		target[ 0 ] = r * ( 1 - weight ) + lr * weight;
+		target[ 1 ] = g * ( 1 - weight ) + lg * weight;
+		target[ 2 ] = b * ( 1 - weight ) + lb * weight;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.weight = 1.0;
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.weightControl._setValue( this.params.weight );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/Module.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/Module.js
@@ -1,0 +1,284 @@
+const _tempRgb = [ 0, 0, 0 ];
+
+/**
+ * Module.js - Base class for LUT 3D Generator Card Modules
+ */
+export class Module {
+
+	constructor( id, name, params = {} ) {
+
+		this.id = id;
+		this.name = name;
+		this.params = params;
+		this.enabled = true;
+		this.domElement = null;
+		this.onChange = null;
+
+	}
+
+	/**
+	 * Applies module transformation directly onto a Float32Array 3D LUT buffer.
+	 * @param {Float32Array} buffer - Buffer of size x size x size x 4 RGBA elements
+	 * @param {number} size - LUT grid dimension
+	 * @returns {Float32Array}
+	 */
+	apply( buffer ) {
+
+		if ( ! this.enabled ) return buffer;
+
+		const len = buffer.length;
+		const target = _tempRgb;
+
+		for ( let i = 0; i < len; i += 4 ) {
+
+			this.applyPixel( buffer[ i ], buffer[ i + 1 ], buffer[ i + 2 ], target );
+			buffer[ i ] = target[ 0 ];
+			buffer[ i + 1 ] = target[ 1 ];
+			buffer[ i + 2 ] = target[ 2 ];
+
+		}
+
+		return buffer;
+
+	}
+
+	/**
+	 * Transforms a single RGB color pixel (0..1 range) into a reusable target array.
+	 * Virtual method to be overridden by sub-classes.
+	 */
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		target[ 0 ] = r;
+		target[ 1 ] = g;
+		target[ 2 ] = b;
+		return target;
+
+	}
+
+	/**
+	 * Helper to create standard card header with title, reset button, and optional remove button.
+	 */
+	createCardHeader( titleText, onReset, onRemove = null ) {
+
+		const header = document.createElement( 'div' );
+		header.className = 'lut-card-header';
+
+		const _createSvgIcon = ( svgPath, width = 11, height = 11, strokeWidth = 2.5 ) => {
+
+			const ns = 'http://www.w3.org/2000/svg';
+			const svg = document.createElementNS( ns, 'svg' );
+			svg.setAttribute( 'width', String( width ) );
+			svg.setAttribute( 'height', String( height ) );
+			svg.setAttribute( 'viewBox', '0 0 24 24' );
+			svg.setAttribute( 'fill', 'none' );
+			svg.setAttribute( 'stroke', 'currentColor' );
+			svg.setAttribute( 'stroke-width', String( strokeWidth ) );
+			svg.setAttribute( 'stroke-linecap', 'round' );
+			svg.setAttribute( 'stroke-linejoin', 'round' );
+			svg.style.display = 'block';
+			svg.innerHTML = svgPath;
+			return svg;
+
+		};
+
+		// Left Drag Handle + Reset Button
+		const dragHandle = document.createElement( 'div' );
+		dragHandle.className = 'lut-card-drag-handle';
+
+		if ( typeof onReset === 'function' ) {
+
+			const resetBtn = document.createElement( 'button' );
+			resetBtn.className = 'card-reset-btn lut-card-reset-btn';
+			resetBtn.appendChild( _createSvgIcon( '<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>', 13, 13, 2.5 ) );
+			resetBtn.title = 'Reset Card';
+			resetBtn.onclick = ( e ) => {
+
+				e.stopPropagation();
+				onReset();
+
+			};
+
+			dragHandle.appendChild( resetBtn );
+
+		}
+
+		header.appendChild( dragHandle );
+
+		const titleLabel = document.createElement( 'span' );
+		titleLabel.className = 'lut-card-title';
+		titleLabel.textContent = titleText;
+		header.appendChild( titleLabel );
+
+		// Right Remove Button (where reset button was)
+		if ( onRemove ) {
+
+			const removeBtn = document.createElement( 'button' );
+			removeBtn.className = 'lut-card-remove-btn';
+			removeBtn.appendChild( _createSvgIcon( '<line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>', 13, 13, 2.5 ) );
+			removeBtn.title = 'Remove Card';
+			removeBtn.onclick = ( e ) => {
+
+				e.stopPropagation();
+				onRemove();
+
+			};
+
+			header.appendChild( removeBtn );
+
+		}
+
+		return header;
+
+	}
+
+	/**
+	 * Helper to create parameter box with label, draggable number input, and range slider.
+	 */
+	createSliderControl( { key, label, min, max, step, def } ) {
+
+		const paramBox = document.createElement( 'div' );
+		paramBox.className = 'param-control value-slider lut-param-box';
+
+		const top = document.createElement( 'div' );
+		top.className = 'lut-param-top';
+
+		const lbl = document.createElement( 'span' );
+		lbl.className = 'lut-param-label';
+		lbl.textContent = label;
+
+		const numInput = document.createElement( 'input' );
+		numInput.type = 'number';
+		numInput.min = min;
+		numInput.max = max;
+		numInput.step = step;
+		const initialVal = Number( this.params[ key ] !== undefined ? this.params[ key ] : def );
+		numInput.value = initialVal.toFixed( step < 0.1 ? 2 : 1 );
+		numInput.className = 'lut-num-input';
+
+		const slider = document.createElement( 'input' );
+		slider.type = 'range';
+		slider.className = 'inspector-slider';
+		slider.min = min;
+		slider.max = max;
+		slider.step = step;
+		slider.value = initialVal;
+
+		const updateVal = ( val ) => {
+
+			const clamped = Math.max( min, Math.min( max, val ) );
+			this.params[ key ] = clamped;
+			slider.value = clamped;
+			numInput.value = clamped.toFixed( step < 0.1 ? 2 : 1 );
+			this.onParamChange();
+
+		};
+
+		slider.oninput = () => {
+
+			updateVal( parseFloat( slider.value ) );
+
+		};
+
+		numInput.onchange = () => {
+
+			const val = parseFloat( numInput.value );
+			updateVal( isNaN( val ) ? def : val );
+
+		};
+
+		let isDragging = false;
+		let startY = 0;
+		let startVal = 0;
+
+		numInput.onpointerdown = ( e ) => {
+
+			isDragging = true;
+			startY = e.clientY;
+			startVal = parseFloat( numInput.value ) || def;
+			numInput.setPointerCapture( e.pointerId );
+
+		};
+
+		numInput.onpointermove = ( e ) => {
+
+			if ( isDragging ) {
+
+				const delta = ( startY - e.clientY ) * step;
+				updateVal( startVal + delta );
+
+			}
+
+		};
+
+		const stopDrag = ( e ) => {
+
+			if ( isDragging ) {
+
+				isDragging = false;
+				try {
+
+					numInput.releasePointerCapture( e.pointerId );
+
+				} catch ( _err ) { /* ignore */ }
+
+			}
+
+		};
+
+		numInput.onpointerup = stopDrag;
+		numInput.onpointercancel = stopDrag;
+
+		top.appendChild( lbl );
+		top.appendChild( numInput );
+		paramBox.appendChild( top );
+		paramBox.appendChild( slider );
+
+		paramBox._setValue = ( v ) => {
+
+			const formatted = Number( v ).toFixed( step < 0.1 ? 2 : 1 );
+			slider.value = v;
+			numInput.value = formatted;
+
+		};
+
+		return paramBox;
+
+	}
+
+	onParamChange() {
+
+		if ( this.onChange ) this.onChange( this );
+
+	}
+
+	reset() {
+
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+	}
+
+	toJSON() {
+
+		return {
+			id: this.id,
+			params: JSON.parse( JSON.stringify( this.params ) )
+		};
+
+	}
+
+	fromJSON( json ) {
+
+		if ( json && json.params ) {
+
+			Object.assign( this.params, json.params );
+			this.updateUI();
+
+		}
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/Module.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/Module.js
@@ -13,6 +13,7 @@ export class Module {
 		this.enabled = true;
 		this.domElement = null;
 		this.onChange = null;
+		this.dragAndDrop = true;
 
 	}
 

--- a/examples/jsm/inspector/extensions/color-grading/modules/OutputModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/OutputModule.js
@@ -1,0 +1,99 @@
+import { Module } from './Module.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class OutputModule extends Module {
+
+	constructor( params = {}, onChange = null ) {
+
+		const initialFileName = params.fileName || 'My Color Grading';
+
+		super( 'output', 'Output', {
+			fileName: initialFileName
+		} );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card output-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset() ) );
+
+		// File Name input control
+		const nameBox = document.createElement( 'div' );
+		nameBox.className = 'param-control lut-param-box';
+		nameBox.style.cssText = 'width: 100%; box-sizing: border-box;';
+
+		this.nameInput = document.createElement( 'input' );
+		this.nameInput.type = 'text';
+		this.nameInput.className = 'lut-input lut-text-input';
+		this.nameInput.style.cssText = 'width: 100%; box-sizing: border-box; background: rgba(0,0,0,0.3); border: 1px solid rgba(74,74,90,0.5); border-radius: 4px; color: #e0e0e0; font-size: 11px; padding: 4px 6px; font-family: var(--font-family, sans-serif); text-align: center; outline: none; transition: border-color 0.15s;';
+		this.nameInput.value = this.params.fileName;
+		this.nameInput.placeholder = 'LUT name...';
+
+		this.nameInput.onfocus = () => {
+
+			this.nameInput.style.borderColor = 'var(--color-accent, #00aaff)';
+
+		};
+
+		this.nameInput.onblur = () => {
+
+			this.nameInput.style.borderColor = 'rgba(74,74,90,0.5)';
+
+		};
+
+		this.nameInput.oninput = () => {
+
+			const raw = this.nameInput.value;
+			this.params.fileName = raw || 'LUT3D';
+			this.onParamChange();
+
+		};
+
+		nameBox.appendChild( this.nameInput );
+		card.appendChild( nameBox );
+
+		const infoBox = document.createElement( 'div' );
+		infoBox.className = 'lut-output-info';
+		infoBox.style.cssText = 'display: flex; align-items: center; justify-content: center; text-align: center; padding: 4px 0 2px 0;';
+
+		this.resVal = document.createElement( 'span' );
+		this.resVal.style.cssText = 'font-size: 11px; color: var(--text-secondary, #9a9aab); font-weight: 400; letter-spacing: 0.2px;';
+		this.resVal.textContent = '3D LUT / TSL';
+
+		infoBox.appendChild( this.resVal );
+		card.appendChild( infoBox );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		target[ 0 ] = r;
+		target[ 1 ] = g;
+		target[ 2 ] = b;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.fileName = 'My Color Grading';
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		if ( this.nameInput ) {
+
+			this.nameInput.value = this.params.fileName;
+
+		}
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/OutputModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/OutputModule.js
@@ -12,6 +12,8 @@ export class OutputModule extends Module {
 			fileName: initialFileName
 		} );
 
+		this.dragAndDrop = false;
+
 		this.onChange = onChange;
 
 		const card = document.createElement( 'div' );

--- a/examples/jsm/inspector/extensions/color-grading/modules/RendererModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/RendererModule.js
@@ -1,0 +1,223 @@
+import { Module } from './Module.js';
+import {
+	NoToneMapping,
+	LinearToneMapping,
+	ReinhardToneMapping,
+	CineonToneMapping,
+	ACESFilmicToneMapping,
+	AgXToneMapping,
+	NeutralToneMapping
+} from 'three/webgpu';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class RendererModule extends Module {
+
+	constructor( params = {}, onChange = null, onRendererChange = null ) {
+
+		const initialToneMapping = params.toneMapping ?? NoToneMapping;
+		const initialExposure = params.exposure ?? 1.0;
+
+		super( 'renderer', 'Renderer', {
+			toneMapping: initialToneMapping,
+			exposure: initialExposure
+		} );
+
+		this.defaultToneMapping = initialToneMapping;
+		this.defaultExposure = initialExposure;
+
+		this.onChange = onChange;
+		this.onRendererChange = onRendererChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card renderer-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset() ) );
+
+		// 1. Tone Mapping Dropdown
+		const tmBox = document.createElement( 'div' );
+		tmBox.className = 'param-control lut-param-box';
+
+		const tmTop = document.createElement( 'div' );
+		tmTop.className = 'lut-param-top';
+
+		const tmLabel = document.createElement( 'span' );
+		tmLabel.className = 'lut-param-label';
+		tmLabel.textContent = 'Tone Mapping';
+
+		this.toneMappingSelect = document.createElement( 'select' );
+		this.toneMappingSelect.className = 'lut-select lut-select-compact';
+
+		const toneMappingModes = [
+			{ name: 'None', value: NoToneMapping },
+			{ name: 'Linear', value: LinearToneMapping },
+			{ name: 'Reinhard', value: ReinhardToneMapping },
+			{ name: 'Cineon', value: CineonToneMapping },
+			{ name: 'ACES Filmic', value: ACESFilmicToneMapping },
+			{ name: 'AgX', value: AgXToneMapping },
+			{ name: 'Neutral', value: NeutralToneMapping }
+		];
+
+		toneMappingModes.forEach( mode => {
+
+			const opt = document.createElement( 'option' );
+			opt.value = mode.value;
+			opt.textContent = mode.name;
+			if ( mode.value === this.params.toneMapping ) opt.selected = true;
+			this.toneMappingSelect.appendChild( opt );
+
+		} );
+
+		this.toneMappingSelect.onchange = ( e ) => {
+
+			this.params.toneMapping = parseInt( e.target.value, 10 );
+			if ( this.onRendererChange ) this.onRendererChange( this );
+
+		};
+
+		tmTop.appendChild( tmLabel );
+		tmTop.appendChild( this.toneMappingSelect );
+		tmBox.appendChild( tmTop );
+		card.appendChild( tmBox );
+
+		// 2. Exposure Control
+		const expBox = document.createElement( 'div' );
+		expBox.className = 'param-control value-slider lut-param-box';
+
+		const expTop = document.createElement( 'div' );
+		expTop.className = 'lut-param-top';
+
+		const expLabel = document.createElement( 'span' );
+		expLabel.className = 'lut-param-label';
+		expLabel.textContent = 'Exposure';
+
+		this.exposureNumInput = document.createElement( 'input' );
+		this.exposureNumInput.type = 'number';
+		this.exposureNumInput.min = '0.1';
+		this.exposureNumInput.max = '5.0';
+		this.exposureNumInput.step = '0.05';
+		this.exposureNumInput.value = this.params.exposure.toFixed( 2 );
+		this.exposureNumInput.className = 'lut-num-input';
+
+		this.exposureSlider = document.createElement( 'input' );
+		this.exposureSlider.type = 'range';
+		this.exposureSlider.className = 'inspector-slider';
+		this.exposureSlider.min = '0.1';
+		this.exposureSlider.max = '5.0';
+		this.exposureSlider.step = '0.05';
+		this.exposureSlider.value = this.params.exposure;
+
+		const onExpChange = ( val ) => {
+
+			this.params.exposure = val;
+			if ( this.onRendererChange ) this.onRendererChange( this );
+
+		};
+
+		this.exposureSlider.oninput = () => {
+
+			const val = parseFloat( this.exposureSlider.value );
+			this.exposureNumInput.value = val.toFixed( 2 );
+			onExpChange( val );
+
+		};
+
+		this.exposureNumInput.onchange = () => {
+
+			const val = Math.max( 0.1, Math.min( 5.0, parseFloat( this.exposureNumInput.value ) || 1.0 ) );
+			this.exposureNumInput.value = val.toFixed( 2 );
+			this.exposureSlider.value = val;
+			onExpChange( val );
+
+		};
+
+		let isDragging = false;
+		let startX = 0;
+		let startVal = 1.0;
+
+		this.exposureNumInput.onmousedown = ( e ) => {
+
+			if ( document.activeElement === this.exposureNumInput ) return;
+
+			isDragging = true;
+			startX = e.clientX;
+			startVal = parseFloat( this.exposureSlider.value );
+
+			const onMouseMove = ( moveEvent ) => {
+
+				if ( ! isDragging ) return;
+				const deltaX = moveEvent.clientX - startX;
+				const newVal = Math.max( 0.1, Math.min( 5.0, startVal + deltaX * 0.01 ) );
+
+				this.exposureNumInput.value = newVal.toFixed( 2 );
+				this.exposureSlider.value = newVal;
+				onExpChange( newVal );
+
+			};
+
+			const onMouseUp = () => {
+
+				isDragging = false;
+				window.removeEventListener( 'mousemove', onMouseMove );
+				window.removeEventListener( 'mouseup', onMouseUp );
+
+			};
+
+			window.addEventListener( 'mousemove', onMouseMove );
+			window.addEventListener( 'mouseup', onMouseUp );
+
+		};
+
+		expTop.appendChild( expLabel );
+		expTop.appendChild( this.exposureNumInput );
+		expBox.appendChild( expTop );
+		expBox.appendChild( this.exposureSlider );
+		card.appendChild( expBox );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		target[ 0 ] = r;
+		target[ 1 ] = g;
+		target[ 2 ] = b;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.toneMapping = this.defaultToneMapping;
+		this.params.exposure = this.defaultExposure;
+		this.updateUI();
+
+		if ( this.onRendererChange ) this.onRendererChange( this );
+
+	}
+
+	updateUI() {
+
+		this.toneMappingSelect.value = String( this.params.toneMapping );
+		this.exposureNumInput.value = this.params.exposure.toFixed( 2 );
+		this.exposureSlider.value = String( this.params.exposure );
+
+	}
+
+	fromJSON( json ) {
+
+		if ( json && json.params ) {
+
+			if ( json.params.toneMapping !== undefined ) this.params.toneMapping = json.params.toneMapping;
+			if ( json.params.exposure !== undefined ) this.params.exposure = json.params.exposure;
+
+		}
+
+		this.updateUI();
+
+		if ( this.onRendererChange ) this.onRendererChange( this );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/RendererModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/RendererModule.js
@@ -23,6 +23,8 @@ export class RendererModule extends Module {
 			exposure: initialExposure
 		} );
 
+		this.dragAndDrop = false;
+
 		this.defaultToneMapping = initialToneMapping;
 		this.defaultExposure = initialExposure;
 

--- a/examples/jsm/inspector/extensions/color-grading/modules/SatVibranceModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/SatVibranceModule.js
@@ -1,0 +1,102 @@
+import { Module } from './Module.js';
+import { rgbToHsv, hsvToRgb } from '../LUTMath.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class SatVibranceModule extends Module {
+
+	constructor( params = {}, onChange = null, onRemove = null, id = 'satVibrance' ) {
+
+		super( id, 'Sat & Vibrance', {
+			saturation: params.saturation ?? 1.0,
+			vibrance: params.vibrance ?? 0
+		} );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset(), onRemove ) );
+
+		this.saturationControl = this.createSliderControl( {
+			key: 'saturation',
+			label: 'Saturation',
+			min: 0,
+			max: 2.0,
+			step: 0.01,
+			def: 1.0
+		} );
+
+		this.vibranceControl = this.createSliderControl( {
+			key: 'vibrance',
+			label: 'Vibrance',
+			min: - 1.0,
+			max: 1.0,
+			step: 0.01,
+			def: 0
+		} );
+
+		card.appendChild( this.saturationControl );
+		card.appendChild( this.vibranceControl );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		const { saturation, vibrance } = this.params;
+
+		if ( saturation === 1.0 && vibrance === 0 ) {
+
+			target[ 0 ] = r;
+			target[ 1 ] = g;
+			target[ 2 ] = b;
+			return target;
+
+		}
+
+		const [ h, origS, origV ] = rgbToHsv( Math.max( 0, r ), Math.max( 0, g ), Math.max( 0, b ) );
+		let s = origS;
+
+		if ( saturation !== 1.0 ) {
+
+			s *= saturation;
+
+		}
+
+		if ( vibrance !== 0 ) {
+
+			s += ( vibrance > 0 ? ( 1 - s ) : s ) * vibrance * 0.5;
+
+		}
+
+		s = Math.max( 0, Math.min( 1, s ) );
+		const v = Math.max( 0, Math.min( 1, origV ) );
+
+		const [ nr, ng, nb ] = hsvToRgb( h, s, v );
+		target[ 0 ] = nr;
+		target[ 1 ] = ng;
+		target[ 2 ] = nb;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.saturation = 1.0;
+		this.params.vibrance = 0;
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.saturationControl._setValue( this.params.saturation );
+		this.vibranceControl._setValue( this.params.vibrance );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/SaturationModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/SaturationModule.js
@@ -1,0 +1,76 @@
+import { Module } from './Module.js';
+import { rgbToHsv, hsvToRgb } from '../LUTMath.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class SaturationModule extends Module {
+
+	constructor( params = {}, onChange = null, onRemove = null, id = 'saturation' ) {
+
+		super( id, 'Saturation', {
+			saturation: params.saturation ?? 1.0
+		} );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset(), onRemove ) );
+
+		this.saturationControl = this.createSliderControl( {
+			key: 'saturation',
+			label: 'Saturation',
+			min: 0,
+			max: 2.0,
+			step: 0.01,
+			def: 1.0
+		} );
+
+		card.appendChild( this.saturationControl );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		const { saturation } = this.params;
+
+		if ( saturation === 1.0 ) {
+
+			target[ 0 ] = r;
+			target[ 1 ] = g;
+			target[ 2 ] = b;
+			return target;
+
+		}
+
+		const [ h, origS, origV ] = rgbToHsv( Math.max( 0, r ), Math.max( 0, g ), Math.max( 0, b ) );
+		let s = origS * saturation;
+		s = Math.max( 0, Math.min( 1, s ) );
+		const v = Math.max( 0, Math.min( 1, origV ) );
+
+		const [ nr, ng, nb ] = hsvToRgb( h, s, v );
+		target[ 0 ] = nr;
+		target[ 1 ] = ng;
+		target[ 2 ] = nb;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.saturation = 1.0;
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.saturationControl._setValue( this.params.saturation );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/VibranceModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/VibranceModule.js
@@ -1,0 +1,76 @@
+import { Module } from './Module.js';
+import { rgbToHsv, hsvToRgb } from '../LUTMath.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class VibranceModule extends Module {
+
+	constructor( params = {}, onChange = null, onRemove = null, id = 'vibrance' ) {
+
+		super( id, 'Vibrance', {
+			vibrance: params.vibrance ?? 0
+		} );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset(), onRemove ) );
+
+		this.vibranceControl = this.createSliderControl( {
+			key: 'vibrance',
+			label: 'Vibrance',
+			min: - 1.0,
+			max: 1.0,
+			step: 0.01,
+			def: 0
+		} );
+
+		card.appendChild( this.vibranceControl );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		const { vibrance } = this.params;
+
+		if ( vibrance === 0 ) {
+
+			target[ 0 ] = r;
+			target[ 1 ] = g;
+			target[ 2 ] = b;
+			return target;
+
+		}
+
+		const [ h, origS, origV ] = rgbToHsv( Math.max( 0, r ), Math.max( 0, g ), Math.max( 0, b ) );
+		let s = origS + ( vibrance > 0 ? ( 1 - origS ) : origS ) * vibrance * 0.5;
+		s = Math.max( 0, Math.min( 1, s ) );
+		const v = Math.max( 0, Math.min( 1, origV ) );
+
+		const [ nr, ng, nb ] = hsvToRgb( h, s, v );
+		target[ 0 ] = nr;
+		target[ 1 ] = ng;
+		target[ 2 ] = nb;
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.vibrance = 0;
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.vibranceControl._setValue( this.params.vibrance );
+
+	}
+
+}

--- a/examples/jsm/inspector/extensions/color-grading/modules/WhiteBalanceModule.js
+++ b/examples/jsm/inspector/extensions/color-grading/modules/WhiteBalanceModule.js
@@ -1,0 +1,86 @@
+import { Module } from './Module.js';
+
+const _tempRgb = [ 0, 0, 0 ];
+
+export class WhiteBalanceModule extends Module {
+
+	constructor( params = {}, onChange = null, onRemove = null, id = 'whiteBalance' ) {
+
+		super( id, 'White Balance', {
+			temperature: params.temperature ?? 0,
+			tint: params.tint ?? 0
+		} );
+
+		this.onChange = onChange;
+
+		const card = document.createElement( 'div' );
+		card.className = 'lut-card';
+
+		card.appendChild( this.createCardHeader( this.name, () => this.reset(), onRemove ) );
+
+		this.temperatureControl = this.createSliderControl( {
+			key: 'temperature',
+			label: 'Temp (K)',
+			min: - 100,
+			max: 100,
+			step: 1,
+			def: 0
+		} );
+
+		this.tintControl = this.createSliderControl( {
+			key: 'tint',
+			label: 'Tint',
+			min: - 100,
+			max: 100,
+			step: 1,
+			def: 0
+		} );
+
+		card.appendChild( this.temperatureControl );
+		card.appendChild( this.tintControl );
+
+		this.domElement = card;
+
+	}
+
+	applyPixel( r, g, b, target = _tempRgb ) {
+
+		const { temperature, tint } = this.params;
+
+		if ( temperature === 0 && tint === 0 ) {
+
+			target[ 0 ] = r;
+			target[ 1 ] = g;
+			target[ 2 ] = b;
+			return target;
+
+		}
+
+		const temp = temperature / 100;
+		const t = tint / 100;
+
+		target[ 0 ] = r + temp * 0.1;
+		target[ 1 ] = g - t * 0.1;
+		target[ 2 ] = b - temp * 0.1;
+
+		return target;
+
+	}
+
+	reset() {
+
+		this.params.temperature = 0;
+		this.params.tint = 0;
+		this.updateUI();
+		this.onParamChange();
+
+	}
+
+	updateUI() {
+
+		this.temperatureControl._setValue( this.params.temperature );
+		this.tintControl._setValue( this.params.tint );
+
+	}
+
+}

--- a/examples/jsm/inspector/tabs/Settings.js
+++ b/examples/jsm/inspector/tabs/Settings.js
@@ -4,6 +4,10 @@ import { getItem, setItem } from '../Inspector.js';
 
 const _extensions = [
 	{
+		name: 'Color Grading',
+		url: '../extensions/color-grading/ColorGrading.js'
+	},
+	{
 		name: 'TSL Graph',
 		url: '../extensions/tsl-graph/TSLGraphEditor.js'
 	}

--- a/examples/jsm/inspector/ui/Profiler.js
+++ b/examples/jsm/inspector/ui/Profiler.js
@@ -199,6 +199,7 @@ export class Profiler extends EventDispatcher {
 			constrainDetachedWindows();
 			constrainMainPanel();
 			this.checkHeaderScroll();
+			this.notifyLayoutChange();
 
 		} );
 
@@ -601,11 +602,18 @@ export class Profiler extends EventDispatcher {
 
 		}
 
+		// Set profiler reference
+		tab.profiler = this;
+
 		// Update panel size when tabs change
 		this.updatePanelSize();
 
-		// Set profiler reference
-		tab.profiler = this;
+		// If newly added tab matches activeTabId from saved layout, activate it
+		if ( this.activeTabId && tab.id === this.activeTabId ) {
+
+			this.setActiveTab( tab.id );
+
+		}
 
 	}
 
@@ -2214,6 +2222,24 @@ export class Profiler extends EventDispatcher {
 			this.miniPanel.classList.remove( 'toggle-bottom' );
 
 		}
+
+		this.notifyLayoutChange();
+
+	}
+
+	isVertical() {
+
+		return this.position === 'left' || this.position === 'right' ||
+			( this.panel && ( this.panel.classList.contains( 'position-left' ) || this.panel.classList.contains( 'position-right' ) ) );
+
+	}
+
+	notifyLayoutChange() {
+
+		const isVert = this.isVertical();
+
+		this.dispatchEvent( { type: 'orientationchange', position: this.position, isVertical: isVert } );
+		this.dispatchEvent( { type: 'layoutchange', position: this.position, isVertical: isVert } );
 
 	}
 

--- a/examples/jsm/inspector/ui/Tab.js
+++ b/examples/jsm/inspector/ui/Tab.js
@@ -264,4 +264,6 @@ export class Tab extends EventDispatcher {
 
 	}
 
+	dispose() { }
+
 }


### PR DESCRIPTION
Related issue: N/A

**Description**

This PR introduces the **Color Grading** extension to the Inspector alongside essential core lifecycle and persistence improvements for Inspector extensions (`Extension`, `Tab`, `Profiler`, `Inspector`).

It is possible to generate 3D LUT files and export them in CUBE or PNG format, as well as import CUBE files to make more subtle adjustments and override the LUT generation pipeline and include new modules.

**[Live example](https://raw.githack.com/mrdoob/three.js/dev/examples/webgpu_postprocessing_ao.html)**

https://github.com/user-attachments/assets/3ace74c2-1a56-4197-8489-9269ac319639
