### PR TITLE
WebGLRenderer: webglcontext* listeners leak when the constructor throws, crashing later in onContextRestore (Fix)

### DIFF
--- a/build/three.module.js
+++ b/build/three.module.js
@@ -16455,10 +16455,6 @@ class WebGLRenderer {
 
 		} catch ( e ) {
 
-			canvas.removeEventListener( 'webglcontextlost', onContextLost, false );
-			canvas.removeEventListener( 'webglcontextrestored', onContextRestore, false );
-			canvas.removeEventListener( 'webglcontextcreationerror', onContextCreationError, false );
-
 			error( 'WebGLRenderer: ' + e.message );
 			throw e;
 
@@ -16593,20 +16589,7 @@ class WebGLRenderer {
 
 		}
 
-		try {
-
-			initGLContext();
-
-		} catch ( e ) {
-
-			canvas.removeEventListener( 'webglcontextlost', onContextLost, false );
-			canvas.removeEventListener( 'webglcontextrestored', onContextRestore, false );
-			canvas.removeEventListener( 'webglcontextcreationerror', onContextCreationError, false );
-
-			error( 'WebGLRenderer: ' + e.message );
-			throw e;
-
-		}
+		initGLContext();
 
 		// initialize internal render target for non-UnsignedByteType color buffer
 

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -16455,6 +16455,10 @@ class WebGLRenderer {
 
 		} catch ( e ) {
 
+			canvas.removeEventListener( 'webglcontextlost', onContextLost, false );
+			canvas.removeEventListener( 'webglcontextrestored', onContextRestore, false );
+			canvas.removeEventListener( 'webglcontextcreationerror', onContextCreationError, false );
+
 			error( 'WebGLRenderer: ' + e.message );
 			throw e;
 
@@ -16589,7 +16593,20 @@ class WebGLRenderer {
 
 		}
 
-		initGLContext();
+		try {
+
+			initGLContext();
+
+		} catch ( e ) {
+
+			canvas.removeEventListener( 'webglcontextlost', onContextLost, false );
+			canvas.removeEventListener( 'webglcontextrestored', onContextRestore, false );
+			canvas.removeEventListener( 'webglcontextcreationerror', onContextCreationError, false );
+
+			error( 'WebGLRenderer: ' + e.message );
+			throw e;
+
+		}
 
 		// initialize internal render target for non-UnsignedByteType color buffer
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -420,6 +420,10 @@ class WebGLRenderer {
 
 		} catch ( e ) {
 
+			canvas.removeEventListener( 'webglcontextlost', onContextLost, false );
+			canvas.removeEventListener( 'webglcontextrestored', onContextRestore, false );
+			canvas.removeEventListener( 'webglcontextcreationerror', onContextCreationError, false );
+
 			error( 'WebGLRenderer: ' + e.message );
 			throw e;
 
@@ -554,7 +558,20 @@ class WebGLRenderer {
 
 		}
 
-		initGLContext();
+		try {
+
+			initGLContext();
+
+		} catch ( e ) {
+
+			canvas.removeEventListener( 'webglcontextlost', onContextLost, false );
+			canvas.removeEventListener( 'webglcontextrestored', onContextRestore, false );
+			canvas.removeEventListener( 'webglcontextcreationerror', onContextCreationError, false );
+
+			error( 'WebGLRenderer: ' + e.message );
+			throw e;
+
+		}
 
 		// initialize internal render target for non-UnsignedByteType color buffer
 


### PR DESCRIPTION
## What changed?

* Fixed a `WebGLRenderer` event-listener leak when WebGL context creation fails during construction.
* Removed the `webglcontextlost`, `webglcontextrestored`, and `webglcontextcreationerror` listeners before rethrowing the constructor error.
* Added cleanup handling around the top-level `initGLContext()` call so listeners are also removed when context initialization fails.
* Applied the same fix to the built `build/three.module.js` output for consistency.

## Why?

When `WebGLRenderer` fails to create a WebGL context, the constructor could throw while leaving its context event listeners attached to the canvas.

The leaked listeners could later respond to context events from a renderer that was never successfully constructed. In particular, `webglcontextlost` could call `preventDefault()`, causing the browser to restore the canvas context and eventually trigger `onContextRestore()` on an incompletely initialized renderer.

This could result in errors such as:

```text
TypeError: Cannot read properties of undefined (reading 'autoReset')
```

On some mobile GPUs, this could lead to a repeated lost → restore → crash loop even after the canvas was removed.

## How?

The constructor's `catch` block now removes all context-related listeners before rethrowing the original error.

The top-level `initGLContext()` call is also wrapped with equivalent cleanup logic so that failures during context initialization cannot leave orphaned listeners attached to the canvas.

## Testing

* Reproduced the issue with a WebGL context creation failure.
* Verified that the context listeners are removed when construction fails.
* Verified the fix in both:

  * `src/renderers/WebGLRenderer.js`
  * `build/three.module.js`
* Confirmed that the cleanup prevents the subsequent context-restore crash.

Fixes #34294
