### PR TITLE
Docs: Drop JSDoc params the functions no longer take

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -815,7 +815,6 @@ class NodeMaterial extends Material {
 	 * Setups the computation of the material's diffuse color.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {BufferGeometry} geometry - The geometry.
 	 */
 	setupDiffuseColor( builder ) {
 

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -233,7 +233,6 @@ class StackNode extends Node {
 	 * Represents a `switch` statement in TSL.
 	 *
 	 * @param {any} expression - Represents the expression.
-	 * @param {Function} method - TSL code which is executed if the condition evaluates to `true`.
 	 * @return {StackNode} A reference to this stack node.
 	 */
 	Switch( expression ) {

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -359,7 +359,6 @@ export const Const = ( node, name = null ) => createVar( node, name, true ).toSt
  * @tsl
  * @function
  * @param {Node} node - The node for which a variable should be created.
- * @param {?string} name - The name of the variable in the shader.
  * @returns {VarNode}
  */
 export const VarIntent = ( node ) => {

--- a/src/renderers/common/BindGroup.js
+++ b/src/renderers/common/BindGroup.js
@@ -14,7 +14,6 @@ class BindGroup {
 	 *
 	 * @param {string} name - The bind group's name.
 	 * @param {Array<Binding>} bindings - An array of bindings.
-	 * @param {number} index - The group index.
 	 */
 	constructor( name = '', bindings = [] ) {
 


### PR DESCRIPTION
Was reading `VarIntent` and the block above it documents a `name` parameter, but the arrow function only takes `node`. The one directly above it, `Const`, takes both, so the block looks like it got copied down and never trimmed. Went through the rest of `src` after that and three more turned up the same way. `Switch` carries a `method` param from `Else` sitting above it, `setupDiffuseColor` documents `geometry` when it actually destructures that out of the builder it is given, and the `BindGroup` constructor still documents an `index` it does not take.

Left alone the TSL factories, where the block sits over something like `nodeProxyIntent( MathNode, MathNode.ALL )` and the documented names belong to the function being produced rather than to the call written underneath, and also the places where a parameter is commented out in the signature, `getPropertyName( node/*, shaderStage*/ )` and friends, since that reads as deliberate rather than stale.
