### PR TITLE
ArrayCamera: Fix setProjectionFromUnion for non-parallel XR cameras

### DIFF
--- a/src/cameras/ArrayCamera.js
+++ b/src/cameras/ArrayCamera.js
@@ -1,4 +1,20 @@
 import { PerspectiveCamera } from './PerspectiveCamera.js';
+import { Vector3 } from '../math/Vector3.js';
+import { Quaternion } from '../math/Quaternion.js';
+
+const _posL = /*@__PURE__*/ new Vector3();
+const _posR = /*@__PURE__*/ new Vector3();
+const _quatL = /*@__PURE__*/ new Quaternion();
+const _quatR = /*@__PURE__*/ new Quaternion();
+const _scale = /*@__PURE__*/ new Vector3();
+const _corner = /*@__PURE__*/ new Vector3();
+const _view = /*@__PURE__*/ new Vector3();
+const _dir = /*@__PURE__*/ new Vector3();
+
+const _ndcCorners = [
+	[ - 1, - 1, - 1 ], [ 1, - 1, - 1 ], [ - 1, 1, - 1 ], [ 1, 1, - 1 ],
+	[ - 1, - 1, 1 ], [ 1, - 1, 1 ], [ - 1, 1, 1 ], [ 1, 1, 1 ]
+];
 
 /**
  * This type of camera can be used in order to efficiently render a scene with a
@@ -46,6 +62,187 @@ class ArrayCamera extends PerspectiveCamera {
 		 * @type {Array<PerspectiveCamera>}
 		 */
 		this.cameras = array;
