### PR TITLE
WebGPURenderer: Load the WebGL fallback on demand.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ test/treeshake/index.webgpu.bundle.js
 test/treeshake/index.webgpu.bundle.min.js
 test/treeshake/index.webgpu.nodes.bundle.js
 test/treeshake/index.webgpu.nodes.bundle.min.js
+test/treeshake/index.webgpu.bundle.*.js
+test/treeshake/index.webgpu.nodes.bundle.*.js
 test/unit/build
 
 **/node_modules

--- a/examples/jsm/inspector/tabs/Settings.js
+++ b/examples/jsm/inspector/tabs/Settings.js
@@ -1,5 +1,5 @@
 import { Parameters } from './Parameters.js';
-import { WebGPURenderer, WebGLBackend, Node } from 'three/webgpu';
+import { WebGPURenderer, Node } from 'three/webgpu';
 import { getItem, setItem } from '../Inspector.js';
 
 const _extensions = [
@@ -21,13 +21,8 @@ function forceWebGL( enable ) {
 
 		WebGPURenderer.prototype.init = async function () {
 
-			if ( this.backend.isWebGLBackend !== true ) {
-
-				const parameters = this.backend.parameters;
-
-				this.backend = new WebGLBackend( parameters );
-
-			}
+			// makes the renderer load its WebGL fallback instead of initializing WebGPU
+			this.backend.parameters.forceWebGL = true;
 
 			return _init.call( this );
 

--- a/examples/jsm/tsl/WebGLNodesHandler.js
+++ b/examples/jsm/tsl/WebGLNodesHandler.js
@@ -21,10 +21,9 @@ import {
 	NodeFrame,
 	Lighting,
 	InspectorBase,
-	GLSLNodeBuilder,
 	BasicNodeLibrary,
-	WebGLCapabilities,
 } from 'three/webgpu';
+import { GLSLNodeBuilder, WebGLCapabilities } from 'three/webgpu/fallback';
 
 // Limitations
 // - VSM shadows not supported

--- a/examples/webgl_tsl_clearcoat.html
+++ b/examples/webgl_tsl_clearcoat.html
@@ -26,6 +26,7 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/webgpu": "../build/three.webgpu.js",
+					"three/webgpu/fallback": "../build/three.webgpu.fallback.js",
 					"three/tsl": "../build/three.tsl.js",
 					"three/addons/": "./jsm/"
 				}

--- a/examples/webgl_tsl_instancing.html
+++ b/examples/webgl_tsl_instancing.html
@@ -35,6 +35,7 @@
 			"imports": {
 				"three": "../build/three.module.js",
 				"three/webgpu": "../build/three.webgpu.js",
+				"three/webgpu/fallback": "../build/three.webgpu.fallback.js",
 				"three/addons/": "./jsm/",
 				"three/tsl": "../build/three.tsl.js"
 			}

--- a/examples/webgl_tsl_shadowmap.html
+++ b/examples/webgl_tsl_shadowmap.html
@@ -29,6 +29,7 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/webgpu": "../build/three.webgpu.js",
+					"three/webgpu/fallback": "../build/three.webgpu.fallback.js",
 					"three/tsl": "../build/three.tsl.js",
 					"three/addons/": "./jsm/"
 				}

--- a/examples/webgl_tsl_skinning.html
+++ b/examples/webgl_tsl_skinning.html
@@ -29,6 +29,7 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/webgpu": "../build/three.webgpu.js",
+					"three/webgpu/fallback": "../build/three.webgpu.fallback.js",
 					"three/tsl": "../build/three.tsl.js",
 					"three/addons/": "./jsm/"
 				}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "./addons/*": "./examples/jsm/*",
     "./src/*": "./src/*",
     "./webgpu": "./build/three.webgpu.js",
