### PR TITLE
Bindings: fix collision-prone bind group cache key

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -441,10 +441,13 @@ class Bindings extends DataMap {
 
 					cacheBindings = false;
 
-				} else {
+				} else if ( cacheBindings === true ) {
 
-					cacheIndex = cacheIndex * 10 + texture.id;
-					version += texture.version;
+					// fold ids/versions with proper bit mixing since e.g. "cacheIndex * 10 + id"
+					// collides for different texture id sequences (ids 12,3 vs 1,23)
+
+					cacheIndex = ( Math.imul( cacheIndex, 0x9E3779B1 ) + ( texture.id + 1 ) ) >>> 0;
+					version = ( Math.imul( version, 31 ) + texture.version ) >>> 0;
 
 				}
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -616,7 +616,6 @@ class Textures extends DataMap {
 					const bindingsData = this.backend.get( bindGroup );
 
 					bindingsData.groups = undefined;
-					bindingsData.versions = undefined;
 
 					// go through all bindings and if one points to the destroyed texture, trigger dispose as well
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -155,14 +155,15 @@ class WebGPUBindingUtils {
 
 			if ( bindingsData.groups === undefined ) {
 
-				bindingsData.groups = [];
-				bindingsData.versions = [];
+				bindingsData.groups = new Map();
 
 			}
 
-			if ( bindingsData.versions[ cacheIndex ] === version ) {
+			const cached = bindingsData.groups.get( cacheIndex );
 
-				bindGroupGPU = bindingsData.groups[ cacheIndex ];
+			if ( cached !== undefined && cached.version === version ) {
+
+				bindGroupGPU = cached.group;
 
 			}
 
@@ -174,8 +175,7 @@ class WebGPUBindingUtils {
 
 			if ( cacheIndex > 0 ) {
 
-				bindingsData.groups[ cacheIndex ] = bindGroupGPU;
-				bindingsData.versions[ cacheIndex ] = version;
+				bindingsData.groups.set( cacheIndex, { group: bindGroupGPU, version: version } );
 
 			}
 


### PR DESCRIPTION
**Related issue:** https://github.com/mrdoob/three.js/issues/34280.

`_update()` folds texture ids into the bind group cache key with `cacheIndex * 10 + texture.id`, which collides for different texture sequences (e.g. ids `12,3` and `1,23` both fold to 143 from the same start). Collisions make two different texture sets share a cache entry, so a needed bind group rebuild can be skipped.

This PR uses a proper hash fold instead (Knuth multiplicative for the ids, ×31 for the versions) and skips the accumulation entirely when `cacheBindings === false`.


**Testing**: `npm run lint`, `npm run test-unit` (1333 passing), and the WebGPU e2e screenshot suite pass. Developed and verified as part of a possible larger performance series I identified using Fable; benchmarks were measured against unmodified `dev` with vsync disabled.

**Disclosure:** this change was developed with AI assistance (Claude Fable 5 High) and then reviewed, benchmarked and verified by me. Happy to answer questions or adjust.