### PR TITLE
SSRNode: Fix TypeError when stochastic is enabled without an environment

### DIFF
--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -956,6 +956,8 @@ class SSRNode extends TempNode {
 
 					const envColor = vec3( 0 ).toVar();
 
+					if ( this._importanceEnvironment === null ) return envColor;
+
 					if ( this.envImportanceSampling ) {
 
 						const Xi2 = bindAnalyticNoise( this._resolution, 59 )( uvPos, this._noiseIndex );


### PR DESCRIPTION
**Description**

With `stochastic: true` and no `environmentNode` / `setEnvMap()`, building the SSR material throws a `TypeError`.

`sampleEnvReflection()` is only defined on the stochastic path, and both of its branches dereference `this._importanceEnvironment`. That field is initialised to `null` and is only assigned when an equirectangular HDR environment is supplied, so the call fails while the node graph is being built.

`webgpu_postprocessing_ssr_denoise.html` is the only example that enables stochastic mode, and it also passes `environmentNode`, so this combination is not covered by the examples.

This returns a black environment contribution when no environment is set, leaving the screen-space result untouched.

Made with [Cursor](https://cursor.com)