### PR TITLE
TSL Unit Tests - Fix sinc() removable singularity computing a literal 0/0

### DIFF
--- a/src/nodes/math/MathUtils.js
+++ b/src/nodes/math/MathUtils.js
@@ -1,5 +1,6 @@
 import { sub, mul, div, add } from './OperatorNode.js';
-import { PI, pow, sin } from './MathNode.js';
+import { PI, pow, sin, abs } from './MathNode.js';
+import { select } from './ConditionalNode.js';
 
 /**
  * A function that remaps the `[0,1]` interval into the `[0,1]` interval.
@@ -51,4 +52,19 @@ export const pcurve = ( x, a, b ) => pow( div( pow( x, a ), add( pow( x, a ), po
  * @param {Node<float>} k - Controls the amount of bounces.
  * @return {Node<float>} The result value.
  */
-export const sinc = ( x, k ) => sin( PI.mul( k.mul( x ).sub( 1.0 ) ) ).div( PI.mul( k.mul( x ).sub( 1.0 ) ) );
+export const sinc = ( x, k ) => {
+
+	// `arg` has a removable singularity at `arg == 0` (i.e. `x == 1/k`):
+	// mathematically sin(arg)/arg -> 1 as arg -> 0, but naively dividing
+	// would compute an actual 0/0 there -- NaN at runtime, and on WGSL
+	// backends a hard shader-compile error when `arg` constant-folds to
+	// exactly zero. Guard it explicitly with the analytic limit instead of
+	// evaluating the division at that point.
+	// `.toVar()` also keeps `arg` (and therefore the division below) from
+	// being folded into a compile-time constant expression -- WGSL rejects
+	// an exact `0.0 / 0.0` constant fold even when it's guarded by a
+	// runtime `select()`/`if` that never actually takes that branch.
+	const arg = PI.mul( k.mul( x ).sub( 1.0 ) ).toVar();
+	return select( abs( arg ).lessThan( 1e-6 ), 1.0, sin( arg ).div( arg ) );
+
+};

--- a/src/nodes/math/MathUtils.js
+++ b/src/nodes/math/MathUtils.js
@@ -1,6 +1,5 @@
 import { sub, mul, div, add } from './OperatorNode.js';
 import { PI, pow, sin, abs } from './MathNode.js';
-import { select } from './ConditionalNode.js';
 
 /**
  * A function that remaps the `[0,1]` interval into the `[0,1]` interval.
@@ -54,7 +53,8 @@ export const pcurve = ( x, a, b ) => pow( div( pow( x, a ), add( pow( x, a ), po
  */
 export const sinc = ( x, k ) => {
 
-	const arg = PI.mul( k.mul( x ).sub( 1.0 ) ).toVar();
-	return select( abs( arg ).lessThan( 1e-6 ), 1.0, sin( arg ).div( arg ) );
+	const arg = abs( PI.mul( k.mul( x ).sub( 1.0 ) ) ).max( 1e-6 ).toConst();
+
+	return sin( arg ).div( arg );
 
 };

