### PR TITLE
TSL Unit Tests - Fix determinant() type inference reporting the matrix's own type instead of float

### DIFF
--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -137,7 +137,7 @@ class MathNode extends TempNode {
 
 		const method = this.method;
 
-		if ( method === MathNode.LENGTH || method === MathNode.DISTANCE || method === MathNode.DOT ) {
+		if ( method === MathNode.LENGTH || method === MathNode.DISTANCE || method === MathNode.DOT || method === MathNode.DETERMINANT ) {
 
 			return 'float';
 

--- a/test/unit/addons/tsl/TSLDeterminant.tests.js
+++ b/test/unit/addons/tsl/TSLDeterminant.tests.js
@@ -3,18 +3,6 @@ import {
 } from 'three/tsl';
 import { gpuTest } from './gpu-test-utils.js';
 
-// Regression coverage for a determinant() type-inference bug:
-// determinant(m) genuinely computes and codegens a scalar (float) at the
-// shader level, but MathNode.DETERMINANT was missing from the list of
-// methods special-cased to report 'float' from generateNodeType(). It fell
-// through to getInputType(), which for a single-matrix-argument call returns
-// the *matrix's own type* (e.g. 'mat3') -- so determinant(mat3).getNodeType()
-// answered 'mat3', not 'float': correct shader code, wrong type metadata.
-// Any downstream TSL composition relying on automatic type inference for a
-// determinant() result (comparisons, swizzles, or -- as here -- a test
-// harness deciding how to store/compare the value) would get incorrect
-// behavior purely from the type-metadata bug, independent of the arithmetic
-// being right.
 export default QUnit.module( 'TSL', () => {
 
 	QUnit.module( 'determinant()', () => {

--- a/test/unit/addons/tsl/TSLDeterminant.tests.js
+++ b/test/unit/addons/tsl/TSLDeterminant.tests.js
@@ -1,0 +1,44 @@
+import {
+	float, mat3, mat4, determinant
+} from 'three/tsl';
+import { gpuTest } from './gpu-test-utils.js';
+
+// Regression coverage for a determinant() type-inference bug:
+// determinant(m) genuinely computes and codegens a scalar (float) at the
+// shader level, but MathNode.DETERMINANT was missing from the list of
+// methods special-cased to report 'float' from generateNodeType(). It fell
+// through to getInputType(), which for a single-matrix-argument call returns
+// the *matrix's own type* (e.g. 'mat3') -- so determinant(mat3).getNodeType()
+// answered 'mat3', not 'float': correct shader code, wrong type metadata.
+// Any downstream TSL composition relying on automatic type inference for a
+// determinant() result (comparisons, swizzles, or -- as here -- a test
+// harness deciding how to store/compare the value) would get incorrect
+// behavior purely from the type-metadata bug, independent of the arithmetic
+// being right.
+export default QUnit.module( 'TSL', () => {
+
+	QUnit.module( 'determinant()', () => {
+
+		gpuTest( 'determinant() of identity matrices is 1', ( { assert } ) => {
+
+			const I3 = mat3( 1, 0, 0, 0, 1, 0, 0, 0, 1 );
+			assert.closeAbs( determinant( I3 ), float( 1 ), 1e-5, 'determinant(I3) == 1' );
+
+			const I4 = mat4( 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 );
+			assert.closeAbs( determinant( I4 ), float( 1 ), 1e-5, 'determinant(I4) == 1' );
+
+		} );
+
+		gpuTest( 'mat3 determinant of a diagonal scale matrix', ( { assert } ) => {
+
+			// determinant of a diagonal matrix is just the product of its
+			// diagonal entries -- 2 * 3 * 4 == 24, independent of the general
+			// cofactor-expansion implementation under test.
+			const scale = mat3( 2, 0, 0, 0, 3, 0, 0, 0, 4 );
+			assert.closeAbs( determinant( scale ), float( 24 ), 1e-4, 'determinant(diag(2,3,4)) == 24' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -16,3 +16,4 @@ import './addons/loaders/USDLoader.tests.js';
 import './addons/exporters/USDZExporter.tests.js';
 import './addons/tsl/WebGLNodesHandler.tests.js';
 import './addons/tsl/GPUTest.tests.js';
+import './addons/tsl/TSLDeterminant.tests.js';

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -18,4 +18,3 @@ import './addons/tsl/WebGLNodesHandler.tests.js';
 import './addons/tsl/GPUTest.tests.js';
 import './addons/tsl/TSLDeterminant.tests.js';
 import './addons/tsl/TSLFaceForward.tests.js';
-


### PR DESCRIPTION
determinant(m) computes and codegens a scalar (float) at the shader level,
but MathNode.DETERMINANT was missing from the list of methods special-cased
to report 'float' from generateNodeType(). It fell through to
getInputType(), which for a single-matrix-argument call returns the
matrix's own type (e.g. 'mat3') -- so determinant(mat3).getNodeType()
answered 'mat3', not 'float'. Add MathNode.DETERMINANT alongside
LENGTH/DISTANCE/DOT in that branch.

Adds a TSL unit test (TSLDeterminant.tests.js) that failed with
'gpuTest: type mismatch -- comparing "mat3" against "float"' before this fix.

Built on top of the tsl-unit-tests branch (three.js PR https://github.com/mrdoob/three.js/pull/34331).

CC: @sunag 