### PR TITLE
Sky/SkyMesh: Remove `up` uniform.

### DIFF
--- a/examples/jsm/objects/Sky.js
+++ b/examples/jsm/objects/Sky.js
@@ -82,7 +82,6 @@ Sky.SkyShader = {
 		'mieCoefficient': { value: 0.005 },
 		'mieDirectionalG': { value: 0.8 },
 		'sunPosition': { value: new Vector3() },
-		'up': { value: new Vector3( 0, 1, 0 ) },
 		'cloudScale': { value: 0.0002 },
 		'cloudSpeed': { value: 0.0001 },
 		'cloudCoverage': { value: 0.4 },
@@ -97,7 +96,6 @@ Sky.SkyShader = {
 		uniform float rayleigh;
 		uniform float turbidity;
 		uniform float mieCoefficient;
-		uniform vec3 up;
 
 		varying vec3 vWorldPosition;
 		varying vec3 vSunDirection;
@@ -149,7 +147,7 @@ Sky.SkyShader = {
 
 			vSunDirection = normalize( sunPosition );
 
-			vSunE = sunIntensity( dot( vSunDirection, up ) );
+			vSunE = sunIntensity( vSunDirection.y );
 
 			vSunfade = 1.0 - clamp( 1.0 - exp( ( sunPosition.y / 450000.0 ) ), 0.0, 1.0 );
 
@@ -172,7 +170,6 @@ Sky.SkyShader = {
 		varying float vSunE;
 
 		uniform float mieDirectionalG;
-		uniform vec3 up;
 		uniform float cloudScale;
 		uniform float cloudSpeed;
 		uniform float cloudCoverage;
@@ -245,7 +242,7 @@ Sky.SkyShader = {
 
 			// optical length
 			// cutoff angle at 90 to avoid singularity in next formula.
-			float zenithAngle = acos( max( 0.0, dot( up, direction ) ) );
+			float zenithAngle = acos( max( 0.0, direction.y ) );
 			float inverse = 1.0 / ( cos( zenithAngle ) + 0.15 * pow( 93.885 - ( ( zenithAngle * 180.0 ) / pi ), -1.253 ) );
 			float sR = rayleighZenithLength * inverse;
 			float sM = mieZenithLength * inverse;
@@ -263,7 +260,7 @@ Sky.SkyShader = {
 			vec3 betaMTheta = vBetaM * mPhase;
 
 			vec3 Lin = pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * ( 1.0 - Fex ), vec3( 1.5 ) );
-			Lin *= mix( vec3( 1.0 ), pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * Fex, vec3( 1.0 / 2.0 ) ), clamp( pow( 1.0 - dot( up, vSunDirection ), 5.0 ), 0.0, 1.0 ) );
+			Lin *= mix( vec3( 1.0 ), pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * Fex, vec3( 1.0 / 2.0 ) ), clamp( pow( 1.0 - vSunDirection.y, 5.0 ), 0.0, 1.0 ) );
 
 			// nightsky
 			float theta = acos( direction.y ); // elevation --> y-axis, [-pi/2, pi/2]

--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -86,13 +86,6 @@ class SkyMesh extends Mesh {
 		this.sunPosition = uniform( new Vector3() );
 
 		/**
-		 * The up position.
-		 *
-		 * @type {UniformNode<vec3>}
-		 */
-		this.upUniform = uniform( new Vector3( 0, 1, 0 ) );
-
-		/**
 		 * The cloud scale uniform.
 		 *
 		 * @type {UniformNode<float>}
@@ -192,7 +185,7 @@ class SkyMesh extends Mesh {
 
 			// varying sun intensity
 
-			const angle = dot( sunDirection, this.upUniform );
+			const angle = sunDirection.y;
 			const zenithAngleCos = clamp( angle, - 1, 1 );
 			const sunIntensity = EE.mul( max( 0.0, float( 1.0 ).sub( pow( e, cutoffAngle.sub( acos( zenithAngleCos ) ).div( steepness ).negate() ) ) ) );
 			vSunE.assign( sunIntensity );
@@ -247,7 +240,7 @@ class SkyMesh extends Mesh {
 
 			// optical length
 			// cutoff angle at 90 to avoid singularity in next formula.
-			const zenithAngle = acos( max( 0.0, dot( this.upUniform, direction ) ) );
+			const zenithAngle = acos( max( 0.0, direction.y ) );
 			const inverse = float( 1.0 ).div( cos( zenithAngle ).add( float( 0.15 ).mul( pow( float( 93.885 ).sub( zenithAngle.mul( 180.0 ).div( pi ) ), - 1.253 ) ) ) );
 			const sR = rayleighZenithLength.mul( inverse );
 			const sM = mieZenithLength.mul( inverse );
@@ -272,7 +265,7 @@ class SkyMesh extends Mesh {
 			const betaMTheta = vBetaM.mul( mPhase );
 
 			const Lin = pow( vSunE.mul( add( betaRTheta, betaMTheta ).div( add( vBetaR, vBetaM ) ) ).mul( sub( 1.0, Fex ) ), vec3( 1.5 ) );
-			Lin.mulAssign( mix( vec3( 1.0 ), pow( vSunE.mul( add( betaRTheta, betaMTheta ).div( add( vBetaR, vBetaM ) ) ).mul( Fex ), vec3( 1.0 / 2.0 ) ), clamp( pow( sub( 1.0, dot( this.upUniform, vSunDirection ) ), 5.0 ), 0.0, 1.0 ) ) );
+			Lin.mulAssign( mix( vec3( 1.0 ), pow( vSunE.mul( add( betaRTheta, betaMTheta ).div( add( vBetaR, vBetaM ) ) ).mul( Fex ), vec3( 1.0 / 2.0 ) ), clamp( pow( sub( 1.0, vSunDirection.y ), 5.0 ), 0.0, 1.0 ) ) );
 
 			// nightsky
 


### PR DESCRIPTION
Fixed #34352.

**Description**

The PR simplifies `Sky` and `SkyMesh` and removes the `up` uniform since in addons like `FirstPersonControls` or `Water2` we've decided to support +y up only (see https://github.com/mrdoob/three.js/issues/17390#issuecomment-4134016126).

This also fixes the fact that the clouds ignored the `up` uniform.
