### PR TITLE
SunLight: Clean up.

### DIFF
--- a/src/Three.Core.js
+++ b/src/Three.Core.js
@@ -61,7 +61,6 @@ export { PointLight } from './lights/PointLight.js';
 export { RectAreaLight } from './lights/RectAreaLight.js';
 export { HemisphereLight } from './lights/HemisphereLight.js';
 export { SunLight } from './lights/SunLight.js';
-export { SunLightShadow } from './lights/SunLightShadow.js';
 export { DirectionalLight } from './lights/DirectionalLight.js';
 export { AmbientLight } from './lights/AmbientLight.js';
 export { Light } from './lights/Light.js';

--- a/src/lights/SunLight.js
+++ b/src/lights/SunLight.js
@@ -1,5 +1,6 @@
 import { Light } from './Light.js';
 import { SunLightShadow } from './SunLightShadow.js';
+import { Object3D } from '../core/Object3D.js';
 
 /**
  * A sun-like light that gets emitted in a specific direction, with rays that
@@ -46,15 +47,15 @@ class SunLight extends Light {
 
 		this.type = 'SunLight';
 
+		this.position.copy( Object3D.DEFAULT_UP );
+		this.updateMatrix();
+
 		/**
-		 * The light's shadow configuration.
+		 * This property holds the light's shadow configuration.
 		 *
 		 * @type {SunLightShadow}
 		 */
 		this.shadow = new SunLightShadow();
-
-		this.position.set( 0, 1, 0 );
-		this.updateMatrix();
 
 	}
 

--- a/src/lights/SunLightShadow.js
+++ b/src/lights/SunLightShadow.js
@@ -10,10 +10,31 @@ const _viewToLightMatrix = /*@__PURE__*/ new Matrix4();
 const _lightDirection = /*@__PURE__*/ new Vector3();
 const _up = /*@__PURE__*/ new Vector3();
 const _center = /*@__PURE__*/ new Vector3();
-const _corner = /*@__PURE__*/ new Vector3();
-const _nearCorners = [ new Vector3(), new Vector3(), new Vector3(), new Vector3() ];
-const _farCorners = [ new Vector3(), new Vector3(), new Vector3(), new Vector3() ];
-const _cascadeCorners = [ new Vector3(), new Vector3(), new Vector3(), new Vector3(), new Vector3(), new Vector3(), new Vector3(), new Vector3() ];
+
+const _nearCorners = [
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3()
+];
+
+const _farCorners = [
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3()
+];
+
+const _cascadeCorners = [
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3(),
+	/*@__PURE__*/ new Vector3()
+];
 
 // must match the cascade count in the sun shadow shader chunks
 
@@ -140,6 +161,10 @@ class SunLightShadow extends LightShadow {
 
 		}
 
+		const resolutionX = this.mapSize.x * ( 1 - 2 * insetX );
+		const resolutionY = this.mapSize.y * ( 1 - 2 * insetY );
+		const resolution = Math.min( resolutionX, resolutionY );
+
 		const camera = this.camera;
 		const cameraNear = viewCamera.near;
 		const cameraFar = Math.max( cameraNear + 1e-6, Math.min( camera.far, viewCamera.far ) );
