### PR TITLE
TSL: Pass `stepSize` to `RaymarchingBox` callback

### DIFF
--- a/examples/jsm/tsl/utils/Raymarching.js
+++ b/examples/jsm/tsl/utils/Raymarching.js
@@ -61,7 +61,7 @@ export const RaymarchingBox = ( steps, callback ) => {
 
 	Loop( { type: 'float', start: bounds.x, end: bounds.y, update: delta }, () => {
 
-		callback( { positionRay } );
+		callback( { positionRay, delta } );
 
 		positionRay.addAssign( rayDir.mul( delta ) );
 

--- a/examples/jsm/tsl/utils/Raymarching.js
+++ b/examples/jsm/tsl/utils/Raymarching.js
@@ -53,17 +53,17 @@ export const RaymarchingBox = ( steps, callback ) => {
 	bounds.assign( vec2( max( bounds.x, 0.0 ), bounds.y ) );
 
 	const inc = vec3( rayDir.abs().reciprocal() ).toVar();
-	const delta = float( min( inc.x, min( inc.y, inc.z ) ) ).toVar();
+	const stepSize = float( min( inc.x, min( inc.y, inc.z ) ) ).toVar();
 
-	delta.divAssign( float( steps ) );
+	stepSize.divAssign( float( steps ) );
 
 	const positionRay = vec3( vOrigin.add( bounds.x.mul( rayDir ) ) ).toVar();
 
-	Loop( { type: 'float', start: bounds.x, end: bounds.y, update: delta }, () => {
+	Loop( { type: 'float', start: bounds.x, end: bounds.y, update: stepSize }, () => {
 
-		callback( { positionRay, delta } );
+		callback( { positionRay, stepSize } );
 
-		positionRay.addAssign( rayDir.mul( delta ) );
+		positionRay.addAssign( rayDir.mul( stepSize ) );
 
 	} );
 


### PR DESCRIPTION
Related issue: -

**Description**

Passes the `stepSize` (delta) parameter to the callback in `RaymarchingBox`, allowing shaders to perform step-distance dependent calculations (e.g., volume accumulation, attenuation, transmittance).

