### PR TITLE
GaussianSplatMesh: Inline splat data reads to improve bounding box generation performance

### DIFF
--- a/examples/jsm/objects/GaussianSplatMesh.js
+++ b/examples/jsm/objects/GaussianSplatMesh.js
@@ -1,9 +1,7 @@
 import {
 	Box3,
 	BufferAttribute,
-	Color,
 	InstancedBufferGeometry,
-	Matrix3,
 	Matrix4,
 	Mesh,
 	NodeMaterial,

--- a/examples/jsm/objects/GaussianSplatMesh.js
+++ b/examples/jsm/objects/GaussianSplatMesh.js
@@ -63,8 +63,7 @@ const _sortDirection = /*@__PURE__*/ new Vector3();
 const _sortDepthRange = /*@__PURE__*/ new Vector2();
 const _worldMatrixInverse = /*@__PURE__*/ new Matrix4();
 const _modelViewMatrix = /*@__PURE__*/ new Matrix4();
-const _splatBox = /*@__PURE__*/ new Box3();
-const _splat = {};
+const _vector = /*@__PURE__*/ new Vector3();
 
 /**
  * A minimal renderer for 3D Gaussian splat geometry.
@@ -261,67 +260,6 @@ class GaussianSplatMesh extends Mesh {
 	}
 
 	/**
-	 * Returns the splat at the given index.
-	 *
-	 * Members that the target does not already have are created, so an empty object can be passed
-	 * and then reused across calls to avoid allocating.
-	 *
-	 * @param {number} index - The splat index.
-	 * @param {Object} [target] - The object the splat is written to.
-	 * @return {Object} The target, with `position`, `covariance`, `color`, `opacity` and `radius` set.
-	 */
-	getSplat( index, target = {} ) {
-
-		const geometry = this.splatGeometry;
-		const positionAttribute = geometry.getAttribute( 'position' );
-		const covarianceAttribute = geometry.getAttribute( 'covariance' );
-		const colorAttribute = geometry.getAttribute( 'color' );
-
-		if ( target.position === undefined ) {
-
-			target.position = new Vector3();
-
-		}
-
-		if ( target.covariance === undefined ) {
-
-			target.covariance = new Matrix3();
-
-		}
-
-		if ( target.color === undefined ) {
-
-			target.color = new Color();
-
-		}
-
-		target.position.fromBufferAttribute( positionAttribute, index );
-
-		const c00 = covarianceAttribute.getComponent( index, 0 );
-		const c01 = covarianceAttribute.getComponent( index, 1 );
-		const c02 = covarianceAttribute.getComponent( index, 2 );
-		const c11 = covarianceAttribute.getComponent( index, 3 );
-		const c12 = covarianceAttribute.getComponent( index, 4 );
-		const c22 = covarianceAttribute.getComponent( index, 5 );
-
-		// the attribute holds the upper triangle of the symmetric covariance
-		target.covariance.set(
-			c00, c01, c02,
-			c01, c11, c12,
-			c02, c12, c22
-		);
-
-		target.color.fromBufferAttribute( colorAttribute, index );
-		target.opacity = colorAttribute.getW( index );
-
-		// the radius of the drawn largest extent
-		target.radius = SPLAT_KERNEL_CUTOFF * Math.sqrt( Math.max( c00, c11, c22, 0 ) );
-
-		return target;
-
-	}
-
-	/**
 	 * Computes the bounding box of the splats, updating {@link GaussianSplatMesh#boundingBox}.
 	 *
 	 * Each splat is expanded by its own extent rather than treated as a point, so the bounds cover
@@ -333,14 +271,25 @@ class GaussianSplatMesh extends Mesh {
 
 		this.boundingBox.makeEmpty();
 
-		const count = this.splatGeometry.getAttribute( 'position' ).count;
+		const positionAttribute = this.splatGeometry.getAttribute( 'position' );
+		const covarianceAttribute = this.splatGeometry.getAttribute( 'covariance' );
+		const count = positionAttribute.count;
 
 		for ( let i = 0; i < count; i ++ ) {
 
-			this.getSplat( i, _splat );
+			const x = positionAttribute.getX( i );
+			const y = positionAttribute.getY( i );
+			const z = positionAttribute.getZ( i );
 
-			_splatBox.set( _splat.position, _splat.position ).expandByScalar( _splat.radius );
-			this.boundingBox.union( _splatBox );
+			const c00 = covarianceAttribute.getComponent( i, 0 );
+			const c11 = covarianceAttribute.getComponent( i, 3 );
+			const c22 = covarianceAttribute.getComponent( i, 5 );
+
+			// the radius of the drawn largest extent
+			const radius = SPLAT_KERNEL_CUTOFF * Math.sqrt( Math.max( c00, c11, c22 ) );
+
+			this.boundingBox.expandByPoint( _vector.set( x - radius, y - radius, z - radius ) );
+			this.boundingBox.expandByPoint( _vector.set( x + radius, y + radius, z + radius ) );
 
 		}
 
@@ -359,15 +308,27 @@ class GaussianSplatMesh extends Mesh {
 		this.computeBoundingBox();
 		this.boundingBox.getBoundingSphere( this.boundingSphere );
 
-		let maxRadius = 0;
+		const positionAttribute = this.splatGeometry.getAttribute( 'position' );
+		const covarianceAttribute = this.splatGeometry.getAttribute( 'covariance' );
+		const count = positionAttribute.count;
 		const center = this.boundingSphere.center;
-		const count = this.splatGeometry.getAttribute( 'position' ).count;
+
+		let maxRadius = 0;
 
 		for ( let i = 0; i < count; i ++ ) {
 
-			this.getSplat( i, _splat );
+			const x = positionAttribute.getX( i );
+			const y = positionAttribute.getY( i );
+			const z = positionAttribute.getZ( i );
 
-			maxRadius = Math.max( maxRadius, center.distanceTo( _splat.position ) + _splat.radius );
+			const c00 = covarianceAttribute.getComponent( i, 0 );
+			const c11 = covarianceAttribute.getComponent( i, 3 );
+			const c22 = covarianceAttribute.getComponent( i, 5 );
+
+			// the radius of the drawn largest extent
+			const radius = SPLAT_KERNEL_CUTOFF * Math.sqrt( Math.max( c00, c11, c22 ) );
+
+			maxRadius = Math.max( maxRadius, center.distanceTo( _vector.set( x, y, z ) ) + radius );
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/34254#discussion_r3789296619

**Description**

Inlines the reads to improve performance - as suggested in https://github.com/mrdoob/three.js/pull/34254#discussion_r3789296619. On my machine it takes me down from ~25ms to ~9-10ms per AABB generation.

cc @bhouston 