+    "./webgpu/fallback": "./build/three.webgpu.fallback.js",
     "./tsl": "./build/three.tsl.js"
   },
   "repository": {

--- a/src/Three.WebGPU.Fallback.js
+++ b/src/Three.WebGPU.Fallback.js
@@ -1,0 +1,3 @@
+export { default as WebGLBackend } from './renderers/webgl-fallback/WebGLBackend.js';
+export { default as WebGLCapabilities } from './renderers/webgl-fallback/utils/WebGLCapabilities.js';
+export { default as GLSLNodeBuilder } from './renderers/webgl-fallback/nodes/GLSLNodeBuilder.js';

--- a/src/Three.WebGPU.Nodes.js
+++ b/src/Three.WebGPU.Nodes.js
@@ -3,7 +3,6 @@ export * from './Three.Core.js';
 export * from './materials/nodes/NodeMaterials.js';
 export { default as WebGPURenderer } from './renderers/webgpu/WebGPURenderer.Nodes.js';
 export { default as WebGPUBackend } from './renderers/webgpu/WebGPUBackend.js';
-export { default as WebGLBackend } from './renderers/webgl-fallback/WebGLBackend.js';
 export { default as Lighting } from './renderers/common/Lighting.js';
 export { default as BundleGroup } from './renderers/common/BundleGroup.js';
 export { default as QuadMesh } from './renderers/common/QuadMesh.js';

--- a/src/Three.WebGPU.js
+++ b/src/Three.WebGPU.js
@@ -3,10 +3,8 @@ export * from './Three.Core.js';
 export * from './materials/nodes/NodeMaterials.js';
 export { default as WebGPURenderer } from './renderers/webgpu/WebGPURenderer.js';
 export { default as WebGPUBackend } from './renderers/webgpu/WebGPUBackend.js';
-export { default as WebGLBackend } from './renderers/webgl-fallback/WebGLBackend.js';
 export { default as Renderer } from './renderers/common/Renderer.js';
 export { default as Backend } from './renderers/common/Backend.js';
-export { default as WebGLCapabilities } from './renderers/webgl-fallback/utils/WebGLCapabilities.js';
 export { default as Lighting } from './renderers/common/Lighting.js';
 export { default as BundleGroup } from './renderers/common/BundleGroup.js';
 export { default as QuadMesh } from './renderers/common/QuadMesh.js';
@@ -32,7 +30,6 @@ export { default as NodeMaterialLoader } from './loaders/nodes/NodeMaterialLoade
 export { default as InspectorBase } from './renderers/common/InspectorBase.js';
 export { default as CanvasTarget } from './renderers/common/CanvasTarget.js';
 export { default as BlendMode } from './renderers/common/BlendMode.js';
-export { default as GLSLNodeBuilder } from './renderers/webgl-fallback/nodes/GLSLNodeBuilder.js';
 export { default as BasicNodeLibrary } from './renderers/webgpu/nodes/BasicNodeLibrary.js';
 export { default as StandardNodeLibrary } from './renderers/webgpu/nodes/StandardNodeLibrary.js';
 export { default as WGSLNodeBuilder } from './renderers/webgpu/nodes/WGSLNodeBuilder.js';

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -67,6 +67,7 @@ class Renderer {
 	 * @property {number} [samples=0] - When `antialias` is `true`, `4` samples are used by default. This parameter can set to any other integer value than 0
 	 * to overwrite the default.
 	 * @property {?Function} [getFallback=null] - This callback function can be used to provide a fallback backend, if the primary backend can't be targeted.
+	 * The callback can return the backend directly or as a Promise.
 	 * @property {number} [outputBufferType=HalfFloatType] - Defines the type of output buffers. The default `HalfFloatType` is recommend for best
 	 * quality. To save memory and bandwidth, `UnsignedByteType` might be used. This will reduce rendering quality though.
 	 * @property {boolean} [multiview=false] - If set to `true`, the renderer will use multiview during WebXR rendering if supported.
@@ -805,7 +806,7 @@ class Renderer {
 
 					try {
 
-						this.backend = backend = this._getFallback( error );
+						this.backend = backend = await this._getFallback( error );
 						await backend.init( this );
 
 					} catch ( error ) {

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -206,6 +206,12 @@ class WebGPUBackend extends Backend {
 
 		const parameters = this.parameters;
 
+		if ( parameters.forceWebGL === true ) {
+
+			throw new Error( 'THREE.WebGPUBackend: WebGL 2 backend requested via "forceWebGL".' );
+
+		}
+
 		// create the device if it is not passed with parameters
 
 		let device;

--- a/src/renderers/webgpu/WebGPURenderer.Nodes.js
+++ b/src/renderers/webgpu/WebGPURenderer.Nodes.js
@@ -1,5 +1,4 @@
 import Renderer from '../common/Renderer.js';
-import WebGLBackend from '../webgl-fallback/WebGLBackend.js';
 import WebGPUBackend from './WebGPUBackend.js';
 import BasicNodeLibrary from './nodes/BasicNodeLibrary.js';
 import { warn } from '../../utils.js';
@@ -20,27 +19,17 @@ class WebGPURenderer extends Renderer {
 	 */
 	constructor( parameters = {} ) {
 
-		let BackendClass;
+		const backend = new WebGPUBackend( parameters );
 
-		if ( parameters.forceWebGL ) {
+		parameters.getFallback = async () => {
 
-			BackendClass = WebGLBackend;
+			if ( backend.parameters.forceWebGL !== true ) warn( 'WebGPURenderer: WebGPU is not available, running under WebGL2 backend.' );
 
-		} else {
+			const { WebGLBackend } = await import( '../../Three.WebGPU.Fallback.js' );
 
-			BackendClass = WebGPUBackend;
+			return new WebGLBackend( parameters );
 
-			parameters.getFallback = () => {
-
-				warn( 'WebGPURenderer: WebGPU is not available, running under WebGL2 backend.' );
-
-				return new WebGLBackend( parameters );
-
-			};
-
-		}
-
-		const backend = new BackendClass( parameters );
+		};
 
 		super( backend, parameters );
 

--- a/src/renderers/webgpu/WebGPURenderer.js
+++ b/src/renderers/webgpu/WebGPURenderer.js
@@ -1,5 +1,4 @@
 import Renderer from '../common/Renderer.js';
-import WebGLBackend from '../webgl-fallback/WebGLBackend.js';
 import WebGPUBackend from './WebGPUBackend.js';
 import StandardNodeLibrary from './nodes/StandardNodeLibrary.js';
 import { warn } from '../../utils.js';
@@ -39,6 +38,7 @@ class WebGPURenderer extends Renderer {
 	 * @property {boolean} [antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
 	 * @property {number} [samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
 	 * @property {boolean} [forceWebGL=false] - If set to `true`, the renderer uses a WebGL 2 backend no matter if WebGPU is supported or not.
+	 * The WebGL 2 backend is loaded on demand during `init()`.
 	 * @property {boolean} [multiview=false] - If set to `true`, the renderer will use multiview during WebXR rendering if supported.
 	 * @property {number} [outputType=undefined] - Texture type for output to canvas. By default, device's preferred format is used; other formats may incur overhead.
 	 * @property {number} [outputBufferType=HalfFloatType] - Defines the type of output buffers. The default `HalfFloatType` is recommend for best
@@ -52,27 +52,17 @@ class WebGPURenderer extends Renderer {
 	 */
 	constructor( parameters = {} ) {
 
-		let BackendClass;
+		const backend = new WebGPUBackend( parameters );
 
-		if ( parameters.forceWebGL ) {
+		parameters.getFallback = async () => {
 
-			BackendClass = WebGLBackend;
+			if ( backend.parameters.forceWebGL !== true ) warn( 'WebGPURenderer: WebGPU is not available, running under WebGL2 backend.' );
 
-		} else {
+			const { WebGLBackend } = await import( '../../Three.WebGPU.Fallback.js' );
 
-			BackendClass = WebGPUBackend;
+			return new WebGLBackend( parameters );
 
-			parameters.getFallback = () => {
-
-				warn( 'WebGPURenderer: WebGPU is not available, running under WebGL2 backend.' );
-
-				return new WebGLBackend( parameters );
-
-			};
-
-		}
-
-		const backend = new BackendClass( parameters );
+		};
 
 		//super( new Proxy( backend, debugHandler ) );
 		super( backend, parameters );

--- a/test/rollup.treeshake.config.js
+++ b/test/rollup.treeshake.config.js
@@ -18,7 +18,7 @@ function filesize() {
 
 					const size = ( chunk.code.length / 1024 ).toFixed( 2 ) + ' KB';
 					const gzipped = ( gzipSync( chunk.code ).length / 1024 ).toFixed( 2 ) + ' KB';
-					const destination = options.file;
+					const destination = options.file || options.dir + '/' + chunk.fileName;
 
 					const lines = [
 						{ label: 'Destination: ', value: destination },
@@ -84,7 +84,9 @@ export default [
 		output: [
 			{
 				format: 'esm',
-				file: 'test/treeshake/index.webgpu.bundle.js'
+				dir: 'test/treeshake',
+				entryFileNames: 'index.webgpu.bundle.js',
+				chunkFileNames: 'index.webgpu.bundle.[name].js'
 			}
 		]
 	},
@@ -98,7 +100,9 @@ export default [
 		output: [
 			{
 				format: 'esm',
-				file: 'test/treeshake/index.webgpu.bundle.min.js'
+				dir: 'test/treeshake',
+				entryFileNames: 'index.webgpu.bundle.min.js',
+				chunkFileNames: 'index.webgpu.bundle.[name].min.js'
 			}
 		]
 	},
@@ -110,7 +114,9 @@ export default [
 		output: [
 			{
 				format: 'esm',
-				file: 'test/treeshake/index.webgpu.nodes.bundle.js'
+				dir: 'test/treeshake',
+				entryFileNames: 'index.webgpu.nodes.bundle.js',
+				chunkFileNames: 'index.webgpu.nodes.bundle.[name].js'
 			}
 		]
 	},
@@ -124,7 +130,9 @@ export default [
 		output: [
 			{
 				format: 'esm',
-				file: 'test/treeshake/index.webgpu.nodes.bundle.min.js'
+				dir: 'test/treeshake',
+				entryFileNames: 'index.webgpu.nodes.bundle.min.js',
+				chunkFileNames: 'index.webgpu.nodes.bundle.[name].min.js'
 			}
 		]
 	}

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -1,4 +1,5 @@
 import MagicString from 'magic-string';
+import path from 'path';
 
 function glsl() {
 
@@ -59,15 +60,63 @@ function header() {
 
 }
 
+// The WebGL fallback backend of WebGPURenderer is a separate entry so it is only loaded when needed.
+// Rollup would otherwise split the modules shared between entries into extra chunks, so every module
+// is assigned to the chunk of the first entry that reaches it, which mirrors the default placement.
+function chunks( input ) {
+
+	let chunkByModule = null;
+
+	return ( id, { getModuleInfo } ) => {
+
+		if ( chunkByModule === null ) {
+
+			chunkByModule = new Map();
+
+			for ( const [ chunkName, entry ] of Object.entries( input ) ) {
+
+				const stack = [ path.resolve( entry ) ];
+
+				while ( stack.length > 0 ) {
+
+					const moduleId = stack.pop();
+
+					if ( chunkByModule.has( moduleId ) ) continue;
+
+					chunkByModule.set( moduleId, chunkName );
+					stack.push( ...getModuleInfo( moduleId ).importedIds );
+
+				}
+
+			}
+
+		}
+
+		return chunkByModule.get( id ) || null;
+
+	};
+
+}
+
+const webgpuNodesInput = {
+	'three.core.js': 'src/Three.Core.js',
+	'three.webgpu.nodes.js': 'src/Three.WebGPU.Nodes.js',
+	'three.webgpu.nodes.fallback.js': 'src/Three.WebGPU.Fallback.js',
+};
+
+const webgpuInput = {
+	'three.core.js': 'src/Three.Core.js',
+	'three.module.js': 'src/Three.js',
+	'three.webgpu.js': 'src/Three.WebGPU.js',
+	'three.webgpu.fallback.js': 'src/Three.WebGPU.Fallback.js',
+};
+
 /**
  * @type {Array<import('rollup').RollupOptions>}
  */
 const builds = [
 	{
-		input: {
-			'three.core.js': 'src/Three.Core.js',
-			'three.webgpu.nodes.js': 'src/Three.WebGPU.Nodes.js',
-		},
+		input: webgpuNodesInput,
 		plugins: [
 			glsl(),
 			header()
@@ -79,15 +128,12 @@ const builds = [
 				dir: 'build',
 				minifyInternalExports: false,
 				entryFileNames: '[name]',
+				manualChunks: chunks( webgpuNodesInput )
 			}
 		]
 	},
 	{
-		input: {
-			'three.core.js': 'src/Three.Core.js',
-			'three.module.js': 'src/Three.js',
-			'three.webgpu.js': 'src/Three.WebGPU.js',
-		},
+		input: webgpuInput,
 		plugins: [
 			glsl(),
 			header()
@@ -99,6 +145,7 @@ const builds = [
 				dir: 'build',
 				minifyInternalExports: false,
 				entryFileNames: '[name]',
+				manualChunks: chunks( webgpuInput )
 			}
 		]
 	},


### PR DESCRIPTION
Related to #34218

**Description**

The WebGL 2 fallback of `WebGPURenderer` is now a separate entry (`build/three.webgpu.fallback.js`, `three/webgpu/fallback`) that the renderer imports dynamically in `init()` when WebGPU is not available or `forceWebGL` is set. Bundlers and browsers with WebGPU support no longer load it.

- `Renderer.init()` awaits `getFallback()`; `WebGPUBackend.init()` bails out when `forceWebGL` is set so the same path is used.
- Build: fallback is an additional rollup input, `manualChunks` keeps every other module where it is today (`three.core.js`, `three.module.js`, `three.tsl.js` are byte-identical).
- `WebGLNodesHandler` and the Inspector's "Force WebGL" setting adapted.

**API change:** `WebGLBackend`, `WebGLCapabilities` and `GLSLNodeBuilder` moved from `three/webgpu` to `three/webgpu/fallback`. Keeping them in `three/webgpu` makes the chunk a static import that circularly imports `three.webgpu.js`, which fails with importmaps (TDZ on `class GLSLNodeBuilder extends NodeBuilder`).

Tree-shaken bundle (minified / gzipped):

| | Before | After | Diff |
|:-:|:-:|:-:|:-:|
| WebGPU | 774,286 <br> **208,727** | 680,858 <br> **184,453** | -93.4 kB (-12.1%) <br> **-24.3 kB (-11.6%)** |
| WebGPU Nodes | 723,250 | 629,832 | -93.4 kB |
| on-demand chunk | | 97,106 <br> **26,307** | |

Verified with the built files via importmap: WebGPU-capable browsers fetch only `three.webgpu.js` + `three.core.js`; `forceWebGL`, no `navigator.gpu` and the Inspector toggle all end up on `WebGLBackend` with the chunk loaded on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZaruZgTn81CcXPMEbLLLX
