### PR TITLE
Docs: Fix usage of `@class` tag.

### DIFF
--- a/src/renderers/common/InspectorBase.js
+++ b/src/renderers/common/InspectorBase.js
@@ -3,7 +3,6 @@ import { EventDispatcher } from '../../core/EventDispatcher.js';
 /**
  * InspectorBase is the base class for all inspectors.
  *
- * @class InspectorBase
  * @augments EventDispatcher
  */
 class InspectorBase extends EventDispatcher {


### PR DESCRIPTION
Fixed #34242.

**Description**

The `@class` annotation is not required when the documented entity is already a class. JSDoc can figure the class type out by itself. An additional `@class` produces two doclets with the same name (`InspectorBase` in this case) and that corrupts the doc page.