### PR TITLE
WebGPURenderer: Refresh shared uniform buffers

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -162,7 +162,7 @@ class Bindings extends DataMap {
 
 			for ( const binding of bindGroup.bindings ) {
 
-				if ( binding.isUniformBuffer === true && binding.groupNode?.shared === true ) {
+				if ( ( binding.isNodeUniformsGroup === true || binding.isNodeUniformBuffer === true ) && binding.groupNode.shared === true ) {
 
 					const updatedGroup = this.nodes.updateGroup( binding );
 

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -162,7 +162,7 @@ class Bindings extends DataMap {
 
 			for ( const binding of bindGroup.bindings ) {
 
-				if ( binding.isNodeUniformsGroup === true && binding.groupNode.shared === true ) {
+				if ( binding.isUniformBuffer === true && binding.groupNode?.shared === true ) {
 
 					const updatedGroup = this.nodes.updateGroup( binding );
 


### PR DESCRIPTION
Shared refreshes only handled NodeUniformsGroup bindings, skipping shared NodeUniformBuffer bindings. WebXR camera matrix arrays use NodeUniformBuffer, so their GPU data could remain stale until another change triggered a full render-object refresh. This caused the rendered scene to freeze intermittently while the XR session continued running. Update all shared uniform buffer bindings so camera data is uploaded without forcing full render-object refreshes.

*This contribution is funded by [Meta](https://meta.com)*
