### PR TITLE
NodeFunction: Filter initial spaces and comments

### DIFF
--- a/src/nodes/parsers/GLSLNodeFunction.js
+++ b/src/nodes/parsers/GLSLNodeFunction.js
@@ -12,7 +12,7 @@ const parse = ( source ) => {
 
 	const pragmaMainIndex = source.indexOf( pragmaMain );
 
-	const mainCode = pragmaMainIndex !== - 1 ? source.slice( pragmaMainIndex + pragmaMain.length ) : source;
+	const mainCode = ( pragmaMainIndex !== - 1 ? source.slice( pragmaMainIndex + pragmaMain.length ) : source ).replace( /^(?:\s*\/\/[^\r\n]*|\s*\/\*[\s\S]*?\*\/|\s*)+/, '' );
 
 	const declaration = mainCode.match( declarationRegexp );
 

--- a/src/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -78,7 +78,7 @@ const wgslTypeLib = {
 
 const parse = ( source ) => {
 
-	source = source.trim();
+	source = source.replace( /^(?:\s*\/\/[^\r\n]*|\s*\/\*[\s\S]*?\*\/|\s*)+/, '' );
 
 	const declaration = source.match( declarationRegexp );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/34085

**Description**

When defining native functions using `glslFn` or `wgslFn`, including leading comments (such as file headers, licenses, or doc comments) before the function declaration would cause `declarationRegexp` parsing to fail.

Create an example in the Tour just to show how the Transpiler could help use GLSL functions on both backends, converting GLSL -> WGSL, We could do the opposite if we creating others encoder/decoder.  

```js
import 'scenes/shaderball';
import Transpiler from 'three/addons/transpiler/Transpiler.js';
import GLSLDecoder from 'three/addons/transpiler/GLSLDecoder.js';
import WGSLEncoder from 'three/addons/transpiler/WGSLEncoder.js';
import { Fn, glslFn, wgslFn, positionLocal, time } from 'three/tsl';

// Dynamic transpiling GLSL function helper
const glslTFn = ( code, includes = [] ) => {

	let compiledWGSLFn = null;
	let compiledGLSLFn = null;

	return Fn( ( params, builder ) => {

		if ( builder.renderer.backend.isWebGPUBackend ) {

			if ( compiledWGSLFn === null ) {

				const transpiler = new Transpiler( new GLSLDecoder(), new WGSLEncoder() );
				const wgslCode = transpiler.parse( code );

				compiledWGSLFn = wgslFn( wgslCode, includes );

			}

			return compiledWGSLFn( ...params );

		} else {

			if ( compiledGLSLFn === null ) {

				compiledGLSLFn = glslFn( code, includes );

			}

			return compiledGLSLFn( ...params );

		}

	} );

};

// Standard GLSL code running seamlessly on both WebGPU and WebGL
const verticalWaves = glslTFn( `
	vec3 verticalWaves( vec3 pos, float t ) {

		float wave = sin( pos.y * 12.0 + t * 3.0 ) * 0.5 + 0.5;

		return mix( vec3( 0.05, 0.8, 0.7 ), vec3( 0.95, 0.2, 0.4 ), wave );

	}
` );

model.material.colorNode = verticalWaves( { pos: positionLocal, t: time } );
```
