### PR TITLE
GaussianSplatMesh: Add support for per-mesh bounding box, frustum culling

### DIFF
--- a/examples/jsm/objects/GaussianSplatMesh.js
+++ b/examples/jsm/objects/GaussianSplatMesh.js
@@ -1,6 +1,9 @@
 import {
+	Box3,
 	BufferAttribute,
+	Color,
 	InstancedBufferGeometry,
+	Matrix3,
 	Matrix4,
 	Mesh,
 	NodeMaterial,
@@ -255,6 +258,123 @@ class GaussianSplatMesh extends Mesh {
 		renderer.compute( this._sphericalHarmonicsComputeNode );
 
 		return true;
+
+	}
+
+	/**
+	 * Returns the splat at the given index.
+	 *
+	 * Members that the target does not already have are created, so an empty object can be passed
+	 * and then reused across calls to avoid allocating.
+	 *
+	 * @param {number} index - The splat index.
+	 * @param {Object} [target] - The object the splat is written to.
+	 * @return {Object} The target, with `position`, `covariance`, `color`, `opacity` and `radius` set.
+	 */
+	getSplat( index, target = {} ) {
+
+		const geometry = this.splatGeometry;
+		const positionAttribute = geometry.getAttribute( 'position' );
+		const covarianceAttribute = geometry.getAttribute( 'covariance' );
+		const colorAttribute = geometry.getAttribute( 'color' );
+
+		if ( target.position === undefined ) {
+
+			target.position = new Vector3();
+
+		}
+
+		if ( target.covariance === undefined ) {
+
+			target.covariance = new Matrix3();
+
+		}
+
+		if ( target.color === undefined ) {
+
+			target.color = new Color();
+
+		}
+
+		target.position.fromBufferAttribute( positionAttribute, index );
+
+		const c00 = covarianceAttribute.getComponent( index, 0 );
+		const c01 = covarianceAttribute.getComponent( index, 1 );
+		const c02 = covarianceAttribute.getComponent( index, 2 );
+		const c11 = covarianceAttribute.getComponent( index, 3 );
+		const c12 = covarianceAttribute.getComponent( index, 4 );
+		const c22 = covarianceAttribute.getComponent( index, 5 );
+
+		// the attribute holds the upper triangle of the symmetric covariance
+		target.covariance.set(
+			c00, c01, c02,
+			c01, c11, c12,
+			c02, c12, c22
+		);
+
+		target.color.fromBufferAttribute( colorAttribute, index );
+		target.opacity = colorAttribute.getW( index );
+
+		// the radius of the drawn largest extent
+		target.radius = SPLAT_KERNEL_CUTOFF * Math.sqrt( Math.max( c00, c11, c22, 0 ) );
+
+		return target;
+
+	}
+
+	/**
+	 * Computes the bounding box of the splats, updating {@link GaussianSplatMesh#boundingBox}.
+	 *
+	 * Each splat is expanded by its own extent rather than treated as a point, so the bounds cover
+	 * what is drawn. Only the splats within the draw range are included.
+	 */
+	computeBoundingBox() {
+
+		if ( this.boundingBox === null ) this.boundingBox = new Box3();
+
+		this.boundingBox.makeEmpty();
+
+		const { start, end } = this._getSplatRange();
+
+		for ( let i = start; i < end; i ++ ) {
+
+			this.getSplat( i, _splat );
+
+			_splatBox.set( _splat.position, _splat.position ).expandByScalar( _splat.radius );
+			this.boundingBox.union( _splatBox );
+
+		}
+
+	}
+
+	/**
+	 * Computes the bounding sphere of the splats, updating {@link GaussianSplatMesh#boundingSphere}.
+	 *
+	 * Each splat is expanded by its own extent rather than treated as a point, so the bounds cover
+	 * what is drawn. Only the splats within the draw range are included.
+	 */
+	computeBoundingSphere() {
+
+		if ( this.boundingSphere === null ) this.boundingSphere = new Sphere();
+
+		this.computeBoundingBox();
+		this.boundingBox.getBoundingSphere( this.boundingSphere );
+
+		// the box corners overstate the radius, so grow it only where a splat actually reaches
+		let maxRadiusSq = 0;
+		const center = this.boundingSphere.center;
+		const { start, end } = this._getSplatRange();
+
+		for ( let i = start; i < end; i ++ ) {
+
+			this.getSplat( i, _splat );
+
+			const distance = center.distanceTo( _splat.position ) + _splat.radius;
+			maxRadiusSq = Math.max( maxRadiusSq, distance * distance );
+
+		}
+
+		this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
 
 	}
 

--- a/examples/jsm/objects/GaussianSplatMesh.js
+++ b/examples/jsm/objects/GaussianSplatMesh.js
@@ -359,8 +359,7 @@ class GaussianSplatMesh extends Mesh {
 		this.computeBoundingBox();
 		this.boundingBox.getBoundingSphere( this.boundingSphere );
 
-		// the box corners overstate the radius, so grow it only where a splat actually reaches
-		let maxRadiusSq = 0;
+		let maxRadius = 0;
 		const center = this.boundingSphere.center;
 		const count = this.splatGeometry.getAttribute( 'position' ).count;
 
@@ -368,12 +367,11 @@ class GaussianSplatMesh extends Mesh {
 
 			this.getSplat( i, _splat );
 
-			const distance = center.distanceTo( _splat.position ) + _splat.radius;
-			maxRadiusSq = Math.max( maxRadiusSq, distance * distance );
+			maxRadius = Math.max( maxRadius, center.distanceTo( _splat.position ) + _splat.radius );
 
 		}
 
-		this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
+		this.boundingSphere.radius = maxRadius;
 
 	}
 

--- a/examples/jsm/objects/GaussianSplatMesh.js
+++ b/examples/jsm/objects/GaussianSplatMesh.js
@@ -130,13 +130,30 @@ class GaussianSplatMesh extends Mesh {
 		this.splatGeometry = splatGeometry;
 
 		/**
+		 * The bounding box of the splats. Can be computed via {@link GaussianSplatMesh#computeBoundingBox}.
+		 *
+		 * The geometry holds a single billboard quad rather than the splats, so the bounds live on
+		 * the mesh, as they do for {@link SkinnedMesh}.
+		 *
+		 * @type {?Box3}
+		 * @default null
+		 */
+		this.boundingBox = null;
+
+		/**
+		 * The bounding sphere of the splats. Can be computed via {@link GaussianSplatMesh#computeBoundingSphere}.
+		 *
+		 * @type {?Sphere}
+		 * @default null
+		 */
+		this.boundingSphere = null;
+
+		/**
 		 * Whether to sort automatically in `onBeforeRender`.
 		 *
 		 * @type {boolean}
 		 */
 		this.autoSort = autoSort;
-
-		this.frustumCulled = false;
 
 		this._buffers = buffers;
 		this._sort = sort;

--- a/examples/jsm/objects/GaussianSplatMesh.js
+++ b/examples/jsm/objects/GaussianSplatMesh.js
@@ -7,6 +7,7 @@ import {
 	Matrix4,
 	Mesh,
 	NodeMaterial,
+	Sphere,
 	StorageBufferAttribute,
 	Vector2,
 	Vector3
@@ -52,6 +53,7 @@ const WORKGROUP_SIZE = 256;
 const SORT_DIRECTION_THRESHOLD = 0.9995;
 const SORT_POSITION_THRESHOLD = 0.0025;
 const KERNEL_2D_SIZE = 0.3;
+const SPLAT_KERNEL_CUTOFF = 2;
 const MAX_SCREEN_SPACE_SPLAT_SIZE = 1024;
 const CLIP_XY = 1.4;
 
@@ -62,6 +64,8 @@ const _cameraPosition = /*@__PURE__*/ new Vector3();
 const _cameraDirection = /*@__PURE__*/ new Vector3();
 const _sortDepthRange = /*@__PURE__*/ new Vector2();
 const _worldMatrixInverse = /*@__PURE__*/ new Matrix4();
+const _splatBox = /*@__PURE__*/ new Box3();
+const _splat = /*@__PURE__*/ { position: new Vector3(), covariance: new Matrix3(), color: new Color(), opacity: 0 };
 
 /**
  * A minimal renderer for 3D Gaussian splat geometry.
@@ -326,7 +330,7 @@ class GaussianSplatMesh extends Mesh {
 	 * Computes the bounding box of the splats, updating {@link GaussianSplatMesh#boundingBox}.
 	 *
 	 * Each splat is expanded by its own extent rather than treated as a point, so the bounds cover
-	 * what is drawn. Only the splats within the draw range are included.
+	 * what is drawn.
 	 */
 	computeBoundingBox() {
 
@@ -334,9 +338,9 @@ class GaussianSplatMesh extends Mesh {
 
 		this.boundingBox.makeEmpty();
 
-		const { start, end } = this._getSplatRange();
+		const count = this.splatGeometry.getAttribute( 'position' ).count;
 
-		for ( let i = start; i < end; i ++ ) {
+		for ( let i = 0; i < count; i ++ ) {
 
 			this.getSplat( i, _splat );
 
@@ -351,7 +355,7 @@ class GaussianSplatMesh extends Mesh {
 	 * Computes the bounding sphere of the splats, updating {@link GaussianSplatMesh#boundingSphere}.
 	 *
 	 * Each splat is expanded by its own extent rather than treated as a point, so the bounds cover
-	 * what is drawn. Only the splats within the draw range are included.
+	 * what is drawn.
 	 */
 	computeBoundingSphere() {
 
@@ -363,9 +367,9 @@ class GaussianSplatMesh extends Mesh {
 		// the box corners overstate the radius, so grow it only where a splat actually reaches
 		let maxRadiusSq = 0;
 		const center = this.boundingSphere.center;
-		const { start, end } = this._getSplatRange();
+		const count = this.splatGeometry.getAttribute( 'position' ).count;
 
-		for ( let i = start; i < end; i ++ ) {
+		for ( let i = 0; i < count; i ++ ) {
 
 			this.getSplat( i, _splat );
 
@@ -441,11 +445,13 @@ class GaussianSplatMesh extends Mesh {
 
 		this._sortMatrix.value.multiplyMatrices( camera.matrixWorldInverse, this.matrixWorld );
 
-		_worldCenter.copy( this.splatGeometry.boundingSphere.center ).applyMatrix4( this.matrixWorld );
+		if ( this.boundingSphere === null ) this.computeBoundingSphere();
+
+		_worldCenter.copy( this.boundingSphere.center ).applyMatrix4( this.matrixWorld );
 		_viewCenter.copy( _worldCenter ).applyMatrix4( camera.matrixWorldInverse );
 		this.getWorldScale( _worldScale );
 
-		const radius = this.splatGeometry.boundingSphere.radius * Math.max( _worldScale.x, _worldScale.y, _worldScale.z );
+		const radius = this.boundingSphere.radius * Math.max( _worldScale.x, _worldScale.y, _worldScale.z );
 		const depth = - _viewCenter.z;
 		const nearDepth = Math.max( camera.near, depth - radius );
 		const farDepth = Math.max( nearDepth + 0.0001, depth + radius );

--- a/examples/jsm/objects/GaussianSplatMesh.js
+++ b/examples/jsm/objects/GaussianSplatMesh.js
@@ -65,7 +65,7 @@ const _cameraDirection = /*@__PURE__*/ new Vector3();
 const _sortDepthRange = /*@__PURE__*/ new Vector2();
 const _worldMatrixInverse = /*@__PURE__*/ new Matrix4();
 const _splatBox = /*@__PURE__*/ new Box3();
-const _splat = /*@__PURE__*/ { position: new Vector3(), covariance: new Matrix3(), color: new Color(), opacity: 0 };
+const _splat = {};
 
 /**
  * A minimal renderer for 3D Gaussian splat geometry.

--- a/examples/jsm/objects/GaussianSplatMesh.js
+++ b/examples/jsm/objects/GaussianSplatMesh.js
@@ -138,9 +138,6 @@ class GaussianSplatMesh extends Mesh {
 		/**
 		 * The bounding box of the splats. Can be computed via {@link GaussianSplatMesh#computeBoundingBox}.
 		 *
-		 * The geometry holds a single billboard quad rather than the splats, so the bounds live on
-		 * the mesh, as they do for {@link SkinnedMesh}.
-		 *
 		 * @type {?Box3}
 		 * @default null
 		 */

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -402,6 +402,7 @@ function denormalize( value, array ) {
 			return value / 65535.0;
 
 		case Uint8Array:
+		case Uint8ClampedArray:
 
 			return value / 255.0;
 
@@ -449,6 +450,7 @@ function normalize( value, array ) {
 			return Math.round( value * 65535.0 );
 
 		case Uint8Array:
+		case Uint8ClampedArray:
 
 			return Math.round( value * 255.0 );
 


### PR DESCRIPTION
Related issue: #33950

**Description**

Adds support for per-mesh boundingBox and boundingSphere - similar to SkinnedMesh. The bounds extend to the edge of the splat rendering and can therefore be used for frustum culling and raycasting (as I intend to submit shortly).

The change also includes a "getSplat" function (similar to SkinnedMeshes' "getVertexPosition" function) for reading a splat and expanding the bounds.

Also fixes an issue with the normalize and denormalize functions in MathUtils not supporting clamped array variants.

cc @bhouston 