### PR TITLE
Tests: Replace empty QUnit stubs with real unit test coverage

### DIFF
--- a/test/unit/src/animation/AnimationUtils.tests.js
+++ b/test/unit/src/animation/AnimationUtils.tests.js
@@ -1,8 +1,513 @@
-// import * as AnimationUtils from '../../../../src/animation/AnimationUtils.js';
+import {
+	convertArray,
+	isTypedArray,
+	getKeyframeOrder,
+	sortedArray,
+	flattenJSON,
+	subclip,
+	makeClipAdditive,
+	AnimationUtils
+} from '../../../../src/animation/AnimationUtils.js';
+
+import { AnimationClip } from '../../../../src/animation/AnimationClip.js';
+import { VectorKeyframeTrack } from '../../../../src/animation/tracks/VectorKeyframeTrack.js';
+import { QuaternionKeyframeTrack } from '../../../../src/animation/tracks/QuaternionKeyframeTrack.js';
+import { BooleanKeyframeTrack } from '../../../../src/animation/tracks/BooleanKeyframeTrack.js';
+import { Vector3 } from '../../../../src/math/Vector3.js';
+import { Quaternion } from '../../../../src/math/Quaternion.js';
+import { AdditiveAnimationBlendMode, NormalAnimationBlendMode } from '../../../../src/constants.js';
 
 export default QUnit.module( 'Animation', () => {
 
 	QUnit.module( 'AnimationUtils', () => {
+
+		// convertArray
+		QUnit.test( 'convertArray - converts a plain array to a typed array', ( assert ) => {
+
+			const result = convertArray( [ 1, 2, 3 ], Float32Array );
+
+			assert.ok( result instanceof Float32Array, 'the result has the requested type' );
+			assert.deepEqual( Array.from( result ), [ 1, 2, 3 ], 'the values are preserved' );
+
+		} );
+
+		QUnit.test( 'convertArray - converts a typed array back to a plain array', ( assert ) => {
+
+			// `Array` has no BYTES_PER_ELEMENT, which selects the slice path.
+			const result = convertArray( new Float32Array( [ 1, 2, 3 ] ), Array );
+
+			assert.ok( Array.isArray( result ), 'the result is a plain Array' );
+			assert.deepEqual( result, [ 1, 2, 3 ], 'the values are preserved' );
+
+		} );
+
+		QUnit.test( 'convertArray - returns the input untouched when it already has the target type', ( assert ) => {
+
+			const typed = new Float32Array( [ 1, 2 ] );
+			const plain = [ 1, 2 ];
+
+			assert.strictEqual( convertArray( typed, Float32Array ), typed, 'a matching typed array is passed through by reference' );
+			assert.strictEqual( convertArray( plain, Array ), plain, 'a matching plain array is passed through by reference' );
+
+		} );
+
+		QUnit.test( 'convertArray - passes falsy input through', ( assert ) => {
+
+			assert.strictEqual( convertArray( undefined, Float32Array ), undefined, 'undefined is returned as-is' );
+			assert.strictEqual( convertArray( null, Float32Array ), null, 'null is returned as-is' );
+
+		} );
+
+		QUnit.test( 'convertArray - narrows values when converting to a smaller type', ( assert ) => {
+
+			const result = convertArray( [ 1.9, - 2.7 ], Int16Array );
+
+			assert.ok( result instanceof Int16Array, 'the result has the requested type' );
+			assert.deepEqual( Array.from( result ), [ 1, - 2 ], 'values are truncated toward zero by the typed array' );
+
+		} );
+
+		// isTypedArray
+		QUnit.test( 'isTypedArray - distinguishes typed arrays from plain arrays', ( assert ) => {
+
+			assert.strictEqual( isTypedArray( new Float32Array( 1 ) ), true, 'Float32Array is a typed array' );
+			assert.strictEqual( isTypedArray( new Uint8Array( 1 ) ), true, 'Uint8Array is a typed array' );
+			assert.strictEqual( isTypedArray( [ 1, 2, 3 ] ), false, 'a plain Array is not a typed array' );
+			assert.strictEqual( isTypedArray( 'abc' ), false, 'a string is not a typed array' );
+			assert.strictEqual( isTypedArray( undefined ), false, 'undefined is not a typed array' );
+
+		} );
+
+		// getKeyframeOrder
+		QUnit.test( 'getKeyframeOrder - returns indices that sort the times ascending', ( assert ) => {
+
+			const times = [ 3, 1, 2, 0 ];
+			const order = getKeyframeOrder( times );
+
+			assert.deepEqual( order, [ 3, 1, 2, 0 ], 'the order indexes the times from smallest to largest' );
+			assert.deepEqual( order.map( i => times[ i ] ), [ 0, 1, 2, 3 ], 'applying the order sorts the times' );
+
+		} );
+
+		QUnit.test( 'getKeyframeOrder - returns the identity for already-sorted times', ( assert ) => {
+
+			assert.deepEqual( getKeyframeOrder( [ 0, 1, 2, 3 ] ), [ 0, 1, 2, 3 ], 'sorted input needs no reordering' );
+
+		} );
+
+		QUnit.test( 'getKeyframeOrder - handles empty and single-element input', ( assert ) => {
+
+			assert.deepEqual( getKeyframeOrder( [] ), [], 'no times produce no order' );
+			assert.deepEqual( getKeyframeOrder( [ 7 ] ), [ 0 ], 'a single time produces a single index' );
+
+		} );
+
+		QUnit.test( 'getKeyframeOrder - does not modify the input array', ( assert ) => {
+
+			const times = [ 3, 1, 2 ];
+			getKeyframeOrder( times );
+
+			assert.deepEqual( times, [ 3, 1, 2 ], 'the caller\'s times array is left untouched' );
+
+		} );
+
+		// sortedArray
+		QUnit.test( 'sortedArray - reorders values in blocks of `stride`', ( assert ) => {
+
+			// Three 2-component values, reordered as 2, 0, 1.
+			const values = [ 10, 11, 20, 21, 30, 31 ];
+			const result = sortedArray( values, 2, [ 2, 0, 1 ] );
+
+			assert.deepEqual( Array.from( result ), [ 30, 31, 10, 11, 20, 21 ], 'each stride-sized block moves as a unit' );
+
+		} );
+
+		QUnit.test( 'sortedArray - preserves the input array type', ( assert ) => {
+
+			const values = new Float32Array( [ 1, 2, 3 ] );
+			const result = sortedArray( values, 1, [ 2, 1, 0 ] );
+
+			assert.ok( result instanceof Float32Array, 'a typed array in yields the same typed array out' );
+			assert.deepEqual( Array.from( result ), [ 3, 2, 1 ], 'the values are reversed' );
+
+		} );
+
+		QUnit.test( 'sortedArray - composes with getKeyframeOrder to sort keyframes', ( assert ) => {
+
+			// The pair is always used together: derive the order from the times,
+			// then apply it to the strided values.
+			const times = [ 2, 0, 1 ];
+			const values = [ 20, 21, 22, 0, 1, 2, 10, 11, 12 ];
+
+			const order = getKeyframeOrder( times );
+
+			assert.deepEqual( Array.from( sortedArray( times, 1, order ) ), [ 0, 1, 2 ], 'times end up ascending' );
+			assert.deepEqual(
+				Array.from( sortedArray( values, 3, order ) ),
+				[ 0, 1, 2, 10, 11, 12, 20, 21, 22 ],
+				'values follow their times'
+			);
+
+		} );
+
+		QUnit.test( 'sortedArray - does not modify the input array', ( assert ) => {
+
+			const values = [ 1, 2, 3 ];
+			sortedArray( values, 1, [ 2, 1, 0 ] );
+
+			assert.deepEqual( values, [ 1, 2, 3 ], 'the caller\'s values array is left untouched' );
+
+		} );
+
+		// flattenJSON
+		QUnit.test( 'flattenJSON - flattens scalar keys', ( assert ) => {
+
+			const times = [], values = [];
+
+			flattenJSON( [ { time: 0, x: 1 }, { time: 1, x: 2 } ], times, values, 'x' );
+
+			assert.deepEqual( times, [ 0, 1 ], 'times are collected' );
+			assert.deepEqual( values, [ 1, 2 ], 'scalar values are pushed as-is' );
+
+		} );
+
+		QUnit.test( 'flattenJSON - spreads array-valued keys', ( assert ) => {
+
+			const times = [], values = [];
+
+			flattenJSON( [ { time: 0, pos: [ 1, 2, 3 ] }, { time: 1, pos: [ 4, 5, 6 ] } ], times, values, 'pos' );
+
+			assert.deepEqual( times, [ 0, 1 ], 'times are collected' );
+			assert.deepEqual( values, [ 1, 2, 3, 4, 5, 6 ], 'array values are flattened in order' );
+
+		} );
+
+		QUnit.test( 'flattenJSON - uses toArray() for math-object keys', ( assert ) => {
+
+			const times = [], values = [];
+
+			flattenJSON(
+				[ { time: 0, pos: new Vector3( 1, 2, 3 ) }, { time: 2, pos: new Vector3( 4, 5, 6 ) } ],
+				times, values, 'pos'
+			);
+
+			assert.deepEqual( times, [ 0, 2 ], 'times are collected' );
+			assert.deepEqual( values, [ 1, 2, 3, 4, 5, 6 ], 'each object is written through toArray()' );
+
+		} );
+
+		QUnit.test( 'flattenJSON - skips leading keys that lack the property', ( assert ) => {
+
+			// The format of the value is decided by the first key that has one,
+			// so leading keys without it must not break the type detection.
+			const times = [], values = [];
+
+			flattenJSON( [ { time: 0 }, { time: 1, x: 5 }, { time: 2, x: 6 } ], times, values, 'x' );
+
+			assert.deepEqual( times, [ 1, 2 ], 'the key without the property is not recorded' );
+			assert.deepEqual( values, [ 5, 6 ], 'only keys carrying the property contribute values' );
+
+		} );
+
+		QUnit.test( 'flattenJSON - skips interior keys that lack the property', ( assert ) => {
+
+			const times = [], values = [];
+
+			flattenJSON( [ { time: 0, x: 1 }, { time: 1 }, { time: 2, x: 3 } ], times, values, 'x' );
+
+			assert.deepEqual( times, [ 0, 2 ], 'the gap is skipped rather than filled' );
+			assert.deepEqual( values, [ 1, 3 ], 'times and values stay in step' );
+
+		} );
+
+		QUnit.test( 'flattenJSON - writes nothing when no key carries the property', ( assert ) => {
+
+			const times = [], values = [];
+
+			flattenJSON( [ { time: 0 }, { time: 1 } ], times, values, 'x' );
+
+			assert.deepEqual( times, [], 'no times are collected' );
+			assert.deepEqual( values, [], 'no values are collected' );
+
+		} );
+
+		QUnit.test( 'flattenJSON - writes nothing for an empty key list', ( assert ) => {
+
+			const times = [], values = [];
+
+			flattenJSON( [], times, values, 'x' );
+
+			assert.deepEqual( times, [], 'no times are collected' );
+			assert.deepEqual( values, [], 'no values are collected' );
+
+		} );
+
+		QUnit.test( 'flattenJSON - appends to arrays that already hold data', ( assert ) => {
+
+			const times = [ - 1 ], values = [ 99 ];
+
+			flattenJSON( [ { time: 0, x: 1 } ], times, values, 'x' );
+
+			assert.deepEqual( times, [ - 1, 0 ], 'existing times are kept' );
+			assert.deepEqual( values, [ 99, 1 ], 'existing values are kept' );
+
+		} );
+
+		// subclip
+		QUnit.test( 'subclip - keeps only keyframes inside [startFrame, endFrame)', ( assert ) => {
+
+			// One keyframe per frame at 30 fps, values 0..4 on x.
+			const track = new VectorKeyframeTrack(
+				'.position',
+				[ 0 / 30, 1 / 30, 2 / 30, 3 / 30, 4 / 30 ],
+				[ 0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0, 4, 0, 0 ]
+			);
+
+			const clip = subclip( new AnimationClip( 'source', - 1, [ track ] ), 'sub', 1, 4 );
+
+			assert.strictEqual( clip.name, 'sub', 'the new clip takes the given name' );
+			assert.strictEqual( clip.tracks.length, 1, 'the track survives' );
+			assert.strictEqual( clip.tracks[ 0 ].times.length, 3, 'frames 1, 2 and 3 are kept -- endFrame is exclusive' );
+			assert.deepEqual(
+				Array.from( clip.tracks[ 0 ].values ),
+				[ 1, 0, 0, 2, 0, 0, 3, 0, 0 ],
+				'the values of the kept frames come along'
+			);
+
+		} );
+
+		QUnit.test( 'subclip - shifts the result so it starts at t = 0', ( assert ) => {
+
+			const track = new VectorKeyframeTrack(
+				'.position',
+				[ 0 / 30, 1 / 30, 2 / 30, 3 / 30 ],
+				[ 0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0 ]
+			);
+
+			const clip = subclip( new AnimationClip( 'source', - 1, [ track ] ), 'sub', 2, 4 );
+
+			assert.numEqual( clip.tracks[ 0 ].times[ 0 ], 0, 'the first kept keyframe lands on t = 0' );
+			assert.numEqual( clip.tracks[ 0 ].times[ 1 ], 1 / 30, 'relative spacing is preserved' );
+			assert.numEqual( clip.duration, 1 / 30, 'the duration is recomputed from the trimmed tracks' );
+
+		} );
+
+		QUnit.test( 'subclip - honours a custom fps', ( assert ) => {
+
+			// At 60 fps the same times map to twice the frame numbers, so a
+			// [1, 3) frame window selects the keyframes at t = 1/60 and 2/60.
+			const track = new VectorKeyframeTrack(
+				'.position',
+				[ 0 / 60, 1 / 60, 2 / 60, 3 / 60 ],
+				[ 0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0 ]
+			);
+
+			const clip = subclip( new AnimationClip( 'source', - 1, [ track ] ), 'sub', 1, 3, 60 );
+
+			assert.strictEqual( clip.tracks[ 0 ].times.length, 2, 'two keyframes fall inside the window at 60 fps' );
+			assert.deepEqual( Array.from( clip.tracks[ 0 ].values ), [ 1, 0, 0, 2, 0, 0 ], 'the expected frames are kept' );
+
+		} );
+
+		QUnit.test( 'subclip - drops tracks with no keyframes in range', ( assert ) => {
+
+			const inRange = new VectorKeyframeTrack( '.position', [ 1 / 30 ], [ 1, 0, 0 ] );
+			const outOfRange = new VectorKeyframeTrack( '.scale', [ 9 / 30 ], [ 9, 0, 0 ] );
+
+			const clip = subclip( new AnimationClip( 'source', - 1, [ inRange, outOfRange ] ), 'sub', 0, 3 );
+
+			assert.strictEqual( clip.tracks.length, 1, 'the empty track is removed entirely' );
+			assert.strictEqual( clip.tracks[ 0 ].name, '.position', 'the track that had data in range is the one kept' );
+
+		} );
+
+		QUnit.test( 'subclip - does not modify the source clip', ( assert ) => {
+
+			const track = new VectorKeyframeTrack(
+				'.position',
+				[ 0 / 30, 1 / 30, 2 / 30 ],
+				[ 0, 0, 0, 1, 0, 0, 2, 0, 0 ]
+			);
+			const source = new AnimationClip( 'source', - 1, [ track ] );
+
+			subclip( source, 'sub', 1, 2 );
+
+			assert.strictEqual( source.name, 'source', 'the source keeps its name' );
+			assert.strictEqual( source.tracks.length, 1, 'the source keeps its tracks' );
+			assert.strictEqual( source.tracks[ 0 ].times.length, 3, 'the source track keeps all of its keyframes' );
+
+		} );
+
+		// makeClipAdditive
+		QUnit.test( 'makeClipAdditive - sets the additive blend mode', ( assert ) => {
+
+			const track = new VectorKeyframeTrack( '.position', [ 0, 1 ], [ 1, 1, 1, 2, 2, 2 ] );
+			const clip = new AnimationClip( 'clip', - 1, [ track ] );
+
+			assert.strictEqual( clip.blendMode, NormalAnimationBlendMode, 'clips start out in normal blend mode' );
+
+			const result = makeClipAdditive( clip );
+
+			assert.strictEqual( result, clip, 'the clip is converted in place and returned' );
+			assert.strictEqual( clip.blendMode, AdditiveAnimationBlendMode, 'the blend mode switches to additive' );
+
+		} );
+
+		QUnit.test( 'makeClipAdditive - subtracts the reference frame from every numeric keyframe', ( assert ) => {
+
+			const track = new VectorKeyframeTrack( '.position', [ 0, 1 ], [ 1, 1, 1, 2, 2, 2 ] );
+
+			makeClipAdditive( new AnimationClip( 'clip', - 1, [ track ] ) );
+
+			// referenceFrame 0 -> the values at t = 0 (1, 1, 1) are the baseline.
+			assert.deepEqual( Array.from( track.values ), [ 0, 0, 0, 1, 1, 1 ], 'values become relative to frame 0' );
+
+		} );
+
+		QUnit.test( 'makeClipAdditive - clamps a reference frame past the last keyframe', ( assert ) => {
+
+			const track = new VectorKeyframeTrack( '.position', [ 0, 1 ], [ 1, 1, 1, 5, 5, 5 ] );
+
+			// Frame 300 at 30 fps is t = 10, well beyond the 1s clip -- the last
+			// keyframe is used rather than extrapolating.
+			makeClipAdditive( new AnimationClip( 'clip', - 1, [ track ] ), 300 );
+
+			assert.deepEqual( Array.from( track.values ), [ - 4, - 4, - 4, 0, 0, 0 ], 'values become relative to the last frame' );
+
+		} );
+
+		QUnit.test( 'makeClipAdditive - interpolates a reference frame between keyframes', ( assert ) => {
+
+			const track = new VectorKeyframeTrack( '.position', [ 0, 1 ], [ 0, 0, 0, 10, 10, 10 ] );
+
+			// Frame 15 at 30 fps is t = 0.5, halfway along -- the baseline is 5.
+			makeClipAdditive( new AnimationClip( 'clip', - 1, [ track ] ), 15 );
+
+			assert.deepEqual( Array.from( track.values ), [ - 5, - 5, - 5, 5, 5, 5 ], 'the baseline is the interpolated value' );
+
+		} );
+
+		QUnit.test( 'makeClipAdditive - falls back to 30 fps for a non-positive fps', ( assert ) => {
+
+			const atZero = new VectorKeyframeTrack( '.position', [ 0, 1 ], [ 0, 0, 0, 10, 10, 10 ] );
+			const atThirty = new VectorKeyframeTrack( '.position', [ 0, 1 ], [ 0, 0, 0, 10, 10, 10 ] );
+
+			makeClipAdditive( new AnimationClip( 'a', - 1, [ atZero ] ), 15, undefined, 0 );
+			makeClipAdditive( new AnimationClip( 'b', - 1, [ atThirty ] ), 15, undefined, 30 );
+
+			assert.deepEqual( Array.from( atZero.values ), Array.from( atThirty.values ), 'fps = 0 behaves like fps = 30' );
+
+		} );
+
+		QUnit.test( 'makeClipAdditive - multiplies by the conjugate for quaternion tracks', ( assert ) => {
+
+			const reference = new Quaternion().setFromAxisAngle( new Vector3( 0, 1, 0 ), Math.PI / 4 );
+			const second = new Quaternion().setFromAxisAngle( new Vector3( 0, 1, 0 ), Math.PI / 2 );
+
+			const track = new QuaternionKeyframeTrack( '.quaternion', [ 0, 1 ], [ ...reference.toArray(), ...second.toArray() ] );
+
+			makeClipAdditive( new AnimationClip( 'clip', - 1, [ track ] ) );
+
+			// Track values are stored as Float32Array, so compare component-wise
+			// with a tolerance rather than using the exact Quaternion.equals().
+			const identity = new Quaternion();
+			for ( let i = 0; i < 4; i ++ ) {
+
+				assert.numEqual( track.values[ i ], identity.toArray()[ i ], `the reference keyframe becomes the identity rotation (component ${ i })` );
+
+			}
+
+			// Both rotations are about Y, so 45 degrees of the original 90 remain.
+			const expected = new Quaternion().setFromAxisAngle( new Vector3( 0, 1, 0 ), Math.PI / 4 ).toArray();
+			for ( let i = 0; i < 4; i ++ ) {
+
+				assert.numEqual( track.values[ 4 + i ], expected[ i ], `the later keyframe holds the rotation relative to the reference (component ${ i })` );
+
+			}
+
+		} );
+
+		QUnit.test( 'makeClipAdditive - applies the conjugate on the left for quaternion tracks', ( assert ) => {
+
+			// Quaternion multiplication does not commute, so with rotations about
+			// different axes the result pins down the operand order: the track
+			// value becomes conjugate(reference) * value, not the other way round.
+			const reference = new Quaternion().setFromAxisAngle( new Vector3( 0, 1, 0 ), Math.PI / 3 );
+			const second = new Quaternion().setFromAxisAngle( new Vector3( 1, 0, 0 ), Math.PI / 2 );
+
+			const track = new QuaternionKeyframeTrack( '.quaternion', [ 0, 1 ], [ ...reference.toArray(), ...second.toArray() ] );
+
+			makeClipAdditive( new AnimationClip( 'clip', - 1, [ track ] ) );
+
+			const conjugateOnTheLeft = reference.clone().conjugate().multiply( second ).toArray();
+
+			for ( let i = 0; i < 4; i ++ ) {
+
+				assert.numEqual( track.values[ 4 + i ], conjugateOnTheLeft[ i ], `component ${ i } matches conjugate(reference) * value` );
+
+			}
+
+		} );
+
+		QUnit.test( 'makeClipAdditive - leaves non-numeric tracks alone', ( assert ) => {
+
+			const track = new BooleanKeyframeTrack( '.visible', [ 0, 1 ], [ true, false ] );
+
+			makeClipAdditive( new AnimationClip( 'clip', - 1, [ track ] ) );
+
+			assert.deepEqual( Array.from( track.values ), [ true, false ], 'boolean track values are untouched' );
+
+		} );
+
+		QUnit.test( 'makeClipAdditive - only touches target tracks matching a reference track', ( assert ) => {
+
+			const referenceTrack = new VectorKeyframeTrack( '.position', [ 0, 1 ], [ 1, 1, 1, 2, 2, 2 ] );
+			const referenceClip = new AnimationClip( 'reference', - 1, [ referenceTrack ] );
+
+			const matching = new VectorKeyframeTrack( '.position', [ 0, 1 ], [ 5, 5, 5, 6, 6, 6 ] );
+			const unmatched = new VectorKeyframeTrack( '.scale', [ 0, 1 ], [ 7, 7, 7, 8, 8, 8 ] );
+			const targetClip = new AnimationClip( 'target', - 1, [ matching, unmatched ] );
+
+			makeClipAdditive( targetClip, 0, referenceClip );
+
+			assert.deepEqual( Array.from( matching.values ), [ 4, 4, 4, 5, 5, 5 ], 'the matching track is made relative to the reference clip' );
+			assert.deepEqual( Array.from( unmatched.values ), [ 7, 7, 7, 8, 8, 8 ], 'a track with no counterpart is left unchanged' );
+
+		} );
+
+		// AnimationUtils facade
+		QUnit.test( 'AnimationUtils - static methods delegate to the module functions', ( assert ) => {
+
+			// The class is a thin facade kept for backwards compatibility; these
+			// checks guard against a method being wired to the wrong function.
+			assert.deepEqual(
+				Array.from( AnimationUtils.convertArray( [ 1, 2 ], Float32Array ) ),
+				[ 1, 2 ],
+				'convertArray'
+			);
+			assert.strictEqual( AnimationUtils.isTypedArray( new Float32Array( 1 ) ), true, 'isTypedArray' );
+			assert.deepEqual( AnimationUtils.getKeyframeOrder( [ 2, 1 ] ), [ 1, 0 ], 'getKeyframeOrder' );
+			assert.deepEqual( Array.from( AnimationUtils.sortedArray( [ 2, 1 ], 1, [ 1, 0 ] ) ), [ 1, 2 ], 'sortedArray' );
+
+			const times = [], values = [];
+			AnimationUtils.flattenJSON( [ { time: 0, x: 1 } ], times, values, 'x' );
+			assert.deepEqual( [ times, values ], [[ 0 ], [ 1 ]], 'flattenJSON' );
+
+			const subTrack = new VectorKeyframeTrack( '.position', [ 0 / 30, 1 / 30 ], [ 0, 0, 0, 1, 0, 0 ] );
+			assert.strictEqual(
+				AnimationUtils.subclip( new AnimationClip( 'source', - 1, [ subTrack ] ), 'sub', 0, 1 ).name,
+				'sub',
+				'subclip'
+			);
+
+			const additiveTrack = new VectorKeyframeTrack( '.position', [ 0, 1 ], [ 1, 1, 1, 2, 2, 2 ] );
+			assert.strictEqual(
+				AnimationUtils.makeClipAdditive( new AnimationClip( 'clip', - 1, [ additiveTrack ] ) ).blendMode,
+				AdditiveAnimationBlendMode,
+				'makeClipAdditive'
+			);
+
+		} );
 
 	} );
 

--- a/test/unit/src/animation/AnimationUtils.tests.js
+++ b/test/unit/src/animation/AnimationUtils.tests.js
@@ -17,6 +17,20 @@ import { Vector3 } from '../../../../src/math/Vector3.js';
 import { Quaternion } from '../../../../src/math/Quaternion.js';
 import { AdditiveAnimationBlendMode, NormalAnimationBlendMode } from '../../../../src/constants.js';
 
+// `assert.numEqual` compares with a fixed absolute tolerance of 0.1, which is
+// far wider than float32 rounding error. Quantities below use this instead so a
+// small numerical regression cannot slip through -- for unit quaternions in
+// particular, a 0.1 component tolerance would admit roughly 50 degrees of
+// rotation error.
+function closeTo( assert, actual, expected, message, eps = 1e-5 ) {
+
+	assert.ok(
+		Math.abs( actual - expected ) < eps,
+		`${ message } (expected ${ expected }, got ${ actual }, tolerance ${ eps })`
+	);
+
+}
+
 export default QUnit.module( 'Animation', () => {
 
 	QUnit.module( 'AnimationUtils', () => {
@@ -278,17 +292,29 @@ export default QUnit.module( 'Animation', () => {
 
 		QUnit.test( 'subclip - shifts the result so it starts at t = 0', ( assert ) => {
 
+			// Deliberately built at 1 fps rather than 30. At 30 fps every value
+			// this test asserts (0, 1/30, 1/30) is smaller than the 0.1 tolerance
+			// `assert.numEqual` uses, so the assertions would hold even if the
+			// shift were removed entirely. Whole-second keyframes put the
+			// expected values well clear of any tolerance, and the tight epsilon
+			// below means dropping `track.shift()` from subclip fails this test.
 			const track = new VectorKeyframeTrack(
 				'.position',
-				[ 0 / 30, 1 / 30, 2 / 30, 3 / 30 ],
+				[ 0, 1, 2, 3 ],
 				[ 0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0 ]
 			);
 
-			const clip = subclip( new AnimationClip( 'source', - 1, [ track ] ), 'sub', 2, 4 );
+			const clip = subclip( new AnimationClip( 'source', - 1, [ track ] ), 'sub', 2, 4, 1 );
 
-			assert.numEqual( clip.tracks[ 0 ].times[ 0 ], 0, 'the first kept keyframe lands on t = 0' );
-			assert.numEqual( clip.tracks[ 0 ].times[ 1 ], 1 / 30, 'relative spacing is preserved' );
-			assert.numEqual( clip.duration, 1 / 30, 'the duration is recomputed from the trimmed tracks' );
+			assert.strictEqual( clip.tracks[ 0 ].times.length, 2, 'frames 2 and 3 are kept' );
+
+			closeTo( assert, clip.tracks[ 0 ].times[ 0 ], 0, 'the first kept keyframe lands on t = 0' );
+			closeTo( assert, clip.tracks[ 0 ].times[ 1 ], 1, 'relative spacing is preserved' );
+			closeTo( assert, clip.duration, 1, 'the duration is recomputed from the trimmed tracks' );
+
+			// Negative control: the unshifted keyframe times would be 2 and 3, so
+			// the assertions above genuinely distinguish shifted from unshifted.
+			assert.notStrictEqual( clip.tracks[ 0 ].times[ 0 ], 2, 'the result is not simply the untouched source times' );
 
 		} );
 
@@ -409,11 +435,14 @@ export default QUnit.module( 'Animation', () => {
 			makeClipAdditive( new AnimationClip( 'clip', - 1, [ track ] ) );
 
 			// Track values are stored as Float32Array, so compare component-wise
-			// with a tolerance rather than using the exact Quaternion.equals().
-			const identity = new Quaternion();
+			// rather than using the exact Quaternion.equals(). The epsilon is
+			// tight on purpose: at the 0.1 tolerance `assert.numEqual` uses, a w
+			// component within 0.1 of 1 still admits a rotation error of roughly
+			// 50 degrees, so a visibly wrong result would pass.
+			const identity = new Quaternion().toArray();
 			for ( let i = 0; i < 4; i ++ ) {
 
-				assert.numEqual( track.values[ i ], identity.toArray()[ i ], `the reference keyframe becomes the identity rotation (component ${ i })` );
+				closeTo( assert, track.values[ i ], identity[ i ], `the reference keyframe becomes the identity rotation (component ${ i })` );
 
 			}
 
@@ -421,7 +450,7 @@ export default QUnit.module( 'Animation', () => {
 			const expected = new Quaternion().setFromAxisAngle( new Vector3( 0, 1, 0 ), Math.PI / 4 ).toArray();
 			for ( let i = 0; i < 4; i ++ ) {
 
-				assert.numEqual( track.values[ 4 + i ], expected[ i ], `the later keyframe holds the rotation relative to the reference (component ${ i })` );
+				closeTo( assert, track.values[ 4 + i ], expected[ i ], `the later keyframe holds the rotation relative to the reference (component ${ i })` );
 
 			}
 
@@ -440,12 +469,21 @@ export default QUnit.module( 'Animation', () => {
 			makeClipAdditive( new AnimationClip( 'clip', - 1, [ track ] ) );
 
 			const conjugateOnTheLeft = reference.clone().conjugate().multiply( second ).toArray();
+			const theOtherOrder = second.clone().multiply( reference.clone().conjugate() ).toArray();
 
 			for ( let i = 0; i < 4; i ++ ) {
 
-				assert.numEqual( track.values[ 4 + i ], conjugateOnTheLeft[ i ], `component ${ i } matches conjugate(reference) * value` );
+				closeTo( assert, track.values[ 4 + i ], conjugateOnTheLeft[ i ], `component ${ i } matches conjugate(reference) * value` );
 
 			}
+
+			// The two orders genuinely differ for these axes, so the assertions
+			// above are actually discriminating between them rather than passing
+			// on a case where multiplication happens to commute.
+			assert.ok(
+				conjugateOnTheLeft.some( ( v, i ) => Math.abs( v - theOtherOrder[ i ] ) > 0.1 ),
+				'the two operand orders produce measurably different quaternions for these axes'
+			);
 
 		} );
 

--- a/test/unit/src/animation/PropertyMixer.tests.js
+++ b/test/unit/src/animation/PropertyMixer.tests.js
@@ -1,8 +1,439 @@
-// import { PropertyMixer } from '../../../../src/animation/PropertyMixer.js';
+import { PropertyMixer } from '../../../../src/animation/PropertyMixer.js';
+
+// Minimal stand-in for a PropertyBinding: PropertyMixer only ever calls
+// getValue()/setValue() on it, so the real binding (and a scene graph to bind
+// to) is not needed here.
+class MockBinding {
+
+	constructor( values ) {
+
+		this.values = values.slice();
+		this.setValueCalls = 0;
+
+	}
+
+	getValue( array, offset ) {
+
+		for ( let i = 0; i < this.values.length; i ++ ) {
+
+			array[ offset + i ] = this.values[ i ];
+
+		}
+
+	}
+
+	setValue( array, offset ) {
+
+		this.setValueCalls ++;
+
+		for ( let i = 0; i < this.values.length; i ++ ) {
+
+			this.values[ i ] = array[ offset + i ];
+
+		}
+
+	}
+
+}
+
+// Buffer layout is [ incoming | accu0 | accu1 | orig | add | (work) ], so the
+// incoming region always starts at 0 and region N starts at N * valueSize.
+function writeIncoming( mixer, values ) {
+
+	for ( let i = 0; i < values.length; i ++ ) {
+
+		mixer.buffer[ i ] = values[ i ];
+
+	}
+
+}
+
+function readRegion( mixer, regionIndex ) {
+
+	const stride = mixer.valueSize;
+	const offset = regionIndex * stride;
+
+	return Array.from( mixer.buffer.slice( offset, offset + stride ) );
+
+}
 
 export default QUnit.module( 'Animation', () => {
 
 	QUnit.module( 'PropertyMixer', () => {
+
+		// INSTANCING
+		QUnit.test( 'Instancing - stores the constructor arguments', ( assert ) => {
+
+			const binding = new MockBinding( [ 0, 0, 0 ] );
+			const mixer = new PropertyMixer( binding, 'vector', 3 );
+
+			assert.strictEqual( mixer.binding, binding, 'the binding is kept' );
+			assert.strictEqual( mixer.valueSize, 3, 'the value size is kept' );
+
+		} );
+
+		QUnit.test( 'Instancing - starts with zeroed weights and counts', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 0 ] ), 'number', 1 );
+
+			assert.strictEqual( mixer.cumulativeWeight, 0, 'cumulativeWeight starts at 0' );
+			assert.strictEqual( mixer.cumulativeWeightAdditive, 0, 'cumulativeWeightAdditive starts at 0' );
+			assert.strictEqual( mixer.useCount, 0, 'useCount starts at 0' );
+			assert.strictEqual( mixer.referenceCount, 0, 'referenceCount starts at 0' );
+
+		} );
+
+		QUnit.test( 'Instancing - allocates a five-region Float64Array for numeric types', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 0, 0, 0 ] ), 'vector', 3 );
+
+			assert.ok( mixer.buffer instanceof Float64Array, 'numeric types use a Float64Array' );
+			assert.strictEqual( mixer.buffer.length, 3 * 5, 'incoming, accu0, accu1, orig and add regions are allocated' );
+
+		} );
+
+		QUnit.test( 'Instancing - allocates an extra work region for quaternion types', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 0, 0, 0, 1 ] ), 'quaternion', 4 );
+
+			assert.ok( mixer.buffer instanceof Float64Array, 'quaternion types use a Float64Array' );
+			assert.strictEqual( mixer.buffer.length, 4 * 6, 'a sixth region is allocated for intermediate results' );
+			assert.strictEqual( mixer._workIndex, 5, 'the work region is the last one' );
+
+		} );
+
+		QUnit.test( 'Instancing - allocates a plain Array for non-numeric types', ( assert ) => {
+
+			// Booleans and strings cannot live in a typed array.
+			for ( const typeName of [ 'bool', 'string' ] ) {
+
+				const mixer = new PropertyMixer( new MockBinding( [ 0 ] ), typeName, 1 );
+
+				assert.ok( Array.isArray( mixer.buffer ), `${ typeName } uses a plain Array` );
+				assert.strictEqual( mixer.buffer.length, 5, `${ typeName } allocates five regions` );
+
+			}
+
+		} );
+
+		// saveOriginalState
+		QUnit.test( 'saveOriginalState - copies the bound value into the orig and both accu regions', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 1, 2, 3 ] ), 'vector', 3 );
+
+			mixer.saveOriginalState();
+
+			assert.deepEqual( readRegion( mixer, 3 ), [ 1, 2, 3 ], 'orig holds the bound value' );
+			assert.deepEqual( readRegion( mixer, 1 ), [ 1, 2, 3 ], 'accu0 is primed with the bound value' );
+			assert.deepEqual( readRegion( mixer, 2 ), [ 1, 2, 3 ], 'accu1 is primed with the bound value' );
+
+		} );
+
+		QUnit.test( 'saveOriginalState - resets the additive region to the numeric identity', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 1, 2, 3 ] ), 'vector', 3 );
+
+			mixer.saveOriginalState();
+
+			assert.deepEqual( readRegion( mixer, 4 ), [ 0, 0, 0 ], 'the additive identity for numbers is zero' );
+
+		} );
+
+		QUnit.test( 'saveOriginalState - resets the additive region to the quaternion identity', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 0, 0.7071, 0, 0.7071 ] ), 'quaternion', 4 );
+
+			mixer.saveOriginalState();
+
+			assert.deepEqual( readRegion( mixer, 4 ), [ 0, 0, 0, 1 ], 'the additive identity for quaternions is (0, 0, 0, 1)' );
+
+		} );
+
+		QUnit.test( 'saveOriginalState - uses the original value as the identity for non-numeric types', ( assert ) => {
+
+			// There is no meaningful "zero" for a bool, so the original value
+			// stands in as the additive identity.
+			const mixer = new PropertyMixer( new MockBinding( [ true ] ), 'bool', 1 );
+
+			mixer.saveOriginalState();
+
+			assert.deepEqual( readRegion( mixer, 4 ), [ true ], 'the additive region mirrors the original value' );
+
+		} );
+
+		QUnit.test( 'saveOriginalState - clears the accumulated weights', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 0 ] ), 'number', 1 );
+
+			mixer.cumulativeWeight = 0.5;
+			mixer.cumulativeWeightAdditive = 0.25;
+
+			mixer.saveOriginalState();
+
+			assert.strictEqual( mixer.cumulativeWeight, 0, 'cumulativeWeight is reset' );
+			assert.strictEqual( mixer.cumulativeWeightAdditive, 0, 'cumulativeWeightAdditive is reset' );
+
+		} );
+
+		// restoreOriginalState
+		QUnit.test( 'restoreOriginalState - writes the saved value back to the binding', ( assert ) => {
+
+			const binding = new MockBinding( [ 1, 2, 3 ] );
+			const mixer = new PropertyMixer( binding, 'vector', 3 );
+
+			mixer.saveOriginalState();
+
+			binding.values = [ 9, 9, 9 ];
+			mixer.restoreOriginalState();
+
+			assert.deepEqual( binding.values, [ 1, 2, 3 ], 'the binding is returned to its saved state' );
+
+		} );
+
+		// accumulate
+		QUnit.test( 'accumulate - the first contribution is copied in unweighted', ( assert ) => {
+
+			// With no accumulated weight yet there is nothing to blend against,
+			// so the incoming value is taken verbatim and the weight is recorded
+			// for the eventual blend against the original in apply().
+			const mixer = new PropertyMixer( new MockBinding( [ 0, 0, 0 ] ), 'vector', 3 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 10, 20, 30 ] );
+			mixer.accumulate( 0, 0.25 );
+
+			assert.deepEqual( readRegion( mixer, 1 ), [ 10, 20, 30 ], 'accu0 holds the incoming value, not a scaled one' );
+			assert.strictEqual( mixer.cumulativeWeight, 0.25, 'the weight is recorded' );
+
+		} );
+
+		QUnit.test( 'accumulate - blends further contributions by relative weight', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 0, 0, 0 ] ), 'vector', 3 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 10, 20, 30 ] );
+			mixer.accumulate( 0, 1 );
+
+			writeIncoming( mixer, [ 0, 0, 0 ] );
+			mixer.accumulate( 0, 1 );
+
+			assert.deepEqual( readRegion( mixer, 1 ), [ 5, 10, 15 ], 'two equal weights average the contributions' );
+			assert.strictEqual( mixer.cumulativeWeight, 2, 'the weights add up' );
+
+		} );
+
+		QUnit.test( 'accumulate - respects unequal weights', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 0 ] ), 'number', 1 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 0 ] );
+			mixer.accumulate( 0, 3 );
+
+			writeIncoming( mixer, [ 100 ] );
+			mixer.accumulate( 0, 1 );
+
+			// mix = 1 / 4, so the result is 0 * 0.75 + 100 * 0.25.
+			assert.numEqual( readRegion( mixer, 1 )[ 0 ], 25, 'the lighter contribution pulls proportionally less' );
+
+		} );
+
+		QUnit.test( 'accumulate - keeps the two accu regions independent', ( assert ) => {
+
+			// The mixer interleaves accu0 and accu1 across frames so apply() can
+			// detect changes; writing one must never disturb the other.
+			const mixer = new PropertyMixer( new MockBinding( [ 0 ] ), 'number', 1 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 7 ] );
+			mixer.accumulate( 1, 1 );
+
+			assert.deepEqual( readRegion( mixer, 2 ), [ 7 ], 'accu1 received the value' );
+			assert.deepEqual( readRegion( mixer, 1 ), [ 0 ], 'accu0 is untouched' );
+
+		} );
+
+		QUnit.test( 'accumulate - picks the heavier value for non-numeric types', ( assert ) => {
+
+			// Booleans cannot be interpolated, so the mixer selects rather than
+			// blends: the incoming value only wins if it is at least half the
+			// accumulated weight.
+			const heavierIncoming = new PropertyMixer( new MockBinding( [ true ] ), 'bool', 1 );
+			heavierIncoming.saveOriginalState();
+			writeIncoming( heavierIncoming, [ true ] );
+			heavierIncoming.accumulate( 0, 1 );
+			writeIncoming( heavierIncoming, [ false ] );
+			heavierIncoming.accumulate( 0, 1 );
+
+			assert.deepEqual( readRegion( heavierIncoming, 1 ), [ false ], 'an equal weight (mix = 0.5) lets the incoming value win' );
+
+			const lighterIncoming = new PropertyMixer( new MockBinding( [ true ] ), 'bool', 1 );
+			lighterIncoming.saveOriginalState();
+			writeIncoming( lighterIncoming, [ true ] );
+			lighterIncoming.accumulate( 0, 1 );
+			writeIncoming( lighterIncoming, [ false ] );
+			lighterIncoming.accumulate( 0, 0.5 );
+
+			assert.deepEqual( readRegion( lighterIncoming, 1 ), [ true ], 'a lighter weight (mix < 0.5) keeps the accumulated value' );
+
+		} );
+
+		// accumulateAdditive
+		QUnit.test( 'accumulateAdditive - adds weighted contributions to the additive region', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 1, 2, 3 ] ), 'vector', 3 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 10, 10, 10 ] );
+			mixer.accumulateAdditive( 0.5 );
+
+			assert.deepEqual( readRegion( mixer, 4 ), [ 5, 5, 5 ], 'the contribution is scaled by its weight' );
+			assert.strictEqual( mixer.cumulativeWeightAdditive, 0.5, 'the additive weight is recorded' );
+
+		} );
+
+		QUnit.test( 'accumulateAdditive - accumulates rather than replaces', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 0, 0, 0 ] ), 'vector', 3 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 10, 10, 10 ] );
+			mixer.accumulateAdditive( 0.5 );
+			mixer.accumulateAdditive( 0.5 );
+
+			assert.deepEqual( readRegion( mixer, 4 ), [ 10, 10, 10 ], 'the two contributions sum' );
+			assert.strictEqual( mixer.cumulativeWeightAdditive, 1, 'the additive weights add up' );
+
+		} );
+
+		QUnit.test( 'accumulateAdditive - resets to the identity on the first contribution', ( assert ) => {
+
+			// apply() zeroes cumulativeWeightAdditive, so the next accumulation
+			// has to discard whatever the previous frame left in the region
+			// instead of adding to it.
+			const mixer = new PropertyMixer( new MockBinding( [ 0 ] ), 'number', 1 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 10 ] );
+			mixer.accumulateAdditive( 1 );
+			mixer.apply( 0 );
+
+			writeIncoming( mixer, [ 10 ] );
+			mixer.accumulateAdditive( 1 );
+
+			assert.deepEqual( readRegion( mixer, 4 ), [ 10 ], 'the stale value from the previous frame is discarded' );
+
+		} );
+
+		// apply
+		QUnit.test( 'apply - writes a fully weighted result straight to the binding', ( assert ) => {
+
+			const binding = new MockBinding( [ 0, 0, 0 ] );
+			const mixer = new PropertyMixer( binding, 'vector', 3 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 10, 20, 30 ] );
+			mixer.accumulate( 0, 1 );
+			mixer.apply( 0 );
+
+			assert.deepEqual( binding.values, [ 10, 20, 30 ], 'a weight of 1 leaves the original out of the blend' );
+
+		} );
+
+		QUnit.test( 'apply - blends the remaining weight against the original value', ( assert ) => {
+
+			const binding = new MockBinding( [ 0, 0, 0 ] );
+			const mixer = new PropertyMixer( binding, 'vector', 3 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 10, 20, 30 ] );
+			mixer.accumulate( 0, 0.25 );
+			mixer.apply( 0 );
+
+			// 25% of the animated value, 75% of the original (0, 0, 0).
+			assert.deepEqual( binding.values, [ 2.5, 5, 7.5 ], 'the unfilled weight is taken from the original' );
+
+		} );
+
+		QUnit.test( 'apply - folds the additive region into the result', ( assert ) => {
+
+			const binding = new MockBinding( [ 0, 0, 0 ] );
+			const mixer = new PropertyMixer( binding, 'vector', 3 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 10, 10, 10 ] );
+			mixer.accumulate( 0, 1 );
+
+			writeIncoming( mixer, [ 10, 10, 10 ] );
+			mixer.accumulateAdditive( 0.5 );
+
+			mixer.apply( 0 );
+
+			assert.deepEqual( binding.values, [ 15, 15, 15 ], 'the additive contribution is added on top' );
+
+		} );
+
+		QUnit.test( 'apply - resets both weights', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( [ 0 ] ), 'number', 1 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 1 ] );
+			mixer.accumulate( 0, 1 );
+			mixer.accumulateAdditive( 1 );
+
+			mixer.apply( 0 );
+
+			assert.strictEqual( mixer.cumulativeWeight, 0, 'cumulativeWeight is cleared for the next frame' );
+			assert.strictEqual( mixer.cumulativeWeightAdditive, 0, 'cumulativeWeightAdditive is cleared for the next frame' );
+
+		} );
+
+		QUnit.test( 'apply - leaves the binding alone when nothing changed', ( assert ) => {
+
+			// Both accus start at the original value, so applying the original
+			// back must not touch the scene graph.
+			const binding = new MockBinding( [ 5, 5, 5 ] );
+			const mixer = new PropertyMixer( binding, 'vector', 3 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 5, 5, 5 ] );
+			mixer.accumulate( 0, 1 );
+			mixer.apply( 0 );
+
+			assert.strictEqual( binding.setValueCalls, 0, 'setValue is not called when the accus agree' );
+
+		} );
+
+		QUnit.test( 'apply - writes to the binding when the accus disagree', ( assert ) => {
+
+			const binding = new MockBinding( [ 5, 5, 5 ] );
+			const mixer = new PropertyMixer( binding, 'vector', 3 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 6, 5, 5 ] );
+			mixer.accumulate( 0, 1 );
+			mixer.apply( 0 );
+
+			assert.strictEqual( binding.setValueCalls, 1, 'a single differing component is enough to trigger a write' );
+			assert.deepEqual( binding.values, [ 6, 5, 5 ], 'the new value reaches the binding' );
+
+		} );
+
+		QUnit.test( 'apply - reads from the accu region it was given', ( assert ) => {
+
+			const binding = new MockBinding( [ 0 ] );
+			const mixer = new PropertyMixer( binding, 'number', 1 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, [ 42 ] );
+			mixer.accumulate( 1, 1 );
+			mixer.apply( 1 );
+
+			assert.deepEqual( binding.values, [ 42 ], 'accumulating and applying accu1 works the same as accu0' );
+
+		} );
 
 	} );
 

