### PR TITLE
MRTNode: Fix blend modes bug in `merge()`.

### DIFF
--- a/src/nodes/core/MRTNode.js
+++ b/src/nodes/core/MRTNode.js
@@ -149,10 +149,10 @@ class MRTNode extends OutputStructNode {
 	merge( mrtNode ) {
 
 		const outputs = { ...this.outputNodes, ...mrtNode.outputNodes };
-		const blendings = { ...this.blendModes, ...mrtNode.blendModes };
+		const blendModes = { ...this.blendModes, ...mrtNode.blendModes };
 
 		const mrtTarget = mrt( outputs );
-		mrtTarget.blendings = blendings;
+		mrtTarget.blendModes = blendModes;
 
 		return mrtTarget;
 


### PR DESCRIPTION
Related issue: -

**Description**

`MRTNode` merges blend modes but applies them to a wrong property. Instead of `blendings` it should be `blendModes`.
