### PR TITLE
Unit tests: import unbuilt source instead of build/ output

### DIFF
--- a/test/unit/UnitTests.html
+++ b/test/unit/UnitTests.html
@@ -17,7 +17,7 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "../../build/three.module.js"
+					"three": "../../src/Three.js"
 				}
 			}
 		</script>

--- a/test/unit/UnitTestsAddons.html
+++ b/test/unit/UnitTestsAddons.html
@@ -17,9 +17,9 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "../../build/three.module.js",
-					"three/webgpu": "../../build/three.webgpu.js",
-					"three/tsl": "../../build/three.tsl.js"
+					"three": "../../src/Three.js",
+					"three/webgpu": "../../src/Three.WebGPU.js",
+					"three/tsl": "../../src/Three.TSL.js"
 				}
 			}
 		</script>


### PR DESCRIPTION
Unit tests were split between importing unbuilt `src/` (232/271 files) and importing via `'three'`/`'three/tsl'`/`'three/webgpu'`, which resolved to committed `build/` output (35 files, all under `test/unit/addons/`) — so those tests only tested whatever was last committed to `build/`, not current source, which caused a real CI failure in #34358.

The solution was to point the three `import map` entries in `UnitTests.html`/`UnitTestsAddons.html` at their `src/` entry files (`src/Three.js`, `src/Three.WebGPU.js`, `src/Three.TSL.js`) instead of `build/`, since every affected file resolves through those same three bare specifiers.
