### PR TITLE
GaussianSplat: Fix WebXR stereo projection

### DIFF
--- a/examples/jsm/objects/GaussianSplat.js
+++ b/examples/jsm/objects/GaussianSplat.js
@@ -22,6 +22,7 @@ import {
 	dot,
 	exp,
 	float,
+	highpModelViewMatrix,
 	instanceIndex,
 	max,
 	mediumpModelViewMatrix,
@@ -54,6 +55,12 @@ const KERNEL_2D_SIZE = 0.3;
 const SPLAT_KERNEL_CUTOFF = 2;
 const MAX_SCREEN_SPACE_SPLAT_SIZE = 1024;
 const CLIP_XY = 1.4;
+
+const splatModelViewMatrix = /*@__PURE__*/ ( Fn( ( { camera } ) => {
+
+	return camera.isArrayCamera && camera.cameras.length > 0 ? mediumpModelViewMatrix : highpModelViewMatrix;
+
+} ).once() )();
 
 const _worldCenter = /*@__PURE__*/ new Vector3();
 const _viewCenter = /*@__PURE__*/ new Vector3();
@@ -726,11 +733,11 @@ function createMaterialNodes( buffers, sort, localCameraPosition ) {
 
 		splatUv.assign( positionGeometry.xy );
 
-		const viewCenter4 = mediumpModelViewMatrix.mul( vec4( center, 1 ) ).toVar( 'viewCenter4' );
+		const viewCenter4 = splatModelViewMatrix.mul( vec4( center, 1 ) ).toVar( 'viewCenter4' );
 		const viewCenter = viewCenter4.xyz.toVar( 'viewCenter' );
 		const centerClip = cameraProjectionMatrix.mul( viewCenter4 ).toVar( 'centerClip' );
 
-		const m = mediumpModelViewMatrix;
+		const m = splatModelViewMatrix;
 		const r0 = vec3( m[ 0 ].x, m[ 1 ].x, m[ 2 ].x ).toVar( 'r0' );
 		const r1 = vec3( m[ 0 ].y, m[ 1 ].y, m[ 2 ].y ).toVar( 'r1' );
 		const r2 = vec3( m[ 0 ].z, m[ 1 ].z, m[ 2 ].z ).toVar( 'r2' );

--- a/examples/jsm/objects/GaussianSplat.js
+++ b/examples/jsm/objects/GaussianSplat.js
@@ -17,17 +17,17 @@ import {
 	If,
 	atan,
 	cameraProjectionMatrix,
+	cameraViewport,
 	cos,
 	dot,
 	exp,
 	float,
-	highpModelViewMatrix,
 	instanceIndex,
 	max,
+	mediumpModelViewMatrix,
 	min,
 	normalize,
 	positionGeometry,
-	screenSize,
 	sin,
 	sqrt,
 	storage,
@@ -726,11 +726,11 @@ function createMaterialNodes( buffers, sort, localCameraPosition ) {
 
 		splatUv.assign( positionGeometry.xy );
 
-		const viewCenter4 = highpModelViewMatrix.mul( vec4( center, 1 ) ).toVar( 'viewCenter4' );
+		const viewCenter4 = mediumpModelViewMatrix.mul( vec4( center, 1 ) ).toVar( 'viewCenter4' );
 		const viewCenter = viewCenter4.xyz.toVar( 'viewCenter' );
 		const centerClip = cameraProjectionMatrix.mul( viewCenter4 ).toVar( 'centerClip' );
 
-		const m = highpModelViewMatrix;
+		const m = mediumpModelViewMatrix;
 		const r0 = vec3( m[ 0 ].x, m[ 1 ].x, m[ 2 ].x ).toVar( 'r0' );
 		const r1 = vec3( m[ 0 ].y, m[ 1 ].y, m[ 2 ].y ).toVar( 'r1' );
 		const r2 = vec3( m[ 0 ].z, m[ 1 ].z, m[ 2 ].z ).toVar( 'r2' );
@@ -753,7 +753,7 @@ function createMaterialNodes( buffers, sort, localCameraPosition ) {
 		const z = min( viewCenter.z, - 0.01 ).toVar( 'z' );
 		const invZ = float( 1 ).div( z ).toVar( 'invZ' );
 		const invZ2 = invZ.mul( invZ ).toVar( 'invZ2' );
-		const focal = screenSize.mul( 0.5 ).mul( vec2( cameraProjectionMatrix[ 0 ].x, cameraProjectionMatrix[ 1 ].y ) ).toVar( 'focal' );
+		const focal = cameraViewport.zw.mul( 0.5 ).mul( vec2( cameraProjectionMatrix[ 0 ].x, cameraProjectionMatrix[ 1 ].y ) ).toVar( 'focal' );
 
 		const j00 = focal.x.negate().mul( invZ ).toVar( 'j00' );
 		const j11 = focal.y.negate().mul( invZ ).toVar( 'j11' );
@@ -799,7 +799,7 @@ function createMaterialNodes( buffers, sort, localCameraPosition ) {
 		const scale1 = min( sqrt( lambda1 ), MAX_SCREEN_SPACE_SPLAT_SIZE ).toVar( 'scale1' );
 		const scale2 = min( sqrt( lambda2 ), MAX_SCREEN_SPACE_SPLAT_SIZE ).toVar( 'scale2' );
 		const offsetPixels = axis1.mul( positionGeometry.x ).mul( scale1 ).add( axis2.mul( positionGeometry.y ).mul( scale2 ) ).toVar( 'offsetPixels' );
-		const offsetNdc = offsetPixels.mul( 2 ).div( screenSize ).toVar( 'offsetNdc' );
+		const offsetNdc = offsetPixels.mul( 2 ).div( cameraViewport.zw ).toVar( 'offsetNdc' );
 		const clip = centerClip.add( vec4( offsetNdc.mul( centerClip.w ), 0, 0 ) ).toVar( 'clip' );
 
 		const clipLimit = centerClip.w.mul( CLIP_XY ).toVar( 'clipLimit' );


### PR DESCRIPTION
Related issue: None

**Description**

Fixes Gaussian splats rendering the same view in both eyes during WebXR sessions.

GaussianSplat used highpModelViewMatrix, which is computed on the CPU from the parent XR ArrayCamera. As a result, both eye draws received the same view transform. It also used screenSize, which is the combined XR framebuffer size, for covariance projection and the NDC offset.

For XR ArrayCamera rendering, this change uses the existing array-aware mediumpModelViewMatrix and cameraViewport accessors. The view transform, focal size, and NDC conversion are therefore selected for the current eye. Non-XR cameras keep the existing CPU-computed highpModelViewMatrix path.

Verified on Meta Quest 3 with WebGPURenderer using the WebGL backend. Both the Gaussian splats and regular mesh depth markers showed matching left/right parallax. The comparison page and diagnostics are available in afjk/afjk.jp#543.

Tests:

- npm test
- npm run test-e2e -- webgpu_gaussian_splat
- npm run test-e2e-webgpu -- webgpu_gaussian_splat

Both Gaussian example screenshot tests reported 0.0% diff.
