### PR TITLE
FBXLoader: Fix missing `userData` copy.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -1017,6 +1017,7 @@ class FBXTreeParser {
 		if ( sceneGraph.children.length === 1 && sceneGraph.children[ 0 ].isGroup ) {
 
 			sceneGraph.children[ 0 ].animations = animations;
+			Object.assign( sceneGraph.children[ 0 ].userData, sceneGraph.userData );
 			sceneGraph = sceneGraph.children[ 0 ];
 
 		}


### PR DESCRIPTION
Fixed #34300.

**Description**

The PR fixes a missing copy of the `userData`  if only single group is part of the final scene graph.