### PR TITLE
USDLoader: Resolve connected attribute values

### DIFF
--- a/examples/jsm/loaders/usd/USDAParser.js
+++ b/examples/jsm/loaders/usd/USDAParser.js
@@ -2,6 +2,8 @@
 const DEF_MATCH_REGEX = /^def\s+(?:(\w+)\s+)?"?([^"]+)"?$/;
 const VARIANT_STRING_REGEX = /^string\s+(\w+)$/;
 const ATTR_MATCH_REGEX = /^(?:uniform\s+)?(\w+(?:\[\])?)\s+(.+)$/;
+// Preserve metadata blocks without changing the legacy parseText value shape.
+const VALUE_METADATA = Symbol( 'valueMetadata' );
 
 // Spec types (must match USDCParser/USDComposer)
 const SpecType = {
@@ -55,10 +57,12 @@ class USDAParser {
 
 					// see #28631
 
-					const values = rhs.slice( 0, - 1 );
+					const values = rhs.slice( 0, - 1 ).trim();
 					target[ lhs ] = values;
 
 					const meta = {};
+					if ( target[ VALUE_METADATA ] === undefined ) target[ VALUE_METADATA ] = {};
+					target[ VALUE_METADATA ][ lhs ] = meta;
 					stack.push( meta );
 
 					target = meta;
@@ -621,9 +625,18 @@ class USDAParser {
 				const relName = key.slice( 4 );
 				const relPath = path + '.' + relName;
 				const target = data[ key ].replace( /[<>]/g, '' );
+				const metadata = data[ VALUE_METADATA ]?.[ key ];
+				const fields = { targetPaths: [ target ] };
+
+				if ( metadata?.bindMaterialAs !== undefined ) {
+
+					fields.bindMaterialAs = this._parseString( String( metadata.bindMaterialAs ).trim() );
+
+				}
+
 				specsByPath[ relPath ] = {
 					specType: SpecType.Relationship,
-					fields: { targetPaths: [ target ] }
+					fields
 				};
 				continue;
 

--- a/examples/jsm/loaders/usd/USDCParser.js
+++ b/examples/jsm/loaders/usd/USDCParser.js
@@ -656,10 +656,7 @@ class USDCParser {
 		const reader = this.reader;
 		reader.seek( section.start );
 
-		// Strings section has an 8-byte count prefix, but string indices stored
-		// elsewhere in the file are relative to the section start (not the data).
-		// So we read the entire section as uint32 values to maintain correct indexing.
-		const numStrings = Math.floor( section.size / 4 );
+		const numStrings = reader.readUint64();
 		this.strings = [];
 
 		for ( let i = 0; i < numStrings; i ++ ) {

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -1082,6 +1082,47 @@ class USDComposer {
 	}
 
 	/**
+	 * Resolve an attribute's authored value, following connections before using
+	 * local fallback values.
+	 */
+	_resolveAttributeValue( path, visited = new Set() ) {
+
+		const cleanPath = String( path ).replace( /<|>/g, '' );
+		if ( visited.has( cleanPath ) ) return undefined;
+
+		const fields = this.specsByPath[ cleanPath ]?.fields;
+		if ( ! fields ) return undefined;
+
+		const nextVisited = new Set( visited );
+		nextVisited.add( cleanPath );
+
+		if ( fields.connectionPaths ) {
+
+			for ( const connectionPath of fields.connectionPaths ) {
+
+				const value = this._resolveAttributeValue( connectionPath, nextVisited );
+				if ( value !== undefined ) return value;
+
+			}
+
+		}
+
+		if ( fields.default !== undefined ) return fields.default;
+
+		const { times, values } = fields.timeSamples || {};
+		if ( times && values && times.length > 0 ) {
+
+			// Find time 0, or use the first available time (rest pose).
+			const index = times.indexOf( 0 );
+			return values[ index >= 0 ? index : 0 ];
+
+		}
+
+		return undefined;
+
+	}
+
+	/**
 	 * Get attributes for a path from attribute specs.
 	 */
 	_getAttributes( path ) {
@@ -1141,21 +1182,10 @@ class USDComposer {
 
 		for ( const [ attrName, attrSpec ] of attrMap ) {
 
-			if ( attrSpec.fields?.default !== undefined ) {
+			const value = this._resolveAttributeValue( path + '.' + attrName );
+			if ( value !== undefined ) {
 
-				attrs[ attrName ] = attrSpec.fields.default;
-
-			} else if ( attrSpec.fields?.timeSamples ) {
-
-				// For animated attributes without default, use the first time sample (rest pose)
-				const { times, values } = attrSpec.fields.timeSamples;
-				if ( times && values && times.length > 0 ) {
-
-					// Find time 0, or use the first available time
-					const idx = times.indexOf( 0 );
-					attrs[ attrName ] = idx >= 0 ? values[ idx ] : values[ 0 ];
-
-				}
+				attrs[ attrName ] = value;
 
 			}
 

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -1664,22 +1664,16 @@ class USDComposer {
 	}
 
 	/**
-	 * Get material binding target path, checking variant paths if needed.
+	 * Get the material binding relationship for a prim, including overrides from
+	 * active variants.
 	 */
-	_getMaterialBindingTarget( primPath ) {
+	_getMaterialBindingSpec( primPath ) {
 
 		const attrName = 'material:binding';
-
-		// First check direct path
 		const directPath = primPath + '.' + attrName;
-		const directSpec = this.specsByPath[ directPath ];
-		if ( directSpec?.fields?.targetPaths?.length > 0 ) {
+		let bindingSpec = this.specsByPath[ directPath ] || null;
 
-			return directSpec.fields.targetPaths[ 0 ];
-
-		}
-
-		// Check variant paths at ancestor levels
+		// A variant on any ancestor may override this prim's relationship.
 		const parts = primPath.split( '/' );
 		for ( let i = 1; i < parts.length; i ++ ) {
 
@@ -1694,7 +1688,7 @@ class USDComposer {
 
 				if ( overrideSpec?.fields?.targetPaths?.length > 0 ) {
 
-					return overrideSpec.fields.targetPaths[ 0 ];
+					bindingSpec = overrideSpec;
 
 				}
 
@@ -1702,7 +1696,35 @@ class USDComposer {
 
 		}
 
-		return null;
+		return bindingSpec;
+
+	}
+
+	/**
+	 * Get the resolved material binding target for a prim. Material bindings are
+	 * inherited, and an ancestor marked strongerThanDescendants takes precedence
+	 * over bindings authored on its descendants.
+	 */
+	_getMaterialBindingTarget( primPath ) {
+
+		const parts = primPath.split( '/' ).filter( Boolean );
+		let resolvedBinding = null;
+
+		for ( let i = 0; i < parts.length; i ++ ) {
+
+			const ancestorPath = '/' + parts.slice( 0, i + 1 ).join( '/' );
+			const bindingSpec = this._getMaterialBindingSpec( ancestorPath );
+			if ( ! bindingSpec?.fields?.targetPaths?.length ) continue;
+
+			if ( ! resolvedBinding || resolvedBinding.fields?.bindMaterialAs !== 'strongerThanDescendants' ) {
+
+				resolvedBinding = bindingSpec;
+
+			}
+
+		}
+
+		return resolvedBinding?.fields.targetPaths[ 0 ] || null;
 
 	}
 
@@ -2947,21 +2969,7 @@ class USDComposer {
 	 */
 	_applyMaterialBinding( mesh, primPath ) {
 
-		// Look for material:binding on this prim
-		const bindingPath = primPath + '.material:binding';
-		const bindingSpec = this.specsByPath[ bindingPath ];
-
-		if ( ! bindingSpec ) return;
-
-		let materialPath = null;
-		const targetPaths = bindingSpec.fields?.targetPaths || bindingSpec.fields?.default;
-
-		if ( targetPaths ) {
-
-			materialPath = Array.isArray( targetPaths ) ? targetPaths[ 0 ] : targetPaths;
-
-		}
-
+		let materialPath = this._getMaterialBindingTarget( primPath );
 		if ( ! materialPath ) return;
 
 		// Clean the material path

--- a/test/unit/addons/loaders/USDLoader.tests.js
+++ b/test/unit/addons/loaders/USDLoader.tests.js
@@ -1,11 +1,92 @@
 import { LoadingManager } from 'three';
 import { USDLoader } from '../../../../examples/jsm/loaders/USDLoader.js';
+import { USDComposer, SpecType } from '../../../../examples/jsm/loaders/usd/USDComposer.js';
+import { USDCParser } from '../../../../examples/jsm/loaders/usd/USDCParser.js';
 
 export default QUnit.module( 'Addons', () => {
 
 	QUnit.module( 'Loaders', () => {
 
 		QUnit.module( 'USDLoader', () => {
+
+			QUnit.test( 'reads the USDC string table after its count prefix', ( assert ) => {
+
+				const parser = new USDCParser();
+				const stringIndices = [ 4, 7, 9 ];
+				let readIndex = 0;
+				let seekOffset = null;
+
+				parser.sections = { STRINGS: { start: 32, size: 20 } };
+				parser.reader = {
+					seek( offset ) {
+
+						seekOffset = offset;
+
+					},
+					readUint64() {
+
+						return stringIndices.length;
+
+					},
+					readUint32() {
+
+						return stringIndices[ readIndex ++ ];
+
+					}
+				};
+
+				parser._readStrings();
+
+				assert.strictEqual( seekOffset, 32, 'The string section start is used.' );
+				assert.deepEqual( parser.strings, stringIndices, 'Only string indices after the count are read.' );
+
+			} );
+
+			QUnit.test( 'resolves inherited material bindings by strength', ( assert ) => {
+
+				const composer = new USDComposer();
+				const parentBinding = {
+					specType: SpecType.Relationship,
+					fields: {
+						bindMaterialAs: 'strongerThanDescendants',
+						targetPaths: [ '/Root/Materials/Green' ]
+					}
+				};
+
+				composer.externalVariantSelections = {};
+				composer.specsByPath = {
+					'/Root': {
+						specType: SpecType.Prim,
+						fields: {
+							typeName: 'Xform',
+							variantSelection: { Material: 'Green' },
+							variantSetChildren: [ 'Material' ]
+						}
+					},
+					'/Root/{Material=Green}/Parent.material:binding': parentBinding,
+					'/Root/Parent/Mesh.material:binding': {
+						specType: SpecType.Relationship,
+						fields: {
+							bindMaterialAs: 'weakerThanDescendants',
+							targetPaths: [ '/Root/Materials/White' ]
+						}
+					}
+				};
+
+				assert.strictEqual(
+					composer._getMaterialBindingTarget( '/Root/Parent/Mesh' ),
+					'/Root/Materials/Green',
+					'A stronger inherited variant binding overrides the descendant binding.'
+				);
+
+				parentBinding.fields.bindMaterialAs = 'weakerThanDescendants';
+				assert.strictEqual(
+					composer._getMaterialBindingTarget( '/Root/Parent/Mesh' ),
+					'/Root/Materials/White',
+					'A descendant binding overrides a weaker inherited binding.'
+				);
+
+			} );
 
 			QUnit.test( 'resolves connected asset inputs before fallback values', ( assert ) => {
 

--- a/test/unit/addons/loaders/USDLoader.tests.js
+++ b/test/unit/addons/loaders/USDLoader.tests.js
@@ -1,3 +1,4 @@
+import { LoadingManager } from 'three';
 import { USDLoader } from '../../../../examples/jsm/loaders/USDLoader.js';
 
 export default QUnit.module( 'Addons', () => {
@@ -5,6 +6,61 @@ export default QUnit.module( 'Addons', () => {
 	QUnit.module( 'Loaders', () => {
 
 		QUnit.module( 'USDLoader', () => {
+
+			QUnit.test( 'resolves connected asset inputs before fallback values', ( assert ) => {
+
+				const usda = `#usda 1.0
+(
+	defaultPrim = "Root"
+)
+
+def Xform "Root"
+{
+	def Material "PlaneMaterial"
+	{
+		asset inputs:baseColorTexture = @base-color.png@
+		token outputs:surface.connect = </Root/PlaneMaterial/PreviewSurface.outputs:surface>
+
+		def Shader "BaseColor"
+		{
+			uniform token info:id = "UsdUVTexture"
+			asset inputs:file = @fallback-orm.png@
+			asset inputs:file.connect = </Root/PlaneMaterial.inputs:baseColorTexture>
+			float3 outputs:rgb
+		}
+
+		def Shader "PreviewSurface"
+		{
+			uniform token info:id = "UsdPreviewSurface"
+			color3f inputs:diffuseColor.connect = </Root/PlaneMaterial/BaseColor.outputs:rgb>
+			token outputs:surface
+		}
+	}
+
+	def Cube "Plane"
+	{
+		rel material:binding = </Root/PlaneMaterial>
+	}
+}`;
+
+				const requestedURLs = [];
+				const manager = new LoadingManager();
+				manager.setURLModifier( ( url ) => {
+
+					requestedURLs.push( url );
+					return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+				} );
+
+				new USDLoader( manager ).parse( usda );
+
+				assert.deepEqual(
+					requestedURLs,
+					[ 'base-color.png' ],
+					'The connected material input overrides the texture node fallback.'
+				);
+
+			} );
 
 			QUnit.test( 'uses timeCodesPerSecond for USDA animation timing', ( assert ) => {
 

--- a/test/unit/addons/loaders/USDLoader.tests.js
+++ b/test/unit/addons/loaders/USDLoader.tests.js
@@ -1,6 +1,7 @@
 import { LoadingManager } from 'three';
 import { USDLoader } from '../../../../examples/jsm/loaders/USDLoader.js';
 import { USDComposer, SpecType } from '../../../../examples/jsm/loaders/usd/USDComposer.js';
+import { USDAParser } from '../../../../examples/jsm/loaders/usd/USDAParser.js';
 import { USDCParser } from '../../../../examples/jsm/loaders/usd/USDCParser.js';
 
 export default QUnit.module( 'Addons', () => {
@@ -84,6 +85,61 @@ export default QUnit.module( 'Addons', () => {
 					composer._getMaterialBindingTarget( '/Root/Parent/Mesh' ),
 					'/Root/Materials/White',
 					'A descendant binding overrides a weaker inherited binding.'
+				);
+
+			} );
+
+			QUnit.test( 'reads USDA material binding strength metadata', ( assert ) => {
+
+				const usda = `#usda 1.0
+
+def Xform "Root"
+{
+	def Xform "Parent"
+	{
+		rel material:binding = </Root/Materials/Green> (
+			bindMaterialAs = "strongerThanDescendants"
+		)
+
+		def Mesh "Mesh"
+		{
+			rel material:binding = </Root/Materials/White> (
+				bindMaterialAs = "weakerThanDescendants"
+			)
+		}
+	}
+}`;
+
+				const parsedData = new USDAParser().parseData( usda );
+				const parentBinding = parsedData.specsByPath[ '/Root/Parent.material:binding' ];
+				const childBinding = parsedData.specsByPath[ '/Root/Parent/Mesh.material:binding' ];
+
+				assert.strictEqual(
+					parentBinding.fields.bindMaterialAs,
+					'strongerThanDescendants',
+					'The parent relationship preserves stronger binding metadata.'
+				);
+				assert.strictEqual(
+					childBinding.fields.bindMaterialAs,
+					'weakerThanDescendants',
+					'The child relationship preserves weaker binding metadata.'
+				);
+
+				const composer = new USDComposer();
+				composer.externalVariantSelections = {};
+				composer.specsByPath = parsedData.specsByPath;
+
+				assert.strictEqual(
+					composer._getMaterialBindingTarget( '/Root/Parent/Mesh' ),
+					'/Root/Materials/Green',
+					'A stronger USDA parent binding overrides the descendant binding.'
+				);
+
+				parentBinding.fields.bindMaterialAs = 'weakerThanDescendants';
+				assert.strictEqual(
+					composer._getMaterialBindingTarget( '/Root/Parent/Mesh' ),
+					'/Root/Materials/White',
+					'A USDA descendant binding overrides a weaker parent binding.'
 				);
 
 			} );


### PR DESCRIPTION
USD attributes may define both a connection and a local fallback value. `USDComposer` previously read the fallback directly without following the connection.

This caused connected material inputs to load the wrong texture—for example, using a packed ORM texture as the diffuse map, resulting in incorrect colors. The loader now recursively resolves connected attributes before using default or time-sampled values, with cycle protection.

The change also fixes two related issues exposed by USDZ assets with material variants:

- `USDCParser` now reads the string-table count prefix correctly, so variant selection maps decode with the intended keys and values.
- `USDComposer` resolves material bindings through active variants and the prim ancestry, honoring `bindMaterialAs="strongerThanDescendants"` when choosing between inherited and descendant bindings.

Together, these changes fix both of these samples:

- [Animated plane](https://ada.is/immersiveweb/models/plane-mini.usdz): the cockpit previously used the ORM texture as its diffuse map and appeared red.
- [Animated chameleon](https://developer.apple.com/quick-look-gallery/models/chameleon/chameleon_anim_mtl_variant.usdz): the textured variant binding was previously ignored in favor of weaker white placeholder materials on child meshes.

*This contribution is funded by [Meta](https://meta.com)*