### PR TITLE
FBXLoader: Use global `URL` instead of `window.URL`.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -378,7 +378,7 @@ class FBXTreeParser {
 		} else { // Binary Format
 
 			const array = new Uint8Array( content );
-			return window.URL.createObjectURL( new Blob( [ array ], { type: type } ) );
+			return URL.createObjectURL( new Blob( [ array ], { type: type } ) );
 
 		}
 


### PR DESCRIPTION
### Description

`FBXLoader` currently resolves embedded binary images with `window.URL.createObjectURL()`. This throws `ReferenceError: window is not defined` when `FBXLoader.parse()` runs in a Web Worker, although `URL`, `Blob`, and `URL.createObjectURL()` are available there.

Now, it uses the standard global `URL` directly, consistent with other loaders, so now embedded FBX textures can be parsed in workers.