### PR TITLE
XRControllerModelFactory: Discard assets of replaced input sources.

### DIFF
--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -325,6 +325,7 @@ class XRControllerModelFactory {
 
 		const controllerModel = new XRControllerModel();
 		let scene = null;
+		let activeInputSource = null;
 
 		controller.addEventListener( 'connected', ( event ) => {
 
@@ -332,15 +333,22 @@ class XRControllerModelFactory {
 
 			if ( xrInputSource.targetRayMode !== 'tracked-pointer' || ! xrInputSource.gamepad || xrInputSource.hand ) return;
 
+			activeInputSource = xrInputSource;
+
 			fetchProfile( xrInputSource, this.path, DEFAULT_PROFILE ).then( ( { profile, assetPath } ) => {
 
-				controllerModel.motionController = new MotionController(
+				// Discard the result if the input source was replaced while the profile was being fetched.
+				if ( activeInputSource !== xrInputSource ) return;
+
+				const motionController = new MotionController(
 					xrInputSource,
 					profile,
 					assetPath
 				);
 
-				const cachedAsset = this._assetCache[ controllerModel.motionController.assetUrl ];
+				controllerModel.motionController = motionController;
+
+				const cachedAsset = this._assetCache[ motionController.assetUrl ];
 				if ( cachedAsset ) {
 
 					scene = cachedAsset.scene.clone();
@@ -358,9 +366,11 @@ class XRControllerModelFactory {
 					}
 
 					this.gltfLoader.setPath( '' );
-					this.gltfLoader.load( controllerModel.motionController.assetUrl, ( asset ) => {
+					this.gltfLoader.load( motionController.assetUrl, ( asset ) => {
 
-						this._assetCache[ controllerModel.motionController.assetUrl ] = asset;
+						this._assetCache[ motionController.assetUrl ] = asset;
+
+						if ( activeInputSource !== xrInputSource ) return;
 
 						scene = asset.scene.clone();
 
@@ -372,7 +382,7 @@ class XRControllerModelFactory {
 					null,
 					() => {
 
-						throw new Error( `THREE.XRControllerModelFactory: Asset ${controllerModel.motionController.assetUrl} missing or malformed.` );
+						throw new Error( `THREE.XRControllerModelFactory: Asset ${motionController.assetUrl} missing or malformed.` );
 
 					} );
 
@@ -388,6 +398,7 @@ class XRControllerModelFactory {
 
 		controller.addEventListener( 'disconnected', () => {
 
+			activeInputSource = null;
 			controllerModel.motionController = null;
 			controllerModel.remove( scene );
 			scene = null;

--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -325,7 +325,7 @@ class XRControllerModelFactory {
 
 		const controllerModel = new XRControllerModel();
 		let scene = null;
-		let activeInputSource = null;
+		let activeConnection = 0;
 
 		controller.addEventListener( 'connected', ( event ) => {
 
@@ -333,12 +333,12 @@ class XRControllerModelFactory {
 
 			if ( xrInputSource.targetRayMode !== 'tracked-pointer' || ! xrInputSource.gamepad || xrInputSource.hand ) return;
 
-			activeInputSource = xrInputSource;
+			const connection = ++ activeConnection;
 
 			fetchProfile( xrInputSource, this.path, DEFAULT_PROFILE ).then( ( { profile, assetPath } ) => {
 
 				// Discard the result if the input source was replaced while the profile was being fetched.
-				if ( activeInputSource !== xrInputSource ) return;
+				if ( connection !== activeConnection ) return;
 
 				const motionController = new MotionController(
 					xrInputSource,
@@ -370,7 +370,7 @@ class XRControllerModelFactory {
 
 						this._assetCache[ motionController.assetUrl ] = asset;
 
-						if ( activeInputSource !== xrInputSource ) return;
+						if ( connection !== activeConnection ) return;
 
 						scene = asset.scene.clone();
 
@@ -398,7 +398,7 @@ class XRControllerModelFactory {
 
 		controller.addEventListener( 'disconnected', () => {
 
-			activeInputSource = null;
+			activeConnection ++;
 			controllerModel.motionController = null;
 			controllerModel.remove( scene );
 			scene = null;

--- a/test/unit/addons/webxr/XRControllerModelFactory.tests.js
+++ b/test/unit/addons/webxr/XRControllerModelFactory.tests.js
@@ -1,0 +1,133 @@
+import { Group, Object3D } from 'three';
+import { XRControllerModelFactory } from '../../../../examples/jsm/webxr/XRControllerModelFactory.js';
+
+const PROFILES_PATH = 'https://threejs.invalid/profiles';
+
+function createProfile( profileId ) {
+
+	return {
+		profileId: profileId,
+		layouts: {
+			right: {
+				assetPath: `${profileId}.glb`,
+				components: {
+					trigger: {
+						type: 'trigger',
+						rootNodeName: `${profileId}_root`,
+						gamepadIndices: { button: 0 },
+						visualResponses: {
+							pressed: {
+								componentProperty: 'button',
+								states: [ 'default', 'touched', 'pressed' ],
+								valueNodeProperty: 'transform',
+								valueNodeName: `${profileId}_value`,
+								minNodeName: `${profileId}_min`,
+								maxNodeName: `${profileId}_max`
+							}
+						}
+					}
+				}
+			}
+		}
+	};
+
+}
+
+function createAsset( profileId ) {
+
+	const scene = new Group();
+
+	for ( const suffix of [ 'root', 'value', 'min', 'max' ] ) {
+
+		const node = new Object3D();
+		node.name = `${profileId}_${suffix}`;
+		scene.add( node );
+
+	}
+
+	return { scene: scene };
+
+}
+
+function createInputSource( profileId ) {
+
+	return {
+		targetRayMode: 'tracked-pointer',
+		handedness: 'right',
+		profiles: [ profileId ],
+		gamepad: { buttons: [ { value: 0, pressed: false, touched: false } ], axes: [] }
+	};
+
+}
+
+export default QUnit.module( 'Addons', () => {
+
+	QUnit.module( 'WebXR', () => {
+
+		QUnit.module( 'XRControllerModelFactory', () => {
+
+			QUnit.test( 'createControllerModel - interaction profile change', async ( assert ) => {
+
+				const profiles = { profileA: createProfile( 'profileA' ), profileB: createProfile( 'profileB' ) };
+				const profilesList = { profileA: { path: 'profileA' }, profileB: { path: 'profileB' } };
+
+				const fetch = globalThis.fetch;
+				globalThis.fetch = async ( url ) => {
+
+					const name = url.slice( PROFILES_PATH.length + 1 );
+					const body = name === 'profilesList.json' ? profilesList : profiles[ name ];
+
+					return { ok: true, json: async () => body };
+
+				};
+
+				const onLoadCallbacks = [];
+				let loadRequested;
+				let onLoadRequested;
+
+				const gltfLoader = {
+					setPath: () => {},
+					load: ( url, onLoad ) => {
+
+						onLoadCallbacks.push( onLoad );
+						onLoadRequested();
+
+					}
+				};
+
+				const controller = new Group();
+				const controllerModel = new XRControllerModelFactory( gltfLoader ).setPath( PROFILES_PATH ).createControllerModel( controller );
+				controller.add( controllerModel );
+
+				loadRequested = new Promise( ( resolve ) => onLoadRequested = resolve );
+				controller.dispatchEvent( { type: 'connected', data: createInputSource( 'profileA' ) } );
+				await loadRequested;
+
+				loadRequested = new Promise( ( resolve ) => onLoadRequested = resolve );
+				controller.dispatchEvent( { type: 'disconnected' } );
+				controller.dispatchEvent( { type: 'connected', data: createInputSource( 'profileB' ) } );
+				await loadRequested;
+
+				// the asset of the second profile arrives before the one of the first profile
+				onLoadCallbacks[ 1 ]( createAsset( 'profileB' ) );
+				onLoadCallbacks[ 0 ]( createAsset( 'profileA' ) );
+
+				globalThis.fetch = fetch;
+
+				const visualResponse = controllerModel.motionController.components.trigger.visualResponses.pressed;
+
+				assert.strictEqual( visualResponse.valueNode.name, 'profileB_value', 'Uses the value node of the connected profile' );
+				assert.strictEqual( visualResponse.minNode.name, 'profileB_min', 'Uses the min node of the connected profile' );
+				assert.strictEqual( visualResponse.maxNode.name, 'profileB_max', 'Uses the max node of the connected profile' );
+
+				controllerModel.updateMatrixWorld( true );
+
+				assert.ok( true, 'Updating the world matrix does not throw' );
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/addons/webxr/XRControllerModelFactory.tests.js
+++ b/test/unit/addons/webxr/XRControllerModelFactory.tests.js
@@ -66,12 +66,19 @@ export default QUnit.module( 'Addons', () => {
 
 		QUnit.module( 'XRControllerModelFactory', () => {
 
-			QUnit.test( 'createControllerModel - interaction profile change', async ( assert ) => {
+			const fetch = globalThis.fetch;
+
+			QUnit.testDone( () => {
+
+				globalThis.fetch = fetch;
+
+			} );
+
+			QUnit.test( 'discards assets of replaced input sources', async ( assert ) => {
 
 				const profiles = { profileA: createProfile( 'profileA' ), profileB: createProfile( 'profileB' ) };
 				const profilesList = { profileA: { path: 'profileA' }, profileB: { path: 'profileB' } };
 
-				const fetch = globalThis.fetch;
 				globalThis.fetch = async ( url ) => {
 
 					const name = url.slice( PROFILES_PATH.length + 1 );
@@ -111,8 +118,6 @@ export default QUnit.module( 'Addons', () => {
 				// the asset of the second profile arrives before the one of the first profile
 				onLoadCallbacks[ 1 ]( createAsset( 'profileB' ) );
 				onLoadCallbacks[ 0 ]( createAsset( 'profileA' ) );
-
-				globalThis.fetch = fetch;
 
 				const visualResponse = controllerModel.motionController.components.trigger.visualResponses.pressed;
 

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -14,3 +14,4 @@ import './addons/loaders/SPZLoader.tests.js';
 import './addons/loaders/USDLoader.tests.js';
 import './addons/exporters/USDZExporter.tests.js';
 import './addons/tsl/WebGLNodesHandler.tests.js';
+import './addons/webxr/XRControllerModelFactory.tests.js';


### PR DESCRIPTION
Fixed #34264.

**Description**

When the interaction profile changes mid session, the pending `fetchProfile()` and `GLTFLoader` callbacks of the previous input source keep running, and they apply their result to whatever `MotionController` is current by then. If the asset of the new profile arrives first, the late callback of the old one looks up the new node names in the old scene, finds none, and leaves `minNode` and `maxNode` undefined while `valueNode` still points at the correct node. The next `updateMatrixWorld()` then throws `Cannot read properties of undefined (reading 'quaternion')`, which kills the XR animation loop.

Both callbacks now return early when the input source they were started for is no longer the connected one. The added unit test swaps profiles and resolves the two loads out of order, so it throws without the fix.
