### PR TITLE
TSL Unit Tests - Fix faceForward() WGSL capitalization bug

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -231,6 +231,7 @@ const wgslMethods = {
 	inverse_mat3: 'tsl_inverse_mat3',
 	inverse_mat4: 'tsl_inverse_mat4',
 	inversesqrt: 'inverseSqrt',
+	faceforward: 'faceForward',
 	bitcast: 'bitcast<f32>',
 	floatpack_snorm_2x16: 'pack2x16snorm',
 	floatpack_unorm_2x16: 'pack2x16unorm',

--- a/test/unit/addons/tsl/TSLFaceForward.tests.js
+++ b/test/unit/addons/tsl/TSLFaceForward.tests.js
@@ -3,16 +3,6 @@ import {
 } from 'three/tsl';
 import { gpuTest } from './gpu-test-utils.js';
 
-// Regression coverage for a WGSL-only faceForward() bug: MathNode.FACEFORWARD
-// is the literal string 'faceforward' (GLSL's own correct, all-lowercase
-// spelling), but WGSL's built-in is spelled `faceForward` (camelCase). With
-// no `faceforward -> faceForward` entry in WGSLNodeBuilder.js's wgslMethods
-// table (the table that already exists specifically to paper over this class
-// of GLSL/WGSL spelling mismatch -- see its `inversesqrt: 'inverseSqrt'`
-// entry for the identical situation), every WebGPU-backend call to
-// faceForward() failed to compile outright ("unresolved call target
-// 'faceforward'"). The GLSL/WebGL backend was unaffected, which is exactly
-// why this needs a two-backend gpuTest to catch.
 export default QUnit.module( 'TSL', () => {
 
 	QUnit.module( 'faceForward()', () => {

--- a/test/unit/addons/tsl/TSLFaceForward.tests.js
+++ b/test/unit/addons/tsl/TSLFaceForward.tests.js
@@ -1,0 +1,34 @@
+import {
+	vec3, faceForward
+} from 'three/tsl';
+import { gpuTest } from './gpu-test-utils.js';
+
+// Regression coverage for a WGSL-only faceForward() bug: MathNode.FACEFORWARD
+// is the literal string 'faceforward' (GLSL's own correct, all-lowercase
+// spelling), but WGSL's built-in is spelled `faceForward` (camelCase). With
+// no `faceforward -> faceForward` entry in WGSLNodeBuilder.js's wgslMethods
+// table (the table that already exists specifically to paper over this class
+// of GLSL/WGSL spelling mismatch -- see its `inversesqrt: 'inverseSqrt'`
+// entry for the identical situation), every WebGPU-backend call to
+// faceForward() failed to compile outright ("unresolved call target
+// 'faceforward'"). The GLSL/WebGL backend was unaffected, which is exactly
+// why this needs a two-backend gpuTest to catch.
+export default QUnit.module( 'TSL', () => {
+
+	QUnit.module( 'faceForward()', () => {
+
+		gpuTest( 'faceForward() picks the side facing the incident ray', ( { assert } ) => {
+
+			const n = vec3( 0, 1, 0 );
+
+			// dot(Nref, I) < 0 -> returns N unchanged.
+			assert.closeAbs( faceForward( n, vec3( 0, - 1, 0 ), vec3( 0, 1, 0 ) ), n, 1e-5, 'faceForward keeps N when Nref and I already face opposite ways' );
+
+			// dot(Nref, I) >= 0 -> returns -N.
+			assert.closeAbs( faceForward( n, vec3( 0, 1, 0 ), vec3( 0, 1, 0 ) ), n.negate(), 1e-5, 'faceForward flips N when Nref and I face the same way' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -16,3 +16,4 @@ import './addons/loaders/USDLoader.tests.js';
 import './addons/exporters/USDZExporter.tests.js';
 import './addons/tsl/WebGLNodesHandler.tests.js';
 import './addons/tsl/GPUTest.tests.js';
+import './addons/tsl/TSLFaceForward.tests.js';


### PR DESCRIPTION
WGSL's faceForward built-in is camelCase (faceForward), but MathNode.FACEFORWARD
is the (correct, GLSL-spelled) all-lowercase string 'faceforward', and
WGSLNodeBuilder's wgslMethods table had no entry mapping it -- so every
WebGPU-backend call to faceForward() failed to compile. Add the missing
wgslMethods entry, mirroring the existing inversesqrt -> inverseSqrt entry.

Adds a two-backend TSL unit test (TSLFaceForward.tests.js) that fails on
[webgpu] and passes on [webgl] before this fix, and passes on both after.

Built on top of the tsl-unit-tests branch (three.js PR https://github.com/mrdoob/three.js/pull/34331).

CC: @sunag