### PR TITLE
CI: Add Core to bundle size report.

### DIFF
--- a/.github/workflows/read-size.yml
+++ b/.github/workflows/read-size.yml
@@ -38,9 +38,14 @@ jobs:
         id: read-size
         run: |
           # minify the builds to measure their size
+          npx terser build/three.core.js --module --compress --mangle --output build/three.core.min.js
           npx terser build/three.module.js --module --compress --mangle --output build/three.module.min.js
           npx terser build/three.webgpu.js --module --compress --mangle --output build/three.webgpu.min.js
           npx terser build/three.webgpu.nodes.js --module --compress --mangle --output build/three.webgpu.nodes.min.js
+
+          CORE_FILESIZE=$(stat --format=%s build/three.core.min.js)
+          gzip -k build/three.core.min.js
+          CORE_FILESIZE_GZIP=$(stat --format=%s build/three.core.min.js.gz)
 
           WEBGL_FILESIZE=$(stat --format=%s build/three.module.min.js)
           gzip -k build/three.module.min.js
@@ -66,7 +71,7 @@ jobs:
           PR=${{ github.event.pull_request.number }}
 
           # write the output in a json file to upload it as artifact
-          node -pe "JSON.stringify({ filesize: $WEBGL_FILESIZE, gzip: $WEBGL_FILESIZE_GZIP, treeshaken: $WEBGL_TREESHAKEN, treeshakenGzip: $WEBGL_TREESHAKEN_GZIP, filesize2: $WEBGPU_FILESIZE, gzip2: $WEBGPU_FILESIZE_GZIP, treeshaken2: $WEBGPU_TREESHAKEN, treeshakenGzip2: $WEBGPU_TREESHAKEN_GZIP, filesize3: $WEBGPU_NODES_FILESIZE, gzip3: $WEBGPU_NODES_FILESIZE_GZIP, treeshaken3: $WEBGPU_NODES_TREESHAKEN, treeshakenGzip3: $WEBGPU_NODES_TREESHAKEN_GZIP, pr: $PR })" > sizes.json
+          node -pe "JSON.stringify({ coreFilesize: $CORE_FILESIZE, coreGzip: $CORE_FILESIZE_GZIP, filesize: $WEBGL_FILESIZE, gzip: $WEBGL_FILESIZE_GZIP, treeshaken: $WEBGL_TREESHAKEN, treeshakenGzip: $WEBGL_TREESHAKEN_GZIP, filesize2: $WEBGPU_FILESIZE, gzip2: $WEBGPU_FILESIZE_GZIP, treeshaken2: $WEBGPU_TREESHAKEN, treeshakenGzip2: $WEBGPU_TREESHAKEN_GZIP, filesize3: $WEBGPU_NODES_FILESIZE, gzip3: $WEBGPU_NODES_FILESIZE_GZIP, treeshaken3: $WEBGPU_NODES_TREESHAKEN, treeshakenGzip3: $WEBGPU_NODES_TREESHAKEN_GZIP, pr: $PR })" > sizes.json
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/report-size.yml
+++ b/.github/workflows/report-size.yml
@@ -74,9 +74,14 @@ jobs:
         id: read-size
         run: |
           # minify the builds to measure their size
+          npx terser build/three.core.js --module --compress --mangle --output build/three.core.min.js
           npx terser build/three.module.js --module --compress --mangle --output build/three.module.min.js
           npx terser build/three.webgpu.js --module --compress --mangle --output build/three.webgpu.min.js
           npx terser build/three.webgpu.nodes.js --module --compress --mangle --output build/three.webgpu.nodes.min.js
+
+          CORE_FILESIZE_BASE=$(stat --format=%s build/three.core.min.js)
+          gzip -k build/three.core.min.js
+          CORE_FILESIZE_BASE_GZIP=$(stat --format=%s build/three.core.min.js.gz)
 
           WEBGL_FILESIZE_BASE=$(stat --format=%s build/three.module.min.js)
           gzip -k build/three.module.min.js
@@ -100,6 +105,12 @@ jobs:
           WEBGPU_NODES_TREESHAKEN_BASE_GZIP=$(stat --format=%s test/treeshake/index.webgpu.nodes.bundle.min.js.gz)
 
           # log to console
