### PR TITLE
Add Beam Lattice support to 3MFLoader

### DIFF
--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -3,6 +3,7 @@ import {
 	BufferGeometry,
 	ClampToEdgeWrapping,
 	Color,
+	CylinderGeometry,
 	FileLoader,
 	Float32BufferAttribute,
 	Group,
@@ -16,8 +17,10 @@ import {
 	MirroredRepeatWrapping,
 	NearestFilter,
 	RepeatWrapping,
+	SphereGeometry,
 	TextureLoader,
-	SRGBColorSpace
+	SRGBColorSpace,
+	Vector3
 } from 'three';
 import { unzipSync } from '../libs/fflate.module.js';
 
@@ -38,6 +41,7 @@ const COLOR_SPACE_3MF = SRGBColorSpace;
  * - Texture 2D Groups
  * - Color Groups (Vertex Colors)
  * - Metallic Display Properties (PBR)
+ * - Beam Lattice (Beams and Balls)
  *
  * ```js
  * const loader = new ThreeMFLoader();
@@ -604,7 +608,123 @@ class ThreeMFLoader extends Loader {
 			meshData[ 'triangleProperties' ] = triangleProperties;
 			meshData[ 'triangles' ] = new Uint32Array( triangles );
 
+			const beamLatticeNode = getChildNode( meshNode, 'beamlattice' );
+
+			if ( beamLatticeNode ) {
+
+				meshData[ 'beamlattice' ] = parseBeamLatticeNode( beamLatticeNode );
+
+			}
+
 			return meshData;
+
+		}
+
+		function getChildNode( node, name ) {
+
+			const childNodes = node.children;
+
+			for ( let i = 0; i < childNodes.length; i ++ ) {
+
+				if ( childNodes[ i ].localName === name ) return childNodes[ i ];
+
+			}
+
+			return null;
+
+		}
+
+		function getChildNodes( node, name ) {
+
+			const nodes = [];
+			const childNodes = node.children;
+
+			for ( let i = 0; i < childNodes.length; i ++ ) {
+
+				if ( childNodes[ i ].localName === name ) nodes.push( childNodes[ i ] );
+
+			}
+
+			return nodes;
+
+		}
+
+		function getOptionalFloatAttribute( node, name ) {
+
+			const value = node.getAttribute( name );
+			return value === null ? undefined : parseFloat( value );
+
+		}
+
+		function getOptionalAttribute( node, name ) {
+
+			const value = node.getAttribute( name );
+			return value === null ? undefined : value;
+
+		}
+
+		function parseBeamLatticeNode( beamLatticeNode ) {
+
+			const beamLatticeData = {
+				minlength: parseFloat( beamLatticeNode.getAttribute( 'minlength' ) ),
+				radius: parseFloat( beamLatticeNode.getAttribute( 'radius' ) ),
+				cap: beamLatticeNode.getAttribute( 'cap' ) || 'sphere',
+				ballmode: beamLatticeNode.getAttribute( 'ballmode' ) || 'none',
+				ballradius: getOptionalFloatAttribute( beamLatticeNode, 'ballradius' ),
+				pid: getOptionalAttribute( beamLatticeNode, 'pid' ),
+				pindex: getOptionalAttribute( beamLatticeNode, 'pindex' ),
+				beams: [],
+				balls: []
+			};
+
+			const beamsNode = getChildNode( beamLatticeNode, 'beams' );
+
+			if ( beamsNode ) {
+
+				const beamNodes = getChildNodes( beamsNode, 'beam' );
+
+				for ( let i = 0; i < beamNodes.length; i ++ ) {
+
+					const beamNode = beamNodes[ i ];
+
+					beamLatticeData.beams.push( {
+						v1: parseInt( beamNode.getAttribute( 'v1' ), 10 ),
+						v2: parseInt( beamNode.getAttribute( 'v2' ), 10 ),
+						r1: getOptionalFloatAttribute( beamNode, 'r1' ),
+						r2: getOptionalFloatAttribute( beamNode, 'r2' ),
+						pid: getOptionalAttribute( beamNode, 'pid' ),
+						p1: getOptionalAttribute( beamNode, 'p1' ),
+						p2: getOptionalAttribute( beamNode, 'p2' ),
+						cap1: getOptionalAttribute( beamNode, 'cap1' ),
+						cap2: getOptionalAttribute( beamNode, 'cap2' )
+					} );
+
+				}
+
+			}
+
+			const ballsNode = getChildNode( beamLatticeNode, 'balls' );
+
+			if ( ballsNode ) {
+
+				const ballNodes = getChildNodes( ballsNode, 'ball' );
+
+				for ( let i = 0; i < ballNodes.length; i ++ ) {
+
+					const ballNode = ballNodes[ i ];
+
+					beamLatticeData.balls.push( {
+						vindex: parseInt( ballNode.getAttribute( 'vindex' ), 10 ),
+						r: getOptionalFloatAttribute( ballNode, 'r' ),
+						pid: getOptionalAttribute( ballNode, 'pid' ),
+						p: getOptionalAttribute( ballNode, 'p' )
+					} );
+
+				}
+
+			}
+
+			return beamLatticeData;
 
 		}
 
@@ -1335,7 +1455,187 @@ class ThreeMFLoader extends Loader {
 
 			}
 
+			if ( meshData.beamlattice ) {
+
+				const beamLatticeMeshes = buildBeamLatticeMeshes( meshData, objects, modelData, textureData, objectData );
+
+				for ( let i = 0; i < beamLatticeMeshes.length; i ++ ) {
+
+					group.add( beamLatticeMeshes[ i ] );
+
+				}
+
+			}
+
 			return group;
+
+		}
+
+		function buildBeamLatticeMeshes( meshData, objects, modelData, textureData, objectData ) {
+
+			const beamLatticeData = meshData.beamlattice;
+			const vertices = meshData.vertices;
+			const meshes = [];
+			const endpointIndices = new Set();
+			const balls = new Map();
+			const materialCache = {};
+			const up = new Vector3( 0, 1, 0 );
+
+			for ( let i = 0; i < beamLatticeData.beams.length; i ++ ) {
+
+				const beam = beamLatticeData.beams[ i ];
+				endpointIndices.add( beam.v1 );
+				endpointIndices.add( beam.v2 );
+
+			}
+
+			if ( beamLatticeData.ballmode !== 'none' ) {
+
+				for ( let i = 0; i < beamLatticeData.balls.length; i ++ ) {
+
+					const ball = beamLatticeData.balls[ i ];
+					balls.set( ball.vindex, ball );
+
+				}
+
+			}
+
+			if ( beamLatticeData.ballmode === 'all' ) {
+
+				for ( const vertexIndex of endpointIndices ) {
+
+					if ( ! balls.has( vertexIndex ) ) balls.set( vertexIndex, { vindex: vertexIndex } );
+
+				}
+
+			}
+
+			function getVertex( index ) {
+
+				const offset = index * 3;
+
+				if ( index < 0 || offset + 2 >= vertices.length ) return null;
+
+				return new Vector3( vertices[ offset ], vertices[ offset + 1 ], vertices[ offset + 2 ] );
+
+			}
+
+			function getMaterial( elementData, propertyIndex ) {
+
+				const pid = elementData.pid !== undefined ? elementData.pid : ( beamLatticeData.pid !== undefined ? beamLatticeData.pid : objectData.pid );
+				const pindex = propertyIndex !== undefined ? propertyIndex : ( beamLatticeData.pindex !== undefined ? beamLatticeData.pindex : objectData.pindex );
+				const key = `${ pid || 'default' }:${ pindex || 0 }`;
+
+				if ( materialCache[ key ] !== undefined ) return materialCache[ key ];
+
+				if ( pid !== undefined && getResourceType( pid, modelData ) === 'material' ) {
+
+					const basematerials = modelData.resources.basematerials[ pid ];
+					const materialData = basematerials.basematerials[ pindex !== undefined ? pindex : 0 ];
+
+					if ( materialData ) {
+
+						materialCache[ key ] = getBuild( materialData, objects, modelData, textureData, objectData, buildBasematerial );
+						return materialCache[ key ];
+
+					}
+
+				}
+
+				materialCache[ key ] = new MeshPhongMaterial( {
+					name: Loader.DEFAULT_MATERIAL_NAME,
+					color: 0xffffff,
+					flatShading: true
+				} );
+
+				return materialCache[ key ];
+
+			}
+
+			function addSphere( center, radius, material, direction ) {
+
+				if ( ! Number.isFinite( radius ) || radius <= 0 ) return;
+
+				const geometry = direction ? new SphereGeometry( radius, 12, 6, 0, Math.PI * 2, 0, Math.PI / 2 ) : new SphereGeometry( radius, 12, 8 );
+				const sphere = new Mesh( geometry, material );
+				sphere.position.copy( center );
+
+				if ( direction ) sphere.quaternion.setFromUnitVectors( up, direction );
+
+				meshes.push( sphere );
+
+			}
+
+			for ( let i = 0; i < beamLatticeData.beams.length; i ++ ) {
+
+				const beam = beamLatticeData.beams[ i ];
+				const start = getVertex( beam.v1 );
+				const end = getVertex( beam.v2 );
+
+				if ( start === null || end === null ) continue;
+
+				const direction = end.clone().sub( start );
+				const length = direction.length();
+
+				if ( ! Number.isFinite( length ) || length < beamLatticeData.minlength ) continue;
+
+				direction.divideScalar( length );
+
+				const radius1 = beam.r1 !== undefined ? beam.r1 : beamLatticeData.radius;
+				const radius2 = beam.r2 !== undefined ? beam.r2 : radius1;
+
+				if ( ! Number.isFinite( radius1 ) || ! Number.isFinite( radius2 ) || radius1 <= 0 || radius2 <= 0 ) continue;
+
+				const material = getMaterial( beam, beam.p1 );
+				const geometry = new CylinderGeometry( radius2, radius1, length, 12 );
+				const mesh = new Mesh( geometry, material );
+				mesh.position.copy( start ).add( end ).multiplyScalar( 0.5 );
+				mesh.quaternion.setFromUnitVectors( up, direction );
+				meshes.push( mesh );
+
+				const caps = [
+					{ vertexIndex: beam.v1, position: start, radius: radius1, cap: beam.cap1 || beamLatticeData.cap, direction: direction.clone().negate() },
+					{ vertexIndex: beam.v2, position: end, radius: radius2, cap: beam.cap2 || beamLatticeData.cap, direction: direction }
+				];
+
+				for ( let j = 0; j < caps.length; j ++ ) {
+
+					const cap = caps[ j ];
+					const ball = balls.get( cap.vertexIndex );
+					const ballRadius = ball && ball.r !== undefined ? ball.r : beamLatticeData.ballradius;
+
+					if ( cap.cap === 'sphere' ) {
+
+						addSphere( cap.position, ballRadius !== undefined ? Math.max( cap.radius, ballRadius ) : cap.radius, material );
+						if ( ball ) balls.delete( cap.vertexIndex );
+
+					} else if ( cap.cap === 'hemisphere' ) {
+
+						if ( ballRadius === undefined || ballRadius < cap.radius ) addSphere( cap.position, cap.radius, material, cap.direction );
+
+						if ( ball && ballRadius >= cap.radius ) {
+
+							addSphere( cap.position, ballRadius, material );
+							balls.delete( cap.vertexIndex );
+
+						}
+
+					}
+
+				}
+
+			}
+
+			for ( const ball of balls.values() ) {
+
+				const position = getVertex( ball.vindex );
+				const radius = ball.r !== undefined ? ball.r : beamLatticeData.ballradius;
+
+				if ( position ) addSphere( position, radius, getMaterial( ball, ball.p ) );
+
+			}
+
+			return meshes;
 
 		}
 

--- a/test/unit/addons/loaders/3MFLoader.tests.js
+++ b/test/unit/addons/loaders/3MFLoader.tests.js
@@ -1,0 +1,69 @@
+import { ThreeMFLoader } from '../../../../examples/jsm/loaders/3MFLoader.js';
+import { strToU8, zipSync } from '../../../../examples/jsm/libs/fflate.module.js';
+
+export default QUnit.module( 'Addons', () => {
+
+	QUnit.module( 'Loaders', () => {
+
+		QUnit.module( '3MFLoader', () => {
+
+			QUnit.test( 'parses Beam Lattice beams and balls', ( assert ) => {
+
+				const rels = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+	<Relationship Target="/3D/3dmodel.model" Id="rel0" Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel" />
+</Relationships>`;
+				const model = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" xmlns:b="http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02" xmlns:b2="http://schemas.microsoft.com/3dmanufacturing/beamlattice/balls/2020/07">
+	<resources>
+		<object id="1" type="model">
+			<mesh>
+				<vertices>
+					<vertex x="0" y="0" z="0" />
+					<vertex x="0" y="10" z="0" />
+				</vertices>
+				<triangles />
+				<b:beamlattice minlength="0.1" radius="1" ballmode="mixed" ballradius="1.5">
+					<b:beams>
+						<b:beam v1="0" v2="1" r1="1" r2="2" cap1="butt" cap2="butt" />
+					</b:beams>
+					<b2:balls>
+						<b2:ball vindex="0" r="3" />
+						<b2:ball vindex="1" />
+					</b2:balls>
+				</b:beamlattice>
+			</mesh>
+		</object>
+	</resources>
+	<build>
+		<item objectid="1" />
+	</build>
+</model>`;
+				const data = zipSync( {
+					'_rels/.rels': strToU8( rels ),
+					'3D/3dmodel.model': strToU8( model )
+				} );
+				const object = new ThreeMFLoader().parse( data.buffer );
+				const geometries = [];
+
+				object.traverse( ( child ) => {
+
+					if ( child.isMesh ) geometries.push( child.geometry );
+
+				} );
+
+				assert.strictEqual( geometries.length, 3, 'One beam and two balls are created.' );
+				assert.strictEqual( geometries[ 0 ].type, 'CylinderGeometry', 'The beam is represented by a cylinder.' );
+				assert.strictEqual( geometries[ 0 ].parameters.radiusBottom, 1, 'The beam uses r1 at its first vertex.' );
+				assert.strictEqual( geometries[ 0 ].parameters.radiusTop, 2, 'The beam uses r2 at its second vertex.' );
+				assert.strictEqual( geometries[ 1 ].type, 'SphereGeometry', 'The first ball is represented by a sphere.' );
+				assert.strictEqual( geometries[ 1 ].parameters.radius, 3, 'The first ball uses its explicit radius.' );
+				assert.strictEqual( geometries[ 2 ].parameters.radius, 1.5, 'The second ball uses the lattice default radius.' );
+
+			} );
+
+		} );
+
+	} );
+
+} );


### PR DESCRIPTION
## Descrição

Implementa suporte básico a Beam Lattice no `3MFLoader`.

### Alterações

* Adicionado suporte para `<b:beams>`.
* Adicionado suporte para `<b2:balls>`.
* Beams são convertidos  em `CylinderGeometry`.
* Balls são convertidos em `SphereGeometry`.
* Suporte aos raios `r1` e `r2` dos beams.
* Suporte ao raio explícito das balls.
* Suporte ao raio padrão definido pelo `beamlattice `.
* Adicionado teste automatizado em `test/unit/addons/loaders/3MFLoader.tests.js`.

Fixes #34234
