### PR TITLE
WebGLRenderer: Support `FrustumArray`.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -20,6 +20,7 @@ import {
 } from '../constants.js';
 import { Color } from '../math/Color.js';
 import { Frustum } from '../math/Frustum.js';
+import { FrustumArray } from '../math/FrustumArray.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector4 } from '../math/Vector4.js';
@@ -341,6 +342,7 @@ class WebGLRenderer {
 		// frustum
 
 		const _frustum = new Frustum();
+		const _frustumArray = new FrustumArray();
 
 		// clipping
 
@@ -1673,7 +1675,16 @@ class WebGLRenderer {
 			renderStateStack.push( currentRenderState );
 
 			_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
-			_frustum.setFromProjectionMatrix( _projScreenMatrix, WebGLCoordinateSystem, camera.reversedDepth );
+
+			if ( camera.isArrayCamera ) {
+
+				_frustumArray.setFromArrayCamera( camera );
+
+			} else {
+
+				_frustum.setFromProjectionMatrix( _projScreenMatrix, WebGLCoordinateSystem, camera.reversedDepth );
+
+			}
 
 			_localClippingEnabled = this.localClippingEnabled;
 			_clippingEnabled = clipping.init( this.clippingPlanes, _localClippingEnabled );
@@ -1878,7 +1889,9 @@ class WebGLRenderer {
 
 				} else if ( object.isSprite ) {
 
-					if ( ! object.frustumCulled || object.intersectsFrustum( _frustum ) ) {
+					const frustum = camera.isArrayCamera ? _frustumArray : _frustum;
+
+					if ( ! object.frustumCulled || object.intersectsFrustum( frustum ) ) {
 
 						if ( sortObjects ) {
 
@@ -1900,7 +1913,9 @@ class WebGLRenderer {
 
 				} else if ( object.isMesh || object.isLine || object.isPoints ) {
 
-					if ( ! object.frustumCulled || object.intersectsFrustum( _frustum ) ) {
+					const frustum = camera.isArrayCamera ? _frustumArray : _frustum;
+
+					if ( ! object.frustumCulled || object.intersectsFrustum( frustum ) ) {
 
 						const geometry = objects.update( object );
 						const material = object.material;

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -581,9 +581,8 @@ class XRManager extends EventDispatcher {
 	/**
 	 * Returns the XR camera.
 	 *
-	 * The camera's projection matrix is copied from the first sub camera and does
-	 * not enclose all views. If you need a combined projection matrix on app level,
-	 * you have to compute it manually from the sub cameras.
+	 * The camera's transformation and projection matrix are derived from the first
+	 * sub camera (e.g. the left eye in a stereo setup).
 	 *
 	 * @return {ArrayCamera} The XR camera.
 	 */

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -19,9 +19,6 @@ import { renderOutput } from '../../nodes/display/RenderOutputNode.js';
 import { RenderTarget } from '../../core/RenderTarget.js';
 import { context } from '../../nodes/core/ContextNode.js';
 
-const _cameraLPos = /*@__PURE__*/ new Vector3();
-const _cameraRPos = /*@__PURE__*/ new Vector3();
-
 const _contextNodeLib = /*@__PURE__*/ new WeakMap();
 
 /**
@@ -583,6 +580,10 @@ class XRManager extends EventDispatcher {
 
 	/**
 	 * Returns the XR camera.
+	 *
+	 * The camera's projection matrix is copied from the first sub camera and does
+	 * not enclose all views. If you need a combined projection matrix on app level,
+	 * you have to compute it manually from the sub cameras.
 	 *
 	 * @return {ArrayCamera} The XR camera.
 	 */
@@ -1424,19 +1425,8 @@ class XRManager extends EventDispatcher {
 
 		}
 
-		// update projection matrix for proper view frustum culling
-
-		if ( cameras.length === 2 ) {
-
-			setProjectionFromUnion( cameraXR, cameraL, cameraR );
-
-		} else {
-
-			// assume single camera setup (AR)
-
-			cameraXR.projectionMatrix.copy( cameraL.projectionMatrix );
-
-		}
+		cameraXR.projectionMatrix.copy( cameraL.projectionMatrix );
+		cameraXR.projectionMatrixInverse.copy( cameraL.projectionMatrixInverse );
 
 		// update user camera and its children
 
@@ -1470,79 +1460,6 @@ class XRManager extends EventDispatcher {
 		}
 
 		return controller;
-
-	}
-
-}
-
-/**
- * Assumes 2 cameras that are parallel and share an X-axis, and that
- * the cameras' projection and world matrices have already been set.
- * And that near and far planes are identical for both cameras.
- * Visualization of this technique: https://computergraphics.stackexchange.com/a/4765
- *
- * @param {ArrayCamera} camera - The camera to update.
- * @param {PerspectiveCamera} cameraL - The left camera.
- * @param {PerspectiveCamera} cameraR - The right camera.
- */
-function setProjectionFromUnion( camera, cameraL, cameraR ) {
-
-	_cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
-	_cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
-
-	const ipd = _cameraLPos.distanceTo( _cameraRPos );
-
-	const projL = cameraL.projectionMatrix.elements;
-	const projR = cameraR.projectionMatrix.elements;
-
-	// VR systems will have identical far and near planes, and
-	// most likely identical top and bottom frustum extents.
-	// Use the left camera for these values.
-	const near = projL[ 14 ] / ( projL[ 10 ] - 1 );
-	const far = projL[ 14 ] / ( projL[ 10 ] + 1 );
-	const topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
-	const bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
-
-	const leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
-	const rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
-	const left = near * leftFov;
-	const right = near * rightFov;
-
-	// Calculate the new camera's position offset from the
-	// left camera. xOffset should be roughly half `ipd`.
-	const zOffset = ipd / ( - leftFov + rightFov );
-	const xOffset = zOffset * - leftFov;
-
-	// TODO: Better way to apply this offset?
-	cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
-	camera.translateX( xOffset );
-	camera.translateZ( zOffset );
-	camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-	camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
-
-	// Check if the projection uses an infinite far plane.
-	if ( projL[ 10 ] === - 1.0 ) {
-
-		// Use the projection matrix from the left eye.
-		// The camera offset is sufficient to include the view volumes
-		// of both eyes (assuming symmetric projections).
-		camera.projectionMatrix.copy( cameraL.projectionMatrix );
-		camera.projectionMatrixInverse.copy( cameraL.projectionMatrixInverse );
-
-	} else {
-
-		// Find the union of the frustum values of the cameras and scale
-		// the values so that the near plane's position does not change in world space,
-		// although must now be relative to the new union camera.
-		const near2 = near + zOffset;
-		const far2 = far + zOffset;
-		const left2 = left - xOffset;
-		const right2 = right + ( ipd - xOffset );
-		const top2 = topFov * far / far2 * near2;
-		const bottom2 = bottomFov * far / far2 * near2;
-
-		camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
-		camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
 
 	}
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -755,9 +755,8 @@ class WebXRManager extends EventDispatcher {
 		 * the XR camera. If you need the fov on app level, you have to compute in
 		 * manually from the XR camera's projection matrices.
 		 *
-		 * The camera's projection matrix is copied from the first sub camera and does
-		 * not enclose all views. If you need a combined projection matrix on app level,
-		 * you have to compute it manually from the sub cameras.
+		 * The camera's transformation and projection matrix are derived from the first
+		 * sub camera (e.g. the left eye in a stereo setup).
 		 *
 		 * @return {ArrayCamera} The XR camera.
 		 */

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -2,7 +2,6 @@ import { ArrayCamera } from '../../cameras/ArrayCamera.js';
 import { EventDispatcher } from '../../core/EventDispatcher.js';
 import { PerspectiveCamera } from '../../cameras/PerspectiveCamera.js';
 import { Vector2 } from '../../math/Vector2.js';
-import { Vector3 } from '../../math/Vector3.js';
 import { Vector4 } from '../../math/Vector4.js';
 import { RAD2DEG } from '../../math/MathUtils.js';
 import { WebGLAnimation } from '../webgl/WebGLAnimation.js';
@@ -632,82 +631,6 @@ class WebXRManager extends EventDispatcher {
 
 		//
 
-		const cameraLPos = new Vector3();
-		const cameraRPos = new Vector3();
-
-		/**
-		 * Assumes 2 cameras that are parallel and share an X-axis, and that
-		 * the cameras' projection and world matrices have already been set.
-		 * And that near and far planes are identical for both cameras.
-		 * Visualization of this technique: https://computergraphics.stackexchange.com/a/4765
-		 *
-		 * @param {ArrayCamera} camera - The camera to update.
-		 * @param {PerspectiveCamera} cameraL - The left camera.
-		 * @param {PerspectiveCamera} cameraR - The right camera.
-		 */
-		function setProjectionFromUnion( camera, cameraL, cameraR ) {
-
-			cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
-			cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
-
-			const ipd = cameraLPos.distanceTo( cameraRPos );
-
-			const projL = cameraL.projectionMatrix.elements;
-			const projR = cameraR.projectionMatrix.elements;
-
-			// VR systems will have identical far and near planes, and
-			// most likely identical top and bottom frustum extents.
-			// Use the left camera for these values.
-			const near = projL[ 14 ] / ( projL[ 10 ] - 1 );
-			const far = projL[ 14 ] / ( projL[ 10 ] + 1 );
-			const topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
-			const bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
-
-			const leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
-			const rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
-			const left = near * leftFov;
-			const right = near * rightFov;
-
-			// Calculate the new camera's position offset from the
-			// left camera. xOffset should be roughly half `ipd`.
-			const zOffset = ipd / ( - leftFov + rightFov );
-			const xOffset = zOffset * - leftFov;
-
-			// TODO: Better way to apply this offset?
-			cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
-			camera.translateX( xOffset );
-			camera.translateZ( zOffset );
-			camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-			camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
-
-			// Check if the projection uses an infinite far plane.
-			if ( projL[ 10 ] === - 1.0 ) {
-
-				// Use the projection matrix from the left eye.
-				// The camera offset is sufficient to include the view volumes
-				// of both eyes (assuming symmetric projections).
-				camera.projectionMatrix.copy( cameraL.projectionMatrix );
-				camera.projectionMatrixInverse.copy( cameraL.projectionMatrixInverse );
-
-			} else {
-
-				// Find the union of the frustum values of the cameras and scale
-				// the values so that the near plane's position does not change in world space,
-				// although must now be relative to the new union camera.
-				const near2 = near + zOffset;
-				const far2 = far + zOffset;
-				const left2 = left - xOffset;
-				const right2 = right + ( ipd - xOffset );
-				const top2 = topFov * far / far2 * near2;
-				const bottom2 = bottomFov * far / far2 * near2;
-
-				camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
-				camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
-
-			}
-
-		}
-
 		function updateCamera( camera, parent ) {
 
 			if ( parent === null ) {
@@ -780,19 +703,8 @@ class WebXRManager extends EventDispatcher {
 
 			}
 
-			// update projection matrix for proper view frustum culling
-
-			if ( cameras.length === 2 ) {
-
-				setProjectionFromUnion( cameraXR, cameraL, cameraR );
-
-			} else {
-
-				// assume single camera setup (AR)
-
-				cameraXR.projectionMatrix.copy( cameraL.projectionMatrix );
-
-			}
+			cameraXR.projectionMatrix.copy( cameraL.projectionMatrix );
+			cameraXR.projectionMatrixInverse.copy( cameraL.projectionMatrixInverse );
 
 			// update user camera and its children
 
@@ -842,6 +754,10 @@ class WebXRManager extends EventDispatcher {
 		 * The camera's `fov` is currently not used and does not reflect the fov of
 		 * the XR camera. If you need the fov on app level, you have to compute in
 		 * manually from the XR camera's projection matrices.
+		 *
+		 * The camera's projection matrix is copied from the first sub camera and does
+		 * not enclose all views. If you need a combined projection matrix on app level,
+		 * you have to compute it manually from the sub cameras.
 		 *
 		 * @return {ArrayCamera} The XR camera.
 		 */


### PR DESCRIPTION
Fixed #31672.
Fixed #16766.
Closes #31677

**Description**

The PR ensures `WebGLRenderer` supports `FrustumArray`. In this way, view frustum culling in XR happens like in `WebGPURenderer` per sub camera.

Now that we cull per camera, we can remove `setProjectionFromUnion()`. To keep ray casting in context of phone AR intact, the XR camera copies the projection matrix from the first sub camera by default. 

Raycasting often uses `setFromCamera()` and that requires a correct projection matrix in the user camera. In VR, raycasting is normally done with the controllers and that involves no projection matrix. A `Raycaster` that should detect intersections along the look direction of the XR camera (gaze-style interaction) will now use the transformation and projection of the left eye only.

This must be noted in the migration guide.

/ping @cabanier 