### PR TITLE
WebGPURenderer: Fix timestamp query limits

### DIFF
--- a/examples/jsm/inspector/Inspector.js
+++ b/examples/jsm/inspector/Inspector.js
@@ -490,9 +490,9 @@ class Inspector extends RendererInspector {
 
 	resolveFrame( frame ) {
 
-		const nextFrame = this.getFrameById( frame.frameId + 1 );
+		const previousFrame = this.getFrameById( frame.frameId - 1 );
 
-		if ( ! nextFrame ) return;
+		if ( ! previousFrame ) return;
 
 		frame.cpu = 0;
 		frame.gpu = 0;
@@ -510,9 +510,9 @@ class Inspector extends RendererInspector {
 
 		}
 
-		// improve stats using next frame
+		// improve stats using previous frame
 
-		frame.deltaTime = nextFrame.startTime - frame.startTime;
+		frame.deltaTime = frame.startTime - previousFrame.startTime;
 		frame.miscellaneous = frame.deltaTime - frame.total;
 
 		if ( frame.miscellaneous < 0 ) {

--- a/examples/jsm/inspector/RendererInspector.js
+++ b/examples/jsm/inspector/RendererInspector.js
@@ -457,6 +457,8 @@ export class RendererInspector extends InspectorBase {
 
 	inspect( node ) {
 
+		if ( this.enabled === false ) return;
+
 		const currentNodes = this.currentNodes;
 
 		if ( currentNodes !== null ) {

--- a/examples/jsm/inspector/RendererInspector.js
+++ b/examples/jsm/inspector/RendererInspector.js
@@ -100,6 +100,8 @@ export class RendererInspector extends InspectorBase {
 
 	begin() {
 
+		super.begin();
+
 		this.currentFrame = this._createFrame();
 		this.currentRender = this.currentFrame;
 		this.currentNodes = [];
@@ -107,6 +109,8 @@ export class RendererInspector extends InspectorBase {
 	}
 
 	finish() {
+
+		super.finish();
 
 		const now = performance.now();
 
@@ -368,9 +372,9 @@ export class RendererInspector extends InspectorBase {
 
 						}
 
-						const nextFrame = this.getFrameById( frame.frameId + 1 );
+						const previousFrame = this.getFrameById( frame.frameId - 1 );
 
-						if ( nextFrame === null ) continue;
+						if ( previousFrame === null ) continue;
 
 						if ( frame.resolvedCompute === false ) {
 

--- a/examples/jsm/lighting/LightProbeGrid.js
+++ b/examples/jsm/lighting/LightProbeGrid.js
@@ -457,6 +457,10 @@ class LightProbeGrid extends Light {
 
 		const { cubemapSize = 8, near = 0.1, far = 100, bounces = 0, sampleCount = 512 } = options;
 
+		const currentInspectorEnabled = renderer.inspector.enable;
+
+		renderer.inspector.enabled = currentInspectorEnabled;
+
 		this._ensureTextures();
 		this.updateBoundingBox();
 
@@ -602,6 +606,8 @@ class LightProbeGrid extends Light {
 			for ( const { light, autoUpdate } of shadowLights ) light.shadow.autoUpdate = autoUpdate;
 
 			this.visible = true;
+
+			renderer.inspector.enabled = currentInspectorEnabled;
 
 		}
 

--- a/examples/jsm/lighting/LightProbeGrid.js
+++ b/examples/jsm/lighting/LightProbeGrid.js
@@ -457,9 +457,9 @@ class LightProbeGrid extends Light {
 
 		const { cubemapSize = 8, near = 0.1, far = 100, bounces = 0, sampleCount = 512 } = options;
 
-		const currentInspectorEnabled = renderer.inspector.enable;
+		const currentInspectorEnabled = renderer.inspector.enabled;
 
-		renderer.inspector.enabled = currentInspectorEnabled;
+		renderer.inspector.enabled = false;
 
 		this._ensureTextures();
 		this.updateBoundingBox();

--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -103,6 +103,8 @@ class Animation {
 	 */
 	stop() {
 
+		if ( this.renderer._inspector.isRunning ) this.renderer._inspector.finish();
+
 		if ( this._context !== null ) this._context.cancelAnimationFrame( this._requestId );
 
 		this._requestId = null;

--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -61,6 +61,15 @@ class Animation {
 		 */
 		this._requestId = null;
 
+		/**
+		 * Indicates whether the current frame needs to be finished
+		 * at the start of the next animation frame.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this._needsFinishFrame = false;
+
 	}
 
 	/**
@@ -72,17 +81,35 @@ class Animation {
 
 			this._requestId = this._context.requestAnimationFrame( update );
 
+			if ( this._needsFinishFrame ) {
+
+				this.renderer._inspector.finish();
+
+				this._needsFinishFrame = false;
+
+			}
+
 			if ( this.info.autoReset === true ) this.info.reset();
 
 			this.nodes.nodeFrame.update();
 
 			this.info.frame = this.nodes.nodeFrame.frameId;
 
-			this.renderer._inspector.begin();
+			if ( this._animationLoop !== null ) {
 
-			if ( this._animationLoop !== null ) this._animationLoop( time, xrFrame );
+				this.renderer._inspector.begin();
 
-			this.renderer._inspector.finish();
+				this._animationLoop( time, xrFrame );
+
+				this.renderer._inspector.finish();
+
+			} else if ( this.renderer.hasInitialized() ) {
+
+				this.renderer._inspector.begin();
+
+				this._needsFinishFrame = true;
+
+			}
 
 		};
 

--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -61,15 +61,6 @@ class Animation {
 		 */
 		this._requestId = null;
 
-		/**
-		 * Indicates whether the current frame needs to be finished
-		 * at the start of the next animation frame.
-		 *
-		 * @type {boolean}
-		 * @default false
-		 */
-		this._needsFinishFrame = false;
-
 	}
 
 	/**
@@ -81,11 +72,9 @@ class Animation {
 
 			this._requestId = this._context.requestAnimationFrame( update );
 
-			if ( this._needsFinishFrame ) {
+			if ( this.renderer._inspector.isRunning ) {
 
 				this.renderer._inspector.finish();
-
-				this._needsFinishFrame = false;
 
 			}
 
@@ -95,19 +84,11 @@ class Animation {
 
 			this.info.frame = this.nodes.nodeFrame.frameId;
 
+			this.renderer._inspector.begin();
+
 			if ( this._animationLoop !== null ) {
 
-				this.renderer._inspector.begin();
-
 				this._animationLoop( time, xrFrame );
-
-				this.renderer._inspector.finish();
-
-			} else if ( this.renderer.hasInitialized() ) {
-
-				this.renderer._inspector.begin();
-
-				this._needsFinishFrame = true;
 
 			}
 

--- a/src/renderers/common/InspectorBase.js
+++ b/src/renderers/common/InspectorBase.js
@@ -30,6 +30,14 @@ class InspectorBase extends EventDispatcher {
 		 */
 		this.currentFrame = null;
 
+		/**
+		 * Indicates whether the inspector is running.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.isRunning = false;
+
 	}
 
 	/**
@@ -76,12 +84,20 @@ class InspectorBase extends EventDispatcher {
 	/**
 	 * Called when a frame begins.
 	 */
-	begin() { }
+	begin() {
+
+		this.isRunning = true;
+
+	}
 
 	/**
 	 * Called when a frame ends.
 	 */
-	finish() { }
+	finish() {
+
+		this.isRunning = false;
+
+	}
 
 	/**
 	 * Inspects a node.

--- a/src/renderers/common/InspectorBase.js
+++ b/src/renderers/common/InspectorBase.js
@@ -38,6 +38,14 @@ class InspectorBase extends EventDispatcher {
 		 */
 		this.isRunning = false;
 
+		/**
+		 * Indicates whether the inspector is enabled.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.enabled = true;
+
 	}
 
 	/**

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -839,13 +839,14 @@ class Renderer {
 
 			//
 
-			this._inspector.init();
-
+			this._animation.start();
 			this._initialized = true;
 
 			//
 
-			this._animation.start();
+			this._inspector.init();
+
+			//
 
 			resolve( this );
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -839,14 +839,13 @@ class Renderer {
 
 			//
 
-			this._animation.start();
+			this._inspector.init();
+
 			this._initialized = true;
 
 			//
 
-			this._inspector.init();
-
-			//
+			this._animation.start();
 
 			resolve( this );
 

--- a/src/renderers/webgl-fallback/utils/WebGLTimestampQueryPool.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTimestampQueryPool.js
@@ -1,4 +1,4 @@
-import { error, warnOnce, warn } from '../../../utils.js';
+import { error, warn } from '../../../utils.js';
 import TimestampQueryPool from '../../common/TimestampQueryPool.js';
 
 /**
@@ -58,11 +58,14 @@ class WebGLTimestampQueryPool extends TimestampQueryPool {
 
 		if ( ! this.trackTimestamp ) return null;
 
-		// Check if we have enough space for a new query pair
 		if ( this.currentQueryIndex + 2 > this.maxQueries ) {
 
-			warnOnce( `WebGLTimestampQueryPool [${ this.type }]: Maximum number of queries exceeded, when using trackTimestamp it is necessary to resolves the queries via renderer.resolveTimestampsAsync( THREE.TimestampQuery.${ this.type.toUpperCase() } ).` );
-			return null;
+			this.resolveQueriesAsync();
+
+			this.currentQueryIndex = 0;
+			this.queryOffsets.clear();
+			this.queryStates.clear();
+			this.activeQuery = null;
 
 		}
 

--- a/src/renderers/webgpu/utils/WebGPUTimestampQueryPool.js
+++ b/src/renderers/webgpu/utils/WebGPUTimestampQueryPool.js
@@ -1,4 +1,4 @@
-import { error, warnOnce } from '../../../utils.js';
+import { error } from '../../../utils.js';
 import TimestampQueryPool from '../../common/TimestampQueryPool.js';
 import { submit } from './WebGPUUtils.js';
 import GPUBufferDescriptor from '../descriptors/GPUBufferDescriptor.js';
@@ -70,8 +70,10 @@ class WebGPUTimestampQueryPool extends TimestampQueryPool {
 
 		if ( this.currentQueryIndex + 2 > this.maxQueries ) {
 
-			warnOnce( `WebGPUTimestampQueryPool [${ this.type }]: Maximum number of queries exceeded, when using trackTimestamp it is necessary to resolves the queries via renderer.resolveTimestampsAsync( THREE.TimestampQuery.${ this.type.toUpperCase() } ).` );
-			return null;
+			this.resolveQueriesAsync();
+
+			this.currentQueryIndex = 0;
+			this.queryOffsets.clear();
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33913

**Description**

The WebGPURenderer timestamp API uses `renderer.resolveTimestampsAsync()` to resolve the queries. However, if it is not called after several render or compute operations, it will eventually exceed the buffer limit.

The issue is that we use `resolveTimestampsAsync()` to wait for the resolved timestamp when the data is needed. However, not all functions require this data, and in some cases it can simply be discarded. In this approach, if the user does not resolve the timestamp before the buffer limit is reached, the timestamp will be resolved and the buffer reset automatically. This allows us to maintain the current behavior while also extending compatibility for timestamp usage without forcing the user to resolve the timestamp after every render or compute call.

The second case involves calls made outside of `setAnimationLoop()`. The Inspector will now be monitored at the beginning of each frame and finalized at the beginning of the next frame. This reduces the likelihood of race-condition-related issues, since the Inspector is continuously monitored. It also enables usage outside of `setAnimationLoop()`, such as when using `requestAnimationFrame`.

The third case is related to Inspector monitoring. `Inspector.enabled` has been introduced. Examples such as `webgpu_lightprobes_sponza` perform many rendering calls, which can unnecessarily overload the Inspector. It can now be disabled during this process to reduce the processing overhead.

/cc @RenaudRohlinger 
