### PR TITLE
STLLoader: Do not read the binary face count past the end of the file

### DIFF
--- a/examples/jsm/loaders/STLLoader.js
+++ b/examples/jsm/loaders/STLLoader.js
@@ -121,6 +121,12 @@ class STLLoader extends Loader {
 
 			const reader = new DataView( data );
 			const face_size = ( 32 / 8 * 3 ) + ( ( 32 / 8 * 3 ) * 3 ) + ( 16 / 8 );
+
+			// A binary STL is an 80 byte header followed by a 4 byte face count, so
+			// anything shorter cannot be one. Reading the count first would throw.
+
+			if ( reader.byteLength < 84 ) return false;
+
 			const n_faces = reader.getUint32( 80, true );
 			const expect = 80 + ( 32 / 8 ) + ( n_faces * face_size );
 

--- a/test/unit/addons/loaders/STLLoader.tests.js
+++ b/test/unit/addons/loaders/STLLoader.tests.js
@@ -1,0 +1,56 @@
+import { STLLoader } from '../../../../examples/jsm/loaders/STLLoader.js';
+
+export default QUnit.module( 'Addons', () => {
+
+	QUnit.module( 'Loaders', () => {
+
+		QUnit.module( 'STLLoader', () => {
+
+			QUnit.test( 'Instancing', ( assert ) => {
+
+				const loader = new STLLoader();
+
+				assert.ok( loader instanceof STLLoader, 'Can instantiate an STLLoader.' );
+
+			} );
+
+			QUnit.test( 'parses an ASCII STL shorter than a binary header', ( assert ) => {
+
+				// Regression: isBinary() read the face count at byte 80 before checking the
+				// length, so an ASCII solid with no facets, which is 15 bytes, threw a
+				// DataView RangeError instead of parsing.
+				const data = new TextEncoder().encode( 'solid\nendsolid\n' ).buffer;
+
+				const geometry = new STLLoader().parse( data );
+
+				assert.ok( geometry.isBufferGeometry, 'Returns a BufferGeometry.' );
+				assert.equal( geometry.attributes.position.count, 0, 'No vertices for a solid with no facets.' );
+
+			} );
+
+			QUnit.test( 'parses an ASCII STL with a single facet', ( assert ) => {
+
+				const source = [
+					'solid single',
+					'facet normal 0 0 1',
+					'outer loop',
+					'vertex 0 0 0',
+					'vertex 1 0 0',
+					'vertex 0 1 0',
+					'endloop',
+					'endfacet',
+					'endsolid single'
+				].join( '\n' );
+
+				const geometry = new STLLoader().parse( new TextEncoder().encode( source ).buffer );
+
+				assert.equal( geometry.attributes.position.count, 3, 'Three vertices for one facet.' );
+				assert.deepEqual( Array.from( geometry.attributes.normal.array.slice( 0, 3 ) ), [ 0, 0, 1 ], 'Reads the facet normal.' );
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -12,6 +12,7 @@ import './addons/loaders/KSPLATLoader.tests.js';
 import './addons/loaders/PLYGaussianSplatLoader.tests.js';
 import './addons/loaders/SPLATLoader.tests.js';
 import './addons/loaders/SPZLoader.tests.js';
+import './addons/loaders/STLLoader.tests.js';
 import './addons/loaders/USDLoader.tests.js';
 import './addons/exporters/USDZExporter.tests.js';
 import './addons/tsl/WebGLNodesHandler.tests.js';


### PR DESCRIPTION
## Description

`STLLoader.parse()` throws `RangeError: Offset is outside the bounds of the DataView` on any file shorter than 84 bytes, because `isBinary()` reads the face count at byte 80 before it knows the file is long enough to have one.

An ASCII solid with no facets is 15 bytes, so it never reaches the parser:

```js
new STLLoader().parse( new TextEncoder().encode( 'solid\nendsolid\n' ).buffer );
// RangeError: Offset is outside the bounds of the DataView
```

A binary STL is an 80 byte header plus a 4 byte face count, so nothing under 84 bytes can be one. The check now says so before reading, and the ASCII path takes over.

The same `RangeError` is what a truncated download produces today, which points at a `DataView` rather than at the file.

## Behaviour change

A file under 84 bytes that is not an STL at all used to throw that `RangeError` and now parses to an empty geometry. That is what the loader already does for a longer file with no facets in it, `parseASCII` finds no `facet ... endfacet` and returns a geometry with zero vertices, so the short case now behaves like the long one instead of the other way around.

Files of 84 bytes or more go through exactly the same code as before.

## Tests

New `test/unit/addons/loaders/STLLoader.tests.js`, registered in `test/unit/three.addons.unit.js`, in the shape of the existing `HDRLoader` regression test. Three cases: instancing, the empty solid, and a single facet to show the normal path still reads positions and normals.

* `npm run test-unit-addons` on `dev`: 41 pass, 0 fail
* with the test and without the one line fix: 43 pass, 1 fail
* with both: 44 pass, 0 fail
* `npm run test-unit`: 1333 pass, 0 fail. `npm run lint`: clean.
