### PR TITLE
Core: Initialize render targets with valid dimensions.

### DIFF
--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -47,7 +47,7 @@ class RTTNode extends TextureNode {
 			resolutionScale = 1
 		} = options;
 
-		const renderTarget = new RenderTarget( width, height, { type: HalfFloatType, ...options } );
+		const renderTarget = new RenderTarget( width ?? 1, height ?? 1, { type: HalfFloatType, ...options } );
 
 		super( renderTarget.texture, uv() );
 

--- a/src/nodes/utils/ReflectorNode.js
+++ b/src/nodes/utils/ReflectorNode.js
@@ -413,7 +413,7 @@ class ReflectorBaseNode extends Node {
 
 		if ( renderTarget === undefined ) {
 
-			renderTarget = new RenderTarget( 0, 0, { type: HalfFloatType, samples: this.samples } );
+			renderTarget = new RenderTarget( 1, 1, { type: HalfFloatType, samples: this.samples } );
 
 			if ( this.generateMipmaps === true ) {
 


### PR DESCRIPTION
Related issue: -

**Description**

`RTTNode` uses `null` dimensions as the sentinel for automatic resizing, but it also passed those values to the internal `RenderTarget`. Before the first `RTTNode.updateBefore()` call, the render target texture therefore reported `null` dimensions.

This becomes observable when an auto-sized RTT is used as the TAAU beauty input. `TAAUNode` reads the texture dimensions in `OnBeforeRenderPipeline()` and passes them to `PerspectiveCamera.setViewOffset()`, which sets the camera aspect and projection matrix to `NaN`.

Initialize only the internal render target with `1 × 1` fallback dimensions while preserving `RTTNode.width` and `RTTNode.height` as `null`, so automatic resizing remains enabled and updates to the drawing-buffer size on the first frame.

**Testing**

- `npm test`
- Verified with a minimal TAAU reproduction that an auto-sized RTT reports valid dimensions before its first update and keeps the camera projection matrix finite.
