### PR TITLE
LightsNode: Detect dynamic shadow map size changes.

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -787,11 +787,15 @@ class NodeMaterialObserver {
 			for ( let i = 0; i < lightsData.length; i ++ ) {
 
 				const lightData = renderObjectData.lights[ i ];
+				const currentLightData = lightsData[ i ];
 
-				if ( lightData.map !== lightsData[ i ].map || lightData.cacheVersion !== lightsData[ i ].cacheVersion ) {
+				if ( lightData.map !== currentLightData.map || lightData.cacheVersion !== currentLightData.cacheVersion ||
+					lightData.shadowMapWidth !== currentLightData.shadowMapWidth || lightData.shadowMapHeight !== currentLightData.shadowMapHeight ) {
 
-					lightData.map = lightsData[ i ].map;
-					lightData.cacheVersion = lightsData[ i ].cacheVersion;
+					lightData.map = currentLightData.map;
+					lightData.cacheVersion = currentLightData.cacheVersion;
+					lightData.shadowMapWidth = currentLightData.shadowMapWidth;
+					lightData.shadowMapHeight = currentLightData.shadowMapHeight;
 
 					return false;
 
@@ -857,13 +861,29 @@ class NodeMaterialObserver {
 
 		for ( const light of materialLights ) {
 
+			let data = null;
+
 			if ( light.isSpotLight === true && light.map !== null ) {
 
 				// only add lights that have a map
 
-				lights.push( { map: light.map.version, cacheVersion: this.getTextureData( light.map )._version } );
+				data = { map: light.map.version, cacheVersion: this.getTextureData( light.map )._version };
 
 			}
+
+			if ( light.castShadow === true ) {
+
+				// resizing a shadow map recreates its textures so the bindings
+				// of all related render objects must be updated
+
+				if ( data === null ) data = {};
+
+				data.shadowMapWidth = light.shadow.mapSize.width;
+				data.shadowMapHeight = light.shadow.mapSize.height;
+
+			}
+
+			if ( data !== null ) lights.push( data );
 
 		}
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -787,15 +787,11 @@ class NodeMaterialObserver {
 			for ( let i = 0; i < lightsData.length; i ++ ) {
 
 				const lightData = renderObjectData.lights[ i ];
-				const currentLightData = lightsData[ i ];
 
-				if ( lightData.map !== currentLightData.map || lightData.cacheVersion !== currentLightData.cacheVersion ||
-					lightData.shadowMapWidth !== currentLightData.shadowMapWidth || lightData.shadowMapHeight !== currentLightData.shadowMapHeight ) {
+				if ( lightData.map !== lightsData[ i ].map || lightData.cacheVersion !== lightsData[ i ].cacheVersion ) {
 
-					lightData.map = currentLightData.map;
-					lightData.cacheVersion = currentLightData.cacheVersion;
-					lightData.shadowMapWidth = currentLightData.shadowMapWidth;
-					lightData.shadowMapHeight = currentLightData.shadowMapHeight;
+					lightData.map = lightsData[ i ].map;
+					lightData.cacheVersion = lightsData[ i ].cacheVersion;
 
 					return false;
 
@@ -861,29 +857,13 @@ class NodeMaterialObserver {
 
 		for ( const light of materialLights ) {
 
-			let data = null;
-
 			if ( light.isSpotLight === true && light.map !== null ) {
 
 				// only add lights that have a map
 
-				data = { map: light.map.version, cacheVersion: this.getTextureData( light.map )._version };
+				lights.push( { map: light.map.version, cacheVersion: this.getTextureData( light.map )._version } );
 
 			}
-
-			if ( light.castShadow === true ) {
-
-				// resizing a shadow map recreates its textures so the bindings
-				// of all related render objects must be updated
-
-				if ( data === null ) data = {};
-
-				data.shadowMapWidth = light.shadow.mapSize.width;
-				data.shadowMapHeight = light.shadow.mapSize.height;
-
-			}
-
-			if ( data !== null ) lights.push( data );
 
 		}
 

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -155,6 +155,12 @@ class LightsNode extends Node {
 			_hashData.push( light.id );
 			_hashData.push( light.castShadow ? 1 : 0 );
 
+			if ( light.castShadow === true && light.shadow !== undefined ) {
+
+				_hashData.push( light.shadow.mapSize.width, light.shadow.mapSize.height );
+
+			}
+
 			if ( light.isSpotLight === true ) {
 
 				const hashMap = ( light.map !== null ) ? light.map.id : - 1;


### PR DESCRIPTION
Fixed #34324.

**Description**

The PR makes sure dynamic changes to shadow map sizes are supported in `WebGPURenderer` like in `WebGLRenderer`.

The suggested changes in #34324 go in the wrong direction. `LightsNode` takes now care of the tracking of shadow map sizes. Putting this into the observer would be an option as well but since its a global setting `LightsNode` is actually the better spot with the right scope.