### PR TITLE
Backends: Don't scale render target viewports by the pixel ratio.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1264,9 +1264,9 @@ class WebGLBackend extends Backend {
 
 			}
 
-			const pixelRatio = this.renderer.getPixelRatio();
-
 			const renderTarget = this._currentContext.renderTarget;
+
+			const pixelRatio = renderTarget !== null ? 1 : this.renderer.getPixelRatio();
 			const isRenderCameraDepthArray = this._isRenderCameraDepthArray( this._currentContext );
 			const prevActiveCubeFace = this._currentContext.activeCubeFace;
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2257,7 +2257,7 @@ class WebGPUBackend extends Backend {
 
 			}
 
-			const pixelRatio = this.renderer.getPixelRatio();
+			const pixelRatio = context.renderTarget !== null ? 1 : this.renderer.getPixelRatio();
 			const indexPos = cameraIndex ? bindings.indexOf( cameraIndex ) : - 1;
 
 			for ( let i = 0, len = cameras.length; i < len; i ++ ) {


### PR DESCRIPTION
Extracted from #34259, as suggested in https://github.com/mrdoob/three.js/pull/34259#discussion_r3789755185.

**Description**

In the array camera path of `_draw()`, both backends scale the per-camera viewports by the renderer's pixel ratio even when rendering into a render target. Render target viewports must not be scaled: the renderer already forces `_currentPixelRatio = 1` for render targets everywhere else, so at a pixel ratio above 1 an `ArrayCamera` rendering into a render target gets misplaced sub-viewports. Not visible in the E2E suite because it runs at pixel ratio 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)