### PR TITLE
E2E: Try to fix the webgpu async timeouts

### DIFF
--- a/test/e2e/deterministic-injection.js
+++ b/test/e2e/deterministic-injection.js
@@ -30,22 +30,17 @@
 
 		if ( window._renderFinished === true ) return;
 
-		if ( window._renderStarted === false ) {
+		const intervalId = setInterval( function () {
 
-			const intervalId = setInterval( function () {
+			if ( window._renderStarted === true ) {
 
-				if ( window._renderStarted === true ) {
+				clearInterval( intervalId );
+				window._renderFinished = true;
+				cb( now() );
 
-					cb( now() );
+			}
 
-					clearInterval( intervalId );
-					window._renderFinished = true;
-
-				}
-
-			}, 100 );
-
-		}
+		}, 100 );
 
 	};
 


### PR DESCRIPTION
Related issue: #33559

**Description**

- I am trying to fix the e2e issues reported in #33559.
- I tried to first force this to always fail and succeeded.
   - I isolated it to the `webgpu_pmrem_cubemap` test.
   - Ran as an actual github action in my fork.
   - Verified that i got nothing to render by putting a mesh with a basic material into the example
- I've been able to get it consistently to pass after this fix.

According to claude:

>The E2E harness replaces `requestAnimationFrame` so each example renders exactly
one deterministic frame. It scheduled a callback only when the frame was requested
before the runner set `window._renderStarted`. It discarded every request arriving
after that moment.
>
>WebGPU device initialization is asynchronous, and it finishes independently of the
network-idle timing the runner gates on. When it finishes late, `Animation.start()`
requests its first frame after the gate has opened, and the harness threw that
request away. Nothing drew. The render timeout elapsed, and the screenshot captured
the page background.
>
>This patch always creates the polling interval, so a request on either side of the
gate runs. It sets `_renderFinished` before invoking the callback, so a frame
re-requested from inside that callback meets the existing guard and stops there.
Exactly one frame still renders.
>
>Several frames may already be pending when the gate opens, and every one of those
callbacks must run. Only requests made after a frame has rendered are dropped.
>
> **Reproduction**
>
>Add a temporary wait before `renderer.setAnimationLoop()` in `webgpu_pmrem_cubemap`
that blocks until `window._renderStarted` is true. This forces the ordering on every
run.
>
>Before: `Render timeout exceeded`, then `Diff wrong in 99.8% of pixels`. Every pixel
of the capture measures 0 — the CSS background, not a dark render. An unlit
`MeshBasicMaterial` sphere placed in front of the camera stays invisible, which
confirms that no frame was drawn.

*This contribution is funded by @pailhead*
