### PR TITLE
OITPassNode: Improve MSAA support.

### DIFF
--- a/examples/jsm/tsl/display/OITPassNode.js
+++ b/examples/jsm/tsl/display/OITPassNode.js
@@ -16,7 +16,9 @@ let _rendererState, _sceneState;
  * incorrectly resolved intersecting geometry are avoided.
  *
  * Only transparent materials using `NormalBlending` and no transmission qualify
- * for OIT. All other objects are rendered as usual. MSAA is not supported.
+ * for OIT. All other objects are rendered as usual.
+ *
+ * MSAA is only supported with the WebGPU backend.
  *
  * MRT configurations assigned via `setMRT()` apply to the default pass only.
  * OIT-qualified objects contribute to the color output but not to custom
@@ -51,7 +53,7 @@ class OITPassNode extends PassNode {
 	 */
 	constructor( scene, camera, options = {} ) {
 
-		super( PassNode.COLOR, scene, camera, { ...options, samples: 0 } );
+		super( PassNode.COLOR, scene, camera, options );
 
 		/**
 		 * This flag can be used for type testing.
@@ -209,6 +211,25 @@ class OITPassNode extends PassNode {
 	setup( builder ) {
 
 		const beautyNode = super.setup( builder );
+
+		// MSAA
+
+		if ( builder.renderer.backend.isWebGPUBackend === true ) {
+
+			// sample counts must match since the depth buffer is shared
+
+			this._oitRenderTarget.samples = this.renderTarget.samples;
+
+		} else {
+
+			// The WebGL backend does not support depth texture sharing with MSAA unless
+			// WEBGL_multisampled_render_to_texture is supported (which isn't available on most devices)
+
+			this.renderTarget.samples = 0;
+
+		}
+
+		// TSL
 
 		const accumNode = texture( this._oitRenderTarget.textures[ 0 ] );
 		const revealageNode = texture( this._oitRenderTarget.textures[ 1 ] ).r;


### PR DESCRIPTION
Related issue: #34253

**Description**

Follow-up of #34253. The PR adds partial support for MSAA. WebGPU supports it now but not WebGL. The respective backend does currently not support shared depth with enabled MSAA.

https://github.com/mrdoob/three.js/blob/db9ebac52df868d6937a92c6dfa5ad834cfba9d8/src/renderers/webgl-fallback/WebGLBackend.js#L2268

Note that this is not a WebGL restriction in general. It's because of the way depth textures are managed in the renderer.