### PR TITLE
TimestampQueryPool: Clear timestamps Map on query resolution and dispose

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLTimestampQueryPool.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTimestampQueryPool.js
@@ -222,6 +222,8 @@ class WebGLTimestampQueryPool extends TimestampQueryPool {
 
 			const frames = [];
 
+			this.timestamps.clear();
+
 			for ( const [ uid, promise ] of resolvePromises ) {
 
 				const match = uid.match( /^(.*):f(\d+)$/ );
@@ -386,6 +388,8 @@ class WebGLTimestampQueryPool extends TimestampQueryPool {
 		this.queries = [];
 		this.queryStates.clear();
 		this.queryOffsets.clear();
+		this.timestamps.clear();
+		this.frames = [];
 		this.lastValue = 0;
 		this.activeQuery = null;
 

--- a/src/renderers/webgpu/utils/WebGPUTimestampQueryPool.js
+++ b/src/renderers/webgpu/utils/WebGPUTimestampQueryPool.js
@@ -200,6 +200,8 @@ class WebGPUTimestampQueryPool extends TimestampQueryPool {
 
 			const frames = [];
 
+			this.timestamps.clear();
+
 			for ( const [ uid, baseOffset ] of currentOffsets ) {
 
 				const match = uid.match( /^(.*):f(\d+)$/ );
@@ -316,6 +318,8 @@ class WebGPUTimestampQueryPool extends TimestampQueryPool {
 		}
 
 		this.queryOffsets.clear();
+		this.timestamps.clear();
+		this.frames = [];
 		this.pendingResolve = null;
 
 	}


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/34241

**Description**

**Description**

Fixes a memory leak where `TimestampQueryPool.timestamps` grew indefinitely.