### PR TITLE
Renderer: Introduce `dispose()` async

### DIFF
--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -814,7 +814,19 @@ class Backend {
 	 *
 	 * @abstract
 	 */
-	dispose() { }
+	async dispose() {
+
+		for ( const queryPool of Object.values( this.timestampQueryPool ) ) {
+
+			if ( queryPool !== null ) {
+
+				await queryPool.dispose();
+
+			}
+
+		}
+
+	}
 
 }
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2700,8 +2700,6 @@ class Renderer {
 
 		if ( this._initialized === true ) {
 
-			await this.backend.dispose();
-
 			this.info.dispose();
 
 			this._animation.dispose();
@@ -2719,6 +2717,8 @@ class Renderer {
 				canvasTarget.dispose();
 
 			}
+
+			await this.backend.dispose();
 
 		}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2696,9 +2696,11 @@ class Renderer {
 	 * Frees all internal resources of the renderer. Call this method if the renderer
 	 * is no longer in use by your app.
 	 */
-	dispose() {
+	async dispose() {
 
 		if ( this._initialized === true ) {
+
+			await this.backend.dispose();
 
 			this.info.dispose();
 
@@ -2717,14 +2719,6 @@ class Renderer {
 				canvasTarget.dispose();
 
 			}
-
-			Object.values( this.backend.timestampQueryPool ).forEach( queryPool => {
-
-				if ( queryPool !== null ) queryPool.dispose();
-
-			} );
-
-			this.backend.dispose();
 
 		}
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2929,7 +2929,9 @@ class WebGLBackend extends Backend {
 	/**
 	 * Frees internal resources.
 	 */
-	dispose() {
+	async dispose() {
+
+		await super.dispose();
 
 		if ( this.textureUtils !== null ) this.textureUtils.dispose();
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -3245,7 +3245,9 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	dispose() {
+	async dispose() {
+
+		await super.dispose();
 
 		this.bindingUtils.dispose();
 		this.textureUtils.dispose();
@@ -3259,16 +3261,6 @@ class WebGPUBackend extends Backend {
 			}
 
 			this.occludedResolveCache.clear();
-
-		}
-
-		if ( this.timestampQueryPool ) {
-
-			for ( const queryPool of Object.values( this.timestampQueryPool ) ) {
-
-				if ( queryPool !== null ) queryPool.dispose();
-
-			}
 
 		}
 


### PR DESCRIPTION
Related issue: -

**Description**

Makes `Renderer.dispose()` and `Backend.dispose()` asynchronous to allow proper awaiting of GPU resource deallocations (e.g. timestamp query pools), and ensures the correct internal teardown order.

The `queryPool` disposal was also duplicated and missing from `WebGLBackend`.