### PR TITLE
test: fix lint error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,8 @@ export default [
 			'**/node_modules/**',
 			'**/build/**',
 			'examples/jsm/libs/**',
+			'test/treeshake/*.bundle.js',
+			'test/treeshake/*.bundle.min.js',
 			'editor/js/libs/acorn/**',
 			'editor/js/libs/codemirror/**',
 			'editor/js/libs/tern-threejs/**',

--- a/test/unit/addons/tsl/GPUTest.tests.js
+++ b/test/unit/addons/tsl/GPUTest.tests.js
@@ -1,5 +1,4 @@
-import { hash, vec3, float } from 'three/tsl';
-import { sRGBTransferEOTF, sRGBTransferOETF } from 'three/tsl';
+import { hash, vec3, float, sRGBTransferEOTF, sRGBTransferOETF } from 'three/tsl';
 import { gpuTest, gpuFuzzTest } from './gpu-test-utils.js';
 
 export default QUnit.module( 'TSL', () => {


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Before:

```bash
❯ npm run lint-test

✖ 292813 problems (292811 errors, 2 warnings)
  292801 errors and 2 warnings potentially fixable with the `--fix` option.
  
# add ignores in eslint.config.js to fix
```

```bash
❯ npm run lint-test
npm notice run three@0.185.0 lint-test
npm notice run eslint test

three.js/test/unit/addons/tsl/GPUTest.tests.js
  2:1  error  'three/tsl' import is duplicated  no-duplicate-imports

✖ 1 problem (1 error, 0 warnings)

# just fix it
```

After

```bash
❯ npm run lint-test
npm notice run three@0.185.0 lint-test
npm notice run eslint test

# no output
```