### PR TITLE
E2E: Don't drop animation frames requested after the render gate opens

### DIFF
--- a/test/e2e/deterministic-injection.js
+++ b/test/e2e/deterministic-injection.js
@@ -30,22 +30,21 @@
 
 		if ( window._renderFinished === true ) return;
 
-		if ( window._renderStarted === false ) {
+		const intervalId = setInterval( function () {
 
-			const intervalId = setInterval( function () {
+			if ( window._renderFinished === true ) {
 
-				if ( window._renderStarted === true ) {
+				clearInterval( intervalId );
 
-					cb( now() );
+			} else if ( window._renderStarted === true ) {
 
-					clearInterval( intervalId );
-					window._renderFinished = true;
+				clearInterval( intervalId );
+				cb( now() );
+				window._renderFinished = true;
 
-				}
+			}
 
-			}, 100 );
-
-		}
+		}, 100 );
 
 	};
 


### PR DESCRIPTION
The deterministic RAF injection only scheduled a callback when the frame was requested before the runner set `window._renderStarted`. WebGPU device initialization is asynchronous and resolves independently of the network idle timing the runner gates on, so a renderer whose first `requestAnimationFrame()` landed after the gate opened had that request discarded. No frame was ever drawn, the render timeout elapsed, and the screenshot captured an untouched canvas.

Always create the polling interval and clear it once rendering finishes. This keeps the one-frame deterministic behavior while accepting a first request on either side of the gate.

Verified by forcing the ordering with a temporary condition wait in webgpu_pmrem_cubemap: before this change the screenshot is uniformly black and 99.8% of pixels differ; after it, the diff is 0.0%.

Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