@@ -249,10 +274,6 @@ class SunLightShadow extends LightShadow {
 
 			// snap to the texel grid to avoid shimmering when the view camera moves
 
-			const resolutionX = this.mapSize.width * this._viewports[ i ].z;
-			const resolutionY = this.mapSize.height * this._viewports[ i ].w;
-			const resolution = Math.min( resolutionX, resolutionY );
-
 			if ( resolution > 1 ) {
 
 				// pad by half a texel so snapping cannot clip a frustum corner
@@ -271,8 +292,7 @@ class SunLightShadow extends LightShadow {
 
 			const cascadeCamera = this._cameras[ i ];
 			cascadeCamera.position.copy( _center );
-			cascadeCamera.up.copy( _up );
-			cascadeCamera.lookAt( _corner.copy( _center ).add( _lightDirection ) );
+			cascadeCamera.quaternion.setFromRotationMatrix( _lightOrientationMatrix );
 			cascadeCamera.left = - radius;
 			cascadeCamera.right = radius;
 			cascadeCamera.top = radius;

--- a/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl.js
@@ -95,6 +95,7 @@ float getSpotAttenuation( const in float coneCosine, const in float penumbraCosi
 
 #endif
 
+
 #if NUM_DIR_LIGHTS > 0
 
 	struct DirectionalLight {

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -296,7 +296,7 @@ export default /* glsl */`
 				sampler2D shadowMap,
 			#endif
 			SunLightShadow sunLightShadow,
-			const in int shadowIndex
+			int shadowIndex
 		) {
 
 			vec4 shadowWorldPosition = vec4( vSunShadowWorldPosition.xyz + vSunShadowWorldNormal * sunLightShadow.shadowNormalBias, 1.0 );
@@ -317,7 +317,7 @@ export default /* glsl */`
 
 					float cascadeShadow = getShadow( shadowMap, sunLightShadow.shadowMapSize, sunLightShadow.shadowIntensity, sunLightShadow.shadowBias, sunLightShadow.shadowRadius, sunShadowMatrix[ cascadeOffset + i ] * shadowWorldPosition );
 
-					shadow = viewDepth < cascade.z ? cascadeShadow : mix( cascadeShadow, shadow, smoothstep( cascade.z, cascade.y, viewDepth ) );
+					shadow = mix( cascadeShadow, shadow, smoothstep( cascade.z, cascade.y, viewDepth ) );
 
 				}
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -308,10 +308,10 @@ function WebGLLights( extensions ) {
 
 					// four cascades per sun light, matching the sun shadow shader chunks
 
-					for ( let i = 0; i < 4; i ++ ) {
+					for ( let j = 0; j < 4; j ++ ) {
 
-						state.sunShadowMatrix[ numSunShadows * 4 + i ] = shadow.getMatrix( i );
-						state.sunShadowCascade[ numSunShadows * 4 + i ] = shadow._cascadeData[ i ];
+						state.sunShadowMatrix[ numSunShadows * 4 + j ] = shadow.getMatrix( j );
+						state.sunShadowCascade[ numSunShadows * 4 + j ] = shadow._cascadeData[ j ];
 
 					}
 
@@ -517,9 +517,9 @@ function WebGLLights( extensions ) {
 			state.directionalShadowMatrix.length = numDirectionalShadows;
 			state.pointShadow.length = numPointShadows;
 			state.pointShadowMap.length = numPointShadows;
+			state.pointShadowMatrix.length = numPointShadows;
 			state.spotShadow.length = numSpotShadows;
 			state.spotShadowMap.length = numSpotShadows;
-			state.pointShadowMatrix.length = numPointShadows;
 			state.spotLightMatrix.length = numSpotShadows + numSpotMaps - numSpotShadowsWithMaps;
 			state.spotLightMap.length = numSpotMaps;
 			state.numSpotLightShadowsWithMaps = numSpotShadowsWithMaps;

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -171,7 +171,6 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 			_shadowMapSize.copy( shadow.mapSize );
 
-			const viewportCount = shadow.getViewportCount();
 			const shadowFrameExtents = shadow.getFrameExtents();
 
 			_shadowMapSize.multiply( shadowFrameExtents );
@@ -287,7 +286,7 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 			// For cube render targets (PointLights), render all 6 faces. Sun lights
 			// render one atlas viewport per cascade.
-			const faceCount = shadow.map.isWebGLCubeRenderTarget ? 6 : viewportCount;
+			const faceCount = shadow.map.isWebGLCubeRenderTarget ? 6 : shadow.getViewportCount();
 
 			if ( light.isPointLight !== true ) shadow.updateMatrices( light, camera );
 


### PR DESCRIPTION
Related issue: #34221

**Description**

- Remove a redundant ternary in the cascade fade (smoothstep already clamps).
- Orient the cascade cameras directly from the light orientation matrix.
- Hoist the loop-invariant snap resolution out of the cascade loop.
- Remove SunLightShadow from the public exports, like the other shadow classes.
- Align code style with the sibling lights and shader chunks.