+
+	}
+
+	/**
+	 * Sets this camera's world transform and projection matrix to a perspective
+	 * frustum that contains the view volumes of both given cameras.
+	 *
+	 * Used by WebXR to build a single culling camera from the left and right
+	 * eye views. The cameras do not need to be parallel or share an axis; their
+	 * projection and world matrices must already be set.
+	 *
+	 * @param {PerspectiveCamera} cameraL - The left camera.
+	 * @param {PerspectiveCamera} cameraR - The right camera.
+	 * @return {ArrayCamera} A reference to this camera.
+	 */
+	setProjectionFromUnion( cameraL, cameraR ) {
+
+		cameraL.matrixWorld.decompose( _posL, _quatL, _scale );
+		cameraR.matrixWorld.decompose( _posR, _quatR, _scale );
+
+		this.position.addVectors( _posL, _posR ).multiplyScalar( 0.5 );
+		this.quaternion.copy( _quatL ).slerp( _quatR, 0.5 );
+		this.scale.set( 1, 1, 1 );
+		this.matrixWorld.compose( this.position, this.quaternion, this.scale );
+		this.matrixWorldInverse.copy( this.matrixWorld ).invert();
+
+		const projL = cameraL.projectionMatrix.elements;
+		const projR = cameraR.projectionMatrix.elements;
+		const infiniteFar = projL[ 10 ] === - 1.0 || projR[ 10 ] === - 1.0;
+
+		let nearSrc = projL[ 14 ] / ( projL[ 10 ] - 1 );
+		const nearR = projR[ 14 ] / ( projR[ 10 ] - 1 );
+
+		if ( Number.isFinite( nearR ) ) {
+
+			nearSrc = Math.min( nearSrc, nearR );
+
+		}
+
+		if ( Number.isFinite( nearSrc ) === false || nearSrc <= 0 ) {
+
+			nearSrc = cameraL.near > 0 ? cameraL.near : 0.1;
+
+		}
+
+		let maxZ = - Infinity;
+		const sources = [ cameraL, cameraR ];
+		const cornerCount = infiniteFar ? 4 : 8;
+
+		for ( let s = 0; s < 2; s ++ ) {
+
+			const src = sources[ s ];
+
+			for ( let i = 0; i < cornerCount; i ++ ) {
+
+				const ndc = _ndcCorners[ i ];
+				_corner.set( ndc[ 0 ], ndc[ 1 ], ndc[ 2 ] );
+				_corner.applyMatrix4( src.projectionMatrixInverse );
+				_corner.applyMatrix4( src.matrixWorld );
+				_view.copy( _corner ).applyMatrix4( this.matrixWorldInverse );
+				maxZ = Math.max( maxZ, _view.z );
+
+			}
+
+		}
+
+		const zOffset = Math.max( 0, maxZ + nearSrc );
+
+		if ( zOffset > 0 ) {
+
+			this.translateZ( zOffset );
+			this.matrixWorld.compose( this.position, this.quaternion, this.scale );
+			this.matrixWorldInverse.copy( this.matrixWorld ).invert();
+
+		}
+
+		let minDepth = Infinity;
+		let maxDepth = - Infinity;
+		let minX = Infinity;
+		let maxX = - Infinity;
+		let minY = Infinity;
+		let maxY = - Infinity;
+
+		for ( let s = 0; s < 2; s ++ ) {
+
+			const src = sources[ s ];
+			const origin = s === 0 ? _posL : _posR;
+
+			for ( let i = 0; i < cornerCount; i ++ ) {
+
+				const ndc = _ndcCorners[ i ];
+				_corner.set( ndc[ 0 ], ndc[ 1 ], ndc[ 2 ] );
+				_corner.applyMatrix4( src.projectionMatrixInverse );
+				_corner.applyMatrix4( src.matrixWorld );
+				_view.copy( _corner ).applyMatrix4( this.matrixWorldInverse );
+
+				const depth = - _view.z;
+				minDepth = Math.min( minDepth, depth );
+				maxDepth = Math.max( maxDepth, depth );
+
+				if ( depth > 1e-6 ) {
+
+					const invZ = 1 / depth;
+					minX = Math.min( minX, _view.x * invZ );
+					maxX = Math.max( maxX, _view.x * invZ );
+					minY = Math.min( minY, _view.y * invZ );
+					maxY = Math.max( maxY, _view.y * invZ );
+
+				}
+
+			}
+
+			if ( infiniteFar === true ) {
+
+				for ( let i = 0; i < 4; i ++ ) {
+
+					const ndc = _ndcCorners[ i ];
+					_corner.set( ndc[ 0 ], ndc[ 1 ], ndc[ 2 ] );
+					_corner.applyMatrix4( src.projectionMatrixInverse );
+					_corner.applyMatrix4( src.matrixWorld );
+					_dir.subVectors( _corner, origin ).transformDirection( this.matrixWorldInverse );
+
+					if ( - _dir.z > 1e-6 ) {
+
+						const invZ = - 1 / _dir.z;
+						minX = Math.min( minX, _dir.x * invZ );
+						maxX = Math.max( maxX, _dir.x * invZ );
+						minY = Math.min( minY, _dir.y * invZ );
+						maxY = Math.max( maxY, _dir.y * invZ );
+
+					}
+
+				}
+
+			}
+
+		}
+
+		const near = Math.max( Math.min( minDepth, nearSrc ), 1e-4 );
+		const far = infiniteFar ? Infinity : Math.max( maxDepth, near + 1e-4 );
+		let left = minX * near;
+		let right = maxX * near;
+		let bottom = minY * near;
+		let top = maxY * near;
+
+		if ( right - left < 1e-6 ) {
+
+			left -= 1e-4;
+			right += 1e-4;
+
+		}
+
+		if ( top - bottom < 1e-6 ) {
+
+			bottom -= 1e-4;
+			top += 1e-4;
+
+		}
+
+		if ( infiniteFar === true ) {
+
+			const te = this.projectionMatrix.elements;
+			const x = 2 * near / ( right - left );
+			const y = 2 * near / ( top - bottom );
+			const a = ( right + left ) / ( right - left );
+			const b = ( top + bottom ) / ( top - bottom );
+
+			te[ 0 ] = x;	te[ 4 ] = 0;	te[ 8 ] = a;	te[ 12 ] = 0;
+			te[ 1 ] = 0;	te[ 5 ] = y;	te[ 9 ] = b;	te[ 13 ] = 0;
+			te[ 2 ] = 0;	te[ 6 ] = 0;	te[ 10 ] = - 1;	te[ 14 ] = - 2 * near;
+			te[ 3 ] = 0;	te[ 7 ] = 0;	te[ 11 ] = - 1;	te[ 15 ] = 0;
+
+		} else {
+
+			this.projectionMatrix.makePerspective( left, right, top, bottom, near, far );
+
+		}
+
+		this.projectionMatrixInverse.copy( this.projectionMatrix ).invert();
+
+		return this;
 
 	}
 

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -19,9 +19,6 @@ import { renderOutput } from '../../nodes/display/RenderOutputNode.js';
 import { RenderTarget } from '../../core/RenderTarget.js';
 import { context } from '../../nodes/core/ContextNode.js';
 
