### PR TITLE
Skip NaN value errors on vector components that attribute itemSize do…

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -702,7 +702,9 @@ class BufferGeometry extends EventDispatcher {
 
 		}
 
-		if ( isNaN( this.boundingBox.min.x ) || isNaN( this.boundingBox.min.y ) || isNaN( this.boundingBox.min.z ) ) {
+		if ( position !== undefined && ( isNaN( this.boundingBox.min.x ) ||
+			 ( position.itemSize > 1 && isNaN( this.boundingBox.min.y ) ) ||
+			 ( position.itemSize > 2 && isNaN( this.boundingBox.min.z ) ) ) ) {
 
 			error( 'BufferGeometry.computeBoundingBox(): Computed min/max have NaN values. The "position" attribute is likely to have NaN values.', this );
 


### PR DESCRIPTION
…esn't target

Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
