### PR TITLE
WebGLTextureUtils: Delete `PIXEL_PACK_BUFFER` after copy.

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -1281,6 +1281,7 @@ class WebGLTextureUtils {
 
 		backend.state.bindFramebuffer( gl.READ_FRAMEBUFFER, null );
 
+		gl.deleteBuffer( buffer );
 		gl.deleteFramebuffer( fb );
 
 		return dstBuffer;


### PR DESCRIPTION
Related issue: #34321

**Description**

While reviewing #34321, I have noticed the WebGL backend of `WebGPURenderer` does not delete its `PIXEL_PACK_BUFFER` after the copy. Not a breaking bug since the GC can do this as well but it's cleaner to do a deterministic manual deletion.
