### PR TITLE
WebGPUBackend: compare GPU bind groups by handle in _draw()

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2015,7 +2015,7 @@ class WebGPUBackend extends Backend {
 	 * @param {GPURenderPassEncoder|GPURenderBundleEncoder} passEncoderGPU - The GPU pass encoder used for recording draw commands.
 	 * @param {Object} currentSets - Tracking object for currently set pipeline, attributes, bind groups, and index state.
 	 */
-	_draw( renderObject, info, renderContextData, pipelineGPU, bindings, vertexBuffers, drawParams, passEncoderGPU, currentSets ) {
+	_draw( renderObject, info, renderContextData, pipelineGPU, bindings, vertexBuffers, drawParams, passEncoderGPU, currentSets, cameraIndexSlot = - 1 ) {
 
 		const { object, material, context } = renderObject;
 
@@ -2037,14 +2037,19 @@ class WebGPUBackend extends Backend {
 
 		for ( let i = 0, l = bindings.length; i < l; i ++ ) {
 
-			const bindGroup = bindings[ i ];
+			// the camera index slot is bound per sub-camera in draw()
 
-			if ( currentBindingGroups[ i ] !== bindGroup.id ) {
+			if ( i === cameraIndexSlot ) continue;
 
-				const bindingsData = this.get( bindGroup );
+			// compare the GPU bind group instead of the BindGroup id since the GPU object
+			// can be replaced for the same BindGroup (e.g. when a texture version changes)
 
-				passEncoderGPU.setBindGroup( i, bindingsData.group );
-				currentBindingGroups[ i ] = bindGroup.id;
+			const bindGroupGPU = this.get( bindings[ i ] ).group;
+
+			if ( currentBindingGroups[ i ] !== bindGroupGPU ) {
+
+				passEncoderGPU.setBindGroup( i, bindGroupGPU );
+				currentBindingGroups[ i ] = bindGroupGPU;
 
 			}
 
@@ -2252,6 +2257,7 @@ class WebGPUBackend extends Backend {
 			}
 
 			const pixelRatio = this.renderer.getPixelRatio();
+			const indexPos = cameraIndex ? bindings.indexOf( cameraIndex ) : - 1;
 
 			for ( let i = 0, len = cameras.length; i < len; i ++ ) {
 
@@ -2289,15 +2295,20 @@ class WebGPUBackend extends Backend {
 					}
 
 					// Set camera index binding for this layer
-					if ( cameraIndex && cameraData.indexesGPU ) {
+					if ( indexPos !== - 1 && cameraData.indexesGPU ) {
 
-						const indexPos = bindings.indexOf( cameraIndex );
-						pass.setBindGroup( indexPos, cameraData.indexesGPU[ i ] );
-						sets.bindingGroups[ indexPos ] = cameraIndex.id;
+						const cameraIndexGPU = cameraData.indexesGPU[ i ];
+
+						if ( sets.bindingGroups[ indexPos ] !== cameraIndexGPU ) {
+
+							pass.setBindGroup( indexPos, cameraIndexGPU );
+							sets.bindingGroups[ indexPos ] = cameraIndexGPU;
+
+						}
 
 					}
 
-					this._draw( renderObject, info, renderContextData, pipelineGPU, bindings, vertexBuffers, drawParams, pass, sets );
+					this._draw( renderObject, info, renderContextData, pipelineGPU, bindings, vertexBuffers, drawParams, pass, sets, indexPos );
 
 				}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2014,6 +2014,7 @@ class WebGPUBackend extends Backend {
 	 * @param {{vertexCount: number, firstVertex: number, instanceCount: number, firstInstance: number}} drawParams - The draw parameters.
 	 * @param {GPURenderPassEncoder|GPURenderBundleEncoder} passEncoderGPU - The GPU pass encoder used for recording draw commands.
 	 * @param {Object} currentSets - Tracking object for currently set pipeline, attributes, bind groups, and index state.
+	 * @param {number} [cameraIndexSlot=-1] - Index of the binding slot holding the camera index bind group.
 	 */
 	_draw( renderObject, info, renderContextData, pipelineGPU, bindings, vertexBuffers, drawParams, passEncoderGPU, currentSets, cameraIndexSlot = - 1 ) {
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2041,10 +2041,10 @@ class WebGPUBackend extends Backend {
 
 			if ( i === cameraIndexSlot ) continue;
 
-			// compare the GPU bind group instead of the BindGroup id since the GPU object
-			// can be replaced for the same BindGroup (e.g. when a texture version changes)
+			// compare native bind groups
 
-			const bindGroupGPU = this.get( bindings[ i ] ).group;
+			const bindGroup = bindings[ i ];
+			const bindGroupGPU = this.get( bindGroup ).group;
 
 			if ( currentBindingGroups[ i ] !== bindGroupGPU ) {
 


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/34282.

**Related issue:** None - found while working on WebGPU backend performance.

`_draw()`'s redundant-`setBindGroup` elimination keys on the engine-side `BindGroup.id`. `WebGPUBindingUtils.createBindings()` can swap the underlying `GPUBindGroup` for the same `BindGroup` instance (e.g. after an async-loaded texture becomes ready), in which case the cache still sees the same id and skips the `setBindGroup` - the draw then runs with the previous GPU bind group (stale resources).

This PR compares the fetched `GPUBindGroup` object itself instead. It adds one backend-data lookup per bind group per draw on the skip path; the series benchmarks (analyzed with Claude Fable 5 High; which include this change) still measure net CPU wins.

**Testing**: `npm run lint`, `npm run test-unit` (1333 passing), and the WebGPU e2e screenshot suite pass. Developed and verified as part of a possible larger performance series I identified using Fable; benchmarks were measured against unmodified `dev` with vsync disabled.

**Disclosure:** this change was developed with AI assistance (Claude Fable 5 High) and then reviewed, benchmarked and verified by me. Happy to answer questions or adjust.