### PR TITLE
TSL: Honor type in `toAttribute()`.

### DIFF
--- a/src/nodes/accessors/BufferAttributeNode.js
+++ b/src/nodes/accessors/BufferAttributeNode.js
@@ -440,4 +440,4 @@ export const instancedBufferAttribute = ( array, type = null, stride = 0, offset
  */
 export const instancedDynamicBufferAttribute = ( array, type = null, stride = 0, offset = 0 ) => createBufferAttribute( array, type, stride, offset, DynamicDrawUsage, true );
 
-addMethodChaining( 'toAttribute', ( bufferNode ) => bufferAttribute( bufferNode.value ) );
+addMethodChaining( 'toAttribute', ( bufferNode ) => bufferAttribute( bufferNode.value, bufferNode.bufferType ) );


### PR DESCRIPTION
Fixed #34329.

**Description**

The PR fixes the type loss in `toAttribute()`. 

The idea is: Instead of always deriving the type from the attribute, we use the node type if defined.