### PR TITLE
WebGLRenderer: fix compileAsync() crashing when a tracked material is disposed mid-flight

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1521,7 +1521,10 @@ class WebGLRenderer {
 						const materialProperties = properties.get( material );
 						const program = materialProperties.currentProgram;
 
-						if ( program.isReady() ) {
+						// the material may have been disposed while compilation was still pending
+						// (e.g. it was removed from the scene and its GPU resources released) -
+						// stop waiting for it instead of throwing on a program that no longer exists.
+						if ( program === undefined || program.isReady() ) {
 
 							// remove any programs that report they're ready to use from the list
 							materials.delete( material );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1521,12 +1521,9 @@ class WebGLRenderer {
 						const materialProperties = properties.get( material );
 						const program = materialProperties.currentProgram;
 
-						// the material may have been disposed while compilation was still pending
-						// (e.g. it was removed from the scene and its GPU resources released) -
-						// stop waiting for it instead of throwing on a program that no longer exists.
 						if ( program === undefined || program.isReady() ) {
 
-							// remove any programs that report they're ready to use from the list
+							// stop waiting for materials that are ready to use or have been disposed
 							materials.delete( material );
 
 						}


### PR DESCRIPTION
## Description

`compileAsync()` polls each material captured by `compile()` until its `currentProgram.isReady()` reports true. If a material is disposed while that compile is still pending - a completely normal thing for an application to do (a fast unmount, a model swap, etc.) - `material.dispose()` clears its entry in `WebGLProperties`. The next poll tick then reads `currentProgram` as `undefined` and calling `.isReady()` on it throws.

Because this happens inside `compileAsync()`'s internal `setTimeout` callback, the exception can't be caught by the caller at all - it surfaces as an uncaught error, and the returned Promise is left permanently unresolved instead of rejecting.

Minimal repro:

```js
const renderer = new THREE.WebGLRenderer();
const scene = new THREE.Scene();
const camera = new THREE.PerspectiveCamera();

const material = new THREE.MeshStandardMaterial();
scene.add(new THREE.Mesh(new THREE.BoxGeometry(), material));

renderer.compileAsync(scene, camera).then(() => console.log('resolved'));
material.dispose(); // <- crashes on the next poll tick instead of just settling the promise
```

## Fix

Treat a missing `currentProgram` as "this material is no longer relevant, stop waiting on it" instead of assuming it still exists.

## Testing

- Verified the repro above reliably crashes on unpatched `dev` and resolves cleanly with this change.
- `npm run lint-core` passes.