--- a/test/unit/src/animation/PropertyMixer.tests.js
+++ b/test/unit/src/animation/PropertyMixer.tests.js
@@ -1,4 +1,25 @@
 import { PropertyMixer } from '../../../../src/animation/PropertyMixer.js';
+import { Quaternion } from '../../../../src/math/Quaternion.js';
+import { Vector3 } from '../../../../src/math/Vector3.js';
+
+// Rotations about +Y, so every expected result below is a plain angle addition
+// or bisection that can be reasoned about without reproducing the slerp code.
+const AXIS_Y = new Vector3( 0, 1, 0 );
+
+function yQuaternion( degrees ) {
+
+	return new Quaternion().setFromAxisAngle( AXIS_Y, degrees * Math.PI / 180 );
+
+}
+
+// Recovers the rotation angle in degrees from four packed quaternion
+// components, so assertions read as angles rather than component soup.
+function angleOf( components ) {
+
+	const q = new Quaternion().fromArray( components );
+	return 2 * Math.acos( Math.min( 1, Math.abs( q.w ) ) ) * 180 / Math.PI;
+
+}
 
 // Minimal stand-in for a PropertyBinding: PropertyMixer only ever calls
 // getValue()/setValue() on it, so the real binding (and a scene graph to bind
@@ -98,7 +119,10 @@ export default QUnit.module( 'Animation', () => {
 
 			assert.ok( mixer.buffer instanceof Float64Array, 'quaternion types use a Float64Array' );
 			assert.strictEqual( mixer.buffer.length, 4 * 6, 'a sixth region is allocated for intermediate results' );
-			assert.strictEqual( mixer._workIndex, 5, 'the work region is the last one' );
+
+			// The work region's index is a private detail; that it is actually
+			// used is covered behaviourally by the quaternion accumulateAdditive
+			// tests below.
 
 		} );
 
@@ -418,6 +442,144 @@ export default QUnit.module( 'Animation', () => {
 
 			assert.strictEqual( binding.setValueCalls, 1, 'a single differing component is enough to trigger a write' );
 			assert.deepEqual( binding.values, [ 6, 5, 5 ], 'the new value reaches the binding' );
+
+		} );
+
+		// quaternion mixing
+		//
+		// Quaternion mixers take a different code path throughout: _slerp instead
+		// of _lerp, _slerpAdditive instead of _lerpAdditive, plus the extra work
+		// region. All rotations below are about +Y so the expected results are
+		// plain angle arithmetic rather than a restatement of the slerp formula.
+		QUnit.test( 'accumulate - slerps between quaternion contributions', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( yQuaternion( 0 ).toArray() ), 'quaternion', 4 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, yQuaternion( 0 ).toArray() );
+			mixer.accumulate( 0, 1 );
+
+			writeIncoming( mixer, yQuaternion( 90 ).toArray() );
+			mixer.accumulate( 0, 1 );
+
+			// Equal weights put the result halfway along the arc from 0 to 90.
+			assert.ok(
+				Math.abs( angleOf( readRegion( mixer, 1 ) ) - 45 ) < 1e-4,
+				`equal weights bisect the rotation (got ${ angleOf( readRegion( mixer, 1 ) ).toFixed( 4 ) } degrees, expected 45)`
+			);
+
+		} );
+
+		QUnit.test( 'accumulate - weights quaternion contributions unequally', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( yQuaternion( 0 ).toArray() ), 'quaternion', 4 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, yQuaternion( 0 ).toArray() );
+			mixer.accumulate( 0, 3 );
+
+			writeIncoming( mixer, yQuaternion( 80 ).toArray() );
+			mixer.accumulate( 0, 1 );
+
+			// mix = 1 / 4, so the result sits a quarter of the way along the arc.
+			assert.ok(
+				Math.abs( angleOf( readRegion( mixer, 1 ) ) - 20 ) < 1e-4,
+				`the lighter contribution moves the rotation proportionally less (got ${ angleOf( readRegion( mixer, 1 ) ).toFixed( 4 ) } degrees, expected 20)`
+			);
+
+		} );
+
+		QUnit.test( 'accumulateAdditive - slerps the quaternion in from the identity', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( yQuaternion( 0 ).toArray() ), 'quaternion', 4 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, yQuaternion( 90 ).toArray() );
+			mixer.accumulateAdditive( 0.5 );
+
+			// The additive region starts at the identity, so a weight of 0.5
+			// lands halfway to the incoming rotation.
+			assert.ok(
+				Math.abs( angleOf( readRegion( mixer, 4 ) ) - 45 ) < 1e-4,
+				`half weight gives half the rotation (got ${ angleOf( readRegion( mixer, 4 ) ).toFixed( 4 ) } degrees, expected 45)`
+			);
+
+		} );
+
+		QUnit.test( 'accumulateAdditive - a full weight takes the quaternion verbatim', ( assert ) => {
+
+			const mixer = new PropertyMixer( new MockBinding( yQuaternion( 0 ).toArray() ), 'quaternion', 4 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, yQuaternion( 60 ).toArray() );
+			mixer.accumulateAdditive( 1 );
+
+			assert.ok(
+				Math.abs( angleOf( readRegion( mixer, 4 ) ) - 60 ) < 1e-4,
+				`a weight of 1 reaches the incoming rotation (got ${ angleOf( readRegion( mixer, 4 ) ).toFixed( 4 ) } degrees, expected 60)`
+			);
+
+		} );
+
+		QUnit.test( 'accumulateAdditive - uses the work region for the intermediate product', ( assert ) => {
+
+			// The sixth buffer region exists purely to hold the intermediate
+			// quaternion product; this is what makes its allocation meaningful.
+			const mixer = new PropertyMixer( new MockBinding( yQuaternion( 0 ).toArray() ), 'quaternion', 4 );
+			mixer.saveOriginalState();
+
+			assert.deepEqual( readRegion( mixer, 5 ), [ 0, 0, 0, 0 ], 'the work region starts untouched' );
+
+			writeIncoming( mixer, yQuaternion( 90 ).toArray() );
+			mixer.accumulateAdditive( 0.5 );
+
+			// work := additive identity * incoming, i.e. the incoming rotation.
+			assert.ok(
+				Math.abs( angleOf( readRegion( mixer, 5 ) ) - 90 ) < 1e-4,
+				`the work region holds the intermediate product (got ${ angleOf( readRegion( mixer, 5 ) ).toFixed( 4 ) } degrees, expected 90)`
+			);
+
+		} );
+
+		QUnit.test( 'apply - composes the additive quaternion onto the accumulated one', ( assert ) => {
+
+			const binding = new MockBinding( yQuaternion( 0 ).toArray() );
+			const mixer = new PropertyMixer( binding, 'quaternion', 4 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, yQuaternion( 90 ).toArray() );
+			mixer.accumulate( 0, 1 );
+
+			writeIncoming( mixer, yQuaternion( 90 ).toArray() );
+			mixer.accumulateAdditive( 0.5 );
+
+			mixer.apply( 0 );
+
+			// 90 degrees accumulated, plus a 45-degree additive contribution
+			// about the same axis, composes to 135.
+			assert.ok(
+				Math.abs( angleOf( binding.values ) - 135 ) < 1e-4,
+				`the additive rotation composes onto the accumulated one (got ${ angleOf( binding.values ).toFixed( 4 ) } degrees, expected 135)`
+			);
+
+		} );
+
+		QUnit.test( 'apply - blends a quaternion against the original by the remaining weight', ( assert ) => {
+
+			const binding = new MockBinding( yQuaternion( 0 ).toArray() );
+			const mixer = new PropertyMixer( binding, 'quaternion', 4 );
+			mixer.saveOriginalState();
+
+			writeIncoming( mixer, yQuaternion( 90 ).toArray() );
+			mixer.accumulate( 0, 0.5 );
+
+			mixer.apply( 0 );
+
+			// Half weight slerps halfway back toward the original rotation of 0.
+			assert.ok(
+				Math.abs( angleOf( binding.values ) - 45 ) < 1e-4,
+				`the unfilled weight pulls back toward the original (got ${ angleOf( binding.values ).toFixed( 4 ) } degrees, expected 45)`
+			);
 
 		} );
 

