### PR TITLE
WebGLRenderer: Support Node Materials in `compile()`.

### DIFF
--- a/examples/jsm/tsl/WebGLNodesHandler.js
+++ b/examples/jsm/tsl/WebGLNodesHandler.js
@@ -34,7 +34,6 @@ import {
 // - Storage textures not supported
 // - Fog / environment do not automatically update - must call "dispose"
 // - instanced mesh geometry cannot be shared
-// - Node materials cannot be used with "compile" function
 
 // hash any object parameters that will impact the resulting shader so we can force
 // a program update
@@ -108,27 +107,34 @@ class SceneContext {
 
 		const { lightsNode, environmentNode, fogNode } = this;
 		const lightsHash = lightsNode.getCacheKey();
-		const envHash = environmentNode ? environmentNode.getCacheKey : 0;
+		const envHash = environmentNode ? environmentNode.getCacheKey() : 0;
 		const fogHash = fogNode ? fogNode.getCacheKey() : 0;
 		return NodeUtils.hashArray( [ lightsHash, envHash, fogHash ] );
 
 	}
 
-	update() {
+	update( object, camera ) {
 
 		const { scene, lightsNode } = this;
 
 		// update lighting
 		const sceneLights = [];
-		scene.traverse( object => {
+		const seenLights = new Set();
+		const collectLight = child => {
 
-			if ( object.isLight ) {
+			if ( child.isLight && child.layers.test( camera.layers ) && seenLights.has( child ) === false ) {
 
-				sceneLights.push( object );
+				seenLights.add( child );
+				sceneLights.push( child );
 
 			}
 
-		} );
+		};
+
+		scene.traverseVisible( collectLight );
+
+		// compile() can receive an object that has not been added to the target scene yet.
+		if ( object !== scene ) object.traverseVisible( collectLight );
 
 		lightsNode.setLights( sceneLights );
 
@@ -402,38 +408,55 @@ export class WebGLNodesHandler {
 	}
 
 
-	renderStart( scene, camera ) {
+	setupNodeMaterial( material ) {
+
+		if ( material && material.isNodeMaterial ) {
+
+			material.customProgramCacheKey = this.customProgramCacheKeyCallback;
+			material.onBeforeRender = this.onBeforeRenderCallback;
+
+		}
+
+	}
+
+	renderStart( scene, camera, targetScene = scene ) {
 
 		const { nodeFrame, renderStack, renderer, sceneContexts } = this;
 		nodeFrame.update();
 		nodeFrame.camera = camera;
-		nodeFrame.scene = scene;
+		nodeFrame.scene = targetScene;
 		nodeFrame.frameId ++;
 
-		let sceneContext = sceneContexts.get( scene );
+		let sceneContext = sceneContexts.get( targetScene );
 		if ( ! sceneContext ) {
 
-			sceneContext = new SceneContext( renderer, scene );
-			sceneContexts.set( scene, sceneContext );
+			sceneContext = new SceneContext( renderer, targetScene );
+			sceneContexts.set( targetScene, sceneContext );
 
 		}
 
-		sceneContext.update();
+		sceneContext.update( scene, camera );
 		renderStack.push( { sceneContext, camera } );
 
 		// ensure all node material callbacks are initialized before
 		// traversal and build
-		const {
-			customProgramCacheKeyCallback,
-			onBeforeRenderCallback,
-		} = this;
-
 		scene.traverse( object => {
 
-			if ( object.material && object.material.isNodeMaterial ) {
+			const material = object.material;
 
-				object.material.customProgramCacheKey = customProgramCacheKeyCallback;
-				object.material.onBeforeRender = onBeforeRenderCallback;
+			if ( material === undefined ) return;
+
+			if ( Array.isArray( material ) ) {
+
+				for ( let i = 0; i < material.length; i ++ ) {
+
+					this.setupNodeMaterial( material[ i ] );
+
+				}
+
+			} else {
+
+				this.setupNodeMaterial( material );
 
 			}
 
@@ -455,6 +478,12 @@ export class WebGLNodesHandler {
 			nodeFrame.scene = sceneContext.scene;
 
 		}
+
+	}
+
+	setObject( object ) {
+
+		this.nodeFrame.object = object;
 
 	}
 

--- a/examples/jsm/tsl/WebGLNodesHandler.js
+++ b/examples/jsm/tsl/WebGLNodesHandler.js
@@ -87,6 +87,15 @@ class WebGLNodeBuilder extends GLSLNodeBuilder {
 
 }
 
+const _lights = new Set();
+let _camera = null;
+
+function collectLight( child ) {
+
+	if ( child.isLight && child.layers.test( _camera.layers ) ) _lights.add( child );
+
+}
+
 // produce and update reusable nodes for a scene
 class SceneContext {
 
@@ -95,6 +104,7 @@ class SceneContext {
 		// TODO: can / should we update the fog and environment node every frame for recompile?
 		this.renderer = renderer;
 		this.scene = scene;
+		this.sceneLights = [];
 		this.lightsNode = renderer.lighting.getNode( scene );
 		this.fogNode = null;
 		this.environmentNode = null;
@@ -115,26 +125,21 @@ class SceneContext {
 
 	update( object, camera ) {
 
-		const { scene, lightsNode } = this;
+		const { scene, lightsNode, sceneLights } = this;
 
 		// update lighting
-		const sceneLights = [];
-		const seenLights = new Set();
-		const collectLight = child => {
-
-			if ( child.isLight && child.layers.test( camera.layers ) && seenLights.has( child ) === false ) {
-
-				seenLights.add( child );
-				sceneLights.push( child );
-
-			}
-
-		};
+		_camera = camera;
+		_lights.clear();
 
 		scene.traverseVisible( collectLight );
 
 		// compile() can receive an object that has not been added to the target scene yet.
 		if ( object !== scene ) object.traverseVisible( collectLight );
+
+		_camera = null;
+
+		sceneLights.length = 0;
+		sceneLights.push( ..._lights );
 
 		lightsNode.setLights( sceneLights );
 

--- a/examples/webgl_tsl_clearcoat.html
+++ b/examples/webgl_tsl_clearcoat.html
@@ -58,12 +58,11 @@
 				scene = new THREE.Scene();
 
 				group = new THREE.Group();
-				scene.add( group );
 
 				new HDRCubeTextureLoader()
 					.setPath( 'textures/cube/pisaHDR/' )
 					.load( [ 'px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr' ],
-						function ( texture ) {
+						async function ( texture ) {
 
 							const geometry = new THREE.SphereGeometry( .8, 64, 32 );
 
@@ -109,6 +108,8 @@
 							let mesh = new THREE.Mesh( geometry, material );
 							mesh.position.x = - 1;
 							mesh.position.y = 1;
+							mesh.castShadow = true;
+							mesh.receiveShadow = true;
 							group.add( mesh );
 
 							// fibers
@@ -123,6 +124,8 @@
 							mesh = new THREE.Mesh( geometry, material );
 							mesh.position.x = 1;
 							mesh.position.y = 1;
+							mesh.castShadow = true;
+							mesh.receiveShadow = true;
 							group.add( mesh );
 
 							// golf
@@ -140,6 +143,8 @@
 							mesh = new THREE.Mesh( geometry, material );
 							mesh.position.x = - 1;
 							mesh.position.y = - 1;
+							mesh.castShadow = true;
+							mesh.receiveShadow = true;
 							group.add( mesh );
 
 							// clearcoat + normalmap
@@ -158,12 +163,20 @@
 							mesh = new THREE.Mesh( geometry, material );
 							mesh.position.x = 1;
 							mesh.position.y = - 1;
+							mesh.castShadow = true;
+							mesh.receiveShadow = true;
 							group.add( mesh );
 
 							//
 
 							scene.background = texture;
 							scene.environment = texture;
+
+							// wait until the models can be added to the scene without blocking due to shader compilation
+
+							await renderer.compileAsync( group, camera, scene );
+
+							scene.add( group );
 
 						}
 
@@ -173,14 +186,17 @@
 
 				particleLight = new THREE.Mesh(
 					new THREE.SphereGeometry( .05, 8, 8 ),
-					new THREE.MeshBasicMaterial( { color: 0xffffff } )
+					new THREE.MeshBasicNodeMaterial( { color: 0xffffff } )
 				);
 				scene.add( particleLight );
 
-				particleLight.add( new THREE.PointLight( 0xffffff, 30 ) );
+				const pointLight = new THREE.PointLight( 0xffffff, 30 );
+				pointLight.castShadow = true;
+				particleLight.add( pointLight );
 
 				renderer = new WebGLRenderer( { antialias: true } );
 				renderer.setNodesHandler( new WebGLNodesHandler() );
+				renderer.shadowMap.enabled = true;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1353,6 +1353,8 @@ class WebGLRenderer {
 
 		function prepareMaterial( material, scene, object ) {
 
+			if ( _nodesHandler !== null && material.isNodeMaterial ) _nodesHandler.setObject( object );
+
 			if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
 
 				material.side = BackSide;
@@ -1388,6 +1390,7 @@ class WebGLRenderer {
 		this.compile = function ( scene, camera, targetScene = null ) {
 
 			if ( targetScene === null ) targetScene = scene;
+			if ( _nodesHandler !== null ) _nodesHandler.renderStart( scene, camera, targetScene );
 
 			currentRenderState = renderStates.get( targetScene );
 			currentRenderState.init( camera );
@@ -1434,6 +1437,10 @@ class WebGLRenderer {
 
 			currentRenderState.setupLights();
 
+			// node materials reference the shadow map when they are built, so it must exist by now
+
+			if ( _nodesHandler !== null ) shadowMap.render( currentRenderState.state.shadowsArray, targetScene, camera );
+
 			// Only initialize materials in the new scene, not the targetScene.
 
 			const materials = new Set();
@@ -1473,6 +1480,7 @@ class WebGLRenderer {
 			} );
 
 			currentRenderState = renderStateStack.pop();
+			if ( _nodesHandler !== null ) _nodesHandler.renderEnd();
 
 			return materials;
 


### PR DESCRIPTION
Closes #34217.

**Description**

Alternative implementation of #34217 with minimal impact on the renderer.