### PR TITLE
WebGPUBackend: don't begin/end occlusion queries on a bundle encoder

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2308,8 +2308,9 @@ class WebGPUBackend extends Backend {
 			// Regular single camera rendering
 			if ( renderContextData.currentPass ) {
 
-				// Handle occlusion queries
-				if ( renderContextData.occlusionQuerySet !== undefined ) {
+				// Handle occlusion queries (unsupported by GPURenderBundleEncoder, so
+				// objects drawn into a render bundle must not begin/end a query)
+				if ( renderContextData.occlusionQuerySet !== undefined && renderContextData.insideBundle !== true ) {
 
 					const lastObject = renderContextData.lastOcclusionObject;
 					if ( lastObject !== object ) {
@@ -2671,6 +2672,7 @@ class WebGPUBackend extends Backend {
 
 		renderContextData.currentSets = { attributes: {}, bindingGroups: [], pipeline: null, index: null };
 		renderContextData.currentPass = this.pipelineUtils.createBundleEncoder( renderContext );
+		renderContextData.insideBundle = true;
 
 	}
 
@@ -2695,6 +2697,7 @@ class WebGPUBackend extends Backend {
 		renderContextData.currentPass = renderContextData._currentPass;
 		renderContextData._currentPass = null;
 		renderContextData._currentSets = null;
+		renderContextData.insideBundle = false;
 
 	}
 


### PR DESCRIPTION
**Related issue:** None - found while working on WebGPU backend performance.

`GPURenderBundleEncoder` does not support occlusion queries. When a scene mixes `occlusionTest` objects with a `BundleGroup`, `draw()` could call `beginOcclusionQuery()` while the bundle encoder was swapped into `renderContextData.currentPass` - an invalid API call. This PR tracks the swap with an explicit `insideBundle` flag and skips query handling for draws recorded into a bundle.

Related pre-existing edge (not changed here, happy to follow up): `finishRender()` calls `executeBundles()` before ending the last open occlusion query; per the WebGPU spec bundles must not execute while a query is active, so a scene whose last drawn object has `occlusionTest` plus a bundle group could still hit a validation error.

**Testing**: `npm run lint`, `npm run test-unit` (1333 passing), and the WebGPU e2e screenshot suite pass. Developed and verified as part of a possible larger performance series I identified using Fable; benchmarks were measured against unmodified `dev` with vsync disabled.

**Disclosure:** this change was developed with AI assistance (Claude Fable 5 High) and then reviewed, benchmarked and verified by me. Happy to answer questions or adjust.