### PR TITLE
Examples: Optimize rain demo.

### DIFF
--- a/examples/webgpu_compute_particles_rain.html
+++ b/examples/webgpu_compute_particles_rain.html
@@ -106,6 +106,7 @@
 
 					const position = positionBuffer.element( instanceIndex );
 					const velocity = velocityBuffer.element( instanceIndex );
+					const ripplePosition = ripplePositionBuffer.element( instanceIndex );
 					const rippleTime = rippleTimeBuffer.element( instanceIndex );
 
 					const randX = hash( instanceIndex );
@@ -117,6 +118,10 @@
 					position.z = randZ.mul( 100 ).add( - 50 );
 
 					velocity.y = randX.mul( - .04 ).add( - .2 );
+
+					ripplePosition.x = randZ.mul( 100 ).add( - 50 );
+					ripplePosition.y = - 1;
+					ripplePosition.z = randY.mul( 100 ).add( - 50 );
 
 					rippleTime.x = 1000;
 


### PR DESCRIPTION
Related issue: -

**Description**

The first seconds when opening `webgpu_compute_particles_rain` run strangely slow on my system. Checkout below video recorded on a macMini, M2 Pro with Chrome:

https://github.com/user-attachments/assets/65029220-1d96-494f-8dfd-308053cc4c43

You can see it settles to 60 FPS but after a very expensive startup.

After some research, it turns out the root cause is the extreme blending overhead of the 25,000 ripple quads which are initially all positioned at the origin. By giving them a random position in the init routine, the blending overhead can be completely eliminated.

It also turns out an opacity of zero does not bypass the overhead. The hardware still performs the expensive blend.

The change has visually no impact on the scene.

Dev: https://rawcdn.githack.com/mrdoob/three.js/dev/examples/webgpu_compute_particles_rain.html
PR: https://rawcdn.githack.com/Mugen87/three.js/fa22dd035d464252c5d3554c4deee92aabf4680e/examples/webgpu_compute_particles_rain.html