--- a/test/unit/src/audio/AudioAnalyser.tests.js
+++ b/test/unit/src/audio/AudioAnalyser.tests.js
@@ -1,8 +1,171 @@
-// import { AudioAnalyser } from '../../../../src/audio/AudioAnalyser.js';
+import { AudioAnalyser } from '../../../../src/audio/AudioAnalyser.js';
+
+// Stands in for an Audio plus its AnalyserNode. `frequencies` is what the
+// mock analyser writes on getByteFrequencyData(), which is the only input
+// getAverageFrequency() has.
+function mockAudio( { frequencies = null } = {} ) {
+
+	const connections = [];
+	const output = {
+		connect( node ) {
+
+			connections.push( node );
+
+		}
+	};
+
+	return {
+		connections,
+		output,
+		getOutput() {
+
+			return output;
+
+		},
+		context: {
+			createAnalyser() {
+
+				return {
+					fftSize: 2048,
+					get frequencyBinCount() {
+
+						return this.fftSize / 2;
+
+					},
+					getByteFrequencyData( array ) {
+
+						if ( frequencies === null ) return;
+
+						for ( let i = 0; i < array.length; i ++ ) {
+
+							array[ i ] = frequencies[ i % frequencies.length ];
+
+						}
+
+					}
+				};
+
+			}
+		}
+	};
+
+}
 
 export default QUnit.module( 'Audios', () => {
 
 	QUnit.module( 'AudioAnalyser', () => {
+
+		// INSTANCING
+		QUnit.test( 'Instancing - creates an analyser on the audio context', ( assert ) => {
+
+			const analyser = new AudioAnalyser( mockAudio() );
+
+			assert.ok( analyser.analyser !== undefined, 'the analyser node is exposed' );
+
+		} );
+
+		QUnit.test( 'Instancing - defaults to an fftSize of 2048', ( assert ) => {
+
+			const analyser = new AudioAnalyser( mockAudio() );
+
+			assert.strictEqual( analyser.analyser.fftSize, 2048, 'the default window size is 2048 samples' );
+
+		} );
+
+		QUnit.test( 'Instancing - applies a custom fftSize', ( assert ) => {
+
+			const analyser = new AudioAnalyser( mockAudio(), 32 );
+
+			assert.strictEqual( analyser.analyser.fftSize, 32, 'the requested window size is used' );
+
+		} );
+
+		QUnit.test( 'Instancing - sizes the data buffer to the bin count', ( assert ) => {
+
+			// frequencyBinCount is always half the fftSize, so a 32-sample
+			// window produces 16 frequency bins.
+			const analyser = new AudioAnalyser( mockAudio(), 32 );
+
+			assert.ok( analyser.data instanceof Uint8Array, 'the data buffer is a Uint8Array' );
+			assert.strictEqual( analyser.data.length, 16, 'the buffer holds one entry per frequency bin' );
+
+		} );
+
+		QUnit.test( 'Instancing - connects the audio output into the analyser', ( assert ) => {
+
+			const audio = mockAudio();
+			const analyser = new AudioAnalyser( audio, 32 );
+
+			assert.deepEqual( audio.connections, [ analyser.analyser ], 'the audio output feeds the analyser node' );
+
+		} );
+
+		// getFrequencyData
+		QUnit.test( 'getFrequencyData - fills and returns the data buffer', ( assert ) => {
+
+			const analyser = new AudioAnalyser( mockAudio( { frequencies: [ 10, 20, 30, 40 ] } ), 8 );
+
+			const data = analyser.getFrequencyData();
+
+			assert.strictEqual( data, analyser.data, 'the buffer is returned rather than a copy' );
+			assert.deepEqual( Array.from( data ), [ 10, 20, 30, 40 ], 'the analyser node wrote into it' );
+
+		} );
+
+		QUnit.test( 'getFrequencyData - reuses the same buffer across calls', ( assert ) => {
+
+			// The buffer is allocated once and refilled, so callers holding a
+			// reference see the updated values.
+			const analyser = new AudioAnalyser( mockAudio( { frequencies: [ 1, 2, 3, 4 ] } ), 8 );
+
+			assert.strictEqual( analyser.getFrequencyData(), analyser.getFrequencyData(), 'the same array comes back every time' );
+
+		} );
+
+		// getAverageFrequency
+		QUnit.test( 'getAverageFrequency - averages the frequency bins', ( assert ) => {
+
+			const analyser = new AudioAnalyser( mockAudio( { frequencies: [ 10, 20, 30, 40 ] } ), 8 );
+
+			assert.numEqual( analyser.getAverageFrequency(), 25, 'the mean of the four bins is returned' );
+
+		} );
+
+		QUnit.test( 'getAverageFrequency - returns zero for silence', ( assert ) => {
+
+			const analyser = new AudioAnalyser( mockAudio( { frequencies: [ 0, 0, 0, 0 ] } ), 8 );
+
+			assert.strictEqual( analyser.getAverageFrequency(), 0, 'silent input averages to zero' );
+
+		} );
+
+		QUnit.test( 'getAverageFrequency - handles the full byte range', ( assert ) => {
+
+			const analyser = new AudioAnalyser( mockAudio( { frequencies: [ 255, 255, 255, 255 ] } ), 8 );
+
+			assert.strictEqual( analyser.getAverageFrequency(), 255, 'a saturated spectrum averages to 255' );
+
+		} );
+
+		QUnit.test( 'getAverageFrequency - refreshes the data before averaging', ( assert ) => {
+
+			// The average has to reflect the current audio, so it must pull new
+			// data rather than reuse whatever was last read.
+			let call = 0;
+
+			const audio = mockAudio();
+			const analyser = new AudioAnalyser( audio, 8 );
+
+			analyser.analyser.getByteFrequencyData = ( array ) => {
+
+				array.fill( ++ call * 10 );
+
+			};
+
+			assert.numEqual( analyser.getAverageFrequency(), 10, 'the first call reads the first sample' );
+			assert.numEqual( analyser.getAverageFrequency(), 20, 'the second call reads fresh data' );
+
+		} );
 
 	} );
 

--- a/test/unit/src/audio/AudioAnalyser.tests.js
+++ b/test/unit/src/audio/AudioAnalyser.tests.js
@@ -26,7 +26,14 @@ function mockAudio( { frequencies = null } = {} ) {
 			createAnalyser() {
 
 				return {
-					fftSize: 2048,
+					// Deliberately not 2048. A real AnalyserNode does default to
+					// 2048, but mirroring that here would make the "defaults to an
+					// fftSize of 2048" test pass even with the assignment removed
+					// from AudioAnalyser -- the assertion would only be reading
+					// the mock's own preset back. Starting from a sentinel forces
+					// the constructor to actually do the work.
+					fftSize: 0,
+					assignedFftSizes: [],
 					get frequencyBinCount() {
 
 						return this.fftSize / 2;
@@ -66,9 +73,12 @@ export default QUnit.module( 'Audios', () => {
 
 		QUnit.test( 'Instancing - defaults to an fftSize of 2048', ( assert ) => {
 
+			// The mock starts at 0, so this only passes if the constructor
+			// actively assigns its default rather than leaving the node alone.
 			const analyser = new AudioAnalyser( mockAudio() );
 
 			assert.strictEqual( analyser.analyser.fftSize, 2048, 'the default window size is 2048 samples' );
+			assert.strictEqual( analyser.data.length, 1024, 'the data buffer is sized from the assigned default' );
 
 		} );
 

--- a/test/unit/src/extras/Earcut.tests.js
+++ b/test/unit/src/extras/Earcut.tests.js
@@ -1,10 +1,114 @@
-// import { Earcut } from '../../../../src/extras/Earcut.js';
+import { Earcut } from '../../../../src/extras/Earcut.js';
+
+// Sums the unsigned area of every triangle in a flat `triangulate()` result,
+// reading vertex coordinates back out of the original `data` array.
+function triangulatedArea( data, indices, dim = 2 ) {
+
+	let area = 0;
+
+	for ( let i = 0; i < indices.length; i += 3 ) {
+
+		const a = indices[ i ] * dim;
+		const b = indices[ i + 1 ] * dim;
+		const c = indices[ i + 2 ] * dim;
+
+		area += Math.abs(
+			( data[ b ] - data[ a ] ) * ( data[ c + 1 ] - data[ a + 1 ] ) -
+			( data[ c ] - data[ a ] ) * ( data[ b + 1 ] - data[ a + 1 ] )
+		) * 0.5;
+
+	}
+
+	return area;
+
+}
 
 export default QUnit.module( 'Extras', () => {
 
 	QUnit.module( 'Earcut', () => {
 
 		// Public
+		QUnit.test( 'triangulate - splits a square into two triangles', ( assert ) => {
+
+			const square = [ 0, 0, 1, 0, 1, 1, 0, 1 ];
+			const indices = Earcut.triangulate( square, [] );
+
+			assert.strictEqual( indices.length, 6, 'a quad yields 2 triangles / 6 indices' );
+
+			// Every index has to address a real vertex, and each of the 4 corners
+			// has to take part -- a triangulation that drops one would still have
+			// the right length.
+			assert.ok( indices.every( i => i >= 0 && i < 4 ), 'all indices are within range' );
+			assert.strictEqual( new Set( indices ).size, 4, 'all 4 corners are used' );
+
+			assert.numEqual( triangulatedArea( square, indices ), 1, 'the triangles cover the full unit square' );
+
+		} );
+
+		QUnit.test( 'triangulate - produces n + 2h - 2 triangles for a polygon with holes', ( assert ) => {
+
+			// Outer unit square (indices 0-3) with a centred square hole (4-7).
+			// The hole must wind opposite to the contour.
+			const data = [
+				0, 0, 4, 0, 4, 4, 0, 4,
+				1, 1, 1, 3, 3, 3, 3, 1
+			];
+
+			const indices = Earcut.triangulate( data, [ 4 ] );
+
+			// n = 8 vertices, h = 1 hole -> 8 triangles.
+			assert.strictEqual( indices.length, 8 * 3, 'a square with one square hole yields 8 triangles' );
+			assert.strictEqual( new Set( indices ).size, 8, 'every contour and hole vertex is used' );
+
+			// Outer square is 16, hole is 4 -- the triangles must cover the
+			// difference and nothing more, which is what catches a hole that was
+			// silently filled in.
+			assert.numEqual( triangulatedArea( data, indices ), 16 - 4, 'the triangles cover the ring, not the hole' );
+
+		} );
+
+		QUnit.test( 'triangulate - honours the dim argument for interleaved 3D data', ( assert ) => {
+
+			// Same unit square, but with a z component that must be skipped over.
+			const square3D = [ 0, 0, 9, 1, 0, 9, 1, 1, 9, 0, 1, 9 ];
+			const indices = Earcut.triangulate( square3D, [], 3 );
+
+			assert.strictEqual( indices.length, 6, 'dim = 3 still yields 2 triangles' );
+			assert.strictEqual( new Set( indices ).size, 4, 'all 4 corners are used' );
+			assert.numEqual( triangulatedArea( square3D, indices, 3 ), 1, 'the stride is applied when reading vertices' );
+
+		} );
+
+		QUnit.test( 'triangulate - returns indices, not coordinates', ( assert ) => {
+
+			// A regression guard on the contract: the return value indexes into
+			// `data` by vertex, so values must stay below the vertex count even
+			// when the coordinates themselves are large.
+			const indices = Earcut.triangulate( [ 0, 0, 100, 0, 100, 100, 0, 100 ], [] );
+
+			assert.ok( indices.every( i => Number.isInteger( i ) && i < 4 ), 'indices are vertex indices, not coordinates' );
+
+		} );
+
+		QUnit.test( 'triangulate - returns no triangles for degenerate input', ( assert ) => {
+
+			assert.strictEqual( Earcut.triangulate( [], [] ).length, 0, 'an empty polygon yields nothing' );
+			assert.strictEqual( Earcut.triangulate( [ 0, 0, 1, 0 ], [] ).length, 0, 'two points cannot form a triangle' );
+			assert.strictEqual( Earcut.triangulate( [ 0, 0, 1, 1, 2, 2 ], [] ).length, 0, 'three collinear points have no area' );
+
+		} );
+
+		QUnit.test( 'triangulate - handles a concave polygon without escaping its outline', ( assert ) => {
+
+			// An L shape -- the classic case a naive fan triangulation gets wrong
+			// by emitting a triangle across the notch.
+			const shape = [ 0, 0, 2, 0, 2, 1, 1, 1, 1, 2, 0, 2 ];
+			const indices = Earcut.triangulate( shape, [] );
+
+			assert.strictEqual( indices.length, ( 6 - 2 ) * 3, 'an L shape yields 4 triangles' );
+			assert.numEqual( triangulatedArea( shape, indices ), 3, 'the triangles cover the L exactly, not its bounding box' );
+
+		} );
 
 	} );
 

--- a/test/unit/src/extras/ImageUtils.tests.js
+++ b/test/unit/src/extras/ImageUtils.tests.js
@@ -1,6 +1,5 @@
 import { ImageUtils } from '../../../../src/extras/ImageUtils.js';
 import { SRGBToLinear } from '../../../../src/math/ColorManagement.js';
-import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
 
 // These tests need a real canvas, so they only run in a browser environment --
 // which is how the suite is executed (see test/unit/README.md).
@@ -160,14 +159,31 @@ export default QUnit.module( 'Extras', () => {
 
 		QUnit.test( 'sRGBToLinear - returns an unsupported image unchanged and warns', ( assert ) => {
 
-			console.level = CONSOLE_LEVEL.ERROR;
+			// The warning is captured rather than merely silenced, so the "and
+			// warns" half of this test's name is actually asserted. The console
+			// wrapper routes through console._warn, so swapping that out records
+			// the message without printing it. Restored in `finally` so a failure
+			// here cannot leave the rest of the suite with a patched console.
+			const warnings = [];
+			const originalWarn = console._warn;
+			console._warn = ( ...args ) => warnings.push( args.join( ' ' ) );
 
 			const image = { width: 1, height: 1 };
-			const result = ImageUtils.sRGBToLinear( image );
+			let result;
 
-			console.level = CONSOLE_LEVEL.DEFAULT;
+			try {
+
+				result = ImageUtils.sRGBToLinear( image );
+
+			} finally {
+
+				console._warn = originalWarn;
+
+			}
 
 			assert.strictEqual( result, image, 'the image is passed through untouched' );
+			assert.strictEqual( warnings.length, 1, 'exactly one warning is emitted' );
+			assert.ok( warnings[ 0 ].includes( 'sRGBToLinear' ), 'the warning names the function that could not convert' );
 
 		} );
 

--- a/test/unit/src/extras/ImageUtils.tests.js
+++ b/test/unit/src/extras/ImageUtils.tests.js
@@ -1,8 +1,175 @@
-// import { ImageUtils } from '../../../../src/extras/ImageUtils.js';
+import { ImageUtils } from '../../../../src/extras/ImageUtils.js';
+import { SRGBToLinear } from '../../../../src/math/ColorManagement.js';
+import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
+
+// These tests need a real canvas, so they only run in a browser environment --
+// which is how the suite is executed (see test/unit/README.md).
+function makeCanvas( width = 2, height = 2, fill = 'rgb(128, 64, 32)' ) {
+
+	const canvas = document.createElement( 'canvas' );
+	canvas.width = width;
+	canvas.height = height;
+
+	const context = canvas.getContext( '2d' );
+	context.fillStyle = fill;
+	context.fillRect( 0, 0, width, height );
+
+	return canvas;
+
+}
 
 export default QUnit.module( 'Extras', () => {
 
 	QUnit.module( 'ImageUtils', () => {
+
+		// getDataURL
+		QUnit.test( 'getDataURL - returns an existing data URI unchanged', ( assert ) => {
+
+			// Re-encoding through a canvas would be lossy and pointless when the
+			// source is already a data URI.
+			const src = 'data:image/png;base64,iVBORw0KGgo=';
+
+			assert.strictEqual( ImageUtils.getDataURL( { src } ), src, 'the source is passed straight through' );
+
+		} );
+
+		QUnit.test( 'getDataURL - matches a data URI case-insensitively', ( assert ) => {
+
+			const src = 'DATA:image/png;base64,iVBORw0KGgo=';
+
+			assert.strictEqual( ImageUtils.getDataURL( { src } ), src, 'an upper-case scheme is still recognised' );
+
+		} );
+
+		QUnit.test( 'getDataURL - encodes a canvas directly', ( assert ) => {
+
+			const canvas = makeCanvas();
+			const url = ImageUtils.getDataURL( canvas );
+
+			assert.ok( url.startsWith( 'data:image/png' ), 'a PNG data URI is produced by default' );
+			assert.strictEqual( url, canvas.toDataURL( 'image/png' ), 'the canvas is encoded without an intermediate copy' );
+
+		} );
+
+		QUnit.test( 'getDataURL - honours the requested MIME type', ( assert ) => {
+
+			const url = ImageUtils.getDataURL( makeCanvas(), 'image/jpeg' );
+
+			assert.ok( url.startsWith( 'data:image/jpeg' ), 'a JPEG data URI is produced' );
+
+		} );
+
+		QUnit.test( 'getDataURL - draws other image sources onto a scratch canvas', ( assert ) => {
+
+			// ImageData is not a canvas, so it takes the putImageData path
+			// through the module's shared scratch canvas.
+			const imageData = new ImageData( 2, 2 );
+
+			for ( let i = 0; i < imageData.data.length; i += 4 ) {
+
+				imageData.data[ i ] = 255;
+				imageData.data[ i + 3 ] = 255;
+
+			}
+
+			const url = ImageUtils.getDataURL( imageData );
+
+			assert.ok( url.startsWith( 'data:image/png' ), 'a PNG data URI is produced' );
+
+			// Decoding the result back has to give the red we put in.
+			const canvas = document.createElement( 'canvas' );
+			canvas.width = 2;
+			canvas.height = 2;
+			const context = canvas.getContext( '2d' );
+			context.putImageData( imageData, 0, 0 );
+
+			assert.strictEqual( url, canvas.toDataURL( 'image/png' ), 'the pixels survive the round trip' );
+
+		} );
+
+		// sRGBToLinear
+		QUnit.test( 'sRGBToLinear - converts a canvas in place of the original', ( assert ) => {
+
+			const canvas = makeCanvas( 1, 1, 'rgb(188, 188, 188)' );
+			const result = ImageUtils.sRGBToLinear( canvas );
+
+			assert.ok( result instanceof HTMLCanvasElement, 'a canvas is returned' );
+			assert.notStrictEqual( result, canvas, 'the source canvas is not modified' );
+			assert.strictEqual( result.width, 1, 'the width is preserved' );
+			assert.strictEqual( result.height, 1, 'the height is preserved' );
+
+			const [ r ] = result.getContext( '2d', { willReadFrequently: true } ).getImageData( 0, 0, 1, 1 ).data;
+
+			// 188/255 in sRGB is roughly 0.5 linear, so the byte drops sharply.
+			// The canvas stores whole bytes, so allow a rounding step either way.
+			const expected = SRGBToLinear( 188 / 255 ) * 255;
+			assert.ok( Math.abs( r - expected ) <= 1, `the channel is converted to linear (${ r } vs ${ expected.toFixed( 2 ) })` );
+			assert.ok( r < 188, 'a mid-grey gets darker in linear space' );
+
+		} );
+
+		QUnit.test( 'sRGBToLinear - leaves the extremes untouched', ( assert ) => {
+
+			// The transfer function fixes 0 and 1, so black and white survive.
+			const black = ImageUtils.sRGBToLinear( makeCanvas( 1, 1, 'rgb(0, 0, 0)' ) );
+			const white = ImageUtils.sRGBToLinear( makeCanvas( 1, 1, 'rgb(255, 255, 255)' ) );
+
+			assert.strictEqual( black.getContext( '2d', { willReadFrequently: true } ).getImageData( 0, 0, 1, 1 ).data[ 0 ], 0, 'black stays black' );
+			assert.strictEqual( white.getContext( '2d', { willReadFrequently: true } ).getImageData( 0, 0, 1, 1 ).data[ 0 ], 255, 'white stays white' );
+
+		} );
+
+		QUnit.test( 'sRGBToLinear - converts a byte data object without mutating it', ( assert ) => {
+
+			const image = { data: new Uint8Array( [ 0, 128, 255, 255 ] ), width: 1, height: 1 };
+			const result = ImageUtils.sRGBToLinear( image );
+
+			assert.notStrictEqual( result, image, 'a new object is returned' );
+			assert.deepEqual( Array.from( image.data ), [ 0, 128, 255, 255 ], 'the source data is untouched' );
+			assert.strictEqual( result.width, 1, 'the width is carried over' );
+			assert.strictEqual( result.height, 1, 'the height is carried over' );
+
+			assert.strictEqual( result.data[ 0 ], 0, 'zero stays zero' );
+			assert.strictEqual( result.data[ 1 ], Math.floor( SRGBToLinear( 128 / 255 ) * 255 ), 'the mid value is converted and floored' );
+			assert.strictEqual( result.data[ 2 ], 255, 'the maximum stays at the maximum' );
+
+		} );
+
+		QUnit.test( 'sRGBToLinear - converts float data without the 0-255 scaling', ( assert ) => {
+
+			// Float images already hold normalised values, so they are fed to
+			// the transfer function directly.
+			const image = { data: new Float32Array( [ 0, 0.5, 1 ] ), width: 3, height: 1 };
+			const result = ImageUtils.sRGBToLinear( image );
+
+			assert.numEqual( result.data[ 0 ], 0, 'zero stays zero' );
+			assert.numEqual( result.data[ 1 ], SRGBToLinear( 0.5 ), 'the mid value is converted directly' );
+			assert.numEqual( result.data[ 2 ], 1, 'one stays one' );
+
+		} );
+
+		QUnit.test( 'sRGBToLinear - preserves the data array type', ( assert ) => {
+
+			const bytes = ImageUtils.sRGBToLinear( { data: new Uint8Array( [ 128 ] ), width: 1, height: 1 } );
+			const floats = ImageUtils.sRGBToLinear( { data: new Float32Array( [ 0.5 ] ), width: 1, height: 1 } );
+
+			assert.ok( bytes.data instanceof Uint8Array, 'byte data stays a Uint8Array' );
+			assert.ok( floats.data instanceof Float32Array, 'float data stays a Float32Array' );
+
+		} );
+
+		QUnit.test( 'sRGBToLinear - returns an unsupported image unchanged and warns', ( assert ) => {
+
+			console.level = CONSOLE_LEVEL.ERROR;
+
+			const image = { width: 1, height: 1 };
+			const result = ImageUtils.sRGBToLinear( image );
+
+			console.level = CONSOLE_LEVEL.DEFAULT;
+
+			assert.strictEqual( result, image, 'the image is passed through untouched' );
+
+		} );
 
 	} );
 

--- a/test/unit/src/extras/ShapeUtils.tests.js
+++ b/test/unit/src/extras/ShapeUtils.tests.js
@@ -1,8 +1,170 @@
-// import { ShapeUtils } from '../../../../src/extras/ShapeUtils.js';
+import { ShapeUtils } from '../../../../src/extras/ShapeUtils.js';
+import { Vector2 } from '../../../../src/math/Vector2.js';
+
+// Sums the unsigned area of every face returned by `triangulateShape()`,
+// resolving indices against the concatenated contour + hole vertex list.
+function facesArea( vertices, faces ) {
+
+	let area = 0;
+
+	for ( const [ i, j, k ] of faces ) {
+
+		const a = vertices[ i ], b = vertices[ j ], c = vertices[ k ];
+
+		area += Math.abs( ( b.x - a.x ) * ( c.y - a.y ) - ( c.x - a.x ) * ( b.y - a.y ) ) * 0.5;
+
+	}
+
+	return area;
+
+}
 
 export default QUnit.module( 'Extras', () => {
 
 	QUnit.module( 'ShapeUtils', () => {
+
+		// Public
+		QUnit.test( 'area - returns the signed area of a contour', ( assert ) => {
+
+			const ccw = [ new Vector2( 0, 0 ), new Vector2( 2, 0 ), new Vector2( 2, 2 ), new Vector2( 0, 2 ) ];
+			const cw = [ ...ccw ].reverse();
+
+			assert.numEqual( ShapeUtils.area( ccw ), 4, 'counter-clockwise winding gives a positive area' );
+			assert.numEqual( ShapeUtils.area( cw ), - 4, 'clockwise winding gives a negative area of equal magnitude' );
+
+		} );
+
+		QUnit.test( 'area - is invariant under translation and vertex rotation', ( assert ) => {
+
+			const triangle = [ new Vector2( 0, 0 ), new Vector2( 4, 0 ), new Vector2( 0, 3 ) ];
+			const shifted = triangle.map( p => new Vector2( p.x + 10, p.y - 7 ) );
+			const rotated = [ triangle[ 1 ], triangle[ 2 ], triangle[ 0 ] ];
+
+			assert.numEqual( ShapeUtils.area( triangle ), 6, 'a 4x3 right triangle has area 6' );
+			assert.numEqual( ShapeUtils.area( shifted ), 6, 'translating the contour does not change its area' );
+			assert.numEqual( ShapeUtils.area( rotated ), 6, 'starting the loop at a different vertex does not change its area' );
+
+		} );
+
+		QUnit.test( 'area - returns zero for degenerate contours', ( assert ) => {
+
+			assert.numEqual( ShapeUtils.area( [] ), 0, 'an empty contour has no area' );
+			assert.numEqual( ShapeUtils.area( [ new Vector2( 1, 1 ) ] ), 0, 'a single point has no area' );
+			assert.numEqual( ShapeUtils.area( [ new Vector2( 0, 0 ), new Vector2( 1, 1 ) ] ), 0, 'a segment has no area' );
+			assert.numEqual(
+				ShapeUtils.area( [ new Vector2( 0, 0 ), new Vector2( 1, 1 ), new Vector2( 2, 2 ) ] ),
+				0,
+				'collinear points have no area'
+			);
+
+		} );
+
+		QUnit.test( 'area - handles a concave contour', ( assert ) => {
+
+			// The same L shape as the Earcut tests -- a shoelace sum handles the
+			// notch correctly where a bounding-box estimate would report 4.
+			const l = [
+				new Vector2( 0, 0 ), new Vector2( 2, 0 ), new Vector2( 2, 1 ),
+				new Vector2( 1, 1 ), new Vector2( 1, 2 ), new Vector2( 0, 2 )
+			];
+
+			assert.numEqual( ShapeUtils.area( l ), 3, 'the concave notch is subtracted' );
+
+		} );
+
+		QUnit.test( 'isClockWise - reports the winding order', ( assert ) => {
+
+			const ccw = [ new Vector2( 0, 0 ), new Vector2( 1, 0 ), new Vector2( 1, 1 ) ];
+			const cw = [ ...ccw ].reverse();
+
+			assert.strictEqual( ShapeUtils.isClockWise( ccw ), false, 'a counter-clockwise contour is not clockwise' );
+			assert.strictEqual( ShapeUtils.isClockWise( cw ), true, 'a clockwise contour is clockwise' );
+
+		} );
+
+		QUnit.test( 'isClockWise - treats a zero-area contour as counter-clockwise', ( assert ) => {
+
+			// area < 0 is strict, so the degenerate case falls on the false side.
+			const collinear = [ new Vector2( 0, 0 ), new Vector2( 1, 1 ), new Vector2( 2, 2 ) ];
+
+			assert.strictEqual( ShapeUtils.isClockWise( collinear ), false, 'zero area is not clockwise' );
+
+		} );
+
+		QUnit.test( 'triangulateShape - returns faces as index triplets', ( assert ) => {
+
+			const contour = [ new Vector2( 0, 0 ), new Vector2( 1, 0 ), new Vector2( 1, 1 ), new Vector2( 0, 1 ) ];
+			const faces = ShapeUtils.triangulateShape( contour, [] );
+
+			assert.strictEqual( faces.length, 2, 'a quad yields 2 faces' );
+			assert.ok( faces.every( f => f.length === 3 ), 'each face has exactly 3 indices' );
+			assert.strictEqual( new Set( faces.flat() ).size, 4, 'all 4 contour vertices are used' );
+			assert.numEqual( facesArea( contour, faces ), 1, 'the faces cover the unit square' );
+
+		} );
+
+		QUnit.test( 'triangulateShape - indexes holes after the contour vertices', ( assert ) => {
+
+			const contour = [ new Vector2( 0, 0 ), new Vector2( 4, 0 ), new Vector2( 4, 4 ), new Vector2( 0, 4 ) ];
+			const hole = [ new Vector2( 1, 1 ), new Vector2( 1, 3 ), new Vector2( 3, 3 ), new Vector2( 3, 1 ) ];
+
+			const faces = ShapeUtils.triangulateShape( contour, [ hole ] );
+			const vertices = [ ...contour, ...hole ];
+
+			// n = 8 vertices, h = 1 hole -> 8 faces.
+			assert.strictEqual( faces.length, 8, 'a square with one square hole yields 8 faces' );
+
+			const used = new Set( faces.flat() );
+			assert.strictEqual( used.size, 8, 'every contour and hole vertex is used' );
+			assert.ok( [ ...used ].every( i => i < 8 ), 'hole indices continue the contour numbering' );
+
+			assert.numEqual( facesArea( vertices, faces ), 16 - 4, 'the faces cover the ring, not the hole' );
+
+		} );
+
+		QUnit.test( 'triangulateShape - drops a duplicated closing point', ( assert ) => {
+
+			// Callers often close the loop explicitly. The duplicate is removed
+			// in place before triangulation, so the input array shrinks too.
+			const contour = [
+				new Vector2( 0, 0 ), new Vector2( 1, 0 ), new Vector2( 1, 1 ),
+				new Vector2( 0, 1 ), new Vector2( 0, 0 )
+			];
+
+			const faces = ShapeUtils.triangulateShape( contour, [] );
+
+			assert.strictEqual( contour.length, 4, 'the repeated closing point is removed from the input array' );
+			assert.strictEqual( faces.length, 2, 'the closed quad still yields 2 faces' );
+			assert.numEqual( facesArea( contour, faces ), 1, 'the faces cover the unit square' );
+
+		} );
+
+		QUnit.test( 'triangulateShape - drops a duplicated closing point on holes as well', ( assert ) => {
+
+			const contour = [ new Vector2( 0, 0 ), new Vector2( 4, 0 ), new Vector2( 4, 4 ), new Vector2( 0, 4 ) ];
+			const hole = [
+				new Vector2( 1, 1 ), new Vector2( 1, 3 ), new Vector2( 3, 3 ),
+				new Vector2( 3, 1 ), new Vector2( 1, 1 )
+			];
+
+			const faces = ShapeUtils.triangulateShape( contour, [ hole ] );
+
+			assert.strictEqual( hole.length, 4, 'the repeated closing point is removed from the hole array' );
+			assert.strictEqual( faces.length, 8, 'the hole is still triangulated as a 4-gon' );
+			assert.numEqual( facesArea( [ ...contour, ...hole ], faces ), 16 - 4, 'the faces cover the ring, not the hole' );
+
+		} );
+
+		QUnit.test( 'triangulateShape - returns no faces for a degenerate contour', ( assert ) => {
+
+			assert.strictEqual( ShapeUtils.triangulateShape( [], [] ).length, 0, 'an empty contour yields no faces' );
+			assert.strictEqual(
+				ShapeUtils.triangulateShape( [ new Vector2( 0, 0 ), new Vector2( 1, 0 ) ], [] ).length,
+				0,
+				'a segment yields no faces'
+			);
+
+		} );
 
 	} );
 

--- a/test/unit/src/extras/core/Interpolations.tests.js
+++ b/test/unit/src/extras/core/Interpolations.tests.js
@@ -1,10 +1,130 @@
-// import { CatmullRom, QuadraticBezier, CubicBezier } from '../../../../../src/extras/core/Interpolations.js';
+import { CatmullRom, QuadraticBezier, CubicBezier } from '../../../../../src/extras/core/Interpolations.js';
 
 export default QUnit.module( 'Extras', () => {
 
 	QUnit.module( 'Core', () => {
 
 		QUnit.module( 'Interpolations', () => {
+
+			// CatmullRom
+			QUnit.test( 'CatmullRom - interpolates between the two middle control points', ( assert ) => {
+
+				// The spline passes through p1 at t = 0 and p2 at t = 1; p0 and p3
+				// only influence the tangents, so the endpoints are exact.
+				assert.numEqual( CatmullRom( 0, 1, 2, 3, 4 ), 2, 't = 0 returns p1' );
+				assert.numEqual( CatmullRom( 1, 1, 2, 3, 4 ), 3, 't = 1 returns p2' );
+
+			} );
+
+			QUnit.test( 'CatmullRom - is linear for evenly spaced control points', ( assert ) => {
+
+				// With p0..p3 = 0,1,2,3 both tangents are 1 and the cubic and
+				// quadratic terms cancel, leaving exactly p1 + t.
+				for ( const t of [ 0, 0.25, 0.5, 0.75, 1 ] ) {
+
+					assert.numEqual( CatmullRom( t, 0, 1, 2, 3 ), 1 + t, `t = ${ t } lies on the straight line` );
+
+				}
+
+			} );
+
+			QUnit.test( 'CatmullRom - is symmetric under reversal of the control points', ( assert ) => {
+
+				// Reversing the control points and the parameter has to trace the
+				// same curve backwards.
+				for ( const t of [ 0.1, 0.35, 0.5, 0.8 ] ) {
+
+					assert.numEqual(
+						CatmullRom( t, 5, 1, 4, 2 ),
+						CatmullRom( 1 - t, 2, 4, 1, 5 ),
+						`t = ${ t } matches the reversed spline at 1 - t`
+					);
+
+				}
+
+			} );
+
+			QUnit.test( 'CatmullRom - returns the shared value when all control points are equal', ( assert ) => {
+
+				assert.numEqual( CatmullRom( 0.42, 7, 7, 7, 7 ), 7, 'a degenerate spline is constant' );
+
+			} );
+
+			// QuadraticBezier
+			QUnit.test( 'QuadraticBezier - passes through its first and last control points', ( assert ) => {
+
+				assert.numEqual( QuadraticBezier( 0, 1, 5, 9 ), 1, 't = 0 returns p0' );
+				assert.numEqual( QuadraticBezier( 1, 1, 5, 9 ), 9, 't = 1 returns p2' );
+
+			} );
+
+			QUnit.test( 'QuadraticBezier - matches the Bernstein basis at the midpoint', ( assert ) => {
+
+				// B(0.5) = 0.25 * p0 + 0.5 * p1 + 0.25 * p2
+				assert.numEqual( QuadraticBezier( 0.5, 1, 5, 9 ), 0.25 * 1 + 0.5 * 5 + 0.25 * 9, 'midpoint uses weights 1/4, 1/2, 1/4' );
+
+			} );
+
+			QUnit.test( 'QuadraticBezier - its basis functions form a partition of unity', ( assert ) => {
+
+				// Weights summing to 1 means equal control points produce that value
+				// for every t -- the property that keeps the curve inside its hull.
+				for ( const t of [ 0, 0.2, 0.5, 0.9, 1 ] ) {
+
+					assert.numEqual( QuadraticBezier( t, 3, 3, 3 ), 3, `t = ${ t } returns the shared control point value` );
+
+				}
+
+			} );
+
+			// CubicBezier
+			QUnit.test( 'CubicBezier - passes through its first and last control points', ( assert ) => {
+
+				assert.numEqual( CubicBezier( 0, 1, 5, 9, 13 ), 1, 't = 0 returns p0' );
+				assert.numEqual( CubicBezier( 1, 1, 5, 9, 13 ), 13, 't = 1 returns p3' );
+
+			} );
+
+			QUnit.test( 'CubicBezier - matches the Bernstein basis at the midpoint', ( assert ) => {
+
+				// B(0.5) = 0.125 * p0 + 0.375 * p1 + 0.375 * p2 + 0.125 * p3
+				assert.numEqual(
+					CubicBezier( 0.5, 1, 5, 9, 13 ),
+					0.125 * 1 + 0.375 * 5 + 0.375 * 9 + 0.125 * 13,
+					'midpoint uses weights 1/8, 3/8, 3/8, 1/8'
+				);
+
+			} );
+
+			QUnit.test( 'CubicBezier - its basis functions form a partition of unity', ( assert ) => {
+
+				for ( const t of [ 0, 0.2, 0.5, 0.9, 1 ] ) {
+
+					assert.numEqual( CubicBezier( t, 4, 4, 4, 4 ), 4, `t = ${ t } returns the shared control point value` );
+
+				}
+
+			} );
+
+			QUnit.test( 'CubicBezier - degree-elevates a quadratic curve exactly', ( assert ) => {
+
+				// A quadratic ( q0, q1, q2 ) is the cubic
+				// ( q0, q0/3 + 2q1/3, 2q1/3 + q2/3, q2 ) -- both must agree everywhere.
+				const q0 = 2, q1 = 6, q2 = - 1;
+				const c1 = q0 / 3 + 2 * q1 / 3;
+				const c2 = 2 * q1 / 3 + q2 / 3;
+
+				for ( const t of [ 0.1, 0.4, 0.7, 0.95 ] ) {
+
+					assert.numEqual(
+						CubicBezier( t, q0, c1, c2, q2 ),
+						QuadraticBezier( t, q0, q1, q2 ),
+						`t = ${ t } agrees with the degree-elevated quadratic`
+					);
+
+				}
+
+			} );
 
 		} );
 

--- a/test/unit/src/renderers/webgl/WebGLAttributes.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLAttributes.tests.js
@@ -330,8 +330,10 @@ export default QUnit.module( 'Renderers', () => {
 
 			QUnit.test( 'update - merges adjacent ranges into one write', ( assert ) => {
 
-				// Ranges that touch are worth merging too -- it saves a call
-				// without writing anything that was not requested.
+				// Ranges that touch are worth merging -- it saves a call, and in
+				// this exactly-adjacent case writes nothing that was not
+				// requested. Note the merge rule is deliberately wider than this:
+				// see the one-element-gap test below.
 				const gl = mockContext();
 				const attributes = new WebGLAttributes( gl );
 				const attribute = new Float32BufferAttribute( [ 0, 1, 2, 3, 4, 5, 6, 7 ], 1 );
@@ -347,6 +349,57 @@ export default QUnit.module( 'Renderers', () => {
 
 				assert.strictEqual( subData.length, 1, 'the adjacent ranges collapse to a single write' );
 				assert.deepEqual( subData[ 0 ].slice( 4 ), [ 0, 4 ], 'the merged range covers both' );
+
+			} );
+
+			QUnit.test( 'update - bridges a one-element gap between ranges', ( assert ) => {
+
+				// The merge condition is `range.start <= previousRange.start +
+				// previousRange.count + 1`. That trailing `+ 1` is deliberate
+				// (see the comment in WebGLAttributes.js): it bridges a gap of a
+				// single element, trading one extra element in the upload for one
+				// fewer draw call. This is the only case that `+ 1` affects, so
+				// without this test it could be deleted from the source without
+				// failing anything.
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 0, 1, 2, 3, 4, 5, 6, 7 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				// Index 2 is requested by neither range.
+				attribute.addUpdateRange( 0, 2 );
+				attribute.addUpdateRange( 3, 2 );
+				attribute.needsUpdate = true;
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				const subData = gl.callsOf( 'bufferSubData' );
+
+				assert.strictEqual( subData.length, 1, 'the one-element gap is bridged into a single write' );
+				assert.deepEqual( subData[ 0 ].slice( 4 ), [ 0, 5 ], 'the merged range spans the gap, covering the unrequested element' );
+
+			} );
+
+			QUnit.test( 'update - keeps ranges separated by more than one element apart', ( assert ) => {
+
+				// A gap of two falls outside the `+ 1` window, so this is the
+				// boundary on the other side of the test above.
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 0, 1, 2, 3, 4, 5, 6, 7 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				attribute.addUpdateRange( 0, 2 );
+				attribute.addUpdateRange( 4, 2 );
+				attribute.needsUpdate = true;
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				const subData = gl.callsOf( 'bufferSubData' );
+
+				assert.strictEqual( subData.length, 2, 'a two-element gap is not bridged' );
+				assert.deepEqual( subData[ 0 ].slice( 4 ), [ 0, 2 ], 'the first range is written on its own' );
+				assert.deepEqual( subData[ 1 ].slice( 4 ), [ 4, 2 ], 'the second range is written on its own' );
 
 			} );
 

--- a/test/unit/src/renderers/webgl/WebGLAttributes.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLAttributes.tests.js
@@ -1,10 +1,531 @@
-// import { WebGLAttributes } from '../../../../../src/renderers/webgl/WebGLAttributes.js';
+import { WebGLAttributes } from '../../../../../src/renderers/webgl/WebGLAttributes.js';
+import {
+	BufferAttribute,
+	Float32BufferAttribute,
+	Float16BufferAttribute,
+	Uint16BufferAttribute,
+	Int16BufferAttribute,
+	Uint32BufferAttribute,
+	Int32BufferAttribute,
+	Int8BufferAttribute,
+	Uint8BufferAttribute,
+	Uint8ClampedBufferAttribute
+} from '../../../../../src/core/BufferAttribute.js';
+import { InterleavedBuffer } from '../../../../../src/core/InterleavedBuffer.js';
+import { InterleavedBufferAttribute } from '../../../../../src/core/InterleavedBufferAttribute.js';
+import { GLBufferAttribute } from '../../../../../src/core/GLBufferAttribute.js';
+import { DynamicDrawUsage } from '../../../../../src/constants.js';
+
+// Records buffer traffic. Buffer handles are unique objects so identity can be
+// asserted, and the type constants are sentinels rather than real enums.
+function mockContext() {
+
+	const calls = [];
+	let nextBuffer = 0;
+
+	return {
+		calls,
+		FLOAT: 'FLOAT',
+		HALF_FLOAT: 'HALF_FLOAT',
+		UNSIGNED_SHORT: 'UNSIGNED_SHORT',
+		SHORT: 'SHORT',
+		UNSIGNED_INT: 'UNSIGNED_INT',
+		INT: 'INT',
+		BYTE: 'BYTE',
+		UNSIGNED_BYTE: 'UNSIGNED_BYTE',
+		ARRAY_BUFFER: 'ARRAY_BUFFER',
+		ELEMENT_ARRAY_BUFFER: 'ELEMENT_ARRAY_BUFFER',
+		createBuffer() {
+
+			const buffer = { id: nextBuffer ++ };
+			calls.push( [ 'createBuffer', buffer ] );
+			return buffer;
+
+		},
+		bindBuffer( ...args ) {
+
+			calls.push( [ 'bindBuffer', ...args ] );
+
+		},
+		bufferData( ...args ) {
+
+			calls.push( [ 'bufferData', ...args ] );
+
+		},
+		bufferSubData( ...args ) {
+
+			calls.push( [ 'bufferSubData', ...args ] );
+
+		},
+		deleteBuffer( ...args ) {
+
+			calls.push( [ 'deleteBuffer', ...args ] );
+
+		},
+		callsOf( name ) {
+
+			return calls.filter( c => c[ 0 ] === name );
+
+		}
+	};
+
+}
 
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
 		QUnit.module( 'WebGLAttributes', () => {
+
+			// INSTANCING
+			QUnit.test( 'Instancing - exposes the expected API', ( assert ) => {
+
+				const attributes = new WebGLAttributes( mockContext() );
+
+				for ( const method of [ 'get', 'remove', 'update' ] ) {
+
+					assert.strictEqual( typeof attributes[ method ], 'function', `${ method }() is exposed` );
+
+				}
+
+			} );
+
+			// get
+			QUnit.test( 'get - returns undefined for an attribute that was never uploaded', ( assert ) => {
+
+				const attributes = new WebGLAttributes( mockContext() );
+
+				assert.strictEqual( attributes.get( new Float32BufferAttribute( [ 1, 2, 3 ], 1 ) ), undefined, 'nothing is cached yet' );
+
+			} );
+
+			// update - creation
+			QUnit.test( 'update - creates and fills a buffer on first upload', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 1, 2, 3 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				assert.deepEqual(
+					gl.calls.map( c => c[ 0 ] ),
+					[ 'createBuffer', 'bindBuffer', 'bufferData' ],
+					'the buffer is created, bound and filled'
+				);
+				assert.strictEqual( gl.calls[ 2 ][ 1 ], gl.ARRAY_BUFFER, 'the requested buffer type is used' );
+				assert.strictEqual( gl.calls[ 2 ][ 2 ], attribute.array, 'the attribute array is uploaded' );
+				assert.strictEqual( gl.calls[ 2 ][ 3 ], attribute.usage, 'the attribute usage hint is passed along' );
+
+			} );
+
+			QUnit.test( 'update - records the buffer description', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 1, 2, 3 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				const data = attributes.get( attribute );
+
+				assert.strictEqual( data.buffer, gl.calls[ 0 ][ 1 ], 'the created buffer handle is stored' );
+				assert.strictEqual( data.type, gl.FLOAT, 'the element type is derived from the array' );
+				assert.strictEqual( data.bytesPerElement, 4, 'the element size is recorded' );
+				assert.strictEqual( data.version, attribute.version, 'the uploaded version is recorded' );
+				assert.strictEqual( data.size, attribute.array.byteLength, 'the byte length is recorded' );
+
+			} );
+
+			QUnit.test( 'update - honours a dynamic usage hint', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+
+				const attribute = new Float32BufferAttribute( [ 1, 2, 3 ], 1 );
+				attribute.setUsage( DynamicDrawUsage );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				assert.strictEqual( gl.callsOf( 'bufferData' )[ 0 ][ 3 ], DynamicDrawUsage, 'the dynamic hint reaches bufferData' );
+
+			} );
+
+			QUnit.test( 'update - invokes the upload callback', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+
+				let called = 0;
+				const attribute = new Float32BufferAttribute( [ 1, 2, 3 ], 1 );
+				attribute.onUpload( () => called ++ );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				assert.strictEqual( called, 1, 'the callback fires once the data is uploaded' );
+
+			} );
+
+			// update - type mapping
+			QUnit.test( 'update - derives the element type from the array type', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+
+				const cases = [
+					[ new Float32BufferAttribute( [ 1 ], 1 ), gl.FLOAT ],
+					[ new Uint16BufferAttribute( [ 1 ], 1 ), gl.UNSIGNED_SHORT ],
+					[ new Int16BufferAttribute( [ 1 ], 1 ), gl.SHORT ],
+					[ new Uint32BufferAttribute( [ 1 ], 1 ), gl.UNSIGNED_INT ],
+					[ new Int32BufferAttribute( [ 1 ], 1 ), gl.INT ],
+					[ new Int8BufferAttribute( [ 1 ], 1 ), gl.BYTE ],
+					[ new Uint8BufferAttribute( [ 1 ], 1 ), gl.UNSIGNED_BYTE ],
+					[ new Uint8ClampedBufferAttribute( [ 1 ], 1 ), gl.UNSIGNED_BYTE ]
+				];
+
+				for ( const [ attribute, type ] of cases ) {
+
+					attributes.update( attribute, gl.ARRAY_BUFFER );
+					assert.strictEqual( attributes.get( attribute ).type, type, `${ attribute.array.constructor.name } maps to ${ type }` );
+
+				}
+
+			} );
+
+			QUnit.test( 'update - distinguishes half float from unsigned short', ( assert ) => {
+
+				// Both are backed by a Uint16Array, so the flag on the attribute
+				// is the only thing that tells them apart.
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+
+				const half = new Float16BufferAttribute( [ 1, 2 ], 1 );
+				const ushort = new Uint16BufferAttribute( [ 1, 2 ], 1 );
+
+				attributes.update( half, gl.ARRAY_BUFFER );
+				attributes.update( ushort, gl.ARRAY_BUFFER );
+
+				assert.strictEqual( attributes.get( half ).type, gl.HALF_FLOAT, 'a float16 attribute uploads as half float' );
+				assert.strictEqual( attributes.get( ushort ).type, gl.UNSIGNED_SHORT, 'a plain uint16 attribute uploads as unsigned short' );
+
+			} );
+
+			QUnit.test( 'update - throws on an unsupported array type', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+
+				const attribute = new BufferAttribute( new Float64Array( [ 1, 2 ] ), 1 );
+
+				assert.throws(
+					() => attributes.update( attribute, gl.ARRAY_BUFFER ),
+					/Unsupported buffer data format/,
+					'a Float64Array cannot be uploaded'
+				);
+
+			} );
+
+			// update - caching
+			QUnit.test( 'update - does nothing when the version is unchanged', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 1, 2, 3 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+				const callCount = gl.calls.length;
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				assert.strictEqual( gl.calls.length, callCount, 'no further GL calls are issued' );
+
+			} );
+
+			QUnit.test( 'update - re-uploads the whole array when the version advances', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 1, 2, 3 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+				attribute.needsUpdate = true;
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				const subData = gl.callsOf( 'bufferSubData' );
+
+				assert.strictEqual( subData.length, 1, 'the data is patched rather than reallocated' );
+				assert.deepEqual( subData[ 0 ].slice( 1 ), [ gl.ARRAY_BUFFER, 0, attribute.array ], 'the full array is written from offset 0' );
+				assert.strictEqual( gl.callsOf( 'createBuffer' ).length, 1, 'the buffer is not recreated' );
+				assert.strictEqual( attributes.get( attribute ).version, attribute.version, 'the recorded version catches up' );
+
+			} );
+
+			QUnit.test( 'update - refuses to resize an existing buffer', ( assert ) => {
+
+				// The GPU buffer was allocated at a fixed size, so growing the
+				// attribute array is an error rather than a silent reallocation.
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 1, 2, 3 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				attribute.array = new Float32Array( [ 1, 2, 3, 4 ] );
+				attribute.needsUpdate = true;
+
+				assert.throws(
+					() => attributes.update( attribute, gl.ARRAY_BUFFER ),
+					/Resizing buffer attributes is not supported/,
+					'a resized array is rejected'
+				);
+
+			} );
+
+			// update - update ranges
+			QUnit.test( 'update - writes only the requested ranges', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 0, 1, 2, 3, 4, 5, 6, 7 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				attribute.addUpdateRange( 0, 1 );
+				attribute.addUpdateRange( 5, 2 );
+				attribute.needsUpdate = true;
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				const subData = gl.callsOf( 'bufferSubData' ).map( c => c.slice( 1 ) );
+
+				assert.deepEqual(
+					subData,
+					[
+						[ gl.ARRAY_BUFFER, 0 * 4, attribute.array, 0, 1 ],
+						[ gl.ARRAY_BUFFER, 5 * 4, attribute.array, 5, 2 ]
+					],
+					'each disjoint range becomes its own byte-offset write'
+				);
+
+			} );
+
+			QUnit.test( 'update - merges overlapping ranges into one write', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 0, 1, 2, 3, 4, 5, 6, 7 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				attribute.addUpdateRange( 0, 4 );
+				attribute.addUpdateRange( 2, 4 );
+				attribute.needsUpdate = true;
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				const subData = gl.callsOf( 'bufferSubData' );
+
+				assert.strictEqual( subData.length, 1, 'the overlap collapses to a single write' );
+				assert.deepEqual( subData[ 0 ].slice( 4 ), [ 0, 6 ], 'the merged range spans both inputs' );
+
+			} );
+
+			QUnit.test( 'update - merges adjacent ranges into one write', ( assert ) => {
+
+				// Ranges that touch are worth merging too -- it saves a call
+				// without writing anything that was not requested.
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 0, 1, 2, 3, 4, 5, 6, 7 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				attribute.addUpdateRange( 0, 2 );
+				attribute.addUpdateRange( 2, 2 );
+				attribute.needsUpdate = true;
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				const subData = gl.callsOf( 'bufferSubData' );
+
+				assert.strictEqual( subData.length, 1, 'the adjacent ranges collapse to a single write' );
+				assert.deepEqual( subData[ 0 ].slice( 4 ), [ 0, 4 ], 'the merged range covers both' );
+
+			} );
+
+			QUnit.test( 'update - sorts ranges before merging them', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 0, 1, 2, 3, 4, 5, 6, 7 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				// Added out of order -- the merge only works on sorted input.
+				attribute.addUpdateRange( 4, 2 );
+				attribute.addUpdateRange( 0, 2 );
+				attribute.addUpdateRange( 2, 2 );
+				attribute.needsUpdate = true;
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				const subData = gl.callsOf( 'bufferSubData' );
+
+				assert.strictEqual( subData.length, 1, 'all three ranges collapse into one' );
+				assert.deepEqual( subData[ 0 ].slice( 4 ), [ 0, 6 ], 'the merged range covers the whole span' );
+
+			} );
+
+			QUnit.test( 'update - keeps a fully contained range from shrinking the merge', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 0, 1, 2, 3, 4, 5, 6, 7 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				attribute.addUpdateRange( 0, 6 );
+				attribute.addUpdateRange( 2, 1 );
+				attribute.needsUpdate = true;
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				assert.deepEqual(
+					gl.callsOf( 'bufferSubData' )[ 0 ].slice( 4 ),
+					[ 0, 6 ],
+					'the enclosing range is not shortened by the one inside it'
+				);
+
+			} );
+
+			QUnit.test( 'update - clears the ranges after applying them', ( assert ) => {
+
+				// Otherwise the next upload would replay stale ranges.
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 0, 1, 2, 3 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				attribute.addUpdateRange( 0, 2 );
+				attribute.needsUpdate = true;
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				assert.strictEqual( attribute.updateRanges.length, 0, 'the update ranges are emptied' );
+
+			} );
+
+			// interleaved attributes
+			QUnit.test( 'update - uploads the shared buffer behind an interleaved attribute', ( assert ) => {
+
+				// Interleaved attributes are views onto one InterleavedBuffer, so
+				// the buffer -- not the view -- is what gets uploaded and cached.
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+
+				const buffer = new InterleavedBuffer( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3 );
+				const a = new InterleavedBufferAttribute( buffer, 2, 0 );
+				const b = new InterleavedBufferAttribute( buffer, 1, 2 );
+
+				attributes.update( a, gl.ARRAY_BUFFER );
+				attributes.update( b, gl.ARRAY_BUFFER );
+
+				assert.strictEqual( gl.callsOf( 'createBuffer' ).length, 1, 'the shared buffer is only created once' );
+				assert.strictEqual( attributes.get( a ), attributes.get( b ), 'both views resolve to the same buffer record' );
+				assert.strictEqual( attributes.get( a ), attributes.get( buffer ), 'the record is keyed on the interleaved buffer' );
+
+			} );
+
+			// GLBufferAttribute
+			QUnit.test( 'update - adopts an externally managed buffer as-is', ( assert ) => {
+
+				// GLBufferAttribute wraps a buffer the application created, so
+				// there is nothing to allocate or upload.
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+
+				const externalBuffer = { external: true };
+				const attribute = new GLBufferAttribute( externalBuffer, gl.FLOAT, 3, 4, 2 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				assert.deepEqual( gl.calls, [], 'no GL calls are issued' );
+
+				const data = attributes.get( attribute );
+
+				assert.strictEqual( data.buffer, externalBuffer, 'the supplied buffer is stored' );
+				assert.strictEqual( data.type, gl.FLOAT, 'the supplied type is stored' );
+				assert.strictEqual( data.bytesPerElement, 4, 'the element size comes from elementSize' );
+
+			} );
+
+			QUnit.test( 'update - refreshes an external buffer when its version advances', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+
+				const attribute = new GLBufferAttribute( { id: 'first' }, gl.FLOAT, 3, 4, 2 );
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				attribute.buffer = { id: 'second' };
+				attribute.version ++;
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				assert.strictEqual( attributes.get( attribute ).buffer.id, 'second', 'the new buffer replaces the cached one' );
+
+			} );
+
+			// remove
+			QUnit.test( 'remove - deletes the buffer and forgets the attribute', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 1, 2, 3 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+				const handle = attributes.get( attribute ).buffer;
+
+				attributes.remove( attribute );
+
+				assert.deepEqual( gl.callsOf( 'deleteBuffer' ), [[ 'deleteBuffer', handle ]], 'the GPU buffer is deleted' );
+				assert.strictEqual( attributes.get( attribute ), undefined, 'the attribute is no longer cached' );
+
+			} );
+
+			QUnit.test( 'remove - is a no-op for an attribute that was never uploaded', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+
+				attributes.remove( new Float32BufferAttribute( [ 1 ], 1 ) );
+
+				assert.deepEqual( gl.callsOf( 'deleteBuffer' ), [], 'nothing is deleted' );
+
+			} );
+
+			QUnit.test( 'remove - resolves an interleaved attribute to its buffer', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+
+				const buffer = new InterleavedBuffer( new Float32Array( [ 1, 2, 3, 4 ] ), 2 );
+				const view = new InterleavedBufferAttribute( buffer, 2, 0 );
+
+				attributes.update( view, gl.ARRAY_BUFFER );
+				attributes.remove( view );
+
+				assert.strictEqual( attributes.get( buffer ), undefined, 'removing a view drops the shared buffer' );
+
+			} );
+
+			QUnit.test( 'remove - allows the attribute to be uploaded again', ( assert ) => {
+
+				const gl = mockContext();
+				const attributes = new WebGLAttributes( gl );
+				const attribute = new Float32BufferAttribute( [ 1, 2, 3 ], 1 );
+
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+				attributes.remove( attribute );
+				attributes.update( attribute, gl.ARRAY_BUFFER );
+
+				assert.strictEqual( gl.callsOf( 'createBuffer' ).length, 2, 'a fresh buffer is allocated' );
+
+			} );
 
 		} );
 

--- a/test/unit/src/renderers/webgl/WebGLBufferRenderer.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLBufferRenderer.tests.js
@@ -1,10 +1,214 @@
-// import { WebGLBufferRenderer } from '../../../../../src/renderers/webgl/WebGLBufferRenderer.js';
+import { WebGLBufferRenderer } from '../../../../../src/renderers/webgl/WebGLBufferRenderer.js';
+import { TrianglesDrawMode } from '../../../../../src/constants.js';
+
+// The renderer only forwards to the context, an extension and WebGLInfo, so
+// recording stand-ins are enough to pin down what it emits.
+function mockContext() {
+
+	const calls = [];
+
+	return {
+		calls,
+		drawArrays( ...args ) {
+
+			calls.push( [ 'drawArrays', ...args ] );
+
+		},
+		drawArraysInstanced( ...args ) {
+
+			calls.push( [ 'drawArraysInstanced', ...args ] );
+
+		}
+	};
+
+}
+
+function mockExtensions( extension ) {
+
+	return {
+		requested: [],
+		get( name ) {
+
+			this.requested.push( name );
+			return extension;
+
+		}
+	};
+
+}
+
+function mockInfo() {
+
+	const updates = [];
+
+	return {
+		updates,
+		update( count, mode, instanceCount ) {
+
+			updates.push( [ count, mode, instanceCount ] );
+
+		}
+	};
+
+}
 
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
 		QUnit.module( 'WebGLBufferRenderer', () => {
+
+			// INSTANCING
+			QUnit.test( 'Instancing - exposes the expected API', ( assert ) => {
+
+				const renderer = new WebGLBufferRenderer( mockContext(), mockExtensions(), mockInfo() );
+
+				for ( const method of [ 'setMode', 'render', 'renderInstances', 'renderMultiDraw' ] ) {
+
+					assert.strictEqual( typeof renderer[ method ], 'function', `${ method }() is exposed` );
+
+				}
+
+			} );
+
+			// render
+			QUnit.test( 'render - draws with the mode set by setMode', ( assert ) => {
+
+				const gl = mockContext();
+				const renderer = new WebGLBufferRenderer( gl, mockExtensions(), mockInfo() );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.render( 6, 12 );
+
+				assert.deepEqual( gl.calls, [[ 'drawArrays', TrianglesDrawMode, 6, 12 ]], 'start and count are forwarded verbatim' );
+
+			} );
+
+			QUnit.test( 'render - reports a single instance to info', ( assert ) => {
+
+				const info = mockInfo();
+				const renderer = new WebGLBufferRenderer( mockContext(), mockExtensions(), info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.render( 0, 12 );
+
+				assert.deepEqual( info.updates, [[ 12, TrianglesDrawMode, 1 ]], 'the vertex count, mode and instance count are recorded' );
+
+			} );
+
+			QUnit.test( 'render - picks up a mode changed between draws', ( assert ) => {
+
+				const gl = mockContext();
+				const renderer = new WebGLBufferRenderer( gl, mockExtensions(), mockInfo() );
+
+				renderer.setMode( 1 );
+				renderer.render( 0, 3 );
+				renderer.setMode( 2 );
+				renderer.render( 0, 3 );
+
+				assert.strictEqual( gl.calls[ 0 ][ 1 ], 1, 'the first draw uses the first mode' );
+				assert.strictEqual( gl.calls[ 1 ][ 1 ], 2, 'the second draw uses the updated mode' );
+
+			} );
+
+			// renderInstances
+			QUnit.test( 'renderInstances - forwards the instance count', ( assert ) => {
+
+				const gl = mockContext();
+				const info = mockInfo();
+				const renderer = new WebGLBufferRenderer( gl, mockExtensions(), info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.renderInstances( 3, 6, 4 );
+
+				assert.deepEqual( gl.calls, [[ 'drawArraysInstanced', TrianglesDrawMode, 3, 6, 4 ]], 'the instanced draw call is issued' );
+				assert.deepEqual( info.updates, [[ 6, TrianglesDrawMode, 4 ]], 'info records the instance count' );
+
+			} );
+
+			QUnit.test( 'renderInstances - skips the draw entirely for zero instances', ( assert ) => {
+
+				const gl = mockContext();
+				const info = mockInfo();
+				const renderer = new WebGLBufferRenderer( gl, mockExtensions(), info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.renderInstances( 0, 6, 0 );
+
+				assert.deepEqual( gl.calls, [], 'no draw call is issued' );
+				assert.deepEqual( info.updates, [], 'nothing is counted' );
+
+			} );
+
+			// renderMultiDraw
+			QUnit.test( 'renderMultiDraw - forwards the draw lists to the extension', ( assert ) => {
+
+				const multiDrawCalls = [];
+				const extensions = mockExtensions( {
+					multiDrawArraysWEBGL( ...args ) {
+
+						multiDrawCalls.push( args );
+
+					}
+				} );
+
+				const renderer = new WebGLBufferRenderer( mockContext(), extensions, mockInfo() );
+
+				const starts = [ 0, 10 ], counts = [ 3, 6 ];
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.renderMultiDraw( starts, counts, 2 );
+
+				assert.deepEqual( extensions.requested, [ 'WEBGL_multi_draw' ], 'the multi draw extension is looked up' );
+				assert.deepEqual(
+					multiDrawCalls,
+					[[ TrianglesDrawMode, starts, 0, counts, 0, 2 ]],
+					'the offsets are zero and the draw count is passed through'
+				);
+
+			} );
+
+			QUnit.test( 'renderMultiDraw - reports the summed element count to info', ( assert ) => {
+
+				const extensions = mockExtensions( { multiDrawArraysWEBGL() {} } );
+				const info = mockInfo();
+				const renderer = new WebGLBufferRenderer( mockContext(), extensions, info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.renderMultiDraw( [ 0, 10, 20 ], [ 3, 6, 9 ], 3 );
+
+				assert.deepEqual( info.updates, [[ 18, TrianglesDrawMode, 1 ]], 'the counts are summed into one update' );
+
+			} );
+
+			QUnit.test( 'renderMultiDraw - only sums the first drawCount entries', ( assert ) => {
+
+				// The arrays are reused buffers that can be longer than the
+				// number of draws actually being issued.
+				const extensions = mockExtensions( { multiDrawArraysWEBGL() {} } );
+				const info = mockInfo();
+				const renderer = new WebGLBufferRenderer( mockContext(), extensions, info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.renderMultiDraw( [ 0, 10, 20 ], [ 3, 6, 999 ], 2 );
+
+				assert.deepEqual( info.updates, [[ 9, TrianglesDrawMode, 1 ]], 'the trailing stale entry is ignored' );
+
+			} );
+
+			QUnit.test( 'renderMultiDraw - skips the draw entirely for zero draws', ( assert ) => {
+
+				const extensions = mockExtensions( { multiDrawArraysWEBGL() {} } );
+				const info = mockInfo();
+				const renderer = new WebGLBufferRenderer( mockContext(), extensions, info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.renderMultiDraw( [], [], 0 );
+
+				assert.deepEqual( extensions.requested, [], 'the extension is not even looked up' );
+				assert.deepEqual( info.updates, [], 'nothing is counted' );
+
+			} );
 
 		} );
 

--- a/test/unit/src/renderers/webgl/WebGLCapabilities.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLCapabilities.tests.js
@@ -103,7 +103,18 @@ export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
-		QUnit.module( 'WebGLCapabilities', () => {
+		QUnit.module( 'WebGLCapabilities', ( hooks ) => {
+
+			// Several tests below suppress the expected precision/extension
+			// warnings by lowering console.level. That is a process-global set by
+			// the console wrapper, so restoring it inline would be skipped if the
+			// code under test threw first, silently muting warnings for the rest
+			// of the suite. Resetting here runs on both success and failure.
+			hooks.afterEach( () => {
+
+				console.level = CONSOLE_LEVEL.DEFAULT;
+
+			} );
 
 			// INSTANCING
 			QUnit.test( 'Instancing - reads the driver limits off the context', ( assert ) => {
@@ -167,7 +178,6 @@ export default QUnit.module( 'Renderers', () => {
 				const noFloat = create( { precisions: { HIGH_FLOAT: 0, MEDIUM_FLOAT: 0 } } );
 				assert.strictEqual( noFloat.precision, 'lowp', 'with neither available it falls back to lowp' );
 
-				console.level = CONSOLE_LEVEL.DEFAULT;
 
 			} );
 
@@ -197,7 +207,6 @@ export default QUnit.module( 'Renderers', () => {
 				assert.strictEqual( capabilities.getMaxPrecision( 'highp' ), 'lowp', 'highp degrades all the way to lowp' );
 				assert.strictEqual( capabilities.getMaxPrecision( 'mediump' ), 'lowp', 'mediump degrades to lowp' );
 
-				console.level = CONSOLE_LEVEL.DEFAULT;
 
 			} );
 
@@ -219,7 +228,6 @@ export default QUnit.module( 'Renderers', () => {
 				const withoutExtension = create( { parameters: { reversedDepthBuffer: true } } );
 				assert.strictEqual( withoutExtension.reversedDepthBuffer, false, 'without the extension it stays off' );
 
-				console.level = CONSOLE_LEVEL.DEFAULT;
 
 				assert.strictEqual( create( { extensions: [ 'EXT_clip_control' ] } ).reversedDepthBuffer, false, 'it is off unless requested' );
 

--- a/test/unit/src/renderers/webgl/WebGLCapabilities.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLCapabilities.tests.js
@@ -1,10 +1,360 @@
-// import { WebGLCapabilities } from '../../../../../src/renderers/webgl/WebGLCapabilities.js';
+import { WebGLCapabilities } from '../../../../../src/renderers/webgl/WebGLCapabilities.js';
+import { FloatType, HalfFloatType, UnsignedByteType, RGBAFormat, RedFormat } from '../../../../../src/constants.js';
+import { CONSOLE_LEVEL } from '../../../utils/console-wrapper.js';
+
+// Distinct sentinels for the pname constants, so getParameter() can be driven
+// from a plain lookup table.
+const GL_CONSTANTS = {
+	MAX_TEXTURE_IMAGE_UNITS: 'MAX_TEXTURE_IMAGE_UNITS',
+	MAX_VERTEX_TEXTURE_IMAGE_UNITS: 'MAX_VERTEX_TEXTURE_IMAGE_UNITS',
+	MAX_TEXTURE_SIZE: 'MAX_TEXTURE_SIZE',
+	MAX_CUBE_MAP_TEXTURE_SIZE: 'MAX_CUBE_MAP_TEXTURE_SIZE',
+	MAX_VERTEX_ATTRIBS: 'MAX_VERTEX_ATTRIBS',
+	MAX_VERTEX_UNIFORM_VECTORS: 'MAX_VERTEX_UNIFORM_VECTORS',
+	MAX_VARYING_VECTORS: 'MAX_VARYING_VECTORS',
+	MAX_FRAGMENT_UNIFORM_VECTORS: 'MAX_FRAGMENT_UNIFORM_VECTORS',
+	MAX_SAMPLES: 'MAX_SAMPLES',
+	SAMPLES: 'SAMPLES',
+	IMPLEMENTATION_COLOR_READ_FORMAT: 'IMPLEMENTATION_COLOR_READ_FORMAT',
+	IMPLEMENTATION_COLOR_READ_TYPE: 'IMPLEMENTATION_COLOR_READ_TYPE',
+	VERTEX_SHADER: 'VERTEX_SHADER',
+	FRAGMENT_SHADER: 'FRAGMENT_SHADER',
+	HIGH_FLOAT: 'HIGH_FLOAT',
+	MEDIUM_FLOAT: 'MEDIUM_FLOAT'
+};
+
+// A context whose limits and shader precision support can be dialled in per
+// test. `precisions` maps a precision constant to the reported bit count; 0
+// means the hardware does not support it.
+function mockContext( { parameters = {}, precisions = { HIGH_FLOAT: 23, MEDIUM_FLOAT: 10 } } = {} ) {
+
+	const limits = {
+		MAX_TEXTURE_IMAGE_UNITS: 16,
+		MAX_VERTEX_TEXTURE_IMAGE_UNITS: 16,
+		MAX_TEXTURE_SIZE: 4096,
+		MAX_CUBE_MAP_TEXTURE_SIZE: 4096,
+		MAX_VERTEX_ATTRIBS: 16,
+		MAX_VERTEX_UNIFORM_VECTORS: 1024,
+		MAX_VARYING_VECTORS: 15,
+		MAX_FRAGMENT_UNIFORM_VECTORS: 1024,
+		MAX_SAMPLES: 4,
+		SAMPLES: 0,
+		...parameters
+	};
+
+	return {
+		...GL_CONSTANTS,
+		getParameter( pname ) {
+
+			return limits[ pname ];
+
+		},
+		getShaderPrecisionFormat( shaderType, precisionType ) {
+
+			return { precision: precisions[ precisionType ] ?? 0 };
+
+		}
+	};
+
+}
+
+function mockExtensions( available = [] ) {
+
+	return {
+		has( name ) {
+
+			return available.includes( name );
+
+		},
+		get( name ) {
+
+			return available.includes( name ) ? { MAX_TEXTURE_MAX_ANISOTROPY_EXT: 'MAX_ANISOTROPY' } : null;
+
+		}
+	};
+
+}
+
+// Stands in for WebGLUtils -- capabilities only calls convert().
+function mockUtils( mapping = {} ) {
+
+	return {
+		convert( p ) {
+
+			return mapping[ p ] !== undefined ? mapping[ p ] : p;
+
+		}
+	};
+
+}
+
+function create( { parameters = {}, precisions, extensions = [], utils = mockUtils(), glParameters = {} } = {} ) {
+
+	return new WebGLCapabilities(
+		mockContext( { parameters: glParameters, precisions } ),
+		mockExtensions( extensions ),
+		parameters,
+		utils
+	);
+
+}
 
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
 		QUnit.module( 'WebGLCapabilities', () => {
+
+			// INSTANCING
+			QUnit.test( 'Instancing - reads the driver limits off the context', ( assert ) => {
+
+				const capabilities = create( {
+					glParameters: {
+						MAX_TEXTURE_IMAGE_UNITS: 32,
+						MAX_VERTEX_TEXTURE_IMAGE_UNITS: 16,
+						MAX_TEXTURE_SIZE: 8192,
+						MAX_CUBE_MAP_TEXTURE_SIZE: 2048,
+						MAX_VERTEX_ATTRIBS: 24,
+						MAX_VERTEX_UNIFORM_VECTORS: 512,
+						MAX_VARYING_VECTORS: 31,
+						MAX_FRAGMENT_UNIFORM_VECTORS: 256,
+						MAX_SAMPLES: 8,
+						SAMPLES: 4
+					}
+				} );
+
+				assert.strictEqual( capabilities.maxTextures, 32, 'maxTextures' );
+				assert.strictEqual( capabilities.maxVertexTextures, 16, 'maxVertexTextures' );
+				assert.strictEqual( capabilities.maxTextureSize, 8192, 'maxTextureSize' );
+				assert.strictEqual( capabilities.maxCubemapSize, 2048, 'maxCubemapSize' );
+				assert.strictEqual( capabilities.maxAttributes, 24, 'maxAttributes' );
+				assert.strictEqual( capabilities.maxVertexUniforms, 512, 'maxVertexUniforms' );
+				assert.strictEqual( capabilities.maxVaryings, 31, 'maxVaryings' );
+				assert.strictEqual( capabilities.maxFragmentUniforms, 256, 'maxFragmentUniforms' );
+				assert.strictEqual( capabilities.maxSamples, 8, 'maxSamples' );
+				assert.strictEqual( capabilities.samples, 4, 'samples' );
+
+			} );
+
+			QUnit.test( 'Instancing - always reports isWebGL2', ( assert ) => {
+
+				// Kept as a constant for backwards compatibility now that WebGL 1
+				// is no longer supported.
+				assert.strictEqual( create().isWebGL2, true, 'isWebGL2 is true' );
+
+			} );
+
+			// precision
+			QUnit.test( 'Instancing - defaults to highp', ( assert ) => {
+
+				assert.strictEqual( create().precision, 'highp', 'highp is the default when the driver supports it' );
+
+			} );
+
+			QUnit.test( 'Instancing - honours a requested precision', ( assert ) => {
+
+				assert.strictEqual( create( { parameters: { precision: 'mediump' } } ).precision, 'mediump', 'the requested precision is used' );
+
+			} );
+
+			QUnit.test( 'Instancing - falls back when the requested precision is unsupported', ( assert ) => {
+
+				console.level = CONSOLE_LEVEL.ERROR;
+
+				const noHighp = create( { precisions: { HIGH_FLOAT: 0, MEDIUM_FLOAT: 10 } } );
+				assert.strictEqual( noHighp.precision, 'mediump', 'highp falls back to mediump' );
+
+				const noFloat = create( { precisions: { HIGH_FLOAT: 0, MEDIUM_FLOAT: 0 } } );
+				assert.strictEqual( noFloat.precision, 'lowp', 'with neither available it falls back to lowp' );
+
+				console.level = CONSOLE_LEVEL.DEFAULT;
+
+			} );
+
+			// getMaxPrecision
+			QUnit.test( 'getMaxPrecision - reports the best precision at or below the request', ( assert ) => {
+
+				const capabilities = create();
+
+				assert.strictEqual( capabilities.getMaxPrecision( 'highp' ), 'highp', 'highp is available' );
+				assert.strictEqual( capabilities.getMaxPrecision( 'mediump' ), 'mediump', 'mediump is available' );
+
+			} );
+
+			QUnit.test( 'getMaxPrecision - never upgrades a request', ( assert ) => {
+
+				// Asking for lowp gets lowp even on hardware that supports more.
+				assert.strictEqual( create().getMaxPrecision( 'lowp' ), 'lowp', 'lowp stays lowp' );
+
+			} );
+
+			QUnit.test( 'getMaxPrecision - degrades when the driver reports no support', ( assert ) => {
+
+				console.level = CONSOLE_LEVEL.ERROR;
+
+				const capabilities = create( { precisions: { HIGH_FLOAT: 0, MEDIUM_FLOAT: 0 } } );
+
+				assert.strictEqual( capabilities.getMaxPrecision( 'highp' ), 'lowp', 'highp degrades all the way to lowp' );
+				assert.strictEqual( capabilities.getMaxPrecision( 'mediump' ), 'lowp', 'mediump degrades to lowp' );
+
+				console.level = CONSOLE_LEVEL.DEFAULT;
+
+			} );
+
+			// logarithmicDepthBuffer / reversedDepthBuffer
+			QUnit.test( 'Instancing - reflects the logarithmicDepthBuffer parameter', ( assert ) => {
+
+				assert.strictEqual( create().logarithmicDepthBuffer, false, 'it is off by default' );
+				assert.strictEqual( create( { parameters: { logarithmicDepthBuffer: true } } ).logarithmicDepthBuffer, true, 'it can be turned on' );
+
+			} );
+
+			QUnit.test( 'Instancing - enables reversedDepthBuffer only with EXT_clip_control', ( assert ) => {
+
+				console.level = CONSOLE_LEVEL.ERROR;
+
+				const withExtension = create( { parameters: { reversedDepthBuffer: true }, extensions: [ 'EXT_clip_control' ] } );
+				assert.strictEqual( withExtension.reversedDepthBuffer, true, 'the extension enables it' );
+
+				const withoutExtension = create( { parameters: { reversedDepthBuffer: true } } );
+				assert.strictEqual( withoutExtension.reversedDepthBuffer, false, 'without the extension it stays off' );
+
+				console.level = CONSOLE_LEVEL.DEFAULT;
+
+				assert.strictEqual( create( { extensions: [ 'EXT_clip_control' ] } ).reversedDepthBuffer, false, 'it is off unless requested' );
+
+			} );
+
+			// getMaxAnisotropy
+			QUnit.test( 'getMaxAnisotropy - reads the limit from the extension', ( assert ) => {
+
+				const capabilities = create( {
+					extensions: [ 'EXT_texture_filter_anisotropic' ],
+					glParameters: { MAX_ANISOTROPY: 16 }
+				} );
+
+				assert.strictEqual( capabilities.getMaxAnisotropy(), 16, 'the driver limit is reported' );
+
+			} );
+
+			QUnit.test( 'getMaxAnisotropy - reports zero without the extension', ( assert ) => {
+
+				assert.strictEqual( create().getMaxAnisotropy(), 0, 'anisotropic filtering is unavailable' );
+
+			} );
+
+			QUnit.test( 'getMaxAnisotropy - caches the queried value', ( assert ) => {
+
+				// The lookup is memoised, so a context that starts reporting a
+				// different value is not picked up again.
+				let queries = 0;
+
+				const gl = mockContext();
+				const originalGetParameter = gl.getParameter;
+				gl.getParameter = function ( pname ) {
+
+					if ( pname === 'MAX_ANISOTROPY' ) {
+
+						queries ++;
+						return 16;
+
+					}
+
+					return originalGetParameter.call( gl, pname );
+
+				};
+
+				const capabilities = new WebGLCapabilities( gl, mockExtensions( [ 'EXT_texture_filter_anisotropic' ] ), {}, mockUtils() );
+
+				capabilities.getMaxAnisotropy();
+				capabilities.getMaxAnisotropy();
+
+				assert.strictEqual( queries, 1, 'the extension is only queried once' );
+
+			} );
+
+			// textureFormatReadable
+			QUnit.test( 'textureFormatReadable - always accepts RGBA', ( assert ) => {
+
+				// RGBA is guaranteed readable, so it short-circuits before the
+				// implementation-defined format is consulted.
+				const capabilities = create( {
+					glParameters: { IMPLEMENTATION_COLOR_READ_FORMAT: 'SOMETHING_ELSE' }
+				} );
+
+				assert.strictEqual( capabilities.textureFormatReadable( RGBAFormat ), true, 'RGBA is readable' );
+
+			} );
+
+			QUnit.test( 'textureFormatReadable - accepts a format matching the implementation format', ( assert ) => {
+
+				const capabilities = create( {
+					utils: mockUtils( { [ RedFormat ]: 'GL_RED' } ),
+					glParameters: { IMPLEMENTATION_COLOR_READ_FORMAT: 'GL_RED' }
+				} );
+
+				assert.strictEqual( capabilities.textureFormatReadable( RedFormat ), true, 'the matching format is readable' );
+
+			} );
+
+			QUnit.test( 'textureFormatReadable - rejects any other format', ( assert ) => {
+
+				const capabilities = create( {
+					utils: mockUtils( { [ RedFormat ]: 'GL_RED' } ),
+					glParameters: { IMPLEMENTATION_COLOR_READ_FORMAT: 'GL_RGBA' }
+				} );
+
+				assert.strictEqual( capabilities.textureFormatReadable( RedFormat ), false, 'a mismatched format is not readable' );
+
+			} );
+
+			// textureTypeReadable
+			QUnit.test( 'textureTypeReadable - always accepts the guaranteed types', ( assert ) => {
+
+				const capabilities = create( {
+					glParameters: { IMPLEMENTATION_COLOR_READ_TYPE: 'SOMETHING_ELSE' }
+				} );
+
+				assert.strictEqual( capabilities.textureTypeReadable( UnsignedByteType ), true, 'unsigned byte is readable' );
+				assert.strictEqual( capabilities.textureTypeReadable( FloatType ), true, 'float is readable' );
+
+			} );
+
+			QUnit.test( 'textureTypeReadable - accepts half float when a color buffer extension is present', ( assert ) => {
+
+				const glParameters = { IMPLEMENTATION_COLOR_READ_TYPE: 'SOMETHING_ELSE' };
+
+				for ( const extension of [ 'EXT_color_buffer_half_float', 'EXT_color_buffer_float' ] ) {
+
+					const capabilities = create( { extensions: [ extension ], glParameters } );
+
+					assert.strictEqual( capabilities.textureTypeReadable( HalfFloatType ), true, `${ extension } makes half float readable` );
+
+				}
+
+			} );
+
+			QUnit.test( 'textureTypeReadable - rejects half float without either extension', ( assert ) => {
+
+				const capabilities = create( {
+					utils: mockUtils( { [ HalfFloatType ]: 'GL_HALF_FLOAT' } ),
+					glParameters: { IMPLEMENTATION_COLOR_READ_TYPE: 'GL_UNSIGNED_BYTE' }
+				} );
+
+				assert.strictEqual( capabilities.textureTypeReadable( HalfFloatType ), false, 'half float is not readable' );
+
+			} );
+
+			QUnit.test( 'textureTypeReadable - accepts a type matching the implementation type', ( assert ) => {
+
+				const capabilities = create( {
+					utils: mockUtils( { 9999: 'GL_SOME_TYPE' } ),
+					glParameters: { IMPLEMENTATION_COLOR_READ_TYPE: 'GL_SOME_TYPE' }
+				} );
+
+				assert.strictEqual( capabilities.textureTypeReadable( 9999 ), true, 'the matching type is readable' );
+
+			} );
 
 		} );
 

--- a/test/unit/src/renderers/webgl/WebGLClipping.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLClipping.tests.js
@@ -1,10 +1,425 @@
-// import { WebGLClipping } from '../../../../../src/renderers/webgl/WebGLClipping.js';
+import { WebGLClipping } from '../../../../../src/renderers/webgl/WebGLClipping.js';
+import { WebGLProperties } from '../../../../../src/renderers/webgl/WebGLProperties.js';
+import { Plane } from '../../../../../src/math/Plane.js';
+import { Vector3 } from '../../../../../src/math/Vector3.js';
+import { PerspectiveCamera } from '../../../../../src/cameras/PerspectiveCamera.js';
+
+// A camera at the origin, so matrixWorldInverse is the identity and planes
+// survive the world -> view projection unchanged.
+function identityCamera() {
+
+	const camera = new PerspectiveCamera();
+	camera.updateMatrixWorld( true );
+	return camera;
+
+}
+
+// Stands in for a Material; setState() only reads these three properties.
+function material( { clippingPlanes = null, clipIntersection = false, clipShadows = false } = {} ) {
+
+	return { clippingPlanes, clipIntersection, clipShadows };
+
+}
 
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
 		QUnit.module( 'WebGLClipping', () => {
+
+			// INSTANCING
+			QUnit.test( 'Instancing - starts with no planes and an empty uniform', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+
+				assert.strictEqual( clipping.numPlanes, 0, 'numPlanes starts at 0' );
+				assert.strictEqual( clipping.numIntersection, 0, 'numIntersection starts at 0' );
+				assert.strictEqual( clipping.uniform.value, null, 'the uniform holds no data yet' );
+				assert.strictEqual( clipping.uniform.needsUpdate, false, 'the uniform does not need an upload yet' );
+
+			} );
+
+			// init
+			QUnit.test( 'init - is disabled when there is nothing to clip', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+
+				assert.strictEqual( clipping.init( [], false ), false, 'no global planes and no local clipping means disabled' );
+
+			} );
+
+			QUnit.test( 'init - is enabled by global planes', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+
+				assert.strictEqual( clipping.init( [ new Plane() ], false ), true, 'a global plane enables clipping' );
+
+			} );
+
+			QUnit.test( 'init - is enabled by local clipping', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+
+				assert.strictEqual( clipping.init( [], true ), true, 'the local clipping flag enables clipping' );
+
+			} );
+
+			QUnit.test( 'init - stays enabled for one more frame after global planes are removed', ( assert ) => {
+
+				// The clipping code has to run once more to reset the shader
+				// state, so the frame that drops the planes still reports true.
+				const clipping = new WebGLClipping( new WebGLProperties() );
+
+				clipping.init( [ new Plane() ], false );
+
+				assert.strictEqual( clipping.init( [], false ), true, 'the frame that removes the planes is still enabled' );
+				assert.strictEqual( clipping.init( [], false ), false, 'the frame after that is disabled' );
+
+			} );
+
+			QUnit.test( 'init - stays enabled for one more frame after local clipping is turned off', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+
+				clipping.init( [], true );
+
+				assert.strictEqual( clipping.init( [], false ), true, 'the frame that turns local clipping off is still enabled' );
+				assert.strictEqual( clipping.init( [], false ), false, 'the frame after that is disabled' );
+
+			} );
+
+			// setGlobalState
+			QUnit.test( 'setGlobalState - packs each plane into four floats', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [ new Plane(), new Plane() ], false );
+				clipping.setGlobalState( [
+					new Plane( new Vector3( 1, 0, 0 ), 2 ),
+					new Plane( new Vector3( 0, 1, 0 ), 3 )
+				], camera );
+
+				assert.ok( clipping.uniform.value instanceof Float32Array, 'the uniform holds a Float32Array' );
+				assert.strictEqual( clipping.uniform.value.length, 8, 'two planes take eight floats' );
+				assert.deepEqual(
+					Array.from( clipping.uniform.value ),
+					[ 1, 0, 0, 2, 0, 1, 0, 3 ],
+					'each plane is stored as normal.xyz followed by its constant'
+				);
+				assert.strictEqual( clipping.numPlanes, 2, 'numPlanes reflects the global planes' );
+				assert.strictEqual( clipping.uniform.needsUpdate, true, 'the uniform is flagged for upload' );
+
+			} );
+
+			QUnit.test( 'setGlobalState - transforms planes into view space', ( assert ) => {
+
+				// A camera pushed back along +z moves the world z = 0 plane to
+				// z = -5 in view space, which shows up as the plane constant.
+				const clipping = new WebGLClipping( new WebGLProperties() );
+
+				const camera = new PerspectiveCamera();
+				camera.position.set( 0, 0, 5 );
+				camera.updateMatrixWorld( true );
+
+				clipping.init( [ new Plane() ], false );
+				clipping.setGlobalState( [ new Plane( new Vector3( 0, 0, 1 ), 0 ) ], camera );
+
+				const [ x, y, z, constant ] = Array.from( clipping.uniform.value );
+
+				assert.numEqual( x, 0, 'the normal x component is unchanged' );
+				assert.numEqual( y, 0, 'the normal y component is unchanged' );
+				assert.numEqual( z, 1, 'the normal z component is unchanged' );
+				assert.numEqual( constant, 5, 'the constant absorbs the camera translation' );
+
+			} );
+
+			QUnit.test( 'setGlobalState - clears the plane count when given no planes', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [ new Plane() ], false );
+				clipping.setGlobalState( [ new Plane( new Vector3( 1, 0, 0 ), 0 ) ], camera );
+				clipping.setGlobalState( [], camera );
+
+				assert.strictEqual( clipping.numPlanes, 0, 'numPlanes drops back to 0' );
+
+			} );
+
+			// setState - global only
+			QUnit.test( 'setState - falls back to the global planes when local clipping is off', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [ new Plane() ], false );
+				clipping.setGlobalState( [ new Plane( new Vector3( 1, 0, 0 ), 1 ) ], camera );
+
+				// The material has local planes, but local clipping was never
+				// enabled, so they are ignored.
+				clipping.setState( material( { clippingPlanes: [ new Plane() ] } ), camera, false );
+
+				assert.strictEqual( clipping.numPlanes, 1, 'only the global plane counts' );
+				assert.strictEqual( clipping.numIntersection, 0, 'no intersection planes' );
+				assert.deepEqual( Array.from( clipping.uniform.value ), [ 1, 0, 0, 1 ], 'the uniform holds the global state' );
+
+			} );
+
+			QUnit.test( 'setState - falls back to the global planes for a material with none', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [ new Plane() ], true );
+				clipping.setGlobalState( [ new Plane( new Vector3( 0, 1, 0 ), 2 ) ], camera );
+
+				clipping.setState( material( { clippingPlanes: null } ), camera, false );
+
+				assert.strictEqual( clipping.numPlanes, 1, 'the global plane still applies' );
+				assert.deepEqual( Array.from( clipping.uniform.value ), [ 0, 1, 0, 2 ], 'the uniform holds the global state' );
+
+			} );
+
+			QUnit.test( 'setState - treats an empty local plane list like none at all', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [ new Plane() ], true );
+				clipping.setGlobalState( [ new Plane( new Vector3( 0, 1, 0 ), 2 ) ], camera );
+
+				clipping.setState( material( { clippingPlanes: [] } ), camera, false );
+
+				assert.strictEqual( clipping.numPlanes, 1, 'the global plane still applies' );
+
+			} );
+
+			// setState - local clipping
+			QUnit.test( 'setState - uses the material planes when local clipping is on', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [], true );
+				clipping.setGlobalState( [], camera );
+
+				clipping.setState( material( { clippingPlanes: [ new Plane( new Vector3( 1, 0, 0 ), 4 ) ] } ), camera, false );
+
+				assert.strictEqual( clipping.numPlanes, 1, 'the material plane is counted' );
+				assert.deepEqual( Array.from( clipping.uniform.value ), [ 1, 0, 0, 4 ], 'the uniform holds the material plane' );
+
+			} );
+
+			QUnit.test( 'setState - places global planes before the material planes', ( assert ) => {
+
+				// The shader reads one flat array, with the global planes first
+				// and the material's own appended after them.
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [ new Plane() ], true );
+				clipping.setGlobalState( [ new Plane( new Vector3( 1, 0, 0 ), 1 ) ], camera );
+
+				clipping.setState( material( { clippingPlanes: [ new Plane( new Vector3( 0, 1, 0 ), 2 ) ] } ), camera, false );
+
+				assert.strictEqual( clipping.uniform.value.length, 8, 'both planes fit in the array' );
+				assert.deepEqual(
+					Array.from( clipping.uniform.value ),
+					[ 1, 0, 0, 1, 0, 1, 0, 2 ],
+					'the global plane occupies the first slot'
+				);
+				assert.strictEqual( clipping.numPlanes, 2, 'both planes are counted' );
+
+			} );
+
+			QUnit.test( 'setState - reports intersection planes only when the material asks for it', ( assert ) => {
+
+				const camera = identityCamera();
+				const localPlanes = [ new Plane( new Vector3( 0, 1, 0 ), 2 ) ];
+
+				const withIntersection = new WebGLClipping( new WebGLProperties() );
+				withIntersection.init( [ new Plane() ], true );
+				withIntersection.setGlobalState( [ new Plane( new Vector3( 1, 0, 0 ), 1 ) ], camera );
+				withIntersection.setState( material( { clippingPlanes: localPlanes, clipIntersection: true } ), camera, false );
+
+				assert.strictEqual( withIntersection.numIntersection, 1, 'the material planes become intersection planes' );
+				assert.strictEqual( withIntersection.numPlanes, 2, 'the global plane is still added to the total' );
+
+				const withoutIntersection = new WebGLClipping( new WebGLProperties() );
+				withoutIntersection.init( [ new Plane() ], true );
+				withoutIntersection.setGlobalState( [ new Plane( new Vector3( 1, 0, 0 ), 1 ) ], camera );
+				withoutIntersection.setState( material( { clippingPlanes: localPlanes, clipIntersection: false } ), camera, false );
+
+				assert.strictEqual( withoutIntersection.numIntersection, 0, 'clipIntersection = false reports no intersection planes' );
+
+			} );
+
+			QUnit.test( 'setState - caches the packed planes on the material properties', ( assert ) => {
+
+				// Reusing the array across frames is what makes the `useCache`
+				// fast path possible, so the buffer must be stashed and reused.
+				const properties = new WebGLProperties();
+				const clipping = new WebGLClipping( properties );
+				const camera = identityCamera();
+
+				const mat = material( { clippingPlanes: [ new Plane( new Vector3( 1, 0, 0 ), 1 ) ] } );
+
+				clipping.init( [], true );
+				clipping.setGlobalState( [], camera );
+				clipping.setState( mat, camera, false );
+
+				const cached = properties.get( mat ).clippingState;
+
+				assert.ok( cached instanceof Float32Array, 'the packed planes are cached on the material' );
+
+				clipping.setState( mat, camera, false );
+
+				assert.strictEqual( properties.get( mat ).clippingState, cached, 'the same buffer is reused on the next frame' );
+
+			} );
+
+			QUnit.test( 'setState - skips the transform when useCache is set', ( assert ) => {
+
+				// With useCache the cached buffer is taken as-is, so a plane
+				// that moved since the last call is not re-projected.
+				const properties = new WebGLProperties();
+				const clipping = new WebGLClipping( properties );
+				const camera = identityCamera();
+
+				const plane = new Plane( new Vector3( 1, 0, 0 ), 1 );
+				const mat = material( { clippingPlanes: [ plane ] } );
+
+				clipping.init( [], true );
+				clipping.setGlobalState( [], camera );
+				clipping.setState( mat, camera, false );
+
+				plane.constant = 99;
+				clipping.setState( mat, camera, true );
+
+				assert.deepEqual( Array.from( clipping.uniform.value ), [ 1, 0, 0, 1 ], 'the cached values are kept' );
+
+				clipping.setState( mat, camera, false );
+
+				assert.deepEqual( Array.from( clipping.uniform.value ), [ 1, 0, 0, 99 ], 'without the cache the plane is re-projected' );
+
+			} );
+
+			QUnit.test( 'setState - keeps separate materials independent', ( assert ) => {
+
+				const properties = new WebGLProperties();
+				const clipping = new WebGLClipping( properties );
+				const camera = identityCamera();
+
+				const a = material( { clippingPlanes: [ new Plane( new Vector3( 1, 0, 0 ), 1 ) ] } );
+				const b = material( { clippingPlanes: [ new Plane( new Vector3( 0, 1, 0 ), 2 ) ] } );
+
+				clipping.init( [], true );
+				clipping.setGlobalState( [], camera );
+
+				clipping.setState( a, camera, false );
+				clipping.setState( b, camera, false );
+
+				assert.notStrictEqual(
+					properties.get( a ).clippingState,
+					properties.get( b ).clippingState,
+					'each material gets its own buffer'
+				);
+				assert.deepEqual( Array.from( properties.get( a ).clippingState ), [ 1, 0, 0, 1 ], 'the first material keeps its plane' );
+				assert.deepEqual( Array.from( properties.get( b ).clippingState ), [ 0, 1, 0, 2 ], 'the second material keeps its plane' );
+
+			} );
+
+			// shadows
+			QUnit.test( 'beginShadows - clears the active planes', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [ new Plane() ], false );
+				clipping.setGlobalState( [ new Plane( new Vector3( 1, 0, 0 ), 1 ) ], camera );
+
+				clipping.beginShadows();
+
+				assert.strictEqual( clipping.numPlanes, 0, 'the shadow pass starts unclipped' );
+				assert.strictEqual( clipping.numIntersection, 0, 'no intersection planes during shadows' );
+
+			} );
+
+			QUnit.test( 'setState - ignores material planes during shadows unless clipShadows is set', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [], true );
+				clipping.setGlobalState( [], camera );
+				clipping.beginShadows();
+
+				clipping.setState( material( { clippingPlanes: [ new Plane() ], clipShadows: false } ), camera, false );
+
+				assert.strictEqual( clipping.numPlanes, 0, 'a material that does not clip shadows contributes nothing' );
+
+			} );
+
+			QUnit.test( 'setState - applies material planes during shadows when clipShadows is set', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [], true );
+				clipping.setGlobalState( [], camera );
+				clipping.beginShadows();
+
+				clipping.setState(
+					material( { clippingPlanes: [ new Plane( new Vector3( 1, 0, 0 ), 3 ) ], clipShadows: true } ),
+					camera,
+					false
+				);
+
+				assert.strictEqual( clipping.numPlanes, 1, 'the material plane clips the shadow pass' );
+				assert.deepEqual( Array.from( clipping.uniform.value ), [ 1, 0, 0, 3 ], 'the uniform holds the material plane' );
+
+			} );
+
+			QUnit.test( 'setState - excludes global planes from the shadow pass', ( assert ) => {
+
+				// Global planes are not applied while rendering shadows, so a
+				// clipShadows material sees only its own planes.
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [ new Plane() ], true );
+				clipping.setGlobalState( [ new Plane( new Vector3( 1, 0, 0 ), 1 ) ], camera );
+				clipping.beginShadows();
+
+				clipping.setState(
+					material( { clippingPlanes: [ new Plane( new Vector3( 0, 1, 0 ), 2 ) ], clipShadows: true } ),
+					camera,
+					false
+				);
+
+				assert.strictEqual( clipping.numPlanes, 1, 'the global plane is not added during shadows' );
+				assert.deepEqual( Array.from( clipping.uniform.value ).slice( 0, 4 ), [ 0, 1, 0, 2 ], 'only the material plane is packed' );
+
+			} );
+
+			QUnit.test( 'endShadows - restores the global planes on the next setState', ( assert ) => {
+
+				const clipping = new WebGLClipping( new WebGLProperties() );
+				const camera = identityCamera();
+
+				clipping.init( [ new Plane() ], false );
+				clipping.setGlobalState( [ new Plane( new Vector3( 1, 0, 0 ), 1 ) ], camera );
+
+				clipping.beginShadows();
+				clipping.setState( material(), camera, false );
+				clipping.endShadows();
+				clipping.setState( material(), camera, false );
+
+				assert.strictEqual( clipping.numPlanes, 1, 'the global plane applies again' );
+				assert.deepEqual( Array.from( clipping.uniform.value ), [ 1, 0, 0, 1 ], 'the uniform holds the global state again' );
+
+			} );
 
 		} );
 