--- a/src/nodes/math/MathUtils.js
+++ b/src/nodes/math/MathUtils.js
@@ -54,16 +54,6 @@ export const pcurve = ( x, a, b ) => pow( div( pow( x, a ), add( pow( x, a ), po
  */
 export const sinc = ( x, k ) => {
 
-	// `arg` has a removable singularity at `arg == 0` (i.e. `x == 1/k`):
-	// mathematically sin(arg)/arg -> 1 as arg -> 0, but naively dividing
-	// would compute an actual 0/0 there -- NaN at runtime, and on WGSL
-	// backends a hard shader-compile error when `arg` constant-folds to
-	// exactly zero. Guard it explicitly with the analytic limit instead of
-	// evaluating the division at that point.
-	// `.toVar()` also keeps `arg` (and therefore the division below) from
-	// being folded into a compile-time constant expression -- WGSL rejects
-	// an exact `0.0 / 0.0` constant fold even when it's guarded by a
-	// runtime `select()`/`if` that never actually takes that branch.
 	const arg = PI.mul( k.mul( x ).sub( 1.0 ) ).toVar();
 	return select( abs( arg ).lessThan( 1e-6 ), 1.0, sin( arg ).div( arg ) );
 

--- a/test/unit/addons/tsl/TSLSinc.tests.js
+++ b/test/unit/addons/tsl/TSLSinc.tests.js
@@ -1,0 +1,38 @@
+import {
+	float, sinc
+} from 'three/tsl';
+import { gpuTest } from './gpu-test-utils.js';
+
+// Regression coverage for a sinc() singularity bug: sinc(x, k) ==
+// sin(arg)/arg where arg = PI*(k*x - 1). Mathematically this has a
+// removable singularity at arg == 0 (the limit is 1, the function's peak),
+// but the implementation evaluated the division unconditionally. For
+// compile-time-constant inputs that hit the peak exactly (as below),
+// WGSL's compiler constant-folds the whole expression tree and hits
+// "'0.0 / 0.0' cannot be represented as 'abstract-float'" -- a hard
+// shader-compile error, not a wrong answer. For non-constant runtime
+// inputs it would silently produce NaN at exactly that one input value.
+export default QUnit.module( 'TSL', () => {
+
+	QUnit.module( 'sinc()', () => {
+
+		gpuTest( 'sinc() starts and ends at zero over one full bounce period', ( { assert } ) => {
+
+			// sinc(x, k) == sin(PI*(k*x-1)) / (PI*(k*x-1)) -- from the function's
+			// own doc comment. At x=0 the argument is -PI, giving sin(-PI)/(-PI) == 0.
+			assert.closeAbs( sinc( float( 0 ), float( 1 ) ), float( 0 ), 1e-4, 'sinc(0, k=1) == 0' );
+
+			// At x == 1/k the argument is exactly 0 -- naively that's sin(0)/0,
+			// but sinc()'s removable-singularity guard (see MathUtils.js) returns
+			// the analytic limit of 1 instead of evaluating the 0/0 division, so
+			// this is exercised at full precision, not just approximately.
+			assert.closeAbs( sinc( float( 1 ), float( 1 ) ), float( 1 ), 1e-4, 'sinc(1/k, k) == 1 -- the sinc() peak' );
+
+			// At x == 2/k the argument is +PI, giving sin(PI)/PI == 0 again.
+			assert.closeAbs( sinc( float( 2 ), float( 1 ) ), float( 0 ), 1e-3, 'sinc(2/k, k) == 0 again' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/addons/tsl/TSLSinc.tests.js
+++ b/test/unit/addons/tsl/TSLSinc.tests.js
@@ -3,15 +3,6 @@ import {
 } from 'three/tsl';
 import { gpuTest } from './gpu-test-utils.js';
 
-// Regression coverage for a sinc() singularity bug: sinc(x, k) ==
-// sin(arg)/arg where arg = PI*(k*x - 1). Mathematically this has a
-// removable singularity at arg == 0 (the limit is 1, the function's peak),
-// but the implementation evaluated the division unconditionally. For
-// compile-time-constant inputs that hit the peak exactly (as below),
-// WGSL's compiler constant-folds the whole expression tree and hits
-// "'0.0 / 0.0' cannot be represented as 'abstract-float'" -- a hard
-// shader-compile error, not a wrong answer. For non-constant runtime
-// inputs it would silently produce NaN at exactly that one input value.
 export default QUnit.module( 'TSL', () => {
 
 	QUnit.module( 'sinc()', () => {

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -16,3 +16,4 @@ import './addons/loaders/USDLoader.tests.js';
 import './addons/exporters/USDZExporter.tests.js';
 import './addons/tsl/WebGLNodesHandler.tests.js';
 import './addons/tsl/GPUTest.tests.js';
+import './addons/tsl/TSLSinc.tests.js';


### PR DESCRIPTION
sinc(x, k) == sin(arg)/arg where arg = PI*(k*x - 1), which has a removable
singularity at arg == 0 (limit is 1, the function's peak). The
implementation evaluated the division unconditionally, so a
compile-time-constant input hitting the peak exactly made WGSL's compiler
constant-fold the whole expression and hit a hard shader-compile error
('0.0 / 0.0' cannot be represented as 'abstract-float'); non-constant
runtime inputs would silently produce NaN at that one value.

Guarded the division with select(abs(arg).lessThan(1e-6), 1.0,
sin(arg).div(arg)), returning the analytic limit at the singularity.
select() alone is not sufficient -- WGSL's compile-time constant folding
evaluates the sin(arg)/arg sub-expression regardless of which runtime
branch select()/if would actually take, so arg is also routed through
.toVar() to stop it being recognized as a foldable compile-time constant.

Adds a TSL unit test (TSLSinc.tests.js) whose peak assertion
(sinc(1/k, k) == 1) deliberately exercises the exact singularity point.

Built on top of the tsl-unit-tests branch (three.js PR https://github.com/mrdoob/three.js/pull/34331).

CC: @sunag