### PR TITLE
WebGLNodesHandler: Fix error with `getCanvasTarget` in WebGLRenderer.

### DIFF
--- a/examples/jsm/tsl/WebGLNodesHandler.js
+++ b/examples/jsm/tsl/WebGLNodesHandler.js
@@ -230,6 +230,12 @@ class RendererProxy {
 
 	}
 
+	getCanvasTarget() {
+
+		return null;
+
+	}
+
 	hasCompatibility( name ) {
 
 		if ( name === Compatibility.TEXTURE_COMPARE ) {


### PR DESCRIPTION
**Description**

TSL nodes may ask the renderer for its canvas target. `Renderer` implements `getCanvasTarget()`, `WebGLRenderer` does not, so with node materials running through this handler the call throws and the material fails to render:

```
Uncaught TypeError: renderer.getCanvasTarget is not a function
```

For example, `ViewportTextureNode` uses that from both `updateReference()` and `updateBefore()`, in general anything sampling the viewport (transmissive and refractive materials). It reproduces with a MaterialX document using a backdrop-sampling BSDF loaded into a `WebGLRenderer`.

The `RendererProxy` already fills in methods like `hasInitialized()`, `getMRT()`, `hasCompatibility()`, so I think this is where this fix belongs. Reporting `null` puts the node on the path it already has for a renderer without a canvas target, where the size comes from the drawing buffer.

To reproduce, add this in `examples/webgl_tsl_clearcoat.html`:

```diff
  import { WebGLNodesHandler } from 'three/addons/tsl/WebGLNodesHandler.js';
+ import { viewportTexture } from 'three/tsl';

  let material = new THREE.MeshPhysicalNodeMaterial( {
+     colorNode: viewportTexture(),
      clearcoat: 1.0,
```

*This contribution is funded by [Needle](https://needle.tools)*
