### PR TITLE
Inspector: Polish split screen divider and select dark theme

### DIFF
--- a/examples/jsm/inspector/extensions/color-grading/LUT3DStyle.js
+++ b/examples/jsm/inspector/extensions/color-grading/LUT3DStyle.js
@@ -24,6 +24,7 @@ export class LUT3DStyle {
 		flex-direction: column;
 		gap: 8px;
 		box-sizing: border-box;
+		color-scheme: dark;
 
 		/* Ultra-Subtle Transparent Blueprint / Checkerboard Grid Background */
 		background-color: transparent;
@@ -96,13 +97,16 @@ export class LUT3DStyle {
 		border: none !important;
 		outline: none;
 		cursor: pointer;
+		color-scheme: dark;
 		transition: color 0.15s;
 	}
 
 	.lut-dock-select option,
-	.lut-container select option {
-		background-color: #1e1e24;
-		color: #e0e0e0;
+	.lut-select option,
+	select option,
+	option {
+		background-color: #1e1e24 !important;
+		color: var(--text-primary, #e0e0e0) !important;
 	}
 
 	.lut-dock-select:hover {
@@ -620,7 +624,7 @@ export class LUT3DStyle {
 		flex-shrink: 0;
 	}
 
-	.lut-select, .lut-container select, .lut-toolbar select {
+	.lut-select, .lut-container select, .lut-toolbar select, select {
 		height: 22px;
 		font-family: var(--font-family, sans-serif);
 		font-size: 11px;
@@ -630,8 +634,15 @@ export class LUT3DStyle {
 		padding: 0 4px;
 		outline: none;
 		cursor: pointer;
+		color-scheme: dark;
 		flex-shrink: 1;
 		min-width: 40px;
+	}
+
+	.lut-select option,
+	select option {
+		background-color: #1e1e24 !important;
+		color: var(--text-primary, #e0e0e0) !important;
 	}
 
 	.lut-select-compact {

--- a/examples/jsm/inspector/tabs/Viewer.js
+++ b/examples/jsm/inspector/tabs/Viewer.js
@@ -624,6 +624,7 @@ class Viewer extends Tab {
 
 		this.splitActive = true;
 		this.splitCanvasData = canvasData;
+		this.splitX = 0.5;
 
 		const renderer = this.inspector.getRenderer();
 		const mainCanvas = renderer.domElement;
@@ -756,13 +757,11 @@ class Viewer extends Tab {
 
 		} else {
 
-			const thickness = float( 1 ).div( this.splitUniforms.viewportWidth );
-			const isLine = screenUV.x.sub( this.splitUniforms.splitX ).abs().lessThan( thickness );
 			finalColor = Fn( () => {
 
 				screenUV.x.lessThan( this.splitUniforms.splitX ).discard();
 
-				return isLine.select( vec4( 0.29, 0.29, 0.35, 1.0 ), targetColorCtx );
+				return targetColorCtx;
 
 			} )();
 
@@ -978,7 +977,7 @@ class Viewer extends Tab {
 
 			}
 
-			if ( this.splitCanvasTarget.domElement.width !== rect.width || this.splitCanvasTarget.domElement.height !== rect.height ) {
+			if ( this.splitCanvasTarget.width !== rect.width || this.splitCanvasTarget.height !== rect.height ) {
 
 				this.splitCanvasTarget.setSize( rect.width, rect.height );
 

--- a/examples/jsm/inspector/ui/Style.js
+++ b/examples/jsm/inspector/ui/Style.js
@@ -2142,19 +2142,20 @@ export class Style {
 		width: 14px;
 		pointer-events: none;
 		background-image:
-			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M1 0.5 L13 0.5 L7 7 Z' fill='%239a9aab' stroke='%231e1e24' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E"),
-			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M1 7.5 L13 7.5 L7 1 Z' fill='%239a9aab' stroke='%231e1e24' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E");
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M0 0 L14 0 L7 8 Z' fill='%239a9aab'/%3E%3C/svg%3E"),
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M0 8 L14 8 L7 0 Z' fill='%239a9aab'/%3E%3C/svg%3E");
 		background-position: top center, bottom center;
 		background-repeat: no-repeat;
 		opacity: 0.8;
+		filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.6));
 		transition: opacity 0.2s, filter 0.2s;
 	}
 
 	.split-screen-line:hover::after {
 		opacity: 1;
 		background-image:
-			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M1 0.5 L13 0.5 L7 7 Z' fill='%2300aaff' stroke='%231e1e24' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E"),
-			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M1 7.5 L13 7.5 L7 1 Z' fill='%2300aaff' stroke='%231e1e24' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E");
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M0 0 L14 0 L7 8 Z' fill='%2300aaff'/%3E%3C/svg%3E"),
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M0 8 L14 8 L7 0 Z' fill='%2300aaff'/%3E%3C/svg%3E");
 		filter: drop-shadow(0 0 4px rgba(0, 170, 255, 0.8));
 	}
 

--- a/examples/jsm/inspector/ui/Style.js
+++ b/examples/jsm/inspector/ui/Style.js
@@ -29,6 +29,7 @@ export class Style {
 		pointer-events: none;
 		z-index: 1000;
 		overflow: hidden;
+		color-scheme: dark;
 	}
 
 	:scope * {
@@ -1437,6 +1438,7 @@ export class Style {
 		font-family: var(--font-mono);
 		width: 100%;
 		box-sizing: border-box;
+		color-scheme: dark;
 	}
 
 	.param-control input:focus {
@@ -2019,6 +2021,16 @@ export class Style {
 		background-color: rgba(255, 255, 255, 0.05);
 	}
 
+	select {
+		color-scheme: dark;
+	}
+
+	select option,
+	option {
+		background-color: #1e1e24;
+		color: var(--text-primary);
+	}
+
 	.select {
 		background: var(--profiler-background);
 		border: 1px solid var(--profiler-border);
@@ -2029,6 +2041,7 @@ export class Style {
 		font-size: 12px;
 		outline: none;
 		cursor: pointer;
+		color-scheme: dark;
 		appearance: none;
 		-webkit-appearance: none;
 		-moz-appearance: none;
@@ -2099,14 +2112,14 @@ export class Style {
 		position: absolute;
 		top: 0;
 		bottom: 0;
-		width: 4px;
-		margin-left: -2px;
+		width: 0;
 		left: 50%;
-		background: var(--profiler-border);
+		background: transparent;
 		cursor: ew-resize;
 		pointer-events: auto !important;
 		z-index: 10;
 		touch-action: none;
+		transform: translateX(-50%);
 	}
 
 	.split-screen-line::before {
@@ -2114,10 +2127,35 @@ export class Style {
 		position: absolute;
 		top: 0;
 		bottom: 0;
-		left: -10px;
+		left: -12px;
 		width: 24px;
 		background: transparent;
 		cursor: ew-resize;
+	}
+
+	.split-screen-line::after {
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: -7px;
+		width: 14px;
+		pointer-events: none;
+		background-image:
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M1 0.5 L13 0.5 L7 7 Z' fill='%239a9aab' stroke='%231e1e24' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E"),
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M1 7.5 L13 7.5 L7 1 Z' fill='%239a9aab' stroke='%231e1e24' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E");
+		background-position: top center, bottom center;
+		background-repeat: no-repeat;
+		opacity: 0.8;
+		transition: opacity 0.2s, filter 0.2s;
+	}
+
+	.split-screen-line:hover::after {
+		opacity: 1;
+		background-image:
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M1 0.5 L13 0.5 L7 7 Z' fill='%2300aaff' stroke='%231e1e24' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E"),
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M1 7.5 L13 7.5 L7 1 Z' fill='%2300aaff' stroke='%231e1e24' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E");
+		filter: drop-shadow(0 0 4px rgba(0, 170, 255, 0.8));
 	}
 
 	/* Grid Mode styles for List component */


### PR DESCRIPTION
Related issue: -

**Description**

The line is a bit wide and could get in the way depending on the comparison; I thought it best to remove it while maintaining standard usability, adding arrows at the top and bottom to help with locating it in extreme cases.

<img width="385" height="470" alt="image" src="https://github.com/user-attachments/assets/b8ca6eda-98fa-40f5-8cd7-74379a26c990" />

- **Split Screen**:
  - Removed duplicate border rendering from the split-screen shader, keeping the seam between comparisons clean and precise.
  - Made the central split line transparent while adding subtle top and bottom indicator markers (grey with blue on hover) and exact subpixel alignment.
  - Fixed `splitCanvasTarget` resize check to compare logical dimensions rather than `domElement` dimensions.


- **Theme Consistency**: Added `color-scheme: dark` and explicit dark theme background styles for `<select>` and `<option>` elements in the Inspector and Color Grading extension so dropdown menus match the dark UI.
