### PR TITLE
ShadowNode: guard against a null shadowMap in updateBefore

### DIFF
--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -795,6 +795,11 @@ class ShadowNode extends ShadowBaseNode {
 
 		if ( frame.renderer._isPreCompiling === true ) return;
 
+		// the shadow map is null before the first setup(), and again after
+		// _reset(), which dispose() calls when a light stops casting
+
+		if ( this.shadowMap === null ) return;
+
 		const { shadow } = this;
 
 		let needsUpdate = shadow.needsUpdate || shadow.autoUpdate;


### PR DESCRIPTION
Related issue: none — found by reading the source, see below.

**Description**

`ShadowNode` declares its shadow map as nullable and initialises it to `null`
(`src/nodes/lighting/ShadowNode.js`, line 162):

```js
/**
 * @type {?RenderTarget}
 * @default null
 */
this.shadowMap = null;
```

`_reset()` sets it back to `null`, and guards its own access (line 758):

```js
if ( this.shadowMap ) {

    this.shadowMap.dispose();
    this.shadowMap = null;

}
```

But `updateShadow()` and `updateBefore()` dereference it **without any guard**:

```js
// line 722, in updateShadow()
const depth = this.shadowMap.depth;

// line 818, in updateBefore()
if ( this.shadowMap.depthTexture.version === this._depthVersionCached ) {
```

So the class documents the field as nullable, guards it in one place, and
assumes it non-null in two others. That alone seems worth fixing, independently
of how the null state is reached.

**How we reach it.** `AnalyticLightNode.setup()` disposes the shadow node when
`light.castShadow` becomes `false` (`src/nodes/lighting/AnalyticLightNode.js`,
line 259):

```js
if ( this.light.castShadow ) {

    if ( builder.object.receiveShadow ) {

        this.setupShadow( builder );

    }

} else if ( this.shadowNode !== null ) {

    this.shadowNode.dispose();     // -> _reset() -> this.shadowMap = null
    this.shadowNode = null;
    this.shadowColorNode = null;

}
```

(`disposeShadow()`, line 128, is a second entry into the same path.)

The node stays registered in the `updateBeforeNodes` of an already built
`NodeBuilderState` — `ShadowBaseNode` sets
`updateBeforeType = NodeUpdateType.RENDER` in its **constructor**, and
`Node.dispose()` does not unregister it. That state survives in the node builder
cache while any render object still references it. On the next frame
`updateBefore` runs and throws:

```
TypeError: Cannot read properties of null (reading 'depthTexture')
```

In our application this froze the whole viewer: the exception is thrown every
frame, at the same place, so the image never updates. It reproduced
systematically for one of our users on a streamed 15 326-tile mesh, as soon as
he touched the light controls.

**Reproduction.** I could not minimise it, and I would rather say so than post a
fiddle that does not fire. It is a race: on a simple scene every render object
is redrawn each frame, so the poisoned cache entry is purged and nothing breaks.
Two attempts on the official `dev` WebGPU template — shared material, objects
entering and leaving the frustum, forced material rebuilds around the toggle —
stayed clean over thirty rounds.

**Suggested fix.** `updateShadow()` has a single caller, `updateBefore()`
(line 816), so one guard covers both dereferences. `PointShadowNode` extends
`ShadowNode` and overrides only `getShadowFilterFn`, `setupShadowCoord`,
`setupShadowFilter`, `setupRenderTarget` and `renderShadow` — neither
`updateBefore` nor `updateShadow` — so it is covered too.

```diff
 	updateBefore( frame ) {
 
 		// do not render shadow maps during precompilation
 
 		if ( frame.renderer._isPreCompiling === true ) return;
 
+		// the shadow map is null before the first setup(), and again after
+		// _reset(), which dispose() calls when a light stops casting
+
+		if ( this.shadowMap === null ) return;
+
 		const { shadow } = this;
```

Read on `dev` on 23 Aug 2026; the dereference is unguarded in `0.184.0` and
`0.185.1` as well.

Happy to turn this into an issue instead if you would rather see the underlying
lifecycle question addressed — arguably `dispose()` should also unregister the
node from the states that still reference it, which would fix the cause rather
than the symptom. The guard seems worth having either way, since the field is
documented as nullable.