-const _cameraLPos = /*@__PURE__*/ new Vector3();
-const _cameraRPos = /*@__PURE__*/ new Vector3();
-
 const _contextNodeLib = /*@__PURE__*/ new WeakMap();
 
 /**
@@ -1428,7 +1425,7 @@ class XRManager extends EventDispatcher {
 
 		if ( cameras.length === 2 ) {
 
-			setProjectionFromUnion( cameraXR, cameraL, cameraR );
+			cameraXR.setProjectionFromUnion( cameraL, cameraR );
 
 		} else {
 
@@ -1470,79 +1467,6 @@ class XRManager extends EventDispatcher {
 		}
 
 		return controller;
-
-	}
-
-}
-
-/**
- * Assumes 2 cameras that are parallel and share an X-axis, and that
- * the cameras' projection and world matrices have already been set.
- * And that near and far planes are identical for both cameras.
- * Visualization of this technique: https://computergraphics.stackexchange.com/a/4765
- *
- * @param {ArrayCamera} camera - The camera to update.
- * @param {PerspectiveCamera} cameraL - The left camera.
- * @param {PerspectiveCamera} cameraR - The right camera.
- */
-function setProjectionFromUnion( camera, cameraL, cameraR ) {
-
-	_cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
-	_cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
-
-	const ipd = _cameraLPos.distanceTo( _cameraRPos );
-
-	const projL = cameraL.projectionMatrix.elements;
-	const projR = cameraR.projectionMatrix.elements;
-
-	// VR systems will have identical far and near planes, and
-	// most likely identical top and bottom frustum extents.
-	// Use the left camera for these values.
-	const near = projL[ 14 ] / ( projL[ 10 ] - 1 );
-	const far = projL[ 14 ] / ( projL[ 10 ] + 1 );
-	const topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
-	const bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
-
-	const leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
-	const rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
-	const left = near * leftFov;
-	const right = near * rightFov;
-
-	// Calculate the new camera's position offset from the
-	// left camera. xOffset should be roughly half `ipd`.
-	const zOffset = ipd / ( - leftFov + rightFov );
-	const xOffset = zOffset * - leftFov;
-
-	// TODO: Better way to apply this offset?
-	cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
-	camera.translateX( xOffset );
-	camera.translateZ( zOffset );
-	camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-	camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
-
-	// Check if the projection uses an infinite far plane.
-	if ( projL[ 10 ] === - 1.0 ) {
-
-		// Use the projection matrix from the left eye.
-		// The camera offset is sufficient to include the view volumes
-		// of both eyes (assuming symmetric projections).
-		camera.projectionMatrix.copy( cameraL.projectionMatrix );
-		camera.projectionMatrixInverse.copy( cameraL.projectionMatrixInverse );
-
-	} else {
-
-		// Find the union of the frustum values of the cameras and scale
-		// the values so that the near plane's position does not change in world space,
-		// although must now be relative to the new union camera.
-		const near2 = near + zOffset;
-		const far2 = far + zOffset;
-		const left2 = left - xOffset;
-		const right2 = right + ( ipd - xOffset );
-		const top2 = topFov * far / far2 * near2;
-		const bottom2 = bottomFov * far / far2 * near2;
-
-		camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
-		camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
 
 	}
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -2,7 +2,6 @@ import { ArrayCamera } from '../../cameras/ArrayCamera.js';
 import { EventDispatcher } from '../../core/EventDispatcher.js';
 import { PerspectiveCamera } from '../../cameras/PerspectiveCamera.js';
 import { Vector2 } from '../../math/Vector2.js';
-import { Vector3 } from '../../math/Vector3.js';
 import { Vector4 } from '../../math/Vector4.js';
 import { RAD2DEG } from '../../math/MathUtils.js';
 import { WebGLAnimation } from '../webgl/WebGLAnimation.js';
@@ -632,82 +631,6 @@ class WebXRManager extends EventDispatcher {
 
 		//
 
-		const cameraLPos = new Vector3();
-		const cameraRPos = new Vector3();
-
-		/**
-		 * Assumes 2 cameras that are parallel and share an X-axis, and that
-		 * the cameras' projection and world matrices have already been set.
-		 * And that near and far planes are identical for both cameras.
-		 * Visualization of this technique: https://computergraphics.stackexchange.com/a/4765
-		 *
-		 * @param {ArrayCamera} camera - The camera to update.
-		 * @param {PerspectiveCamera} cameraL - The left camera.
-		 * @param {PerspectiveCamera} cameraR - The right camera.
-		 */
-		function setProjectionFromUnion( camera, cameraL, cameraR ) {
-
-			cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
-			cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
-
-			const ipd = cameraLPos.distanceTo( cameraRPos );
-
-			const projL = cameraL.projectionMatrix.elements;
-			const projR = cameraR.projectionMatrix.elements;
-
-			// VR systems will have identical far and near planes, and
-			// most likely identical top and bottom frustum extents.
-			// Use the left camera for these values.
-			const near = projL[ 14 ] / ( projL[ 10 ] - 1 );
-			const far = projL[ 14 ] / ( projL[ 10 ] + 1 );
-			const topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
-			const bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
-
-			const leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
-			const rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
-			const left = near * leftFov;
-			const right = near * rightFov;
-
-			// Calculate the new camera's position offset from the
-			// left camera. xOffset should be roughly half `ipd`.
-			const zOffset = ipd / ( - leftFov + rightFov );
-			const xOffset = zOffset * - leftFov;
-
-			// TODO: Better way to apply this offset?
-			cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
-			camera.translateX( xOffset );
-			camera.translateZ( zOffset );
-			camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-			camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
-
-			// Check if the projection uses an infinite far plane.
-			if ( projL[ 10 ] === - 1.0 ) {
-
-				// Use the projection matrix from the left eye.
-				// The camera offset is sufficient to include the view volumes
-				// of both eyes (assuming symmetric projections).
-				camera.projectionMatrix.copy( cameraL.projectionMatrix );
-				camera.projectionMatrixInverse.copy( cameraL.projectionMatrixInverse );
-
-			} else {
-
-				// Find the union of the frustum values of the cameras and scale
-				// the values so that the near plane's position does not change in world space,
-				// although must now be relative to the new union camera.
-				const near2 = near + zOffset;
-				const far2 = far + zOffset;
-				const left2 = left - xOffset;
-				const right2 = right + ( ipd - xOffset );
-				const top2 = topFov * far / far2 * near2;
-				const bottom2 = bottomFov * far / far2 * near2;
-
-				camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
-				camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
-
-			}
-
-		}
-
 		function updateCamera( camera, parent ) {
 
 			if ( parent === null ) {
@@ -784,7 +707,7 @@ class WebXRManager extends EventDispatcher {
 
 			if ( cameras.length === 2 ) {
 
-				setProjectionFromUnion( cameraXR, cameraL, cameraR );
+				cameraXR.setProjectionFromUnion( cameraL, cameraR );
 
 			} else {
 

--- a/test/unit/src/cameras/ArrayCamera.tests.js
+++ b/test/unit/src/cameras/ArrayCamera.tests.js
@@ -1,10 +1,97 @@
 import { ArrayCamera } from '../../../../src/cameras/ArrayCamera.js';
 
 import { PerspectiveCamera } from '../../../../src/cameras/PerspectiveCamera.js';
+import { Frustum } from '../../../../src/math/Frustum.js';
+import { Matrix4 } from '../../../../src/math/Matrix4.js';
+import { Vector3 } from '../../../../src/math/Vector3.js';
 
 export default QUnit.module( 'Cameras', () => {
 
 	QUnit.module( 'ArrayCamera', () => {
+
+		const NDC_INSET = [
+			[ 0, 0, 0 ],
+			[ - 0.9, - 0.9, - 0.9 ], [ 0.9, - 0.9, - 0.9 ],
+			[ - 0.9, 0.9, - 0.9 ], [ 0.9, 0.9, - 0.9 ],
+			[ - 0.9, - 0.9, 0.9 ], [ 0.9, - 0.9, 0.9 ],
+			[ - 0.9, 0.9, 0.9 ], [ 0.9, 0.9, 0.9 ]
+		];
+
+		function createEyeCamera( x, rotationY, rotationZ, left, right, top, bottom, near, far ) {
+
+			const camera = new PerspectiveCamera();
+			camera.position.set( x, 0, 0 );
+			camera.rotation.set( 0, rotationY, rotationZ );
+
+			if ( far === Infinity ) {
+
+				const te = camera.projectionMatrix.elements;
+				const xScale = 2 * near / ( right - left );
+				const yScale = 2 * near / ( top - bottom );
+				const a = ( right + left ) / ( right - left );
+				const b = ( top + bottom ) / ( top - bottom );
+				te[ 0 ] = xScale; te[ 4 ] = 0; te[ 8 ] = a; te[ 12 ] = 0;
+				te[ 1 ] = 0; te[ 5 ] = yScale; te[ 9 ] = b; te[ 13 ] = 0;
+				te[ 2 ] = 0; te[ 6 ] = 0; te[ 10 ] = - 1; te[ 14 ] = - 2 * near;
+				te[ 3 ] = 0; te[ 7 ] = 0; te[ 11 ] = - 1; te[ 15 ] = 0;
+
+			} else {
+
+				camera.projectionMatrix.makePerspective( left, right, top, bottom, near, far );
+
+			}
+
+			camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
+			camera.updateMatrixWorld( true );
+			return camera;
+
+		}
+
+		function sampleEyePoints( camera, infiniteFar ) {
+
+			const origin = new Vector3().setFromMatrixPosition( camera.matrixWorld );
+			const points = [];
+			const count = infiniteFar ? 5 : NDC_INSET.length;
+
+			for ( let i = 0; i < count; i ++ ) {
+
+				const ndc = NDC_INSET[ i ];
+				const point = new Vector3( ndc[ 0 ], ndc[ 1 ], ndc[ 2 ] );
+				point.applyMatrix4( camera.projectionMatrixInverse );
+				point.applyMatrix4( camera.matrixWorld );
+				points.push( point );
+
+				if ( infiniteFar === true && i > 0 && i < 5 ) {
+
+					points.push( point.clone().sub( origin ).normalize().multiplyScalar( 40 ).add( origin ) );
+
+				}
+
+			}
+
+			return points;
+
+		}
+
+		function unionContainsEyePoints( camera, cameraL, cameraR, infiniteFar ) {
+
+			const projScreen = new Matrix4().multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
+			const frustum = new Frustum().setFromProjectionMatrix( projScreen );
+			const points = sampleEyePoints( cameraL, infiniteFar ).concat( sampleEyePoints( cameraR, infiniteFar ) );
+
+			for ( let i = 0; i < points.length; i ++ ) {
+
+				if ( frustum.containsPoint( points[ i ] ) === false ) {
+
+					return false;
+
+				}
+
+			}
+
+			return true;
+
+		}
 
 		// INHERITANCE
 		QUnit.test( 'Extending', ( assert ) => {
@@ -32,6 +119,79 @@ export default QUnit.module( 'Cameras', () => {
 			assert.ok(
 				object.isArrayCamera,
 				'ArrayCamera.isArrayCamera should be true'
+			);
+
+		} );
+
+		QUnit.test( 'setProjectionFromUnion/parallel cameras', ( assert ) => {
+
+			const near = 0.1;
+			const far = 100;
+			const cameraL = createEyeCamera( - 0.032, 0, 0, - 0.08, 0.06, 0.07, - 0.07, near, far );
+			const cameraR = createEyeCamera( 0.032, 0, 0, - 0.06, 0.08, 0.07, - 0.07, near, far );
+			const camera = new ArrayCamera();
+
+			camera.setProjectionFromUnion( cameraL, cameraR );
+
+			assert.ok(
+				unionContainsEyePoints( camera, cameraL, cameraR, false ),
+				'Union frustum contains both parallel eye view volumes'
+			);
+
+			const projScreen = new Matrix4().multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
+			const frustum = new Frustum().setFromProjectionMatrix( projScreen );
+			assert.ok(
+				frustum.containsPoint( new Vector3( 0, 0, 10 ) ) === false,
+				'Point behind the stereo pair is culled'
+			);
+
+		} );
+
+		QUnit.test( 'setProjectionFromUnion/non-parallel cameras', ( assert ) => {
+
+			// Eye-tracked / Magic Leap style: unique FOVs plus a relative rotation.
+			const near = 0.1;
+			const far = 100;
+			const toeIn = 10 * Math.PI / 180;
+			const roll = 6 * Math.PI / 180;
+			const cameraL = createEyeCamera( - 0.032, toeIn, roll, - 0.08, 0.06, 0.07, - 0.07, near, far );
+			const cameraR = createEyeCamera( 0.032, - toeIn, - roll, - 0.06, 0.08, 0.075, - 0.065, near, far );
+			const camera = new ArrayCamera();
+
+			camera.setProjectionFromUnion( cameraL, cameraR );
+
+			assert.ok(
+				unionContainsEyePoints( camera, cameraL, cameraR, false ),
+				'Union frustum contains both non-parallel eye view volumes'
+			);
+
+			const projScreen = new Matrix4().multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
+			const frustum = new Frustum().setFromProjectionMatrix( projScreen );
+			assert.ok(
+				frustum.containsPoint( new Vector3( 0, 0, 10 ) ) === false,
+				'Point behind the stereo pair is culled'
+			);
+
+		} );
+
+		QUnit.test( 'setProjectionFromUnion/infinite far plane', ( assert ) => {
+
+			const near = 0.1;
+			const toeIn = 10 * Math.PI / 180;
+			const cameraL = createEyeCamera( - 0.032, toeIn, 0, - 0.08, 0.06, 0.07, - 0.07, near, Infinity );
+			const cameraR = createEyeCamera( 0.032, - toeIn, 0, - 0.06, 0.08, 0.07, - 0.07, near, Infinity );
+			const camera = new ArrayCamera();
+
+			camera.setProjectionFromUnion( cameraL, cameraR );
+
+			assert.strictEqual(
+				camera.projectionMatrix.elements[ 10 ],
+				- 1,
+				'Union projection keeps an infinite far plane'
+			);
+			assert.ok(
+				unionContainsEyePoints( camera, cameraL, cameraR, true ),
+				'Union frustum contains both infinite eye view volumes'
 			);
 
 		} );


### PR DESCRIPTION
Related issue: #16766

**Description**

`setProjectionFromUnion` assumed the two XR eye cameras were parallel and shared an X-axis. That does not hold on eye-tracked devices (for example Magic Leap), where each view can have its own IPD, FOV, and a relative rotation. The combined culling frustum was then wrong.

The helper now lives on `ArrayCamera` and builds the union from both cameras' world-space view volumes. Parallel stereo still works; non-parallel and infinite-far projections are covered as well.

Fixes #16766