### PR TITLE
WebGPURenderer: Release attribute buffers when a BufferAttribute is disposed

### DIFF
--- a/src/renderers/common/Attributes.js
+++ b/src/renderers/common/Attributes.js
@@ -49,6 +49,12 @@ class Attributes extends DataMap {
 
 		if ( attributeData !== null ) {
 
+			if ( attributeData.onDispose !== undefined && typeof attribute.removeEventListener === 'function' ) {
+
+				attribute.removeEventListener( 'dispose', attributeData.onDispose );
+
+			}
+
 			this.backend.destroyAttribute( attribute );
 
 			this.info.destroyAttribute( attribute );
@@ -91,6 +97,14 @@ class Attributes extends DataMap {
 
 				this.backend.createIndirectStorageAttribute( attribute );
 				this.info.createIndirectStorageAttribute( attribute );
+
+			}
+
+			if ( typeof attribute.addEventListener === 'function' ) {
+
+				const onDispose = () => this.delete( attribute );
+				attribute.addEventListener( 'dispose', onDispose );
+				data.onDispose = onDispose;
 
 			}
 


### PR DESCRIPTION
**Description**

`BufferAttribute.dispose()` is documented as *"Disposes of the buffer attribute. Available only in `WebGPURenderer`"* and dispatches a `dispose` event, but nothing in the renderer listens for it, so calling it does not release the backend buffer.

Attribute buffers are currently released only from `Geometries.js`, when the owning **geometry** is disposed — that is the only caller of `Attributes.delete()`. Disposing an attribute directly, or replacing a geometry's attribute and disposing the old one, therefore leaks the backend buffer for the lifetime of the renderer.

This registers a `dispose` listener when the attribute is first uploaded and removes it on delete, mirroring what `Textures.js` already does for textures and render targets.

The `typeof attribute.addEventListener === 'function'` guard is needed because `Attributes.update()` also receives `InterleavedBufferAttribute`, which is not an `EventDispatcher`.

Made with [Cursor](https://cursor.com)