--- a/test/unit/src/renderers/webgl/WebGLGeometries.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLGeometries.tests.js
@@ -81,7 +81,7 @@ export default QUnit.module( 'Renderers', () => {
 
 			QUnit.test( 'get - only registers a geometry once', ( assert ) => {
 
-				const { geometries, info } = harness();
+				const { geometries, info, calls } = harness();
 				const geometry = triangle();
 
 				geometries.get( {}, geometry );
@@ -89,7 +89,15 @@ export default QUnit.module( 'Renderers', () => {
 				geometries.get( {}, geometry );
 
 				assert.strictEqual( info.memory.geometries, 1, 'repeated calls do not inflate the count' );
-				assert.strictEqual( geometry._listeners.dispose.length, 1, 'the dispose listener is only added once' );
+
+				// Asserted behaviourally rather than by reading the private
+				// _listeners array: if the dispose listener had been added once
+				// per get(), a single dispose event would run the handler three
+				// times, releasing three times and driving the count negative.
+				geometry.dispatchEvent( { type: 'dispose' } );
+
+				assert.strictEqual( calls.released.length, 1, 'one dispose event releases binding states exactly once' );
+				assert.strictEqual( info.memory.geometries, 0, 'the count returns to zero rather than going negative' );
 
 			} );
 

--- a/test/unit/src/renderers/webgl/WebGLGeometries.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLGeometries.tests.js
@@ -1,10 +1,377 @@
-// import { WebGLGeometries } from '../../../../../src/renderers/webgl/WebGLGeometries.js';
+import { WebGLGeometries } from '../../../../../src/renderers/webgl/WebGLGeometries.js';
+import { BufferGeometry } from '../../../../../src/core/BufferGeometry.js';
+import { InstancedBufferGeometry } from '../../../../../src/core/InstancedBufferGeometry.js';
+import { Float32BufferAttribute, Uint16BufferAttribute, Uint32BufferAttribute } from '../../../../../src/core/BufferAttribute.js';
+
+// Recording stand-ins for the collaborators WebGLGeometries talks to.
+function harness() {
+
+	const calls = { update: [], remove: [], released: [] };
+
+	const gl = { ARRAY_BUFFER: 'ARRAY_BUFFER' };
+
+	const attributes = {
+		update( attribute, bufferType ) {
+
+			calls.update.push( [ attribute, bufferType ] );
+
+		},
+		remove( attribute ) {
+
+			calls.remove.push( attribute );
+
+		}
+	};
+
+	const info = { memory: { geometries: 0 } };
+
+	const bindingStates = {
+		releaseStatesOfGeometry( geometry ) {
+
+			calls.released.push( geometry );
+
+		}
+	};
+
+	return { calls, gl, attributes, info, bindingStates, geometries: new WebGLGeometries( gl, attributes, info, bindingStates ) };
+
+}
+
+// A single triangle, indexed or not.
+function triangle( { indexed = false } = {} ) {
+
+	const geometry = new BufferGeometry();
+	geometry.setAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 1, 0, 0, 0, 1, 0 ], 3 ) );
+
+	if ( indexed ) geometry.setIndex( new Uint16BufferAttribute( [ 0, 1, 2 ], 1 ) );
+
+	return geometry;
+
+}
 
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
 		QUnit.module( 'WebGLGeometries', () => {
+
+			// INSTANCING
+			QUnit.test( 'Instancing - exposes the expected API', ( assert ) => {
+
+				const { geometries } = harness();
+
+				for ( const method of [ 'get', 'update', 'getWireframeAttribute' ] ) {
+
+					assert.strictEqual( typeof geometries[ method ], 'function', `${ method }() is exposed` );
+
+				}
+
+			} );
+
+			// get
+			QUnit.test( 'get - returns the geometry and counts it', ( assert ) => {
+
+				const { geometries, info } = harness();
+				const geometry = triangle();
+
+				assert.strictEqual( geometries.get( {}, geometry ), geometry, 'the geometry is returned' );
+				assert.strictEqual( info.memory.geometries, 1, 'the geometry is counted in the memory stats' );
+
+			} );
+
+			QUnit.test( 'get - only registers a geometry once', ( assert ) => {
+
+				const { geometries, info } = harness();
+				const geometry = triangle();
+
+				geometries.get( {}, geometry );
+				geometries.get( {}, geometry );
+				geometries.get( {}, geometry );
+
+				assert.strictEqual( info.memory.geometries, 1, 'repeated calls do not inflate the count' );
+				assert.strictEqual( geometry._listeners.dispose.length, 1, 'the dispose listener is only added once' );
+
+			} );
+
+			QUnit.test( 'get - counts distinct geometries separately', ( assert ) => {
+
+				const { geometries, info } = harness();
+
+				geometries.get( {}, triangle() );
+				geometries.get( {}, triangle() );
+
+				assert.strictEqual( info.memory.geometries, 2, 'each geometry is counted' );
+
+			} );
+
+			// update
+			QUnit.test( 'update - uploads every vertex attribute', ( assert ) => {
+
+				const { geometries, calls, gl } = harness();
+
+				const geometry = triangle();
+				geometry.setAttribute( 'normal', new Float32BufferAttribute( [ 0, 0, 1, 0, 0, 1, 0, 0, 1 ], 3 ) );
+
+				geometries.update( geometry );
+
+				assert.deepEqual(
+					calls.update,
+					[
+						[ geometry.attributes.position, gl.ARRAY_BUFFER ],
+						[ geometry.attributes.normal, gl.ARRAY_BUFFER ]
+					],
+					'each attribute is uploaded as an array buffer'
+				);
+
+			} );
+
+			QUnit.test( 'update - leaves the index to WebGLBindingStates', ( assert ) => {
+
+				// The index buffer is bound as part of the VAO, so it is not
+				// uploaded here.
+				const { geometries, calls } = harness();
+				const geometry = triangle( { indexed: true } );
+
+				geometries.update( geometry );
+
+				assert.strictEqual( calls.update.length, 1, 'only the position attribute is uploaded' );
+				assert.ok( calls.update.every( ( [ attribute ] ) => attribute !== geometry.index ), 'the index is not among them' );
+
+			} );
+
+			// getWireframeAttribute - indexed
+			QUnit.test( 'getWireframeAttribute - turns indexed triangles into line pairs', ( assert ) => {
+
+				// Each triangle a,b,c becomes the three edges ab, bc, ca.
+				const { geometries } = harness();
+				const geometry = triangle( { indexed: true } );
+
+				const wireframe = geometries.getWireframeAttribute( geometry );
+
+				assert.deepEqual( Array.from( wireframe.array ), [ 0, 1, 1, 2, 2, 0 ], 'the three edges of the triangle are emitted' );
+				assert.strictEqual( wireframe.itemSize, 1, 'the attribute holds bare indices' );
+
+			} );
+
+			QUnit.test( 'getWireframeAttribute - handles several indexed triangles', ( assert ) => {
+
+				const { geometries } = harness();
+
+				const geometry = new BufferGeometry();
+				geometry.setAttribute( 'position', new Float32BufferAttribute( new Array( 4 * 3 ).fill( 0 ), 3 ) );
+				geometry.setIndex( new Uint16BufferAttribute( [ 0, 1, 2, 0, 2, 3 ], 1 ) );
+
+				const wireframe = geometries.getWireframeAttribute( geometry );
+
+				assert.deepEqual(
+					Array.from( wireframe.array ),
+					[ 0, 1, 1, 2, 2, 0, 0, 2, 2, 3, 3, 0 ],
+					'both triangles contribute three edges each'
+				);
+
+			} );
+
+			// getWireframeAttribute - non-indexed
+			QUnit.test( 'getWireframeAttribute - derives edges from position order when unindexed', ( assert ) => {
+
+				const { geometries } = harness();
+				const geometry = triangle();
+
+				const wireframe = geometries.getWireframeAttribute( geometry );
+
+				assert.deepEqual( Array.from( wireframe.array ), [ 0, 1, 1, 2, 2, 0 ], 'consecutive vertices form each triangle' );
+
+			} );
+
+			QUnit.test( 'getWireframeAttribute - handles several unindexed triangles', ( assert ) => {
+
+				const { geometries } = harness();
+
+				const geometry = new BufferGeometry();
+				geometry.setAttribute( 'position', new Float32BufferAttribute( new Array( 6 * 3 ).fill( 0 ), 3 ) );
+
+				const wireframe = geometries.getWireframeAttribute( geometry );
+
+				assert.deepEqual(
+					Array.from( wireframe.array ),
+					[ 0, 1, 1, 2, 2, 0, 3, 4, 4, 5, 5, 3 ],
+					'each group of three vertices forms its own triangle'
+				);
+
+			} );
+
+			QUnit.test( 'getWireframeAttribute - returns nothing without a position attribute', ( assert ) => {
+
+				const { geometries } = harness();
+
+				assert.strictEqual( geometries.getWireframeAttribute( new BufferGeometry() ), undefined, 'there is nothing to build edges from' );
+
+			} );
+
+			// getWireframeAttribute - index width
+			QUnit.test( 'getWireframeAttribute - uses 16-bit indices for small geometries', ( assert ) => {
+
+				const { geometries } = harness();
+
+				const wireframe = geometries.getWireframeAttribute( triangle( { indexed: true } ) );
+
+				assert.ok( wireframe.array instanceof Uint16Array, 'a Uint16Array is enough' );
+
+			} );
+
+			QUnit.test( 'getWireframeAttribute - switches to 32-bit indices at 65535 vertices', ( assert ) => {
+
+				// The threshold accounts for PRIMITIVE_RESTART_FIXED_INDEX, which
+				// reserves 65535 in a 16-bit index buffer.
+				const { geometries } = harness();
+
+				const geometry = new BufferGeometry();
+				geometry.setAttribute( 'position', new Float32BufferAttribute( new Float32Array( 65535 * 3 ), 3 ) );
+				geometry.setIndex( new Uint32BufferAttribute( [ 0, 1, 2 ], 1 ) );
+
+				const wireframe = geometries.getWireframeAttribute( geometry );
+
+				assert.strictEqual( geometry.attributes.position.count, 65535, 'the geometry sits exactly on the threshold' );
+				assert.ok( wireframe.array instanceof Uint32Array, 'a Uint32Array is used' );
+
+			} );
+
+			// getWireframeAttribute - caching
+			QUnit.test( 'getWireframeAttribute - reuses the built attribute', ( assert ) => {
+
+				const { geometries } = harness();
+				const geometry = triangle( { indexed: true } );
+
+				assert.strictEqual(
+					geometries.getWireframeAttribute( geometry ),
+					geometries.getWireframeAttribute( geometry ),
+					'the same attribute comes back'
+				);
+
+			} );
+
+			QUnit.test( 'getWireframeAttribute - rebuilds when the index changes', ( assert ) => {
+
+				const { geometries, calls } = harness();
+				const geometry = triangle( { indexed: true } );
+
+				const first = geometries.getWireframeAttribute( geometry );
+
+				geometry.index.needsUpdate = true;
+				const second = geometries.getWireframeAttribute( geometry );
+
+				assert.notStrictEqual( second, first, 'a stale attribute is replaced' );
+				assert.deepEqual( calls.remove, [ first ], 'the superseded attribute is released' );
+
+			} );
+
+			QUnit.test( 'getWireframeAttribute - tracks the index version it was built from', ( assert ) => {
+
+				const { geometries } = harness();
+				const geometry = triangle( { indexed: true } );
+
+				geometry.index.needsUpdate = true;
+				const wireframe = geometries.getWireframeAttribute( geometry );
+
+				assert.strictEqual( wireframe.version, geometry.index.version, 'the version is carried over so staleness can be detected' );
+
+			} );
+
+			QUnit.test( 'getWireframeAttribute - does not rebuild an unindexed geometry', ( assert ) => {
+
+				// Without an index there is no version to compare against, so the
+				// cached attribute is kept.
+				const { geometries } = harness();
+				const geometry = triangle();
+
+				const first = geometries.getWireframeAttribute( geometry );
+				geometry.attributes.position.needsUpdate = true;
+
+				assert.strictEqual( geometries.getWireframeAttribute( geometry ), first, 'the cached attribute is reused' );
+
+			} );
+
+			// dispose
+			QUnit.test( 'disposing a geometry removes its attribute buffers', ( assert ) => {
+
+				const { geometries, calls } = harness();
+				const geometry = triangle( { indexed: true } );
+
+				geometries.get( {}, geometry );
+				geometry.dispose();
+
+				assert.ok( calls.remove.includes( geometry.index ), 'the index buffer is removed' );
+				assert.ok( calls.remove.includes( geometry.attributes.position ), 'the position buffer is removed' );
+
+			} );
+
+			QUnit.test( 'disposing a geometry releases its binding states and decrements the count', ( assert ) => {
+
+				const { geometries, calls, info } = harness();
+				const geometry = triangle();
+
+				geometries.get( {}, geometry );
+				geometry.dispose();
+
+				assert.deepEqual( calls.released, [ geometry ], 'the binding states are released' );
+				assert.strictEqual( info.memory.geometries, 0, 'the memory count goes back down' );
+
+			} );
+
+			QUnit.test( 'disposing a geometry removes its wireframe attribute', ( assert ) => {
+
+				const { geometries, calls } = harness();
+				const geometry = triangle( { indexed: true } );
+
+				geometries.get( {}, geometry );
+				const wireframe = geometries.getWireframeAttribute( geometry );
+
+				geometry.dispose();
+
+				assert.ok( calls.remove.includes( wireframe ), 'the wireframe buffer is removed too' );
+
+			} );
+
+			QUnit.test( 'disposing a geometry unsubscribes the listener', ( assert ) => {
+
+				const { geometries, info } = harness();
+				const geometry = triangle();
+
+				geometries.get( {}, geometry );
+				geometry.dispose();
+				geometry.dispose();
+
+				assert.strictEqual( info.memory.geometries, 0, 'a second dispose does not decrement again' );
+
+			} );
+
+			QUnit.test( 'disposing a geometry allows it to be registered again', ( assert ) => {
+
+				const { geometries, info } = harness();
+				const geometry = triangle();
+
+				geometries.get( {}, geometry );
+				geometry.dispose();
+				geometries.get( {}, geometry );
+
+				assert.strictEqual( info.memory.geometries, 1, 'the geometry is counted again' );
+
+			} );
+
+			QUnit.test( 'disposing an instanced geometry clears its cached instance count', ( assert ) => {
+
+				const { geometries } = harness();
+
+				const geometry = new InstancedBufferGeometry();
+				geometry.setAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0 ], 3 ) );
+				geometry._maxInstanceCount = 8;
+
+				geometries.get( {}, geometry );
+				geometry.dispose();
+
+				assert.strictEqual( geometry._maxInstanceCount, undefined, 'the cached instance count is dropped' );
+
+			} );
 
 		} );
 

