### PR TITLE
TSL Unit Tests - Fix rotate() 3D Euler-angle path rotating in the wrong direction

### DIFF
--- a/src/nodes/utils/RotateNode.js
+++ b/src/nodes/utils/RotateNode.js
@@ -75,14 +75,6 @@ class RotateNode extends TempNode {
 
 		} else {
 
-			// Note: mat4( v0, v1, v2, v3 ) takes v0..v3 as *columns* (standard
-			// GLSL/WGSL constructor semantics), unlike TSL's flat 16-scalar
-			// mat4(a,b,...,p) constructor, which is row-major (see docs). Each
-			// matrix below is therefore written column-by-column so it matches
-			// the conventional row-major right-hand-rule rotation matrix it's
-			// meant to represent -- e.g. rotationZMatrix's columns are
-			// (cos,sin,0,0)/(-sin,cos,0,0)/(0,0,1,0)/(0,0,0,1), i.e. the
-			// standard [[cos,-sin,0],[sin,cos,0],[0,0,1]] read column-first.
 			const rotation = rotationNode;
 			const rotationXMatrix = mat4( vec4( 1.0, 0.0, 0.0, 0.0 ), vec4( 0.0, cos( rotation.x ), sin( rotation.x ), 0.0 ), vec4( 0.0, sin( rotation.x ).negate(), cos( rotation.x ), 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
 			const rotationYMatrix = mat4( vec4( cos( rotation.y ), 0.0, sin( rotation.y ).negate(), 0.0 ), vec4( 0.0, 1.0, 0.0, 0.0 ), vec4( sin( rotation.y ), 0.0, cos( rotation.y ), 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );

--- a/src/nodes/utils/RotateNode.js
+++ b/src/nodes/utils/RotateNode.js
@@ -75,10 +75,18 @@ class RotateNode extends TempNode {
 
 		} else {
 
+			// Note: mat4( v0, v1, v2, v3 ) takes v0..v3 as *columns* (standard
+			// GLSL/WGSL constructor semantics), unlike TSL's flat 16-scalar
+			// mat4(a,b,...,p) constructor, which is row-major (see docs). Each
+			// matrix below is therefore written column-by-column so it matches
+			// the conventional row-major right-hand-rule rotation matrix it's
+			// meant to represent -- e.g. rotationZMatrix's columns are
+			// (cos,sin,0,0)/(-sin,cos,0,0)/(0,0,1,0)/(0,0,0,1), i.e. the
+			// standard [[cos,-sin,0],[sin,cos,0],[0,0,1]] read column-first.
 			const rotation = rotationNode;
-			const rotationXMatrix = mat4( vec4( 1.0, 0.0, 0.0, 0.0 ), vec4( 0.0, cos( rotation.x ), sin( rotation.x ).negate(), 0.0 ), vec4( 0.0, sin( rotation.x ), cos( rotation.x ), 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
-			const rotationYMatrix = mat4( vec4( cos( rotation.y ), 0.0, sin( rotation.y ), 0.0 ), vec4( 0.0, 1.0, 0.0, 0.0 ), vec4( sin( rotation.y ).negate(), 0.0, cos( rotation.y ), 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
-			const rotationZMatrix = mat4( vec4( cos( rotation.z ), sin( rotation.z ).negate(), 0.0, 0.0 ), vec4( sin( rotation.z ), cos( rotation.z ), 0.0, 0.0 ), vec4( 0.0, 0.0, 1.0, 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
+			const rotationXMatrix = mat4( vec4( 1.0, 0.0, 0.0, 0.0 ), vec4( 0.0, cos( rotation.x ), sin( rotation.x ), 0.0 ), vec4( 0.0, sin( rotation.x ).negate(), cos( rotation.x ), 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
+			const rotationYMatrix = mat4( vec4( cos( rotation.y ), 0.0, sin( rotation.y ).negate(), 0.0 ), vec4( 0.0, 1.0, 0.0, 0.0 ), vec4( sin( rotation.y ), 0.0, cos( rotation.y ), 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
+			const rotationZMatrix = mat4( vec4( cos( rotation.z ), sin( rotation.z ), 0.0, 0.0 ), vec4( sin( rotation.z ).negate(), cos( rotation.z ), 0.0, 0.0 ), vec4( 0.0, 0.0, 1.0, 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
 
 			return rotationXMatrix.mul( rotationYMatrix ).mul( rotationZMatrix ).mul( vec4( positionNode, 1.0 ) ).xyz;
 

--- a/test/unit/addons/tsl/TSLRotate.tests.js
+++ b/test/unit/addons/tsl/TSLRotate.tests.js
@@ -3,23 +3,6 @@ import {
 } from 'three/tsl';
 import { gpuTest } from './gpu-test-utils.js';
 
-// Regression coverage for a rotate() direction bug: rotate()'s 3D
-// (Euler-angle) path rotated in the opposite direction from its own
-// documented 2D case, on all three axes.
-//
-// mat4(v0,v1,v2,v3) (four vec4 arguments) takes v0..v3 as *columns*,
-// matching standard GLSL/WGSL constructor semantics -- unlike TSL's *other*
-// mat4(a,b,...,p) constructor (16 flat scalars), which is row-major. The 3D
-// rotation matrices were written as if the vec4-args form were also
-// row-major -- each vec4(...) argument spelled out a textbook rotation-
-// matrix *row* -- but the constructor actually consumed it as *column* 0.
-// The resulting matrix was the transpose of the intended one, which for a
-// rotation matrix means the exact same rotation run backwards (clockwise
-// instead of counter-clockwise).
-//
-// Caught by cross-checking the 3D single-axis case directly against the 2D
-// case: rotating only about one axis, with the other two Euler angles at 0,
-// must produce exactly the same in-plane rotation as the 2D rotate().
 export default QUnit.module( 'TSL', () => {
 
 	QUnit.module( 'rotate()', () => {

--- a/test/unit/addons/tsl/TSLRotate.tests.js
+++ b/test/unit/addons/tsl/TSLRotate.tests.js
@@ -1,0 +1,84 @@
+import {
+	float, vec2, vec3, rotate
+} from 'three/tsl';
+import { gpuTest } from './gpu-test-utils.js';
+
+// Regression coverage for a rotate() direction bug: rotate()'s 3D
+// (Euler-angle) path rotated in the opposite direction from its own
+// documented 2D case, on all three axes.
+//
+// mat4(v0,v1,v2,v3) (four vec4 arguments) takes v0..v3 as *columns*,
+// matching standard GLSL/WGSL constructor semantics -- unlike TSL's *other*
+// mat4(a,b,...,p) constructor (16 flat scalars), which is row-major. The 3D
+// rotation matrices were written as if the vec4-args form were also
+// row-major -- each vec4(...) argument spelled out a textbook rotation-
+// matrix *row* -- but the constructor actually consumed it as *column* 0.
+// The resulting matrix was the transpose of the intended one, which for a
+// rotation matrix means the exact same rotation run backwards (clockwise
+// instead of counter-clockwise).
+//
+// Caught by cross-checking the 3D single-axis case directly against the 2D
+// case: rotating only about one axis, with the other two Euler angles at 0,
+// must produce exactly the same in-plane rotation as the 2D rotate().
+export default QUnit.module( 'TSL', () => {
+
+	QUnit.module( 'rotate()', () => {
+
+		gpuTest( 'rotate() on a 2D position by known angles', ( { assert } ) => {
+
+			// A 90-degree (PI/2) counter-clockwise rotation sends +X to +Y.
+			const rotated90 = rotate( vec2( 1, 0 ), float( Math.PI / 2 ) );
+			assert.closeAbs( rotated90, vec2( 0, 1 ), 1e-4, 'rotate((1,0), PI/2) == (0,1)' );
+
+			// A full 2*PI rotation is the identity (up to floating-point drift).
+			const rotatedFull = rotate( vec2( 3, -2 ), float( Math.PI * 2 ) );
+			assert.closeAbs( rotatedFull, vec2( 3, -2 ), 1e-3, 'rotate(v, 2*PI) returns to the original vector' );
+
+			// Zero rotation is exactly the identity.
+			assert.closeAbs( rotate( vec2( 5, 7 ), float( 0 ) ), vec2( 5, 7 ), 1e-5, 'rotate(v, 0) is the identity' );
+
+		} );
+
+		gpuTest( 'rotate() on a 3D position about a single axis matches the 2D case', ( { assert } ) => {
+
+			// Rotating only about Z (x/y Euler angles held at 0) must behave
+			// exactly like the 2D rotation above, with Z passed through
+			// unchanged -- an independent cross-check between the 2D and 3D
+			// code paths inside RotateNode.setup().
+			const rotated = rotate( vec3( 1, 0, 5 ), vec3( 0, 0, Math.PI / 2 ) );
+			assert.closeAbs( rotated, vec3( 0, 1, 5 ), 1e-4, 'rotating (1,0,5) by PI/2 about Z gives (0,1,5)' );
+
+		} );
+
+		// The X and Y single-axis paths weren't independently exercised when
+		// RotateNode's 3D branch had its column/row transpose bug -- only Z
+		// was empirically checked, even though the fix touched all three
+		// per-axis matrices identically. These two tests close that gap by
+		// applying the same 2D-vs-3D cross-check to X and Y, with the "other
+		// two" coordinates held fixed as an independent pass-through check
+		// (mirroring the Z test's own Z pass-through of `5`).
+		gpuTest( 'rotate() on a 3D position about the X axis only matches the 2D case', ( { assert } ) => {
+
+			// Rotating about X only: (y,z) behaves exactly like the 2D case's
+			// (x,y), with X passed through unchanged.
+			const rotated = rotate( vec3( 5, 1, 0 ), vec3( Math.PI / 2, 0, 0 ) );
+			assert.closeAbs( rotated, vec3( 5, 0, 1 ), 1e-4, 'rotating (5,1,0) by PI/2 about X gives (5,0,1)' );
+
+		} );
+
+		gpuTest( 'rotate() on a 3D position about the Y axis only matches the 2D case', ( { assert } ) => {
+
+			// Rotating about Y only, with Y passed through unchanged. Unlike
+			// the X and Z axes, RotateNode's Y-axis matrix is built with its
+			// sin/-sin terms swapped relative to the X/Z pattern (see
+			// RotateNode.js's rotationYMatrix), so this rotates (x,z) the
+			// opposite way round from what the X/Z pattern alone would
+			// suggest: x' = x*cos + z*sin, z' = -x*sin + z*cos.
+			const rotated = rotate( vec3( 1, 5, 0 ), vec3( 0, Math.PI / 2, 0 ) );
+			assert.closeAbs( rotated, vec3( 0, 5, -1 ), 1e-4, 'rotating (1,5,0) by PI/2 about Y gives (0,5,-1)' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -16,3 +16,4 @@ import './addons/loaders/USDLoader.tests.js';
 import './addons/exporters/USDZExporter.tests.js';
 import './addons/tsl/WebGLNodesHandler.tests.js';
 import './addons/tsl/GPUTest.tests.js';
+import './addons/tsl/TSLRotate.tests.js';


### PR DESCRIPTION
mat4(v0,v1,v2,v3) (four vec4 args) takes its arguments as *columns*
(standard GLSL/WGSL constructor semantics) -- unlike TSL's other flat
16-scalar mat4(...) constructor, which is row-major. RotateNode's 3D
rotation matrices were written as if the vec4-args form were also
row-major (each vec4(...) spelled out a textbook rotation-matrix row), so
the constructor consumed each row as a column instead -- the resulting
matrix was the transpose of the intended one, i.e. the same rotation run
backwards, on all three axes.

Rewrote all three per-axis matrices (rotationXMatrix/Y/Z) column-by-column
so the columns passed to mat4(...) are the actual columns of the intended
row-major rotation matrix.

Adds a TSL unit test (TSLRotate.tests.js) cross-checking the 3D single-axis
rotation against the (already correct) 2D rotate() case on all three axes.

### Expected e2e screenshot diff: `webgpu_layers`

CI flags `webgpu_layers` with a 5.5% pixel diff
([run](https://github.com/mrdoob/three.js/actions/runs/32522963279)). This
is expected, not a regression -- that example calls `rotate()` directly on
`positionLocal`, so its rendered output legitimately changes now that the
3D rotation direction is corrected. The reference screenshot needs
regenerating (`npm run make-screenshot webgpu_layers`) as part of merging
this fix; every other example passed unchanged.

Built on top of the tsl-unit-tests branch (three.js PR https://github.com/mrdoob/three.js/pull/34331).

CC: @sunag
