### PR TITLE
WebGPURenderer: Dispose render objects when the renderer is disposed.

### DIFF
--- a/src/renderers/common/RenderObjects.js
+++ b/src/renderers/common/RenderObjects.js
@@ -181,12 +181,7 @@ class RenderObjects {
 	 */
 	dispose() {
 
-		// Dispose the render objects so they remove their 'dispose' event
-		// listeners. Listeners left on long-lived objects (e.g. the shared
-		// geometry of QuadMesh) would otherwise keep the disposed renderer
-		// reachable and prevent its garbage collection.
-
-		for ( const renderObject of Array.from( this.renderObjects ) ) {
+		for ( const renderObject of this.renderObjects ) {
 
 			renderObject.dispose();
 

--- a/src/renderers/common/RenderObjects.js
+++ b/src/renderers/common/RenderObjects.js
@@ -72,6 +72,15 @@ class RenderObjects {
 		 */
 		this.chainMaps = {};
 
+		/**
+		 * All render objects created by this component. Chain maps are backed
+		 * by WeakMaps and can't be enumerated, so this set is required to
+		 * dispose all render objects when the renderer is disposed.
+		 *
+		 * @type {Set<RenderObject>}
+		 */
+		this.renderObjects = new Set();
+
 	}
 
 	/**
@@ -172,6 +181,18 @@ class RenderObjects {
 	 */
 	dispose() {
 
+		// Dispose the render objects so they remove their 'dispose' event
+		// listeners. Listeners left on long-lived objects (e.g. the shared
+		// geometry of QuadMesh) would otherwise keep the disposed renderer
+		// reachable and prevent its garbage collection.
+
+		for ( const renderObject of Array.from( this.renderObjects ) ) {
+
+			renderObject.dispose();
+
+		}
+
+		this.renderObjects.clear();
 		this.chainMaps = {};
 
 	}
@@ -206,7 +227,11 @@ class RenderObjects {
 
 			chainMap.delete( renderObject.getChainArray() );
 
+			this.renderObjects.delete( renderObject );
+
 		};
+
+		this.renderObjects.add( renderObject );
 
 		return renderObject;
 

--- a/src/renderers/common/RenderObjects.js
+++ b/src/renderers/common/RenderObjects.js
@@ -68,18 +68,18 @@ class RenderObjects {
 		 * A dictionary that manages render contexts in chain maps
 		 * for each pass ID.
 		 *
+		 * @private
 		 * @type {Object<string,ChainMap>}
 		 */
-		this.chainMaps = {};
+		this._chainMaps = {};
 
 		/**
-		 * All render objects created by this component. Chain maps are backed
-		 * by WeakMaps and can't be enumerated, so this set is required to
-		 * dispose all render objects when the renderer is disposed.
+		 * Stores all render objects created by this component.
 		 *
+		 * @private
 		 * @type {Set<RenderObject>}
 		 */
-		this.renderObjects = new Set();
+		this._renderObjects = new Set();
 
 	}
 
@@ -172,7 +172,7 @@ class RenderObjects {
 	 */
 	getChainMap( passId = 'default' ) {
 
-		return this.chainMaps[ passId ] || ( this.chainMaps[ passId ] = new ChainMap() );
+		return this._chainMaps[ passId ] || ( this._chainMaps[ passId ] = new ChainMap() );
 
 	}
 
@@ -181,14 +181,15 @@ class RenderObjects {
 	 */
 	dispose() {
 
-		for ( const renderObject of this.renderObjects ) {
+		for ( const renderObject of this._renderObjects ) {
 
 			renderObject.dispose();
 
 		}
 
-		this.renderObjects.clear();
-		this.chainMaps = {};
+		this._renderObjects.clear();
+
+		this._chainMaps = {};
 
 	}
 
@@ -222,11 +223,11 @@ class RenderObjects {
 
 			chainMap.delete( renderObject.getChainArray() );
 
-			this.renderObjects.delete( renderObject );
+			this._renderObjects.delete( renderObject );
 
 		};
 
-		this.renderObjects.add( renderObject );
+		this._renderObjects.add( renderObject );
 
 		return renderObject;
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2702,15 +2702,8 @@ class Renderer {
 
 			this.info.dispose();
 
-			// Dispose the render objects before the backend so their cleanup
-			// (e.g. releasing bindings and samplers) still runs against live
-			// backend caches, like it does at runtime.
-
-			this._objects.dispose();
-
-			this.backend.dispose();
-
 			this._animation.dispose();
+			this._objects.dispose();
 			this._geometries.dispose();
 			this._pipelines.dispose();
 			this._nodes.dispose();
@@ -2730,6 +2723,8 @@ class Renderer {
 				if ( queryPool !== null ) queryPool.dispose();
 
 			} );
+
+			this.backend.dispose();
 
 		}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2701,10 +2701,16 @@ class Renderer {
 		if ( this._initialized === true ) {
 
 			this.info.dispose();
+
+			// Dispose the render objects before the backend so their cleanup
+			// (e.g. releasing bindings and samplers) still runs against live
+			// backend caches, like it does at runtime.
+
+			this._objects.dispose();
+
 			this.backend.dispose();
 
 			this._animation.dispose();
-			this._objects.dispose();
 			this._geometries.dispose();
 			this._pipelines.dispose();
 			this._nodes.dispose();


### PR DESCRIPTION
fixes wcandillon/react-native-webgpu#445

The issue was first reported in wcandillon/react-native-webgpu#445

Please try the file below with `?lib=cdn` to see the leak and against this patch to see the fix. 
If there is a path to have this integrated in the test suite let me know (didn't look like there is).

[repro-renderer-leak.html](https://github.com/user-attachments/files/31304562/repro-renderer-leak.html)