--- a/test/unit/src/renderers/webgl/WebGLIndexedBufferRenderer.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLIndexedBufferRenderer.tests.js
@@ -1,10 +1,252 @@
-// import { WebGLIndexedBufferRenderer } from '../../../../../src/renderers/webgl/WebGLIndexedBufferRenderer.js';
+import { WebGLIndexedBufferRenderer } from '../../../../../src/renderers/webgl/WebGLIndexedBufferRenderer.js';
+import { TrianglesDrawMode } from '../../../../../src/constants.js';
+
+// Recording stand-ins for the context, the multi-draw extension and WebGLInfo.
+function mockContext() {
+
+	const calls = [];
+
+	return {
+		calls,
+		drawElements( ...args ) {
+
+			calls.push( [ 'drawElements', ...args ] );
+
+		},
+		drawElementsInstanced( ...args ) {
+
+			calls.push( [ 'drawElementsInstanced', ...args ] );
+
+		}
+	};
+
+}
+
+function mockExtensions( extension ) {
+
+	return {
+		requested: [],
+		get( name ) {
+
+			this.requested.push( name );
+			return extension;
+
+		}
+	};
+
+}
+
+function mockInfo() {
+
+	const updates = [];
+
+	return {
+		updates,
+		update( count, mode, instanceCount ) {
+
+			updates.push( [ count, mode, instanceCount ] );
+
+		}
+	};
+
+}
+
+// Stands in for the index attribute's buffer description, which is all
+// setIndex() reads.
+const UINT16_INDEX = { type: 5123, bytesPerElement: 2 };
+const UINT32_INDEX = { type: 5125, bytesPerElement: 4 };
 
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
 		QUnit.module( 'WebGLIndexedBufferRenderer', () => {
+
+			// INSTANCING
+			QUnit.test( 'Instancing - exposes the expected API', ( assert ) => {
+
+				const renderer = new WebGLIndexedBufferRenderer( mockContext(), mockExtensions(), mockInfo() );
+
+				for ( const method of [ 'setMode', 'setIndex', 'render', 'renderInstances', 'renderMultiDraw' ] ) {
+
+					assert.strictEqual( typeof renderer[ method ], 'function', `${ method }() is exposed` );
+
+				}
+
+			} );
+
+			// render
+			QUnit.test( 'render - converts the start index into a byte offset', ( assert ) => {
+
+				// drawElements takes a byte offset, not an element index, so the
+				// start has to be scaled by the index type's size.
+				const gl = mockContext();
+				const renderer = new WebGLIndexedBufferRenderer( gl, mockExtensions(), mockInfo() );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.setIndex( UINT16_INDEX );
+				renderer.render( 3, 6 );
+
+				assert.deepEqual(
+					gl.calls,
+					[[ 'drawElements', TrianglesDrawMode, 6, UINT16_INDEX.type, 3 * 2 ]],
+					'a 16-bit index scales the start by 2'
+				);
+
+			} );
+
+			QUnit.test( 'render - scales the offset by the current index type', ( assert ) => {
+
+				const gl = mockContext();
+				const renderer = new WebGLIndexedBufferRenderer( gl, mockExtensions(), mockInfo() );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.setIndex( UINT32_INDEX );
+				renderer.render( 3, 6 );
+
+				assert.strictEqual( gl.calls[ 0 ][ 3 ], UINT32_INDEX.type, 'the index type is forwarded' );
+				assert.strictEqual( gl.calls[ 0 ][ 4 ], 3 * 4, 'a 32-bit index scales the start by 4' );
+
+			} );
+
+			QUnit.test( 'render - picks up an index changed between draws', ( assert ) => {
+
+				const gl = mockContext();
+				const renderer = new WebGLIndexedBufferRenderer( gl, mockExtensions(), mockInfo() );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.setIndex( UINT16_INDEX );
+				renderer.render( 1, 3 );
+				renderer.setIndex( UINT32_INDEX );
+				renderer.render( 1, 3 );
+
+				assert.strictEqual( gl.calls[ 0 ][ 4 ], 2, 'the first draw uses the 16-bit stride' );
+				assert.strictEqual( gl.calls[ 1 ][ 4 ], 4, 'the second draw uses the 32-bit stride' );
+
+			} );
+
+			QUnit.test( 'render - reports a single instance to info', ( assert ) => {
+
+				const info = mockInfo();
+				const renderer = new WebGLIndexedBufferRenderer( mockContext(), mockExtensions(), info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.setIndex( UINT16_INDEX );
+				renderer.render( 0, 12 );
+
+				assert.deepEqual( info.updates, [[ 12, TrianglesDrawMode, 1 ]], 'the index count, mode and instance count are recorded' );
+
+			} );
+
+			// renderInstances
+			QUnit.test( 'renderInstances - forwards the instance count', ( assert ) => {
+
+				const gl = mockContext();
+				const info = mockInfo();
+				const renderer = new WebGLIndexedBufferRenderer( gl, mockExtensions(), info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.setIndex( UINT16_INDEX );
+				renderer.renderInstances( 3, 6, 4 );
+
+				assert.deepEqual(
+					gl.calls,
+					[[ 'drawElementsInstanced', TrianglesDrawMode, 6, UINT16_INDEX.type, 3 * 2, 4 ]],
+					'the instanced draw call carries the same byte offset'
+				);
+				assert.deepEqual( info.updates, [[ 6, TrianglesDrawMode, 4 ]], 'info records the instance count' );
+
+			} );
+
+			QUnit.test( 'renderInstances - skips the draw entirely for zero instances', ( assert ) => {
+
+				const gl = mockContext();
+				const info = mockInfo();
+				const renderer = new WebGLIndexedBufferRenderer( gl, mockExtensions(), info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.setIndex( UINT16_INDEX );
+				renderer.renderInstances( 0, 6, 0 );
+
+				assert.deepEqual( gl.calls, [], 'no draw call is issued' );
+				assert.deepEqual( info.updates, [], 'nothing is counted' );
+
+			} );
+
+			// renderMultiDraw
+			QUnit.test( 'renderMultiDraw - forwards the draw lists to the extension', ( assert ) => {
+
+				const multiDrawCalls = [];
+				const extensions = mockExtensions( {
+					multiDrawElementsWEBGL( ...args ) {
+
+						multiDrawCalls.push( args );
+
+					}
+				} );
+
+				const renderer = new WebGLIndexedBufferRenderer( mockContext(), extensions, mockInfo() );
+
+				const starts = [ 0, 20 ], counts = [ 3, 6 ];
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.setIndex( UINT16_INDEX );
+				renderer.renderMultiDraw( starts, counts, 2 );
+
+				assert.deepEqual( extensions.requested, [ 'WEBGL_multi_draw' ], 'the multi draw extension is looked up' );
+
+				// Note the argument order differs from the non-indexed variant:
+				// counts come before the index type, starts after it.
+				assert.deepEqual(
+					multiDrawCalls,
+					[[ TrianglesDrawMode, counts, 0, UINT16_INDEX.type, starts, 0, 2 ]],
+					'counts, index type and starts are passed in the order the extension expects'
+				);
+
+			} );
+
+			QUnit.test( 'renderMultiDraw - reports the summed element count to info', ( assert ) => {
+
+				const extensions = mockExtensions( { multiDrawElementsWEBGL() {} } );
+				const info = mockInfo();
+				const renderer = new WebGLIndexedBufferRenderer( mockContext(), extensions, info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.setIndex( UINT16_INDEX );
+				renderer.renderMultiDraw( [ 0, 10, 20 ], [ 3, 6, 9 ], 3 );
+
+				assert.deepEqual( info.updates, [[ 18, TrianglesDrawMode, 1 ]], 'the counts are summed into one update' );
+
+			} );
+
+			QUnit.test( 'renderMultiDraw - only sums the first drawCount entries', ( assert ) => {
+
+				const extensions = mockExtensions( { multiDrawElementsWEBGL() {} } );
+				const info = mockInfo();
+				const renderer = new WebGLIndexedBufferRenderer( mockContext(), extensions, info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.setIndex( UINT16_INDEX );
+				renderer.renderMultiDraw( [ 0, 10, 20 ], [ 3, 6, 999 ], 2 );
+
+				assert.deepEqual( info.updates, [[ 9, TrianglesDrawMode, 1 ]], 'the trailing stale entry is ignored' );
+
+			} );
+
+			QUnit.test( 'renderMultiDraw - skips the draw entirely for zero draws', ( assert ) => {
+
+				const extensions = mockExtensions( { multiDrawElementsWEBGL() {} } );
+				const info = mockInfo();
+				const renderer = new WebGLIndexedBufferRenderer( mockContext(), extensions, info );
+
+				renderer.setMode( TrianglesDrawMode );
+				renderer.setIndex( UINT16_INDEX );
+				renderer.renderMultiDraw( [], [], 0 );
+
+				assert.deepEqual( extensions.requested, [], 'the extension is not even looked up' );
+				assert.deepEqual( info.updates, [], 'nothing is counted' );
+
+			} );
 
 		} );
 

--- a/test/unit/src/renderers/webgl/WebGLObjects.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLObjects.tests.js
@@ -1,10 +1,318 @@
-// import { WebGLObjects } from '../../../../../src/renderers/webgl/WebGLObjects.js';
+import { WebGLObjects } from '../../../../../src/renderers/webgl/WebGLObjects.js';
+import { BufferGeometry } from '../../../../../src/core/BufferGeometry.js';
+import { MeshBasicMaterial } from '../../../../../src/materials/MeshBasicMaterial.js';
+import { Mesh } from '../../../../../src/objects/Mesh.js';
+import { InstancedMesh } from '../../../../../src/objects/InstancedMesh.js';
+import { SkinnedMesh } from '../../../../../src/objects/SkinnedMesh.js';
+import { Skeleton } from '../../../../../src/objects/Skeleton.js';
+import { Bone } from '../../../../../src/objects/Bone.js';
+import { Color } from '../../../../../src/math/Color.js';
+
+// Recording stand-ins for the five collaborators WebGLObjects talks to.
+function harness() {
+
+	const calls = { geometriesGet: [], geometriesUpdate: [], attributesUpdate: [], attributesRemove: [], released: [] };
+
+	const gl = { ARRAY_BUFFER: 'ARRAY_BUFFER' };
+
+	const geometries = {
+		// The real WebGLGeometries maps an object's geometry to a buffer
+		// geometry; here the geometry stands in for its own buffer geometry.
+		get( object, geometry ) {
+
+			calls.geometriesGet.push( [ object, geometry ] );
+			return geometry;
+
+		},
+		update( buffergeometry ) {
+
+			calls.geometriesUpdate.push( buffergeometry );
+
+		}
+	};
+
+	const attributes = {
+		update( attribute, bufferType ) {
+
+			calls.attributesUpdate.push( [ attribute, bufferType ] );
+
+		},
+		remove( attribute ) {
+
+			calls.attributesRemove.push( attribute );
+
+		}
+	};
+
+	const bindingStates = {
+		releaseStatesOfObject( object ) {
+
+			calls.released.push( object );
+
+		}
+	};
+
+	const info = { render: { frame: 0 } };
+
+	return { calls, gl, geometries, attributes, bindingStates, info, objects: new WebGLObjects( gl, geometries, attributes, bindingStates, info ) };
+
+}
+
+function mesh() {
+
+	return new Mesh( new BufferGeometry(), new MeshBasicMaterial() );
+
+}
 
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
 		QUnit.module( 'WebGLObjects', () => {
+
+			// INSTANCING
+			QUnit.test( 'Instancing - exposes the expected API', ( assert ) => {
+
+				const { objects } = harness();
+
+				assert.strictEqual( typeof objects.update, 'function', 'update() is exposed' );
+				assert.strictEqual( typeof objects.dispose, 'function', 'dispose() is exposed' );
+
+			} );
+
+			// update
+			QUnit.test( 'update - returns the buffer geometry for the object', ( assert ) => {
+
+				const { objects, calls } = harness();
+				const object = mesh();
+
+				const result = objects.update( object );
+
+				assert.strictEqual( result, object.geometry, 'the resolved buffer geometry is returned' );
+				assert.deepEqual( calls.geometriesGet, [[ object, object.geometry ]], 'the object and its geometry are handed to WebGLGeometries' );
+
+			} );
+
+			QUnit.test( 'update - updates the geometry once per frame', ( assert ) => {
+
+				// Several objects can share a geometry, so the update has to be
+				// deduplicated within a frame.
+				const { objects, calls, info } = harness();
+				const object = mesh();
+
+				objects.update( object );
+				objects.update( object );
+
+				assert.strictEqual( calls.geometriesUpdate.length, 1, 'the second call in the same frame is skipped' );
+
+				info.render.frame = 1;
+				objects.update( object );
+
+				assert.strictEqual( calls.geometriesUpdate.length, 2, 'a new frame triggers another update' );
+
+			} );
+
+			QUnit.test( 'update - deduplicates per geometry, not per object', ( assert ) => {
+
+				const { objects, calls } = harness();
+
+				const geometry = new BufferGeometry();
+				const a = new Mesh( geometry, new MeshBasicMaterial() );
+				const b = new Mesh( geometry, new MeshBasicMaterial() );
+
+				objects.update( a );
+				objects.update( b );
+
+				assert.strictEqual( calls.geometriesUpdate.length, 1, 'a shared geometry is only updated once' );
+
+			} );
+
+			QUnit.test( 'update - tracks geometries independently', ( assert ) => {
+
+				const { objects, calls } = harness();
+
+				objects.update( mesh() );
+				objects.update( mesh() );
+
+				assert.strictEqual( calls.geometriesUpdate.length, 2, 'each distinct geometry is updated' );
+
+			} );
+
+			QUnit.test( 'update - leaves a plain mesh\'s attributes alone', ( assert ) => {
+
+				const { objects, calls } = harness();
+
+				objects.update( mesh() );
+
+				assert.deepEqual( calls.attributesUpdate, [], 'nothing instance-specific is uploaded' );
+
+			} );
+
+			// update - InstancedMesh
+			QUnit.test( 'update - uploads the instance matrix for an instanced mesh', ( assert ) => {
+
+				const { objects, calls, gl } = harness();
+				const object = new InstancedMesh( new BufferGeometry(), new MeshBasicMaterial(), 4 );
+
+				objects.update( object );
+
+				assert.deepEqual(
+					calls.attributesUpdate,
+					[[ object.instanceMatrix, gl.ARRAY_BUFFER ]],
+					'the instance matrix is uploaded as an array buffer'
+				);
+
+			} );
+
+			QUnit.test( 'update - uploads the instance color when there is one', ( assert ) => {
+
+				const { objects, calls, gl } = harness();
+				const object = new InstancedMesh( new BufferGeometry(), new MeshBasicMaterial(), 4 );
+
+				object.setColorAt( 0, new Color( 0xff0000 ) );
+				objects.update( object );
+
+				assert.deepEqual(
+					calls.attributesUpdate,
+					[[ object.instanceMatrix, gl.ARRAY_BUFFER ], [ object.instanceColor, gl.ARRAY_BUFFER ]],
+					'both instance attributes are uploaded'
+				);
+
+			} );
+
+			QUnit.test( 'update - uploads the instance attributes once per frame', ( assert ) => {
+
+				const { objects, calls, info } = harness();
+				const object = new InstancedMesh( new BufferGeometry(), new MeshBasicMaterial(), 4 );
+
+				objects.update( object );
+				objects.update( object );
+
+				assert.strictEqual( calls.attributesUpdate.length, 1, 'the second call in the same frame is skipped' );
+
+				info.render.frame = 1;
+				objects.update( object );
+
+				assert.strictEqual( calls.attributesUpdate.length, 2, 'a new frame uploads again' );
+
+			} );
+
+			QUnit.test( 'update - subscribes to the instanced mesh\'s dispose event exactly once', ( assert ) => {
+
+				const { objects, info } = harness();
+				const object = new InstancedMesh( new BufferGeometry(), new MeshBasicMaterial(), 4 );
+
+				objects.update( object );
+				info.render.frame = 1;
+				objects.update( object );
+
+				assert.strictEqual( object._listeners.dispose.length, 1, 'the listener is not added twice' );
+
+			} );
+
+			// update - SkinnedMesh
+			QUnit.test( 'update - updates a skinned mesh\'s skeleton once per frame', ( assert ) => {
+
+				const { objects, info } = harness();
+
+				const object = new SkinnedMesh( new BufferGeometry(), new MeshBasicMaterial() );
+				const skeleton = new Skeleton( [ new Bone() ] );
+				object.bind( skeleton );
+
+				let updates = 0;
+				skeleton.update = () => updates ++;
+
+				objects.update( object );
+				objects.update( object );
+
+				assert.strictEqual( updates, 1, 'the second call in the same frame is skipped' );
+
+				info.render.frame = 1;
+				objects.update( object );
+
+				assert.strictEqual( updates, 2, 'a new frame updates the skeleton again' );
+
+			} );
+
+			QUnit.test( 'update - deduplicates a shared skeleton across meshes', ( assert ) => {
+
+				const { objects } = harness();
+
+				const skeleton = new Skeleton( [ new Bone() ] );
+
+				let updates = 0;
+				skeleton.update = () => updates ++;
+
+				for ( let i = 0; i < 2; i ++ ) {
+
+					const object = new SkinnedMesh( new BufferGeometry(), new MeshBasicMaterial() );
+					object.bind( skeleton );
+					objects.update( object );
+
+				}
+
+				assert.strictEqual( updates, 1, 'a shared skeleton is only updated once per frame' );
+
+			} );
+
+			// dispose of an instanced mesh
+			QUnit.test( 'disposing an instanced mesh releases its GPU resources', ( assert ) => {
+
+				const { objects, calls } = harness();
+				const object = new InstancedMesh( new BufferGeometry(), new MeshBasicMaterial(), 4 );
+
+				objects.update( object );
+				object.dispatchEvent( { type: 'dispose' } );
+
+				assert.deepEqual( calls.released, [ object ], 'the binding states are released' );
+				assert.deepEqual( calls.attributesRemove, [ object.instanceMatrix ], 'the instance matrix buffer is removed' );
+
+			} );
+
+			QUnit.test( 'disposing an instanced mesh also removes its instance color', ( assert ) => {
+
+				const { objects, calls } = harness();
+				const object = new InstancedMesh( new BufferGeometry(), new MeshBasicMaterial(), 4 );
+
+				object.setColorAt( 0, new Color( 0xff0000 ) );
+				objects.update( object );
+				object.dispatchEvent( { type: 'dispose' } );
+
+				assert.deepEqual(
+					calls.attributesRemove,
+					[ object.instanceMatrix, object.instanceColor ],
+					'both instance buffers are removed'
+				);
+
+			} );
+
+			QUnit.test( 'disposing an instanced mesh unsubscribes the listener', ( assert ) => {
+
+				// Otherwise a mesh disposed twice would release twice.
+				const { objects, calls } = harness();
+				const object = new InstancedMesh( new BufferGeometry(), new MeshBasicMaterial(), 4 );
+
+				objects.update( object );
+				object.dispatchEvent( { type: 'dispose' } );
+				object.dispatchEvent( { type: 'dispose' } );
+
+				assert.strictEqual( calls.released.length, 1, 'the second dispose is not handled' );
+
+			} );
+
+			// dispose
+			QUnit.test( 'dispose - forgets which objects were updated this frame', ( assert ) => {
+
+				const { objects, calls } = harness();
+				const object = mesh();
+
+				objects.update( object );
+				objects.dispose();
+				objects.update( object );
+
+				assert.strictEqual( calls.geometriesUpdate.length, 2, 'the geometry is updated again after disposal' );
+
+			} );
 
 		} );
 

--- a/test/unit/src/renderers/webgl/WebGLObjects.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLObjects.tests.js
@@ -199,14 +199,25 @@ export default QUnit.module( 'Renderers', () => {
 
 			QUnit.test( 'update - subscribes to the instanced mesh\'s dispose event exactly once', ( assert ) => {
 
-				const { objects, info } = harness();
+				const { objects, info, calls } = harness();
 				const object = new InstancedMesh( new BufferGeometry(), new MeshBasicMaterial(), 4 );
 
 				objects.update( object );
 				info.render.frame = 1;
 				objects.update( object );
 
-				assert.strictEqual( object._listeners.dispose.length, 1, 'the listener is not added twice' );
+				// Asserted behaviourally rather than by reading the private
+				// _listeners array: a listener subscribed twice would run the
+				// dispose handler twice for a single event, releasing the object
+				// and removing its instance matrix twice over.
+				object.dispatchEvent( { type: 'dispose' } );
+
+				assert.strictEqual( calls.released.length, 1, 'one dispose event releases the object exactly once' );
+				assert.strictEqual(
+					calls.attributesRemove.filter( a => a === object.instanceMatrix ).length,
+					1,
+					'the instance matrix is removed exactly once'
+				);
 
 			} );
 

--- a/test/unit/src/renderers/webgl/WebGLProperties.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLProperties.tests.js
@@ -140,10 +140,28 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'remove - is a no-op for an unknown object', ( assert ) => {
 
 				const properties = new WebGLProperties();
+				const known = {};
 
-				properties.remove( {} );
+				properties.get( known ).value = 1;
 
-				assert.ok( true, 'removing an unregistered object does not throw' );
+				// Stated as an observation rather than assert.ok( true ), which
+				// passes unconditionally and records an assertion that checked
+				// nothing. Removing an unknown object must neither throw nor
+				// disturb what is already stored.
+				let threw = false;
+
+				try {
+
+					properties.remove( {} );
+
+				} catch ( error ) {
+
+					threw = true;
+
+				}
+
+				assert.strictEqual( threw, false, 'removing an unregistered object does not throw' );
+				assert.strictEqual( properties.get( known ).value, 1, 'and leaves registered objects alone' );
 
 			} );
 

--- a/test/unit/src/renderers/webgl/WebGLProperties.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLProperties.tests.js
@@ -1,10 +1,181 @@
-// import { WebGLProperties } from '../../../../../src/renderers/webgl/WebGLProperties.js';
+import { WebGLProperties } from '../../../../../src/renderers/webgl/WebGLProperties.js';
 
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
 		QUnit.module( 'WebGLProperties', () => {
+
+			// INSTANCING
+			QUnit.test( 'Instancing - exposes the expected API', ( assert ) => {
+
+				const properties = new WebGLProperties();
+
+				for ( const method of [ 'has', 'get', 'remove', 'update', 'dispose' ] ) {
+
+					assert.strictEqual( typeof properties[ method ], 'function', `${ method }() is exposed` );
+
+				}
+
+			} );
+
+			// has
+			QUnit.test( 'has - reports whether an object has properties yet', ( assert ) => {
+
+				const properties = new WebGLProperties();
+				const object = {};
+
+				assert.strictEqual( properties.has( object ), false, 'an unseen object has no properties' );
+
+				properties.get( object );
+
+				assert.strictEqual( properties.has( object ), true, 'get() registers the object' );
+
+			} );
+
+			// get
+			QUnit.test( 'get - lazily creates an empty property object', ( assert ) => {
+
+				const properties = new WebGLProperties();
+				const map = properties.get( {} );
+
+				assert.strictEqual( typeof map, 'object', 'an object is returned' );
+				assert.deepEqual( map, {}, 'it starts out empty' );
+
+			} );
+
+			QUnit.test( 'get - returns the same object on repeated calls', ( assert ) => {
+
+				// The renderer stashes GPU resources on this object across
+				// frames, so identity has to be stable.
+				const properties = new WebGLProperties();
+				const object = {};
+
+				const first = properties.get( object );
+				first.texture = 'gpu-handle';
+
+				assert.strictEqual( properties.get( object ), first, 'the same property object comes back' );
+				assert.strictEqual( properties.get( object ).texture, 'gpu-handle', 'values written earlier are still there' );
+
+			} );
+
+			QUnit.test( 'get - keeps separate objects independent', ( assert ) => {
+
+				const properties = new WebGLProperties();
+				const a = {}, b = {};
+
+				properties.get( a ).value = 1;
+				properties.get( b ).value = 2;
+
+				assert.strictEqual( properties.get( a ).value, 1, 'the first object keeps its own value' );
+				assert.strictEqual( properties.get( b ).value, 2, 'the second object keeps its own value' );
+
+			} );
+
+			// update
+			QUnit.test( 'update - writes a single key on an already registered object', ( assert ) => {
+
+				const properties = new WebGLProperties();
+				const object = {};
+
+				properties.get( object );
+				properties.update( object, 'version', 3 );
+
+				assert.strictEqual( properties.get( object ).version, 3, 'the key is set' );
+
+			} );
+
+			QUnit.test( 'update - overwrites an existing key', ( assert ) => {
+
+				const properties = new WebGLProperties();
+				const object = {};
+
+				properties.get( object ).version = 1;
+				properties.update( object, 'version', 2 );
+
+				assert.strictEqual( properties.get( object ).version, 2, 'the new value replaces the old one' );
+
+			} );
+
+			QUnit.test( 'update - requires the object to be registered first', ( assert ) => {
+
+				// update() indexes the stored map directly, so it throws rather
+				// than silently creating one -- callers are expected to have
+				// called get() already.
+				const properties = new WebGLProperties();
+
+				assert.throws( () => properties.update( {}, 'key', 1 ), 'updating an unregistered object throws' );
+
+			} );
+
+			// remove
+			QUnit.test( 'remove - forgets an object\'s properties', ( assert ) => {
+
+				const properties = new WebGLProperties();
+				const object = {};
+
+				properties.get( object ).texture = 'gpu-handle';
+				properties.remove( object );
+
+				assert.strictEqual( properties.has( object ), false, 'the object is no longer known' );
+				assert.deepEqual( properties.get( object ), {}, 'a later get() starts from scratch' );
+
+			} );
+
+			QUnit.test( 'remove - only affects the given object', ( assert ) => {
+
+				const properties = new WebGLProperties();
+				const a = {}, b = {};
+
+				properties.get( a ).value = 1;
+				properties.get( b ).value = 2;
+
+				properties.remove( a );
+
+				assert.strictEqual( properties.has( a ), false, 'the removed object is gone' );
+				assert.strictEqual( properties.get( b ).value, 2, 'the other object is untouched' );
+
+			} );
+
+			QUnit.test( 'remove - is a no-op for an unknown object', ( assert ) => {
+
+				const properties = new WebGLProperties();
+
+				properties.remove( {} );
+
+				assert.ok( true, 'removing an unregistered object does not throw' );
+
+			} );
+
+			// dispose
+			QUnit.test( 'dispose - drops every stored property object', ( assert ) => {
+
+				const properties = new WebGLProperties();
+				const a = {}, b = {};
+
+				properties.get( a ).value = 1;
+				properties.get( b ).value = 2;
+
+				properties.dispose();
+
+				assert.strictEqual( properties.has( a ), false, 'the first object is forgotten' );
+				assert.strictEqual( properties.has( b ), false, 'the second object is forgotten' );
+
+			} );
+
+			QUnit.test( 'dispose - leaves the instance usable', ( assert ) => {
+
+				const properties = new WebGLProperties();
+				const object = {};
+
+				properties.get( object ).value = 1;
+				properties.dispose();
+
+				properties.get( object ).value = 2;
+
+				assert.strictEqual( properties.get( object ).value, 2, 'new properties can be stored after disposal' );
+
+			} );
 
 		} );
 

--- a/test/unit/src/renderers/webgl/WebGLShader.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLShader.tests.js
@@ -1,10 +1,94 @@
-// import { WebGLShader } from '../../../../../src/renderers/webgl/WebGLShader.js';
+import { WebGLShader } from '../../../../../src/renderers/webgl/WebGLShader.js';
+
+// Records the WebGL calls WebGLShader() makes. A real context is not needed --
+// the module is a thin create/source/compile wrapper.
+function mockContext() {
+
+	const calls = [];
+
+	return {
+		calls,
+		VERTEX_SHADER: 35633,
+		FRAGMENT_SHADER: 35632,
+		createShader( type ) {
+
+			const shader = { type };
+			calls.push( [ 'createShader', type ] );
+			return shader;
+
+		},
+		shaderSource( shader, string ) {
+
+			calls.push( [ 'shaderSource', shader, string ] );
+
+		},
+		compileShader( shader ) {
+
+			calls.push( [ 'compileShader', shader ] );
+
+		}
+	};
+
+}
 
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
 		QUnit.module( 'WebGLShader', () => {
+
+			QUnit.test( 'creates a shader of the requested type', ( assert ) => {
+
+				const gl = mockContext();
+
+				WebGLShader( gl, gl.VERTEX_SHADER, 'void main() {}' );
+
+				assert.deepEqual( gl.calls[ 0 ], [ 'createShader', gl.VERTEX_SHADER ], 'the type is passed through to createShader' );
+
+			} );
+
+			QUnit.test( 'uploads the source and compiles it', ( assert ) => {
+
+				const gl = mockContext();
+				const source = 'void main() { gl_FragColor = vec4( 1.0 ); }';
+
+				const shader = WebGLShader( gl, gl.FRAGMENT_SHADER, source );
+
+				assert.deepEqual(
+					gl.calls.map( c => c[ 0 ] ),
+					[ 'createShader', 'shaderSource', 'compileShader' ],
+					'the calls happen in create, source, compile order'
+				);
+				assert.strictEqual( gl.calls[ 1 ][ 1 ], shader, 'the source is attached to the shader that was created' );
+				assert.strictEqual( gl.calls[ 1 ][ 2 ], source, 'the source string is passed through unmodified' );
+				assert.strictEqual( gl.calls[ 2 ][ 1 ], shader, 'the same shader is compiled' );
+
+			} );
+
+			QUnit.test( 'returns the created shader', ( assert ) => {
+
+				const gl = mockContext();
+
+				const shader = WebGLShader( gl, gl.VERTEX_SHADER, '' );
+
+				assert.strictEqual( shader.type, gl.VERTEX_SHADER, 'the returned object is the one createShader produced' );
+
+			} );
+
+			QUnit.test( 'does not check the compile status', ( assert ) => {
+
+				// Compile errors are surfaced later by WebGLProgram, so this
+				// function must not query or throw on them itself.
+				const gl = mockContext();
+
+				WebGLShader( gl, gl.VERTEX_SHADER, 'this is not valid glsl' );
+
+				assert.ok(
+					gl.calls.every( c => c[ 0 ] !== 'getShaderParameter' ),
+					'getShaderParameter is never called'
+				);
+
+			} );
 
 		} );
 

--- a/test/unit/src/renderers/webgl/WebGLShader.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLShader.tests.js
@@ -26,6 +26,22 @@ function mockContext() {
 
 			calls.push( [ 'compileShader', shader ] );
 
+		},
+		// Recorded rather than omitted on purpose: the "does not check the
+		// compile status" test asserts these are never called, and an assertion
+		// about a method the mock does not define could never fail -- calling it
+		// would throw a TypeError instead of showing up in `calls`.
+		getShaderParameter( shader, pname ) {
+
+			calls.push( [ 'getShaderParameter', shader, pname ] );
+			return true;
+
+		},
+		getShaderInfoLog( shader ) {
+
+			calls.push( [ 'getShaderInfoLog', shader ] );
+			return '';
+
 		}
 	};
 
@@ -78,14 +94,22 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'does not check the compile status', ( assert ) => {
 
 				// Compile errors are surfaced later by WebGLProgram, so this
-				// function must not query or throw on them itself.
+				// function must not query or throw on them itself. The mock
+				// records getShaderParameter/getShaderInfoLog, so if that ever
+				// changed the calls would appear here and fail the assertion.
 				const gl = mockContext();
 
 				WebGLShader( gl, gl.VERTEX_SHADER, 'this is not valid glsl' );
 
-				assert.ok(
-					gl.calls.every( c => c[ 0 ] !== 'getShaderParameter' ),
-					'getShaderParameter is never called'
+				const statusQueries = gl.calls.filter(
+					c => c[ 0 ] === 'getShaderParameter' || c[ 0 ] === 'getShaderInfoLog'
+				);
+
+				assert.deepEqual( statusQueries, [], 'the compile status is never queried' );
+				assert.deepEqual(
+					gl.calls.map( c => c[ 0 ] ),
+					[ 'createShader', 'shaderSource', 'compileShader' ],
+					'only the create, source and compile calls are made'
 				);
 
 			} );

--- a/test/unit/src/renderers/webgl/WebGLUtils.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLUtils.tests.js
@@ -1,10 +1,366 @@
-// import { WebGLUtils } from '../../../../../src/renderers/webgl/WebGLUtils.js';
+import { WebGLUtils } from '../../../../../src/renderers/webgl/WebGLUtils.js';
+import {
+	UnsignedByteType, ByteType, ShortType, UnsignedShortType, IntType, UnsignedIntType,
+	FloatType, HalfFloatType, UnsignedShort4444Type, UnsignedShort5551Type,
+	UnsignedInt5999Type, UnsignedInt101111Type, UnsignedInt248Type,
+	AlphaFormat, RGBFormat, RGBAFormat, DepthFormat, DepthStencilFormat,
+	RedFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBAIntegerFormat,
+	RGB_S3TC_DXT1_Format, RGBA_S3TC_DXT1_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT5_Format,
+	RGB_PVRTC_4BPPV1_Format, RGBA_PVRTC_2BPPV1_Format,
+	RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, R11_EAC_Format, SIGNED_RG11_EAC_Format,
+	RGBA_ASTC_4x4_Format, RGBA_ASTC_12x12_Format,
+	RGBA_BPTC_Format, RGB_BPTC_SIGNED_Format,
+	RED_RGTC1_Format, SIGNED_RED_GREEN_RGTC2_Format,
+	SRGBColorSpace, LinearSRGBColorSpace, NoColorSpace
+} from '../../../../../src/constants.js';
+
+// The subset of WebGL2 enum values convert() reads off the context. The exact
+// numbers do not matter -- distinct sentinels are enough to prove the right
+// branch was taken.
+function mockContext() {
+
+	return {
+		UNSIGNED_BYTE: 'UNSIGNED_BYTE',
+		BYTE: 'BYTE',
+		SHORT: 'SHORT',
+		UNSIGNED_SHORT: 'UNSIGNED_SHORT',
+		INT: 'INT',
+		UNSIGNED_INT: 'UNSIGNED_INT',
+		FLOAT: 'FLOAT',
+		HALF_FLOAT: 'HALF_FLOAT',
+		UNSIGNED_SHORT_4_4_4_4: 'UNSIGNED_SHORT_4_4_4_4',
+		UNSIGNED_SHORT_5_5_5_1: 'UNSIGNED_SHORT_5_5_5_1',
+		UNSIGNED_INT_5_9_9_9_REV: 'UNSIGNED_INT_5_9_9_9_REV',
+		UNSIGNED_INT_10F_11F_11F_REV: 'UNSIGNED_INT_10F_11F_11F_REV',
+		UNSIGNED_INT_24_8: 'UNSIGNED_INT_24_8',
+		ALPHA: 'ALPHA',
+		RGB: 'RGB',
+		RGBA: 'RGBA',
+		DEPTH_COMPONENT: 'DEPTH_COMPONENT',
+		DEPTH_STENCIL: 'DEPTH_STENCIL',
+		RED: 'RED',
+		RED_INTEGER: 'RED_INTEGER',
+		RG: 'RG',
+		RG_INTEGER: 'RG_INTEGER',
+		RGBA_INTEGER: 'RGBA_INTEGER'
+	};
+
+}
+
+// Returns an `extensions` stub that resolves only the named extensions and
+// reports null for everything else, mirroring WebGLExtensions.get().
+function mockExtensions( available = {} ) {
+
+	return {
+		requested: [],
+		get( name ) {
+
+			this.requested.push( name );
+			return Object.prototype.hasOwnProperty.call( available, name ) ? available[ name ] : null;
+
+		}
+	};
+
+}
 
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
 
 		QUnit.module( 'WebGLUtils', () => {
+
+			// INSTANCING
+			QUnit.test( 'Instancing - exposes convert()', ( assert ) => {
+
+				const utils = new WebGLUtils( mockContext(), mockExtensions() );
+
+				assert.strictEqual( typeof utils.convert, 'function', 'convert() is exposed' );
+
+			} );
+
+			// convert - types
+			QUnit.test( 'convert - maps the data types to their WebGL enums', ( assert ) => {
+
+				const gl = mockContext();
+				const utils = new WebGLUtils( gl, mockExtensions() );
+
+				const expected = [
+					[ UnsignedByteType, gl.UNSIGNED_BYTE ],
+					[ ByteType, gl.BYTE ],
+					[ ShortType, gl.SHORT ],
+					[ UnsignedShortType, gl.UNSIGNED_SHORT ],
+					[ IntType, gl.INT ],
+					[ UnsignedIntType, gl.UNSIGNED_INT ],
+					[ FloatType, gl.FLOAT ],
+					[ HalfFloatType, gl.HALF_FLOAT ],
+					[ UnsignedShort4444Type, gl.UNSIGNED_SHORT_4_4_4_4 ],
+					[ UnsignedShort5551Type, gl.UNSIGNED_SHORT_5_5_5_1 ],
+					[ UnsignedInt5999Type, gl.UNSIGNED_INT_5_9_9_9_REV ],
+					[ UnsignedInt101111Type, gl.UNSIGNED_INT_10F_11F_11F_REV ],
+					[ UnsignedInt248Type, gl.UNSIGNED_INT_24_8 ]
+				];
+
+				for ( const [ type, glEnum ] of expected ) {
+
+					assert.strictEqual( utils.convert( type ), glEnum, `${ glEnum } is resolved` );
+
+				}
+
+			} );
+
+			// convert - formats
+			QUnit.test( 'convert - maps the uncompressed formats to their WebGL enums', ( assert ) => {
+
+				const gl = mockContext();
+				const utils = new WebGLUtils( gl, mockExtensions() );
+
+				const expected = [
+					[ AlphaFormat, gl.ALPHA ],
+					[ RGBFormat, gl.RGB ],
+					[ RGBAFormat, gl.RGBA ],
+					[ DepthFormat, gl.DEPTH_COMPONENT ],
+					[ DepthStencilFormat, gl.DEPTH_STENCIL ],
+					[ RedFormat, gl.RED ],
+					[ RedIntegerFormat, gl.RED_INTEGER ],
+					[ RGFormat, gl.RG ],
+					[ RGIntegerFormat, gl.RG_INTEGER ],
+					[ RGBAIntegerFormat, gl.RGBA_INTEGER ]
+				];
+
+				for ( const [ format, glEnum ] of expected ) {
+
+					assert.strictEqual( utils.convert( format ), glEnum, `${ glEnum } is resolved` );
+
+				}
+
+			} );
+
+			QUnit.test( 'convert - ignores the color space for uncompressed formats', ( assert ) => {
+
+				// Only the compressed formats have separate sRGB variants.
+				const gl = mockContext();
+				const utils = new WebGLUtils( gl, mockExtensions() );
+
+				assert.strictEqual( utils.convert( RGBAFormat, SRGBColorSpace ), gl.RGBA, 'sRGB still resolves to RGBA' );
+				assert.strictEqual( utils.convert( RGBAFormat, LinearSRGBColorSpace ), gl.RGBA, 'linear still resolves to RGBA' );
+
+			} );
+
+			// convert - S3TC
+			QUnit.test( 'convert - resolves S3TC formats through the linear extension', ( assert ) => {
+
+				const extensions = mockExtensions( {
+					WEBGL_compressed_texture_s3tc: {
+						COMPRESSED_RGB_S3TC_DXT1_EXT: 'RGB_DXT1',
+						COMPRESSED_RGBA_S3TC_DXT1_EXT: 'RGBA_DXT1',
+						COMPRESSED_RGBA_S3TC_DXT3_EXT: 'RGBA_DXT3',
+						COMPRESSED_RGBA_S3TC_DXT5_EXT: 'RGBA_DXT5'
+					}
+				} );
+
+				const utils = new WebGLUtils( mockContext(), extensions );
+
+				assert.strictEqual( utils.convert( RGB_S3TC_DXT1_Format, NoColorSpace ), 'RGB_DXT1', 'DXT1 RGB' );
+				assert.strictEqual( utils.convert( RGBA_S3TC_DXT1_Format, NoColorSpace ), 'RGBA_DXT1', 'DXT1 RGBA' );
+				assert.strictEqual( utils.convert( RGBA_S3TC_DXT3_Format, NoColorSpace ), 'RGBA_DXT3', 'DXT3' );
+				assert.strictEqual( utils.convert( RGBA_S3TC_DXT5_Format, NoColorSpace ), 'RGBA_DXT5', 'DXT5' );
+				assert.ok( extensions.requested.includes( 'WEBGL_compressed_texture_s3tc' ), 'the linear extension is the one queried' );
+
+			} );
+
+			QUnit.test( 'convert - resolves S3TC formats through the sRGB extension for an sRGB color space', ( assert ) => {
+
+				const extensions = mockExtensions( {
+					WEBGL_compressed_texture_s3tc_srgb: {
+						COMPRESSED_SRGB_S3TC_DXT1_EXT: 'SRGB_DXT1',
+						COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT: 'SRGB_A_DXT5'
+					}
+				} );
+
+				const utils = new WebGLUtils( mockContext(), extensions );
+
+				assert.strictEqual( utils.convert( RGB_S3TC_DXT1_Format, SRGBColorSpace ), 'SRGB_DXT1', 'the sRGB DXT1 variant is used' );
+				assert.strictEqual( utils.convert( RGBA_S3TC_DXT5_Format, SRGBColorSpace ), 'SRGB_A_DXT5', 'the sRGB DXT5 variant is used' );
+				assert.ok( extensions.requested.includes( 'WEBGL_compressed_texture_s3tc_srgb' ), 'the sRGB extension is the one queried' );
+
+			} );
+
+			QUnit.test( 'convert - returns null when the S3TC extension is unavailable', ( assert ) => {
+
+				const utils = new WebGLUtils( mockContext(), mockExtensions() );
+
+				assert.strictEqual( utils.convert( RGBA_S3TC_DXT5_Format, NoColorSpace ), null, 'the linear path returns null' );
+				assert.strictEqual( utils.convert( RGBA_S3TC_DXT5_Format, SRGBColorSpace ), null, 'the sRGB path returns null' );
+
+			} );
+
+			// convert - PVRTC
+			QUnit.test( 'convert - resolves PVRTC formats through their extension', ( assert ) => {
+
+				const extensions = mockExtensions( {
+					WEBGL_compressed_texture_pvrtc: {
+						COMPRESSED_RGB_PVRTC_4BPPV1_IMG: 'RGB_4BPP',
+						COMPRESSED_RGBA_PVRTC_2BPPV1_IMG: 'RGBA_2BPP'
+					}
+				} );
+
+				const utils = new WebGLUtils( mockContext(), extensions );
+
+				assert.strictEqual( utils.convert( RGB_PVRTC_4BPPV1_Format ), 'RGB_4BPP', '4bpp RGB' );
+				assert.strictEqual( utils.convert( RGBA_PVRTC_2BPPV1_Format ), 'RGBA_2BPP', '2bpp RGBA' );
+
+			} );
+
+			QUnit.test( 'convert - returns null when the PVRTC extension is unavailable', ( assert ) => {
+
+				const utils = new WebGLUtils( mockContext(), mockExtensions() );
+
+				assert.strictEqual( utils.convert( RGB_PVRTC_4BPPV1_Format ), null, 'an unsupported format resolves to null' );
+
+			} );
+
+			// convert - ETC
+			QUnit.test( 'convert - picks the sRGB ETC variants for an sRGB color space', ( assert ) => {
+
+				const extensions = mockExtensions( {
+					WEBGL_compressed_texture_etc: {
+						COMPRESSED_RGB8_ETC2: 'RGB8_ETC2',
+						COMPRESSED_SRGB8_ETC2: 'SRGB8_ETC2',
+						COMPRESSED_RGBA8_ETC2_EAC: 'RGBA8_EAC',
+						COMPRESSED_SRGB8_ALPHA8_ETC2_EAC: 'SRGB8_A8_EAC',
+						COMPRESSED_R11_EAC: 'R11_EAC',
+						COMPRESSED_SIGNED_RG11_EAC: 'SIGNED_RG11_EAC'
+					}
+				} );
+
+				const utils = new WebGLUtils( mockContext(), extensions );
+
+				assert.strictEqual( utils.convert( RGB_ETC2_Format, NoColorSpace ), 'RGB8_ETC2', 'linear ETC2 RGB' );
+				assert.strictEqual( utils.convert( RGB_ETC2_Format, SRGBColorSpace ), 'SRGB8_ETC2', 'sRGB ETC2 RGB' );
+				assert.strictEqual( utils.convert( RGBA_ETC2_EAC_Format, NoColorSpace ), 'RGBA8_EAC', 'linear ETC2 RGBA' );
+				assert.strictEqual( utils.convert( RGBA_ETC2_EAC_Format, SRGBColorSpace ), 'SRGB8_A8_EAC', 'sRGB ETC2 RGBA' );
+
+			} );
+
+			QUnit.test( 'convert - maps ETC1 onto the ETC2 enums', ( assert ) => {
+
+				// There is no separate ETC1 path -- ETC2 is backwards compatible.
+				const extensions = mockExtensions( {
+					WEBGL_compressed_texture_etc: { COMPRESSED_RGB8_ETC2: 'RGB8_ETC2' }
+				} );
+
+				const utils = new WebGLUtils( mockContext(), extensions );
+
+				assert.strictEqual( utils.convert( RGB_ETC1_Format, NoColorSpace ), 'RGB8_ETC2', 'ETC1 resolves to the ETC2 enum' );
+
+			} );
+
+			QUnit.test( 'convert - resolves the EAC single- and dual-channel formats', ( assert ) => {
+
+				const extensions = mockExtensions( {
+					WEBGL_compressed_texture_etc: {
+						COMPRESSED_R11_EAC: 'R11_EAC',
+						COMPRESSED_SIGNED_RG11_EAC: 'SIGNED_RG11_EAC'
+					}
+				} );
+
+				const utils = new WebGLUtils( mockContext(), extensions );
+
+				assert.strictEqual( utils.convert( R11_EAC_Format ), 'R11_EAC', 'R11 EAC' );
+				assert.strictEqual( utils.convert( SIGNED_RG11_EAC_Format ), 'SIGNED_RG11_EAC', 'signed RG11 EAC' );
+
+			} );
+
+			// convert - ASTC
+			QUnit.test( 'convert - picks the sRGB ASTC variants for an sRGB color space', ( assert ) => {
+
+				const extensions = mockExtensions( {
+					WEBGL_compressed_texture_astc: {
+						COMPRESSED_RGBA_ASTC_4x4_KHR: 'RGBA_4x4',
+						COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR: 'SRGB_4x4',
+						COMPRESSED_RGBA_ASTC_12x12_KHR: 'RGBA_12x12',
+						COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR: 'SRGB_12x12'
+					}
+				} );
+
+				const utils = new WebGLUtils( mockContext(), extensions );
+
+				assert.strictEqual( utils.convert( RGBA_ASTC_4x4_Format, NoColorSpace ), 'RGBA_4x4', 'linear 4x4' );
+				assert.strictEqual( utils.convert( RGBA_ASTC_4x4_Format, SRGBColorSpace ), 'SRGB_4x4', 'sRGB 4x4' );
+				assert.strictEqual( utils.convert( RGBA_ASTC_12x12_Format, NoColorSpace ), 'RGBA_12x12', 'linear 12x12' );
+				assert.strictEqual( utils.convert( RGBA_ASTC_12x12_Format, SRGBColorSpace ), 'SRGB_12x12', 'sRGB 12x12' );
+
+			} );
+
+			// convert - BPTC
+			QUnit.test( 'convert - resolves BPTC formats, with an sRGB variant only for the UNORM one', ( assert ) => {
+
+				// The signed and unsigned float formats are HDR, so they have no
+				// sRGB counterpart to switch to.
+				const extensions = mockExtensions( {
+					EXT_texture_compression_bptc: {
+						COMPRESSED_RGBA_BPTC_UNORM_EXT: 'RGBA_UNORM',
+						COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT: 'SRGB_A_UNORM',
+						COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT: 'RGB_SIGNED_FLOAT'
+					}
+				} );
+
+				const utils = new WebGLUtils( mockContext(), extensions );
+
+				assert.strictEqual( utils.convert( RGBA_BPTC_Format, NoColorSpace ), 'RGBA_UNORM', 'linear UNORM' );
+				assert.strictEqual( utils.convert( RGBA_BPTC_Format, SRGBColorSpace ), 'SRGB_A_UNORM', 'sRGB UNORM' );
+				assert.strictEqual( utils.convert( RGB_BPTC_SIGNED_Format, SRGBColorSpace ), 'RGB_SIGNED_FLOAT', 'the float format ignores the color space' );
+
+			} );
+
+			// convert - RGTC
+			QUnit.test( 'convert - resolves RGTC formats through their extension', ( assert ) => {
+
+				const extensions = mockExtensions( {
+					EXT_texture_compression_rgtc: {
+						COMPRESSED_RED_RGTC1_EXT: 'RED_RGTC1',
+						COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT: 'SIGNED_RG_RGTC2'
+					}
+				} );
+
+				const utils = new WebGLUtils( mockContext(), extensions );
+
+				assert.strictEqual( utils.convert( RED_RGTC1_Format ), 'RED_RGTC1', 'RGTC1' );
+				assert.strictEqual( utils.convert( SIGNED_RED_GREEN_RGTC2_Format ), 'SIGNED_RG_RGTC2', 'signed RGTC2' );
+
+			} );
+
+			QUnit.test( 'convert - returns null when the RGTC extension is unavailable', ( assert ) => {
+
+				const utils = new WebGLUtils( mockContext(), mockExtensions() );
+
+				assert.strictEqual( utils.convert( RED_RGTC1_Format ), null, 'an unsupported format resolves to null' );
+
+			} );
+
+			// convert - fallback
+			QUnit.test( 'convert - falls back to a named constant on the context', ( assert ) => {
+
+				// Undocumented escape hatch: an unrecognised value is looked up
+				// as a property name on the context, which lets applications
+				// name packed formats the enum list does not cover.
+				const gl = mockContext();
+				gl.RGB565 = 'RGB565';
+
+				const utils = new WebGLUtils( gl, mockExtensions() );
+
+				assert.strictEqual( utils.convert( 'RGB565' ), 'RGB565', 'the string names a context constant' );
+
+			} );
+
+			QUnit.test( 'convert - returns null for an unrecognised value', ( assert ) => {
+
+				const utils = new WebGLUtils( mockContext(), mockExtensions() );
+
+				assert.strictEqual( utils.convert( 'NOT_A_REAL_FORMAT' ), null, 'an unknown name resolves to null' );
+				assert.strictEqual( utils.convert( - 1 ), null, 'an unknown numeric constant resolves to null' );
+
+			} );
 
 		} );
 


### PR DESCRIPTION
Part of #34371.

## Related Issue

#34371 — a number of files under `test/unit/src` contain only nested `QUnit.module` scaffolding with no `QUnit.test` calls. They run as part of `npm run test-unit` while asserting nothing.

## Description

This fills in 17 of those files with **276 tests**, covering the group that does not need a live GL context:

| File | Tests |
| --- | --- |
| `animation/AnimationUtils` | 37 |
| `animation/PropertyMixer` | 26 |
| `renderers/webgl/WebGLAttributes` | 25 |
| `renderers/webgl/WebGLClipping` | 23 |
| `renderers/webgl/WebGLGeometries` | 23 |
| `renderers/webgl/WebGLCapabilities` | 20 |
| `renderers/webgl/WebGLUtils` | 18 |
| `renderers/webgl/WebGLObjects` | 16 |
| `renderers/webgl/WebGLProperties` | 13 |
| `audio/AudioAnalyser` | 11 |
| `extras/ImageUtils` | 11 |
| `extras/ShapeUtils` | 11 |
| `extras/core/Interpolations` | 11 |
| `renderers/webgl/WebGLIndexedBufferRenderer` | 11 |
| `renderers/webgl/WebGLBufferRenderer` | 10 |
| `extras/Earcut` | 6 |
| `renderers/webgl/WebGLShader` | 4 |

### Approach

The renderer modules are driven through recording stand-ins for the WebGL context, the extensions registry and `WebGLInfo` rather than a real context, so they run in the existing headless setup with no GPU requirement and no new dependencies. `ImageUtils` and `AudioAnalyser` use the browser's canvas and Web Audio APIs, which the puppeteer-driven runner already provides.

Tests aim at behaviour that is easy to regress rather than restating the implementation. Some examples:

- `WebGLIndexedBufferRenderer` converts a start index to a **byte** offset, so the tests pin the scaling to the index type (2 vs 4 bytes) — and that `renderMultiDraw` passes counts *before* the index type, unlike the non-indexed variant.
- `WebGLClipping.init()` deliberately stays enabled for one extra frame after planes are removed, so the shader state can reset. That is asserted explicitly.
- `AnimationUtils.makeClipAdditive()` applies the reference quaternion's conjugate on the **left**. Since quaternion multiplication does not commute, there is a test using rotations about different axes that fails if the operand order is ever flipped.
- `WebGLBufferRenderer.renderMultiDraw()` only sums the first `drawCount` entries, because the arrays are reused buffers that may hold stale trailing values.

### Out of scope

The remaining stubs need a live GL context and considerably more scaffolding, and are untouched here: `WebGLRenderer`, `WebGLTextures`, `WebGLState`, `WebGLProgram`, `WebGLPrograms`, `WebGLShadowMap`, `WebGLLights`, `WebGLBackground`, `WebGLMorphtargets`, `WebGLUniforms`, `PMREMGenerator`.

No source files are changed — this is tests only.

## Verification

```
npm run test-unit
1..1592
# pass 1591
# skip 0
# todo 1
# fail 0
```

Up from 1316 before this change. The single `todo` is the pre-existing `Mesh.raycast` one. `npx eslint` is clean on every file in the diff.