+          echo "CORE_FILESIZE_BASE=$CORE_FILESIZE_BASE"
+          echo "CORE_FILESIZE_BASE_GZIP=$CORE_FILESIZE_BASE_GZIP"
+
+          echo "CORE_FILESIZE_BASE=$CORE_FILESIZE_BASE" >> $GITHUB_OUTPUT
+          echo "CORE_FILESIZE_BASE_GZIP=$CORE_FILESIZE_BASE_GZIP" >> $GITHUB_OUTPUT
+
           echo "WEBGL_FILESIZE_BASE=$WEBGL_FILESIZE_BASE"
           echo "WEBGL_FILESIZE_BASE_GZIP=$WEBGL_FILESIZE_BASE_GZIP"
           echo "WEBGL_TREESHAKEN_BASE=$WEBGL_TREESHAKEN_BASE"
@@ -135,6 +146,10 @@ jobs:
         # It's important these are passed as env variables.
         # https://securitylab.github.com/research/github-actions-untrusted-input/
         env:
+          CORE_FILESIZE: ${{ fromJSON(steps.download-artifact.outputs.result).coreFilesize }}
+          CORE_FILESIZE_GZIP: ${{ fromJSON(steps.download-artifact.outputs.result).coreGzip }}
+          CORE_FILESIZE_BASE: ${{ steps.read-size.outputs.CORE_FILESIZE_BASE }}
+          CORE_FILESIZE_BASE_GZIP: ${{ steps.read-size.outputs.CORE_FILESIZE_BASE_GZIP }}
           WEBGL_FILESIZE: ${{ fromJSON(steps.download-artifact.outputs.result).filesize }}
           WEBGL_FILESIZE_GZIP: ${{ fromJSON(steps.download-artifact.outputs.result).gzip }}
           WEBGL_FILESIZE_BASE: ${{ steps.read-size.outputs.WEBGL_FILESIZE_BASE }}
@@ -160,6 +175,13 @@ jobs:
           WEBGPU_NODES_TREESHAKEN_BASE: ${{ steps.read-size.outputs.WEBGPU_NODES_TREESHAKEN_BASE }}
           WEBGPU_NODES_TREESHAKEN_BASE_GZIP: ${{ steps.read-size.outputs.WEBGPU_NODES_TREESHAKEN_BASE_GZIP }}
         run: |
+          CORE_FILESIZE_FORM=$(node ./test/treeshake/utils/format-size.js "$CORE_FILESIZE")
+          CORE_FILESIZE_GZIP_FORM=$(node ./test/treeshake/utils/format-size.js "$CORE_FILESIZE_GZIP")
+          CORE_FILESIZE_BASE_FORM=$(node ./test/treeshake/utils/format-size.js "$CORE_FILESIZE_BASE")
+          CORE_FILESIZE_BASE_GZIP_FORM=$(node ./test/treeshake/utils/format-size.js "$CORE_FILESIZE_BASE_GZIP")
+          CORE_FILESIZE_DIFF=$(node ./test/treeshake/utils/format-diff.js "$CORE_FILESIZE" "$CORE_FILESIZE_BASE")
+          CORE_FILESIZE_DIFF_GZIP=$(node ./test/treeshake/utils/format-diff.js "$CORE_FILESIZE_GZIP" "$CORE_FILESIZE_BASE_GZIP")
+
           WEBGL_FILESIZE_FORM=$(node ./test/treeshake/utils/format-size.js "$WEBGL_FILESIZE")
           WEBGL_FILESIZE_GZIP_FORM=$(node ./test/treeshake/utils/format-size.js "$WEBGL_FILESIZE_GZIP")
           WEBGL_FILESIZE_BASE_FORM=$(node ./test/treeshake/utils/format-size.js "$WEBGL_FILESIZE_BASE")
@@ -201,6 +223,13 @@ jobs:
           WEBGPU_NODES_TREESHAKEN_BASE_GZIP_FORM=$(node ./test/treeshake/utils/format-size.js "$WEBGPU_NODES_TREESHAKEN_BASE_GZIP")
           WEBGPU_NODES_TREESHAKEN_DIFF=$(node ./test/treeshake/utils/format-diff.js "$WEBGPU_NODES_TREESHAKEN" "$WEBGPU_NODES_TREESHAKEN_BASE")
           WEBGPU_NODES_TREESHAKEN_DIFF_GZIP=$(node ./test/treeshake/utils/format-diff.js "$WEBGPU_NODES_TREESHAKEN_GZIP" "$WEBGPU_NODES_TREESHAKEN_BASE_GZIP")
