### PR TITLE
RotateNode: Add support for Euler Order

### DIFF
--- a/src/nodes/utils/RotateNode.js
+++ b/src/nodes/utils/RotateNode.js
@@ -136,11 +136,11 @@ class RotateNode extends TempNode {
 				'Z': rotationZMatrix
 			};
 
-			const customMatrixChain = matrixMap[ order.charAt( 0 ) ]
+			const matrixChain = matrixMap[ order.charAt( 0 ) ]
 				.mul( matrixMap[ order.charAt( 1 ) ] )
 				.mul( matrixMap[ order.charAt( 2 ) ] );
 
-			return customMatrixChain.mul( vec4( positionNode, 1.0 ) ).xyz;
+			return matrixChain.mul( vec4( positionNode, 1.0 ) ).xyz;
 
 		}
 

--- a/src/nodes/utils/RotateNode.js
+++ b/src/nodes/utils/RotateNode.js
@@ -1,6 +1,7 @@
 import TempNode from '../core/TempNode.js';
 import { nodeProxy, vec4, mat2, mat4 } from '../tsl/TSLBase.js';
 import { cos, sin } from '../math/MathNode.js';
+import { hashString } from '../core/NodeUtils.js';
 
 /**
  * Applies a rotation to the given position node.
@@ -21,7 +22,7 @@ class RotateNode extends TempNode {
 	 * @param {Node} positionNode - The position node.
 	 * @param {Node} rotationNode - Represents the rotation that is applied to the position node. Depending
 	 * on whether the position data are 2D or 3D, the rotation is expressed a single float value or an Euler value.
-	 * @param {string} [order='XYZ'] - The Euler rotation order string (e.g., 'YXZ', 'ZXY'). Only used for 3D rotations.
+	 * @param {string} [order='XYZ'] - The Euler rotation order. Only used for 3D rotation.
 	 */
 	constructor( positionNode, rotationNode, order = 'XYZ' ) {
 
@@ -35,8 +36,8 @@ class RotateNode extends TempNode {
 		this.positionNode = positionNode;
 
 		/**
-		 *  Represents the rotation that is applied to the position node.
-		 *  Depending on whether the position data are 2D or 3D, the rotation is expressed a single float value or an Euler value.
+		 * Represents the rotation that is applied to the position node.
+		 * Depending on whether the position data are 2D or 3D, the rotation is expressed a single float value or an Euler value.
 		 *
 		 * @type {Node}
 		 */
@@ -45,10 +46,48 @@ class RotateNode extends TempNode {
 		/**
 		 * The Euler rotation order.
 		 *
+		 * @private
 		 * @type {string}
 		 * @default 'XYZ'
 		 */
-		this.order = order;
+		this._order = order;
+
+	}
+
+	/**
+	 * Overwrites the default `customCacheKey()` implementation by including the
+	 * Euler order into the cache key.
+	 *
+	 * @return {number} The hash.
+	 */
+	customCacheKey() {
+
+		return hashString( this._order );
+
+	}
+
+	/**
+	 * Sets the Euler rotation order.
+	 *
+	 * @param {string} value - The Euler rotation order.
+	 * @return {RotateNode} A reference to this node.
+	 */
+	setOrder( value ) {
+
+		this._order = value;
+
+		return this;
+
+	}
+
+	/**
+	 * Gets the Euler rotation order.
+	 *
+	 * @return {string} The Euler rotation order.
+	 */
+	getOrder() {
+
+		return this._order;
 
 	}
 
@@ -66,7 +105,7 @@ class RotateNode extends TempNode {
 
 	setup( builder ) {
 
-		const { rotationNode, positionNode, order } = this;
+		const { rotationNode, positionNode } = this;
 
 		const nodeType = this.getNodeType( builder );
 
@@ -85,6 +124,8 @@ class RotateNode extends TempNode {
 		} else {
 
 			const rotation = rotationNode;
+			const order = this._order;
+
 			const rotationXMatrix = mat4( vec4( 1.0, 0.0, 0.0, 0.0 ), vec4( 0.0, cos( rotation.x ), sin( rotation.x ), 0.0 ), vec4( 0.0, sin( rotation.x ).negate(), cos( rotation.x ), 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
 			const rotationYMatrix = mat4( vec4( cos( rotation.y ), 0.0, sin( rotation.y ).negate(), 0.0 ), vec4( 0.0, 1.0, 0.0, 0.0 ), vec4( sin( rotation.y ), 0.0, cos( rotation.y ), 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
 			const rotationZMatrix = mat4( vec4( cos( rotation.z ), sin( rotation.z ), 0.0, 0.0 ), vec4( sin( rotation.z ).negate(), cos( rotation.z ), 0.0, 0.0 ), vec4( 0.0, 0.0, 1.0, 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
@@ -109,7 +150,7 @@ class RotateNode extends TempNode {
 
 		super.serialize( data );
 
-		data.order = this.order;
+		data.order = this._order;
 
 	}
 
@@ -117,7 +158,7 @@ class RotateNode extends TempNode {
 
 		super.deserialize( data );
 
-		this.order = data.order;
+		this._order = data.order;
 
 	}
 
@@ -133,7 +174,7 @@ export default RotateNode;
  * @param {Node} positionNode - The position node.
  * @param {Node} rotationNode - Represents the rotation that is applied to the position node. Depending
  * on whether the position data are 2D or 3D, the rotation is expressed a single float value or an Euler value.
- * @param {string} [order='XYZ'] - The Euler rotation order string (e.g., 'YXZ', 'ZXY'). Only used for 3D rotations.
+ * @param {string} [order='XYZ'] - The Euler rotation order. Only used for 3D rotation.
  * @returns {RotateNode}
  */
 export const rotate = /*@__PURE__*/ nodeProxy( RotateNode ).setParameterLength( 2, 3 );

--- a/src/nodes/utils/RotateNode.js
+++ b/src/nodes/utils/RotateNode.js
@@ -21,8 +21,9 @@ class RotateNode extends TempNode {
 	 * @param {Node} positionNode - The position node.
 	 * @param {Node} rotationNode - Represents the rotation that is applied to the position node. Depending
 	 * on whether the position data are 2D or 3D, the rotation is expressed a single float value or an Euler value.
+	 * @param {string} [order='XYZ'] - The Euler rotation order string (e.g., 'YXZ', 'ZXY'). Only used for 3D rotations.
 	 */
-	constructor( positionNode, rotationNode ) {
+	constructor( positionNode, rotationNode, order = 'XYZ' ) {
 
 		super();
 
@@ -41,6 +42,14 @@ class RotateNode extends TempNode {
 		 */
 		this.rotationNode = rotationNode;
 
+		/**
+		 * The Euler rotation order.
+		 *
+		 * @type {string}
+		 * @default 'XYZ'
+		 */
+		this.order = order;
+
 	}
 
 	/**
@@ -57,7 +66,7 @@ class RotateNode extends TempNode {
 
 	setup( builder ) {
 
-		const { rotationNode, positionNode } = this;
+		const { rotationNode, positionNode, order } = this;
 
 		const nodeType = this.getNodeType( builder );
 
@@ -80,9 +89,35 @@ class RotateNode extends TempNode {
 			const rotationYMatrix = mat4( vec4( cos( rotation.y ), 0.0, sin( rotation.y ).negate(), 0.0 ), vec4( 0.0, 1.0, 0.0, 0.0 ), vec4( sin( rotation.y ), 0.0, cos( rotation.y ), 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
 			const rotationZMatrix = mat4( vec4( cos( rotation.z ), sin( rotation.z ), 0.0, 0.0 ), vec4( sin( rotation.z ).negate(), cos( rotation.z ), 0.0, 0.0 ), vec4( 0.0, 0.0, 1.0, 0.0 ), vec4( 0.0, 0.0, 0.0, 1.0 ) );
 
-			return rotationXMatrix.mul( rotationYMatrix ).mul( rotationZMatrix ).mul( vec4( positionNode, 1.0 ) ).xyz;
+			const matrixMap = {
+				'X': rotationXMatrix,
+				'Y': rotationYMatrix,
+				'Z': rotationZMatrix
+			};
+
+			const customMatrixChain = matrixMap[ order.charAt( 0 ) ]
+				.mul( matrixMap[ order.charAt( 1 ) ] )
+				.mul( matrixMap[ order.charAt( 2 ) ] );
+
+			return customMatrixChain.mul( vec4( positionNode, 1.0 ) ).xyz;
 
 		}
+
+	}
+
+	serialize( data ) {
+
+		super.serialize( data );
+
+		data.order = this.order;
+
+	}
+
+	deserialize( data ) {
+
+		super.deserialize( data );
+
+		this.order = data.order;
 
 	}
 
@@ -98,6 +133,7 @@ export default RotateNode;
  * @param {Node} positionNode - The position node.
  * @param {Node} rotationNode - Represents the rotation that is applied to the position node. Depending
  * on whether the position data are 2D or 3D, the rotation is expressed a single float value or an Euler value.
+ * @param {string} [order='XYZ'] - The Euler rotation order string (e.g., 'YXZ', 'ZXY'). Only used for 3D rotations.
  * @returns {RotateNode}
  */
-export const rotate = /*@__PURE__*/ nodeProxy( RotateNode ).setParameterLength( 2 );
+export const rotate = /*@__PURE__*/ nodeProxy( RotateNode ).setParameterLength( 2, 3 );

--- a/test/unit/addons/tsl/TSLRotate.tests.js
+++ b/test/unit/addons/tsl/TSLRotate.tests.js
@@ -14,8 +14,8 @@ export default QUnit.module( 'TSL', () => {
 			assert.closeAbs( rotated90, vec2( 0, 1 ), 1e-4, 'rotate((1,0), PI/2) == (0,1)' );
 
 			// A full 2*PI rotation is the identity (up to floating-point drift).
-			const rotatedFull = rotate( vec2( 3, -2 ), float( Math.PI * 2 ) );
-			assert.closeAbs( rotatedFull, vec2( 3, -2 ), 1e-3, 'rotate(v, 2*PI) returns to the original vector' );
+			const rotatedFull = rotate( vec2( 3, - 2 ), float( Math.PI * 2 ) );
+			assert.closeAbs( rotatedFull, vec2( 3, - 2 ), 1e-3, 'rotate(v, 2*PI) returns to the original vector' );
 
 			// Zero rotation is exactly the identity.
 			assert.closeAbs( rotate( vec2( 5, 7 ), float( 0 ) ), vec2( 5, 7 ), 1e-5, 'rotate(v, 0) is the identity' );
@@ -58,7 +58,49 @@ export default QUnit.module( 'TSL', () => {
 			// opposite way round from what the X/Z pattern alone would
 			// suggest: x' = x*cos + z*sin, z' = -x*sin + z*cos.
 			const rotated = rotate( vec3( 1, 5, 0 ), vec3( 0, Math.PI / 2, 0 ) );
-			assert.closeAbs( rotated, vec3( 0, 5, -1 ), 1e-4, 'rotating (1,5,0) by PI/2 about Y gives (0,5,-1)' );
+			assert.closeAbs( rotated, vec3( 0, 5, - 1 ), 1e-4, 'rotating (1,5,0) by PI/2 about Y gives (0,5,-1)' );
+
+		} );
+
+		gpuTest( 'rotate() default order is XYZ', ( { assert } ) => {
+
+			// Omitting the order argument must be identical to passing 'XYZ'.
+			const position = vec3( 1, 0, 0 );
+			const rotation = vec3( Math.PI / 2, Math.PI / 4, 0 );
+
+			assert.closeAbs(
+				rotate( position, rotation ),
+				rotate( position, rotation, 'XYZ' ),
+				1e-5,
+				'omit order == order "XYZ"'
+			);
+
+		} );
+
+		gpuTest( 'rotate() with order XYZ applies Rx*Ry*Rz', ( { assert } ) => {
+
+			// (1,0,0) rotated by (π/2, π/4, 0) under XYZ → (√2/2, √2/2, 0).
+			const rotated = rotate( vec3( 1, 0, 0 ), vec3( Math.PI / 2, Math.PI / 4, 0 ), 'XYZ' );
+			assert.closeAbs( rotated, vec3( Math.SQRT1_2, Math.SQRT1_2, 0 ), 1e-4,
+				'XYZ: (1,0,0) by (π/2, π/4, 0) → (√2/2, √2/2, 0)' );
+
+		} );
+
+		gpuTest( 'rotate() with order YXZ applies Ry*Rx*Rz', ( { assert } ) => {
+
+			// Same angles under YXZ → (√2/2, 0, -√2/2). Distinct from the XYZ result above.
+			const rotated = rotate( vec3( 1, 0, 0 ), vec3( Math.PI / 2, Math.PI / 4, 0 ), 'YXZ' );
+			assert.closeAbs( rotated, vec3( Math.SQRT1_2, 0, - Math.SQRT1_2 ), 1e-4,
+				'YXZ: (1,0,0) by (π/2, π/4, 0) → (√2/2, 0, -√2/2)' );
+
+		} );
+
+		gpuTest( 'rotate() zero rotation is identity for non-default orders', ( { assert } ) => {
+
+			const v = vec3( 3, - 2, 7 );
+
+			assert.closeAbs( rotate( v, vec3( 0, 0, 0 ), 'YXZ' ), v, 1e-5, 'YXZ zero rotation is identity' );
+			assert.closeAbs( rotate( v, vec3( 0, 0, 0 ), 'ZYX' ), v, 1e-5, 'ZYX zero rotation is identity' );
 
 		} );
 


### PR DESCRIPTION
Previously, the Euler order was hardwired to 'XYZ'.

In this PR, the `RotateNode` constructor is modified to accept an optional argument `order` (defaulting to `'XYZ'`).

The unit test has also been updated.

The Three.js-Shading-Language wiki will have to be updated separately.