+
+          echo "CORE_FILESIZE=$CORE_FILESIZE_FORM" >> $GITHUB_OUTPUT
+          echo "CORE_FILESIZE_GZIP=$CORE_FILESIZE_GZIP_FORM" >> $GITHUB_OUTPUT
+          echo "CORE_FILESIZE_BASE=$CORE_FILESIZE_BASE_FORM" >> $GITHUB_OUTPUT
+          echo "CORE_FILESIZE_BASE_GZIP=$CORE_FILESIZE_BASE_GZIP_FORM" >> $GITHUB_OUTPUT
+          echo "CORE_FILESIZE_DIFF=$CORE_FILESIZE_DIFF" >> $GITHUB_OUTPUT
+          echo "CORE_FILESIZE_DIFF_GZIP=$CORE_FILESIZE_DIFF_GZIP" >> $GITHUB_OUTPUT
 
           echo "WEBGL_FILESIZE=$WEBGL_FILESIZE_FORM" >> $GITHUB_OUTPUT
           echo "WEBGL_FILESIZE_GZIP=$WEBGL_FILESIZE_GZIP_FORM" >> $GITHUB_OUTPUT
@@ -264,6 +293,7 @@ jobs:
 
             || Before | After | Diff |
             |:-:|:-:|:-:|:-:|
+            | Core | ${{ steps.format.outputs.CORE_FILESIZE_BASE }} <br> **${{ steps.format.outputs.CORE_FILESIZE_BASE_GZIP }}** | ${{ steps.format.outputs.CORE_FILESIZE }} <br> **${{ steps.format.outputs.CORE_FILESIZE_GZIP }}** | ${{ steps.format.outputs.CORE_FILESIZE_DIFF }} <br> **${{ steps.format.outputs.CORE_FILESIZE_DIFF_GZIP }}** |
             | WebGL | ${{ steps.format.outputs.WEBGL_FILESIZE_BASE }} <br> **${{ steps.format.outputs.WEBGL_FILESIZE_BASE_GZIP }}** | ${{ steps.format.outputs.WEBGL_FILESIZE }} <br> **${{ steps.format.outputs.WEBGL_FILESIZE_GZIP }}** | ${{ steps.format.outputs.WEBGL_FILESIZE_DIFF }} <br> **${{ steps.format.outputs.WEBGL_FILESIZE_DIFF_GZIP }}** |
             | WebGPU | ${{ steps.format.outputs.WEBGPU_FILESIZE_BASE }} <br> **${{ steps.format.outputs.WEBGPU_FILESIZE_BASE_GZIP }}** | ${{ steps.format.outputs.WEBGPU_FILESIZE }} <br> **${{ steps.format.outputs.WEBGPU_FILESIZE_GZIP }}** | ${{ steps.format.outputs.WEBGPU_FILESIZE_DIFF }} <br> **${{ steps.format.outputs.WEBGPU_FILESIZE_DIFF_GZIP }}** |
             | WebGPU Nodes | ${{ steps.format.outputs.WEBGPU_NODES_FILESIZE_BASE }} <br> **${{ steps.format.outputs.WEBGPU_NODES_FILESIZE_BASE_GZIP }}** | ${{ steps.format.outputs.WEBGPU_NODES_FILESIZE }} <br> **${{ steps.format.outputs.WEBGPU_NODES_FILESIZE_GZIP }}** | ${{ steps.format.outputs.WEBGPU_NODES_FILESIZE_DIFF }} <br> **${{ steps.format.outputs.WEBGPU_NODES_FILESIZE_DIFF_GZIP }}** |


### PR DESCRIPTION
**Description**

Since the r171 build split, `three.module.js` / `three.webgpu.js` / `three.webgpu.nodes.js` only re-export from `three.core.js`, and terser does not follow imports. So the "Bundle size" table has only been measuring the renderer entry files, and any change to core (math, loaders, materials, lights, ...) showed up as ~0 B. Example: #34326 moves ~3 kB minified / ~0.9 kB gzipped out of core and reported +3 B / -1 B.

This adds a **Core** row (`three.core.js`, minified and gzipped) to the report. Existing rows and the tree-shaking table are unchanged.

Expected table for #34326 after this lands:

|| Before | After | Diff |
|:-:|:-:|:-:|:-:|
| Core | 391.61 <br> **103.03** | 388.49 <br> **102.1** | -3.12 kB <br> **-933 B** |
| WebGL | 372.43 <br> **87.92** | 372.43 <br> **87.92** | +3 B <br> **-1 B** |
| WebGPU | 700.29 <br> **193.24** | 700.3 <br> **193.24** | +3 B <br> **-2 B** |

Note: `report-size.yml` runs from `dev`, so the new row only appears in PR comments after this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZaruZgTn81CcXPMEbLLLX
