### PR TITLE
WebGPU: fix stale bind group reuse when a repointed storage buffer shares a bind group with an unchanged texture

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -366,14 +366,12 @@ class Bindings extends DataMap {
 
 		for ( const binding of bindGroup.bindings ) {
 
-			const updatedGroup = this.nodes.updateGroup( binding );
-
-			// every uniforms group is a uniform buffer. So if no update is required,
-			// we move one with the next binding. Otherwise the next if block will update the group.
-
-			if ( updatedGroup === false ) continue;
-
-			//
+			// A storage node's `.value` can be repointed to a different attribute without the
+			// enclosing render/frame group ever being invalidated (the group tracks per-frame
+			// invalidation, not the node's own attribute identity). So the attribute-sync/cache-key
+			// logic below has to run unconditionally, independent of `updateGroup()`'s result -- unlike
+			// the uniform-buffer/texture/sampler branches further down, which are fine being skipped
+			// when their group hasn't changed.
 
 			if ( binding.isStorageBuffer ) {
 
@@ -398,7 +396,34 @@ class Bindings extends DataMap {
 				cacheKey += attribute.id + ',';
 				version += attribute.version;
 
+				// keep track which bind groups refer to the current attribute so cached bind
+				// groups can be evicted when the attribute is disposed (mirrors the texture
+				// bind group tracking below, which exists for the same reason)
+
+				const attributeData = this.attributes.get( attribute );
+
+				if ( attributeData.bindGroups === undefined ) {
+
+					attributeData.bindGroups = new Set();
+
+					const onDispose = () => this._destroyStorageBufferBindGroups( attribute );
+
+					attribute.addEventListener( 'dispose', onDispose );
+
+				}
+
+				attributeData.bindGroups.add( bindGroup );
+
 			}
+
+			const updatedGroup = this.nodes.updateGroup( binding );
+
+			// every uniforms group is a uniform buffer. So if no update is required,
+			// we move one with the next binding. Otherwise the next if block will update the group.
+
+			if ( updatedGroup === false ) continue;
+
+			//
 
 			if ( binding.isUniformBuffer ) {
 
@@ -474,21 +499,29 @@ class Bindings extends DataMap {
 
 			} else if ( binding.isSampler ) {
 
-				const updated = binding.update();
+				// `binding.update()` only reports a change when the bound texture's `version`
+				// bumps, but sampler settings (wrap/filter/anisotropy) don't bump that version.
+				// So the sampler key has to be recomputed and compared unconditionally -- gating
+				// it behind `update()` would mean a sampler-only settings change is never even
+				// detected, let alone folded into the cache key below.
 
-				if ( updated ) {
+				binding.update();
 
-					const samplerKey = this.textures.updateSampler( binding );
+				const samplerKey = this.textures.updateSampler( binding );
 
-					if ( binding.samplerKey !== samplerKey ) {
+				if ( binding.samplerKey !== samplerKey ) {
 
-						binding.samplerKey = samplerKey;
+					binding.samplerKey = samplerKey;
 
-						needsBindingsUpdate = true;
-
-					}
+					needsBindingsUpdate = true;
 
 				}
+
+				// Fold the sampler's key into the cache key, mirroring the isSampledTexture
+				// branch above, so a bind group isn't reused after only the sampler's own
+				// settings changed.
+
+				cacheKey += binding.samplerKey + ',';
 
 			}
 
@@ -503,6 +536,35 @@ class Bindings extends DataMap {
 		if ( needsBindingsUpdate === true ) {
 
 			this.backend.updateBindings( bindGroup, bindings, cacheBindings ? cacheKey : '', version );
+
+		}
+
+	}
+
+	/**
+	 * Evicts every cached bind group entry tied to the given storage attribute. Called when
+	 * the attribute is disposed, so a bind group's per-cache-key GPU objects (keyed in part by
+	 * `attribute.id`, see `_update()`) don't keep accumulating for an attribute id that will
+	 * never be referenced again. Mirrors the cleanup `Textures.js` performs for disposed textures.
+	 *
+	 * @param {BufferAttribute} attribute - The disposed storage attribute.
+	 */
+	_destroyStorageBufferBindGroups( attribute ) {
+
+		const attributeData = this.attributes.get( attribute );
+
+		if ( attributeData.bindGroups ) {
+
+			for ( const bindGroup of attributeData.bindGroups ) {
+
+				const bindingsData = this.backend.get( bindGroup );
+
+				bindingsData.groups = undefined;
+				bindingsData.versions = undefined;
+
+			}
+
+			attributeData.bindGroups.clear();
 
 		}
 

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -392,6 +392,12 @@ class Bindings extends DataMap {
 
 				}
 
+				// Fold the attribute's identity/version into the cache key, mirroring the
+				// isSampledTexture branch below.
+
+				cacheKey += attribute.id + ',';
+				version += attribute.version;
+
 			}
 
 			if ( binding.isUniformBuffer ) {

--- a/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
+++ b/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
@@ -5,22 +5,13 @@ import {
 } from 'three/tsl';
 import { getSharedRenderer } from './gpu-test-utils.js';
 
-// A minimal, FFT-independent repro of the mechanism suspected in FFT2D.js's ping-pong buffer
-// sharing attempt (see that file's constructor comment): a *single* compiled compute kernel,
-// built once, whose storage buffer nodes are repointed (`.value = someOtherAttribute`) at a
-// *different* buffer immediately before each of many back-to-back `renderer.compute()` calls,
-// with no `await` between them. FFT2D's version of this pattern intermittently corrupted data on
-// real hardware for large (non-fused, many-dispatch-per-transform) images; this test strips away
-// the FFT math entirely to isolate just the repointing mechanism, so a failure here would confirm
-// a genuine three.js/TSL WebGPU-backend bug rather than anything FFT-specific.
-//
-// Two ping-pong `StorageBufferAttribute`s (`bufA`/`bufB`), one `float` each, `count` elements.
-// One kernel, built once: `out[i] = in[i] + 1`. `count` iterations run back-to-back, alternating
-// which buffer is "in" and which is "out" (mirroring `FFT2D`'s reverted `_dispatchPingPong`), all
-// recorded before the first readback. If every dispatch's bind group correctly captured the
-// node values *at the time `renderer.compute()` was called*, the final live buffer holds
-// `initial + iterations` in every element; any staleness/aliasing in that repointing would show
-// up as a wrong value there.
+// Minimal reproduction for a WebGPU bind-group caching bug: when a storage buffer node's
+// `.value` is repointed at a different `BufferAttribute` (`node.value = otherAttribute`) between
+// `renderer.compute()` calls, the new attribute wasn't folded into the bind group's cache
+// key/version, so a stale bind group -- still wired to the previous attribute -- could be reused.
+// Each test below builds a compute kernel once, then repoints its storage node(s) immediately
+// before each dispatch, with no `await` in between, and checks that every dispatch actually wrote
+// to the buffer it was pointed at.
 
 function makeBuffer( count, initialValue ) {
 
@@ -38,8 +29,7 @@ async function readBuffer( renderer, attribute, count ) {
 
 }
 
-// `vec2`-typed buffer, matching FFT2D's actual `(real, imag)` element type (as opposed to the
-// `float` used above) and, in the tests below, FFT2D's actual `width*height` element counts.
+// `vec2`-typed buffer, for tests that exercise a 2-component element type instead of `float`.
 function makeVec2Buffer( count, initialX, initialY ) {
 
 	const data = new Float32Array( count * 2 );
@@ -105,8 +95,7 @@ export default QUnit.module( 'TSL', () => {
 				const attrA = makeBuffer( count, initialValue );
 				const attrB = makeBuffer( count, 0 );
 
-				// One shared, repointable read/write node pair -- exactly the pattern reverted in
-				// FFT2D.js. `readNode` is read-only, matching FFT2D's usage.
+				// One shared, repointable read/write node pair.
 				const readNode = storage( attrA, 'float', count ).toReadOnly();
 				const writeNode = storage( attrB, 'float', count );
 
@@ -165,10 +154,10 @@ export default QUnit.module( 'TSL', () => {
 
 		repointTest( 'two distinct kernels sharing one repointed node pair stay correct when interleaved', async ( assert, renderer ) => {
 
-			// Closer to FFT2D's real shape: several *different* compiled kernels (not just one)
-			// all referencing the same shared read/write node pair, dispatched in an interleaved
-			// sequence -- in case cross-kernel bind-group aliasing on the shared nodes, rather
-			// than same-kernel reuse, is what matters.
+			// Several *different* compiled kernels (not just one) all referencing the same shared
+			// read/write node pair, dispatched in an interleaved sequence -- in case cross-kernel
+			// bind-group aliasing on the shared nodes, rather than same-kernel reuse, is what
+			// matters.
 
 			const count = 64;
 			const iterations = 64;
@@ -238,9 +227,8 @@ export default QUnit.module( 'TSL', () => {
 		repointTest( 'repeated repoint-and-dispatch runs stay correct across many separate calls (not just one long chain)', async ( assert, renderer ) => {
 
 			// Runs the single-kernel repoint chain from the first test many times over, each with
-			// its own fresh buffers/kernel, to catch nondeterministic ("sometimes") corruption that
-			// a single run might not hit -- matching what was actually observed (works most of the
-			// time, occasionally doesn't).
+			// its own fresh buffers/kernel, to catch nondeterministic corruption that a single run
+			// might not hit.
 
 			const count = 64;
 			const iterations = 32;
@@ -305,13 +293,9 @@ export default QUnit.module( 'TSL', () => {
 
 		} );
 
-		// From here down: closer in *scale* and *shape* to FFT2D's actual butterfly-stage kernels
-		// (which is where the real corruption showed up), not just the mechanism in isolation --
-		// `vec2` elements at FFT2D's real `width*height` element counts, and a uniform value
-		// changed on every dispatch in lockstep with the storage-node repointing, exactly
-		// mirroring `_runAxisPass`'s non-fused fallback loop (`this._pUniform.value = 1 << s;
-		// renderer.compute(...)`). If the isolated, small-scale repoint above is safe but this
-		// isn't, that would point at scale/uniform-interaction rather than repointing itself.
+		// From here down: larger scale (`vec2` elements, up to 1,048,576 elements) and a uniform
+		// value changed on every dispatch in lockstep with the storage-node repointing, to check
+		// that scale and a concurrently-changing uniform don't affect the fix.
 
 		[ 65536, 1048576 ].forEach( ( count ) => {
 
@@ -377,13 +361,11 @@ export default QUnit.module( 'TSL', () => {
 
 		repointTest( 'uniform value changed every dispatch alongside repointed storage nodes (per-stage fallback shape, 1048576 elements x 20 stages)', async ( assert, renderer ) => {
 
-			// This is the closest analog to what actually broke: FFT2D's `buildMultiDispatchStage`
-			// fallback dispatches once per stage (`log2(N)` times) over the *whole* buffer, at real
-			// image scale, changing `_pUniform.value` and repointing the storage nodes together
-			// immediately before each `renderer.compute()` call, with zero `await` between stages.
+			// A uniform value and the storage-node repointing both change together immediately
+			// before each `renderer.compute()` call, with zero `await` between stages.
 
-			const count = 1048576; // 1024x1024, matching the reported "brick"/"hardwood" scale
-			const stages = 20; // comfortably more than log2(1048576) = 20 for a single axis
+			const count = 1048576; // 1024x1024
+			const stages = 20;
 
 			const attrA = makeVec2Buffer( count, 0, 0 );
 			const attrB = makeVec2Buffer( count, 0, 0 );
@@ -392,9 +374,8 @@ export default QUnit.module( 'TSL', () => {
 			const writeNode = storage( attrB, 'vec2', count );
 			const stageUniform = uniform( 1, 'uint' );
 
-			// out[i] = in[i] + stageUniform -- mirrors `_pUniform` being read inside the real
-			// per-stage kernel body, just with trivial (but exactly verifiable) math instead of the
-			// real butterfly.
+			// out[i] = in[i] + stageUniform, kept trivial so the expected result stays exactly
+			// verifiable.
 			const kernel = Fn( () => {
 
 				const v = readNode.element( instanceIndex ).toVar();
@@ -449,7 +430,7 @@ export default QUnit.module( 'TSL', () => {
 		repointTest( 'per-stage fallback shape repeated across 6 separate runs (1048576 elements x 20 stages each)', async ( assert, renderer ) => {
 
 			// Same as the previous test, but repeated -- to catch nondeterministic corruption a
-			// single run might not hit, at the scale most likely to matter.
+			// single run might not hit.
 
 			const count = 1048576;
 			const stages = 20;
@@ -517,16 +498,13 @@ export default QUnit.module( 'TSL', () => {
 
 		} );
 
-		// A faithful copy of FFT2D.js's `buildTransposeStage` (minus the conjugate/scale option):
-		// a tiled, workgroup-shared-memory, 2D-dispatched transpose, with an explicit
-		// `workgroupBarrier()` between the load and store phases. Every other kernel in this file
-		// is a flat, global-memory-only, 1D-dispatched kernel -- structurally nothing like this.
-		// `_runButterflyPasses` in FFT2D.js alternates between exactly these two *kinds* of kernel
-		// (global-memory row/column passes, shared-memory transpose passes) sharing the same
-		// repointed nodes throughout, which nothing above actually exercises. Since a transpose is
-		// a pure permutation (it moves values, never changes them), composing
-		// transpose-forward + transpose-back is the identity -- so a value-preserving invariant
-		// stays checkable even through the permutation.
+		// A tiled, workgroup-shared-memory, 2D-dispatched transpose kernel, with an explicit
+		// `workgroupBarrier()` between the load and store phases -- structurally different from
+		// the flat, global-memory-only, 1D-dispatched kernels used above, to check that kernels
+		// alternating between these two shapes while sharing the same repointed nodes stay
+		// correct. Since a transpose is a pure permutation (it moves values, never changes them),
+		// composing transpose-forward + transpose-back is the identity -- so a value-preserving
+		// invariant stays checkable even through the permutation.
 		function buildTransposeKernel( rows, cols, tile, readNode, writeNode ) {
 
 			const sharedTile = workgroupArray( 'vec2', tile * tile );
@@ -569,13 +547,13 @@ export default QUnit.module( 'TSL', () => {
 
 			repointTest( `mixed global-memory / shared-memory kernels sharing repointed nodes, matching _runButterflyPasses' shape (${ width }x${ height })`, async ( assert, renderer ) => {
 
-				// Mirrors _runButterflyPasses' literal sequence: row pass (several per-stage
-				// dispatches, global memory) -> transpose (one dispatch, shared memory + barrier)
-				// -> column pass (several per-stage dispatches, global memory) -> transpose back
-				// (one dispatch, shared memory + barrier) -- all sharing the same 2 repointed nodes,
-				// no `await` anywhere in the sequence. The row/column "butterfly" math is replaced
-				// by a simple, position-independent `x += stageValue` so the expected result stays
-				// exactly checkable regardless of how the transposes permute element positions.
+				// A row pass (several per-stage dispatches, global memory) -> transpose (one
+				// dispatch, shared memory + barrier) -> column pass (several per-stage dispatches,
+				// global memory) -> transpose back (one dispatch, shared memory + barrier) -- all
+				// sharing the same 2 repointed nodes, no `await` anywhere in the sequence. The
+				// row/column math is a simple, position-independent `x += stageValue` so the
+				// expected result stays exactly checkable regardless of how the transposes permute
+				// element positions.
 
 				const count = width * height;
 				const tile = 16;
@@ -664,8 +642,8 @@ export default QUnit.module( 'TSL', () => {
 
 		repointTest( 'mixed global-memory / shared-memory kernel sequence repeated across 6 separate runs (1024x1024)', async ( assert, renderer ) => {
 
-			// Same sequence as above, repeated -- the actual report was "fails about 1 out of 2
-			// times", so a single run is not enough to trust a pass.
+			// Same sequence as above, repeated, since a single run is not enough to trust a pass
+			// against nondeterministic corruption.
 
 			const width = 1024, height = 1024;
 			const count = width * height;

--- a/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
+++ b/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
@@ -127,7 +127,7 @@ export default QUnit.module( 'TSL', () => {
 				const result = await readBuffer( renderer, liveAttribute, count );
 
 				const expected = initialValue + iterations;
-				let firstWrong = -1;
+				let firstWrong = - 1;
 
 				for ( let i = 0; i < count; i ++ ) {
 
@@ -140,7 +140,7 @@ export default QUnit.module( 'TSL', () => {
 
 				}
 
-				assert.ok( firstWrong === -1, firstWrong === -1
+				assert.ok( firstWrong === - 1, firstWrong === - 1
 					? `all ${ count } elements equal ${ expected } after ${ iterations } repointed dispatches`
 					: `element ${ firstWrong } was ${ result[ firstWrong ] }, expected ${ expected } after ${ iterations } repointed dispatches (first mismatch)`
 				);
@@ -201,7 +201,7 @@ export default QUnit.module( 'TSL', () => {
 			const liveAttribute = current === 'A' ? attrA : attrB;
 			const result = await readBuffer( renderer, liveAttribute, count );
 
-			let firstWrong = -1;
+			let firstWrong = - 1;
 
 			for ( let i = 0; i < count; i ++ ) {
 
@@ -214,7 +214,7 @@ export default QUnit.module( 'TSL', () => {
 
 			}
 
-			assert.ok( firstWrong === -1, firstWrong === -1
+			assert.ok( firstWrong === - 1, firstWrong === - 1
 				? `all ${ count } elements equal ${ expected } after ${ iterations } interleaved dispatches across 2 kernels`
 				: `element ${ firstWrong } was ${ result[ firstWrong ] }, expected ${ expected } (first mismatch)`
 			);
@@ -268,7 +268,7 @@ export default QUnit.module( 'TSL', () => {
 				const result = await readBuffer( renderer, liveAttribute, count );
 
 				const expected = initialValue + iterations;
-				let firstWrong = -1;
+				let firstWrong = - 1;
 
 				for ( let i = 0; i < count; i ++ ) {
 
@@ -281,7 +281,7 @@ export default QUnit.module( 'TSL', () => {
 
 				}
 
-				assert.ok( firstWrong === -1, firstWrong === -1
+				assert.ok( firstWrong === - 1, firstWrong === - 1
 					? `run ${ run }: all elements equal ${ expected }`
 					: `run ${ run }: element ${ firstWrong } was ${ result[ firstWrong ] }, expected ${ expected } (first mismatch)`
 				);
@@ -303,7 +303,7 @@ export default QUnit.module( 'TSL', () => {
 
 				const iterations = 32;
 
-				const attrA = makeVec2Buffer( count, 1, -1 );
+				const attrA = makeVec2Buffer( count, 1, - 1 );
 				const attrB = makeVec2Buffer( count, 0, 0 );
 
 				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
@@ -333,8 +333,8 @@ export default QUnit.module( 'TSL', () => {
 				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
 
 				const expectedX = 1 + iterations;
-				const expectedY = -1 - iterations;
-				let firstWrong = -1;
+				const expectedY = - 1 - iterations;
+				let firstWrong = - 1;
 
 				for ( let i = 0; i < count; i ++ ) {
 
@@ -347,7 +347,7 @@ export default QUnit.module( 'TSL', () => {
 
 				}
 
-				assert.ok( firstWrong === -1, firstWrong === -1
+				assert.ok( firstWrong === - 1, firstWrong === - 1
 					? `all ${ count } elements equal (${ expectedX }, ${ expectedY }) after ${ iterations } repointed dispatches`
 					: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expectedX }, ${ expectedY }) (first mismatch)`
 				);
@@ -404,7 +404,7 @@ export default QUnit.module( 'TSL', () => {
 			const liveAttribute = current === 'A' ? attrA : attrB;
 			const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
 
-			let firstWrong = -1;
+			let firstWrong = - 1;
 
 			for ( let i = 0; i < count; i ++ ) {
 
@@ -417,7 +417,7 @@ export default QUnit.module( 'TSL', () => {
 
 			}
 
-			assert.ok( firstWrong === -1, firstWrong === -1
+			assert.ok( firstWrong === - 1, firstWrong === - 1
 				? `all ${ count } elements equal ${ expected } after ${ stages } stages of repointed dispatches`
 				: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) after ${ stages } stages (first mismatch)`
 			);
@@ -473,7 +473,7 @@ export default QUnit.module( 'TSL', () => {
 				const liveAttribute = current === 'A' ? attrA : attrB;
 				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
 
-				let firstWrong = -1;
+				let firstWrong = - 1;
 
 				for ( let i = 0; i < count; i ++ ) {
 
@@ -486,7 +486,7 @@ export default QUnit.module( 'TSL', () => {
 
 				}
 
-				assert.ok( firstWrong === -1, firstWrong === -1
+				assert.ok( firstWrong === - 1, firstWrong === - 1
 					? `run ${ run }: all elements equal ${ expected }`
 					: `run ${ run }: element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
 				);
@@ -543,7 +543,7 @@ export default QUnit.module( 'TSL', () => {
 
 		}
 
-		[ [ 1024, 1024 ], [ 2048, 1024 ] ].forEach( ( [ width, height ] ) => {
+		[[ 1024, 1024 ], [ 2048, 1024 ]].forEach( ( [ width, height ] ) => {
 
 			repointTest( `mixed global-memory / shared-memory kernels sharing repointed nodes, matching _runButterflyPasses' shape (${ width }x${ height })`, async ( assert, renderer ) => {
 
@@ -615,7 +615,7 @@ export default QUnit.module( 'TSL', () => {
 				const liveAttribute = current === 'A' ? attrA : attrB;
 				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
 
-				let firstWrong = -1;
+				let firstWrong = - 1;
 
 				for ( let i = 0; i < count; i ++ ) {
 
@@ -628,7 +628,7 @@ export default QUnit.module( 'TSL', () => {
 
 				}
 
-				assert.ok( firstWrong === -1, firstWrong === -1
+				assert.ok( firstWrong === - 1, firstWrong === - 1
 					? `all ${ count } elements equal ${ expected } after the full row/transpose/col/transpose-back sequence`
 					: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
 				);
@@ -709,7 +709,7 @@ export default QUnit.module( 'TSL', () => {
 				const liveAttribute = current === 'A' ? attrA : attrB;
 				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
 
-				let firstWrong = -1;
+				let firstWrong = - 1;
 
 				for ( let i = 0; i < count; i ++ ) {
 
@@ -722,7 +722,7 @@ export default QUnit.module( 'TSL', () => {
 
 				}
 
-				assert.ok( firstWrong === -1, firstWrong === -1
+				assert.ok( firstWrong === - 1, firstWrong === - 1
 					? `run ${ run }: all elements equal ${ expected }`
 					: `run ${ run }: element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
 				);
@@ -793,7 +793,7 @@ export default QUnit.module( 'TSL', () => {
 				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
 
 				const expectedX = iterations;
-				let firstWrong = -1;
+				let firstWrong = - 1;
 
 				for ( let i = 0; i < count; i ++ ) {
 
@@ -806,7 +806,7 @@ export default QUnit.module( 'TSL', () => {
 
 				}
 
-				assert.ok( firstWrong === -1, firstWrong === -1
+				assert.ok( firstWrong === - 1, firstWrong === - 1
 					? `all ${ count } elements equal (${ expectedX }, 0) after ${ iterations } dispatches of a slow kernel`
 					: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expectedX }, 0) (first mismatch)`
 				);
@@ -867,7 +867,7 @@ export default QUnit.module( 'TSL', () => {
 				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
 
 				const expected = rowStages + colStages;
-				let firstWrong = -1;
+				let firstWrong = - 1;
 
 				for ( let i = 0; i < count; i ++ ) {
 
@@ -880,7 +880,7 @@ export default QUnit.module( 'TSL', () => {
 
 				}
 
-				assert.ok( firstWrong === -1, firstWrong === -1
+				assert.ok( firstWrong === - 1, firstWrong === - 1
 					? `run ${ run }: all elements equal (${ expected }, 0)`
 					: `run ${ run }: element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
 				);
@@ -918,8 +918,8 @@ export default QUnit.module( 'TSL', () => {
 			const sourceTexture = new THREE.DataTexture( sourceData, width, height, THREE.RGBAFormat, THREE.FloatType );
 			sourceTexture.needsUpdate = true;
 
-			const attrA = makeVec2Buffer( count, -1, -1 );
-			const attrB = makeVec2Buffer( count, -1, -1 );
+			const attrA = makeVec2Buffer( count, - 1, - 1 );
+			const attrB = makeVec2Buffer( count, - 1, - 1 );
 
 			const sourceNode = texture( sourceTexture );
 			const writeNode = storage( attrA, 'vec2', count );
@@ -937,12 +937,12 @@ export default QUnit.module( 'TSL', () => {
 			} )().compute( count );
 
 			let target = 'A';
-			let firstWrong = -1;
-			let firstWrongCall = -1;
+			let firstWrong = - 1;
+			let firstWrongCall = - 1;
 			let firstWrongValue = null;
 			let firstWrongOtherBuffer = null;
 
-			for ( let call = 0; call < calls && firstWrong === -1; call ++ ) {
+			for ( let call = 0; call < calls && firstWrong === - 1; call ++ ) {
 
 				// Both buffers were seeded with (-1, -1) above, so a stale bind group that
 				// silently keeps writing to the *other* buffer (or doesn't write at all) shows up
@@ -974,7 +974,7 @@ export default QUnit.module( 'TSL', () => {
 
 			}
 
-			assert.ok( firstWrong === -1, firstWrong === -1
+			assert.ok( firstWrong === - 1, firstWrong === - 1
 				? `all ${ calls } calls (alternating storage target, same reused texture) wrote (7, 3) correctly`
 				: `call ${ firstWrongCall }: element ${ firstWrong } was (${ firstWrongValue.x }, ${ firstWrongValue.y }), expected (7, 3); other buffer's element ${ firstWrong } is (${ firstWrongOtherBuffer.x[ firstWrong ] }, ${ firstWrongOtherBuffer.y[ firstWrong ] })`
 			);

--- a/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
+++ b/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
@@ -1,17 +1,15 @@
 import * as THREE from 'three/webgpu';
-import {
-	Fn, If, Loop, instanceIndex, storage, texture, uniform, vec2, float, int, uint, ivec2, sin,
-	workgroupArray, workgroupBarrier, workgroupId, globalId, localId
-} from 'three/tsl';
+import { Fn, instanceIndex, storage, texture, int, uint, ivec2 } from 'three/tsl';
 import { getSharedRenderer } from './gpu-test-utils.js';
 
 // Minimal reproduction for a WebGPU bind-group caching bug: when a storage buffer node's
 // `.value` is repointed at a different `BufferAttribute` (`node.value = otherAttribute`) between
 // `renderer.compute()` calls, the new attribute wasn't folded into the bind group's cache
 // key/version, so a stale bind group -- still wired to the previous attribute -- could be reused.
-// Each test below builds a compute kernel once, then repoints its storage node(s) immediately
-// before each dispatch, with no `await` in between, and checks that every dispatch actually wrote
-// to the buffer it was pointed at.
+// Fixed in `Bindings.js` by folding the attribute's id/version into the same cache key used for
+// sampled textures. Each test below builds a compute kernel once, then repoints its storage
+// node(s) immediately before each dispatch, with no `await` in between, and checks that every
+// dispatch actually wrote to the buffer it was pointed at.
 
 function makeBuffer( count, initialValue ) {
 
@@ -29,7 +27,7 @@ async function readBuffer( renderer, attribute, count ) {
 
 }
 
-// `vec2`-typed buffer, for tests that exercise a 2-component element type instead of `float`.
+// `vec2`-typed buffer, for the texture+storage test below.
 function makeVec2Buffer( count, initialX, initialY ) {
 
 	const data = new Float32Array( count * 2 );
@@ -62,6 +60,18 @@ async function readVec2Buffer( renderer, attribute, count ) {
 
 }
 
+function firstMismatch( count, isWrong ) {
+
+	for ( let i = 0; i < count; i ++ ) {
+
+		if ( isWrong( i ) ) return i;
+
+	}
+
+	return - 1;
+
+}
+
 export default QUnit.module( 'TSL', () => {
 
 	QUnit.module( 'Storage buffer node repointing (GPGPU, WebGPU-only)', () => {
@@ -85,70 +95,56 @@ export default QUnit.module( 'TSL', () => {
 
 		}
 
-		[ 8, 64, 256 ].forEach( ( iterations ) => {
+		repointTest( 'single shared kernel survives rapid back-to-back repointed dispatches', async ( assert, renderer ) => {
 
-			repointTest( `single shared kernel survives ${ iterations } rapid back-to-back repointed dispatches`, async ( assert, renderer ) => {
+			const count = 64;
+			const iterations = 32;
+			const initialValue = 1;
 
-				const count = 64;
-				const initialValue = 1;
+			const attrA = makeBuffer( count, initialValue );
+			const attrB = makeBuffer( count, 0 );
 
-				const attrA = makeBuffer( count, initialValue );
-				const attrB = makeBuffer( count, 0 );
+			// One shared, repointable read/write node pair. Built once; every iteration below
+			// reuses this same compiled kernel, only repointing `readNode`/`writeNode`'s `.value`
+			// beforehand -- never rebuilding it.
+			const readNode = storage( attrA, 'float', count ).toReadOnly();
+			const writeNode = storage( attrB, 'float', count );
 
-				// One shared, repointable read/write node pair.
-				const readNode = storage( attrA, 'float', count ).toReadOnly();
-				const writeNode = storage( attrB, 'float', count );
+			const kernel = Fn( () => {
 
-				// Built once; every iteration below reuses this same compiled kernel, only
-				// repointing `readNode`/`writeNode`'s `.value` beforehand -- never rebuilding it.
-				const kernel = Fn( () => {
+				const v = readNode.element( instanceIndex ).toVar();
+				writeNode.element( instanceIndex ).assign( v.add( 1 ) );
 
-					const v = readNode.element( instanceIndex ).toVar();
-					writeNode.element( instanceIndex ).assign( v.add( 1 ) );
+			} )().compute( count );
 
-				} )().compute( count );
+			let current = 'A'; // which attribute currently holds the live data
 
-				let current = 'A'; // which attribute currently holds the live data
+			for ( let i = 0; i < iterations; i ++ ) {
 
-				for ( let i = 0; i < iterations; i ++ ) {
+				readNode.value = current === 'A' ? attrA : attrB;
+				writeNode.value = current === 'A' ? attrB : attrA;
 
-					readNode.value = current === 'A' ? attrA : attrB;
-					writeNode.value = current === 'A' ? attrB : attrA;
+				renderer.compute( kernel );
 
-					renderer.compute( kernel );
+				current = current === 'A' ? 'B' : 'A';
 
-					current = current === 'A' ? 'B' : 'A';
+			}
 
-				}
+			// After the loop, `current` names the buffer the *next* pass would read from --
+			// i.e. the one the last dispatch just wrote to, which holds the live result.
+			const liveAttribute = current === 'A' ? attrA : attrB;
+			const result = await readBuffer( renderer, liveAttribute, count );
 
-				// After the loop, `current` names the buffer the *next* pass would read from --
-				// i.e. the one the last dispatch just wrote to, which holds the live result.
-				const liveAttribute = current === 'A' ? attrA : attrB;
-				const result = await readBuffer( renderer, liveAttribute, count );
+			const expected = initialValue + iterations;
+			const firstWrong = firstMismatch( count, ( i ) => result[ i ] !== expected );
 
-				const expected = initialValue + iterations;
-				let firstWrong = - 1;
+			assert.ok( firstWrong === - 1, firstWrong === - 1
+				? `all ${ count } elements equal ${ expected } after ${ iterations } repointed dispatches`
+				: `element ${ firstWrong } was ${ result[ firstWrong ] }, expected ${ expected } after ${ iterations } repointed dispatches (first mismatch)`
+			);
 
-				for ( let i = 0; i < count; i ++ ) {
-
-					if ( result[ i ] !== expected ) {
-
-						firstWrong = i;
-						break;
-
-					}
-
-				}
-
-				assert.ok( firstWrong === - 1, firstWrong === - 1
-					? `all ${ count } elements equal ${ expected } after ${ iterations } repointed dispatches`
-					: `element ${ firstWrong } was ${ result[ firstWrong ] }, expected ${ expected } after ${ iterations } repointed dispatches (first mismatch)`
-				);
-
-				attrA.dispose?.();
-				attrB.dispose?.();
-
-			} );
+			attrA.dispose?.();
+			attrB.dispose?.();
 
 		} );
 
@@ -160,7 +156,7 @@ export default QUnit.module( 'TSL', () => {
 			// matters.
 
 			const count = 64;
-			const iterations = 64;
+			const iterations = 32;
 
 			const attrA = makeBuffer( count, 1 );
 			const attrB = makeBuffer( count, 0 );
@@ -201,18 +197,7 @@ export default QUnit.module( 'TSL', () => {
 			const liveAttribute = current === 'A' ? attrA : attrB;
 			const result = await readBuffer( renderer, liveAttribute, count );
 
-			let firstWrong = - 1;
-
-			for ( let i = 0; i < count; i ++ ) {
-
-				if ( result[ i ] !== expected ) {
-
-					firstWrong = i;
-					break;
-
-				}
-
-			}
+			const firstWrong = firstMismatch( count, ( i ) => result[ i ] !== expected );
 
 			assert.ok( firstWrong === - 1, firstWrong === - 1
 				? `all ${ count } elements equal ${ expected } after ${ iterations } interleaved dispatches across 2 kernels`
@@ -224,685 +209,17 @@ export default QUnit.module( 'TSL', () => {
 
 		} );
 
-		repointTest( 'repeated repoint-and-dispatch runs stay correct across many separate calls (not just one long chain)', async ( assert, renderer ) => {
-
-			// Runs the single-kernel repoint chain from the first test many times over, each with
-			// its own fresh buffers/kernel, to catch nondeterministic corruption that a single run
-			// might not hit.
-
-			const count = 64;
-			const iterations = 32;
-			const runs = 12;
-
-			for ( let run = 0; run < runs; run ++ ) {
-
-				const initialValue = run + 1;
-
-				const attrA = makeBuffer( count, initialValue );
-				const attrB = makeBuffer( count, 0 );
-
-				const readNode = storage( attrA, 'float', count ).toReadOnly();
-				const writeNode = storage( attrB, 'float', count );
-
-				const kernel = Fn( () => {
-
-					const v = readNode.element( instanceIndex ).toVar();
-					writeNode.element( instanceIndex ).assign( v.add( 1 ) );
-
-				} )().compute( count );
-
-				let current = 'A';
-
-				for ( let i = 0; i < iterations; i ++ ) {
-
-					readNode.value = current === 'A' ? attrA : attrB;
-					writeNode.value = current === 'A' ? attrB : attrA;
-
-					renderer.compute( kernel );
-
-					current = current === 'A' ? 'B' : 'A';
-
-				}
-
-				const liveAttribute = current === 'A' ? attrA : attrB;
-				const result = await readBuffer( renderer, liveAttribute, count );
-
-				const expected = initialValue + iterations;
-				let firstWrong = - 1;
-
-				for ( let i = 0; i < count; i ++ ) {
-
-					if ( result[ i ] !== expected ) {
-
-						firstWrong = i;
-						break;
-
-					}
-
-				}
-
-				assert.ok( firstWrong === - 1, firstWrong === - 1
-					? `run ${ run }: all elements equal ${ expected }`
-					: `run ${ run }: element ${ firstWrong } was ${ result[ firstWrong ] }, expected ${ expected } (first mismatch)`
-				);
-
-				attrA.dispose?.();
-				attrB.dispose?.();
-
-			}
-
-		} );
-
-		// From here down: larger scale (`vec2` elements, up to 1,048,576 elements) and a uniform
-		// value changed on every dispatch in lockstep with the storage-node repointing, to check
-		// that scale and a concurrently-changing uniform don't affect the fix.
-
-		[ 65536, 1048576 ].forEach( ( count ) => {
-
-			repointTest( `vec2 buffer at large scale (${ count } elements) survives 32 rapid repointed dispatches`, async ( assert, renderer ) => {
-
-				const iterations = 32;
-
-				const attrA = makeVec2Buffer( count, 1, - 1 );
-				const attrB = makeVec2Buffer( count, 0, 0 );
-
-				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
-				const writeNode = storage( attrB, 'vec2', count );
-
-				const kernel = Fn( () => {
-
-					const v = readNode.element( instanceIndex ).toVar();
-					writeNode.element( instanceIndex ).assign( vec2( v.x.add( 1 ), v.y.sub( 1 ) ) );
-
-				} )().compute( count );
-
-				let current = 'A';
-
-				for ( let i = 0; i < iterations; i ++ ) {
-
-					readNode.value = current === 'A' ? attrA : attrB;
-					writeNode.value = current === 'A' ? attrB : attrA;
-
-					renderer.compute( kernel );
-
-					current = current === 'A' ? 'B' : 'A';
-
-				}
-
-				const liveAttribute = current === 'A' ? attrA : attrB;
-				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
-
-				const expectedX = 1 + iterations;
-				const expectedY = - 1 - iterations;
-				let firstWrong = - 1;
-
-				for ( let i = 0; i < count; i ++ ) {
-
-					if ( x[ i ] !== expectedX || y[ i ] !== expectedY ) {
-
-						firstWrong = i;
-						break;
-
-					}
-
-				}
-
-				assert.ok( firstWrong === - 1, firstWrong === - 1
-					? `all ${ count } elements equal (${ expectedX }, ${ expectedY }) after ${ iterations } repointed dispatches`
-					: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expectedX }, ${ expectedY }) (first mismatch)`
-				);
-
-				attrA.dispose?.();
-				attrB.dispose?.();
-
-			} );
-
-		} );
-
-		repointTest( 'uniform value changed every dispatch alongside repointed storage nodes (per-stage fallback shape, 1048576 elements x 20 stages)', async ( assert, renderer ) => {
-
-			// A uniform value and the storage-node repointing both change together immediately
-			// before each `renderer.compute()` call, with zero `await` between stages.
-
-			const count = 1048576; // 1024x1024
-			const stages = 20;
-
-			const attrA = makeVec2Buffer( count, 0, 0 );
-			const attrB = makeVec2Buffer( count, 0, 0 );
-
-			const readNode = storage( attrA, 'vec2', count ).toReadOnly();
-			const writeNode = storage( attrB, 'vec2', count );
-			const stageUniform = uniform( 1, 'uint' );
-
-			// out[i] = in[i] + stageUniform, kept trivial so the expected result stays exactly
-			// verifiable.
-			const kernel = Fn( () => {
-
-				const v = readNode.element( instanceIndex ).toVar();
-				const s = float( stageUniform );
-				writeNode.element( instanceIndex ).assign( vec2( v.x.add( s ), v.y ) );
-
-			} )().compute( count );
-
-			let current = 'A';
-			let expected = 0;
-
-			for ( let s = 0; s < stages; s ++ ) {
-
-				stageUniform.value = 1 << s;
-
-				readNode.value = current === 'A' ? attrA : attrB;
-				writeNode.value = current === 'A' ? attrB : attrA;
-
-				renderer.compute( kernel );
-
-				expected += 1 << s;
-				current = current === 'A' ? 'B' : 'A';
-
-			}
-
-			const liveAttribute = current === 'A' ? attrA : attrB;
-			const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
-
-			let firstWrong = - 1;
-
-			for ( let i = 0; i < count; i ++ ) {
-
-				if ( x[ i ] !== expected || y[ i ] !== 0 ) {
-
-					firstWrong = i;
-					break;
-
-				}
-
-			}
-
-			assert.ok( firstWrong === - 1, firstWrong === - 1
-				? `all ${ count } elements equal ${ expected } after ${ stages } stages of repointed dispatches`
-				: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) after ${ stages } stages (first mismatch)`
-			);
-
-			attrA.dispose?.();
-			attrB.dispose?.();
-
-		} );
-
-		repointTest( 'per-stage fallback shape repeated across 6 separate runs (1048576 elements x 20 stages each)', async ( assert, renderer ) => {
-
-			// Same as the previous test, but repeated -- to catch nondeterministic corruption a
-			// single run might not hit.
-
-			const count = 1048576;
-			const stages = 20;
-			const runs = 6;
-
-			for ( let run = 0; run < runs; run ++ ) {
-
-				const attrA = makeVec2Buffer( count, 0, 0 );
-				const attrB = makeVec2Buffer( count, 0, 0 );
-
-				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
-				const writeNode = storage( attrB, 'vec2', count );
-				const stageUniform = uniform( 1, 'uint' );
-
-				const kernel = Fn( () => {
-
-					const v = readNode.element( instanceIndex ).toVar();
-					const s = float( stageUniform );
-					writeNode.element( instanceIndex ).assign( vec2( v.x.add( s ), v.y ) );
-
-				} )().compute( count );
-
-				let current = 'A';
-				let expected = 0;
-
-				for ( let s = 0; s < stages; s ++ ) {
-
-					stageUniform.value = 1 << s;
-
-					readNode.value = current === 'A' ? attrA : attrB;
-					writeNode.value = current === 'A' ? attrB : attrA;
-
-					renderer.compute( kernel );
-
-					expected += 1 << s;
-					current = current === 'A' ? 'B' : 'A';
-
-				}
-
-				const liveAttribute = current === 'A' ? attrA : attrB;
-				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
-
-				let firstWrong = - 1;
-
-				for ( let i = 0; i < count; i ++ ) {
-
-					if ( x[ i ] !== expected || y[ i ] !== 0 ) {
-
-						firstWrong = i;
-						break;
-
-					}
-
-				}
-
-				assert.ok( firstWrong === - 1, firstWrong === - 1
-					? `run ${ run }: all elements equal ${ expected }`
-					: `run ${ run }: element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
-				);
-
-				attrA.dispose?.();
-				attrB.dispose?.();
-
-			}
-
-		} );
-
-		// A tiled, workgroup-shared-memory, 2D-dispatched transpose kernel, with an explicit
-		// `workgroupBarrier()` between the load and store phases -- structurally different from
-		// the flat, global-memory-only, 1D-dispatched kernels used above, to check that kernels
-		// alternating between these two shapes while sharing the same repointed nodes stay
-		// correct. Since a transpose is a pure permutation (it moves values, never changes them),
-		// composing transpose-forward + transpose-back is the identity -- so a value-preserving
-		// invariant stays checkable even through the permutation.
-		function buildTransposeKernel( rows, cols, tile, readNode, writeNode ) {
-
-			const sharedTile = workgroupArray( 'vec2', tile * tile );
-
-			const numWorkgroupsX = Math.ceil( cols / tile );
-			const numWorkgroupsY = Math.ceil( rows / tile );
-
-			return Fn( () => {
-
-				const gx = globalId.x;
-				const gy = globalId.y;
-				const lx = localId.x;
-				const ly = localId.y;
-				const wx = workgroupId.x;
-				const wy = workgroupId.y;
-
-				If( gx.lessThan( uint( cols ) ).and( gy.lessThan( uint( rows ) ) ), () => {
-
-					sharedTile.element( ly.mul( uint( tile ) ).add( lx ) ).assign( readNode.element( gy.mul( uint( cols ) ).add( gx ) ) );
-
-				} );
-
-				workgroupBarrier();
-
-				const outX = wy.mul( uint( tile ) ).add( lx );
-				const outY = wx.mul( uint( tile ) ).add( ly );
-
-				If( outX.lessThan( uint( rows ) ).and( outY.lessThan( uint( cols ) ) ), () => {
-
-					const v = sharedTile.element( lx.mul( uint( tile ) ).add( ly ) ).toVar();
-					writeNode.element( outY.mul( uint( rows ) ).add( outX ) ).assign( v );
-
-				} );
-
-			} )().compute( [ numWorkgroupsX, numWorkgroupsY ], [ tile, tile ] );
-
-		}
-
-		[[ 1024, 1024 ], [ 2048, 1024 ]].forEach( ( [ width, height ] ) => {
-
-			repointTest( `mixed global-memory / shared-memory kernels sharing repointed nodes, matching _runButterflyPasses' shape (${ width }x${ height })`, async ( assert, renderer ) => {
-
-				// A row pass (several per-stage dispatches, global memory) -> transpose (one
-				// dispatch, shared memory + barrier) -> column pass (several per-stage dispatches,
-				// global memory) -> transpose back (one dispatch, shared memory + barrier) -- all
-				// sharing the same 2 repointed nodes, no `await` anywhere in the sequence. The
-				// row/column math is a simple, position-independent `x += stageValue` so the
-				// expected result stays exactly checkable regardless of how the transposes permute
-				// element positions.
-
-				const count = width * height;
-				const tile = 16;
-				const rowStages = Math.round( Math.log2( width ) );
-				const colStages = Math.round( Math.log2( height ) );
-
-				const attrA = makeVec2Buffer( count, 0, 0 );
-				const attrB = makeVec2Buffer( count, 0, 0 );
-
-				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
-				const writeNode = storage( attrB, 'vec2', count );
-				const stageUniform = uniform( 1, 'uint' );
-
-				const addKernel = Fn( () => {
-
-					const v = readNode.element( instanceIndex ).toVar();
-					const s = float( stageUniform );
-					writeNode.element( instanceIndex ).assign( vec2( v.x.add( s ), v.y ) );
-
-				} )().compute( count );
-
-				const transposeFwdKernel = buildTransposeKernel( height, width, tile, readNode, writeNode );
-				const transposeBackKernel = buildTransposeKernel( width, height, tile, readNode, writeNode );
-
-				let current = 'A';
-				let expected = 0;
-
-				const dispatchPingPong = ( kernel ) => {
-
-					readNode.value = current === 'A' ? attrA : attrB;
-					writeNode.value = current === 'A' ? attrB : attrA;
-
-					renderer.compute( kernel );
-
-					current = current === 'A' ? 'B' : 'A';
-
-				};
-
-				for ( let s = 0; s < rowStages; s ++ ) {
-
-					stageUniform.value = 1 << s;
-					dispatchPingPong( addKernel );
-					expected += 1 << s;
-
-				}
-
-				dispatchPingPong( transposeFwdKernel );
-
-				for ( let s = 0; s < colStages; s ++ ) {
-
-					stageUniform.value = 1 << s;
-					dispatchPingPong( addKernel );
-					expected += 1 << s;
-
-				}
-
-				dispatchPingPong( transposeBackKernel );
-
-				const liveAttribute = current === 'A' ? attrA : attrB;
-				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
-
-				let firstWrong = - 1;
-
-				for ( let i = 0; i < count; i ++ ) {
-
-					if ( x[ i ] !== expected || y[ i ] !== 0 ) {
-
-						firstWrong = i;
-						break;
-
-					}
-
-				}
-
-				assert.ok( firstWrong === - 1, firstWrong === - 1
-					? `all ${ count } elements equal ${ expected } after the full row/transpose/col/transpose-back sequence`
-					: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
-				);
-
-				attrA.dispose?.();
-				attrB.dispose?.();
-
-			} );
-
-		} );
-
-		repointTest( 'mixed global-memory / shared-memory kernel sequence repeated across 6 separate runs (1024x1024)', async ( assert, renderer ) => {
-
-			// Same sequence as above, repeated, since a single run is not enough to trust a pass
-			// against nondeterministic corruption.
-
-			const width = 1024, height = 1024;
-			const count = width * height;
-			const tile = 16;
-			const rowStages = Math.round( Math.log2( width ) );
-			const colStages = Math.round( Math.log2( height ) );
-			const runs = 6;
-
-			for ( let run = 0; run < runs; run ++ ) {
-
-				const attrA = makeVec2Buffer( count, 0, 0 );
-				const attrB = makeVec2Buffer( count, 0, 0 );
-
-				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
-				const writeNode = storage( attrB, 'vec2', count );
-				const stageUniform = uniform( 1, 'uint' );
-
-				const addKernel = Fn( () => {
-
-					const v = readNode.element( instanceIndex ).toVar();
-					const s = float( stageUniform );
-					writeNode.element( instanceIndex ).assign( vec2( v.x.add( s ), v.y ) );
-
-				} )().compute( count );
-
-				const transposeFwdKernel = buildTransposeKernel( height, width, tile, readNode, writeNode );
-				const transposeBackKernel = buildTransposeKernel( width, height, tile, readNode, writeNode );
-
-				let current = 'A';
-				let expected = 0;
-
-				const dispatchPingPong = ( kernel ) => {
-
-					readNode.value = current === 'A' ? attrA : attrB;
-					writeNode.value = current === 'A' ? attrB : attrA;
-
-					renderer.compute( kernel );
-
-					current = current === 'A' ? 'B' : 'A';
-
-				};
-
-				for ( let s = 0; s < rowStages; s ++ ) {
-
-					stageUniform.value = 1 << s;
-					dispatchPingPong( addKernel );
-					expected += 1 << s;
-
-				}
-
-				dispatchPingPong( transposeFwdKernel );
-
-				for ( let s = 0; s < colStages; s ++ ) {
-
-					stageUniform.value = 1 << s;
-					dispatchPingPong( addKernel );
-					expected += 1 << s;
-
-				}
-
-				dispatchPingPong( transposeBackKernel );
-
-				const liveAttribute = current === 'A' ? attrA : attrB;
-				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
-
-				let firstWrong = - 1;
-
-				for ( let i = 0; i < count; i ++ ) {
-
-					if ( x[ i ] !== expected || y[ i ] !== 0 ) {
-
-						firstWrong = i;
-						break;
-
-					}
-
-				}
-
-				assert.ok( firstWrong === - 1, firstWrong === - 1
-					? `run ${ run }: all elements equal ${ expected }`
-					: `run ${ run }: element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
-				);
-
-				attrA.dispose?.();
-				attrB.dispose?.();
-
-			}
-
-		} );
-
-		// Every kernel above is cheap -- a handful of ALU ops per invocation. A kernel that runs
-		// measurably longer on the GPU gives any CPU/GPU timing race a bigger window, ruling out
-		// a driver-timing race rather than a pure JS-side binding bug (which should be
-		// timing-independent). This burns real GPU cycles (many `sin` calls) per invocation while
-		// keeping the arithmetic result exactly verifiable: `sin(i) - sin(i)` is exactly 0 in
-		// IEEE754 (same computed value subtracted from itself), so the busy-work never perturbs
-		// the expected total.
-		function buildSlowAddKernel( count, busyIterations, readNode, writeNode ) {
-
-			return Fn( () => {
-
-				const v = readNode.element( instanceIndex ).toVar();
-				const acc = float( 0 ).toVar();
-
-				Loop( { start: 0, end: busyIterations, type: 'int' }, ( { i } ) => {
-
-					const angle = float( i ).add( instanceIndex.toFloat() );
-					acc.assign( acc.add( sin( angle ) ).sub( sin( angle ) ) );
-
-				} );
-
-				writeNode.element( instanceIndex ).assign( vec2( v.x.add( 1 ).add( acc ), v.y.add( acc ) ) );
-
-			} )().compute( count );
-
-		}
-
-		[ 4, 64 ].forEach( ( busyIterations ) => {
-
-			repointTest( `slow kernel (${ busyIterations }x busy-work per invocation) sharing repointed nodes survives 64 rapid dispatches (1048576 elements)`, async ( assert, renderer ) => {
-
-				const count = 1048576;
-				const iterations = 64;
-
-				const attrA = makeVec2Buffer( count, 0, 0 );
-				const attrB = makeVec2Buffer( count, 0, 0 );
-
-				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
-				const writeNode = storage( attrB, 'vec2', count );
-
-				const kernel = buildSlowAddKernel( count, busyIterations, readNode, writeNode );
-
-				let current = 'A';
-
-				for ( let i = 0; i < iterations; i ++ ) {
-
-					readNode.value = current === 'A' ? attrA : attrB;
-					writeNode.value = current === 'A' ? attrB : attrA;
-
-					renderer.compute( kernel );
-
-					current = current === 'A' ? 'B' : 'A';
-
-				}
-
-				const liveAttribute = current === 'A' ? attrA : attrB;
-				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
-
-				const expectedX = iterations;
-				let firstWrong = - 1;
-
-				for ( let i = 0; i < count; i ++ ) {
-
-					if ( x[ i ] !== expectedX || y[ i ] !== 0 ) {
-
-						firstWrong = i;
-						break;
-
-					}
-
-				}
-
-				assert.ok( firstWrong === - 1, firstWrong === - 1
-					? `all ${ count } elements equal (${ expectedX }, 0) after ${ iterations } dispatches of a slow kernel`
-					: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expectedX }, 0) (first mismatch)`
-				);
-
-				attrA.dispose?.();
-				attrB.dispose?.();
-
-			} );
-
-		} );
-
-		// Combines the slow kernel with the mixed global-memory/shared-memory transpose sequence
-		// from above, repeated -- the most demanding single test in this file.
-		repointTest( 'slow kernels + transpose sequence sharing repointed nodes, repeated 4x (2048x1024)', async ( assert, renderer ) => {
-
-			const width = 2048, height = 1024;
-			const count = width * height;
-			const tile = 16;
-			const busyIterations = 16;
-			const rowStages = Math.round( Math.log2( width ) );
-			const colStages = Math.round( Math.log2( height ) );
-			const runs = 4;
-
-			for ( let run = 0; run < runs; run ++ ) {
-
-				const attrA = makeVec2Buffer( count, 0, 0 );
-				const attrB = makeVec2Buffer( count, 0, 0 );
-
-				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
-				const writeNode = storage( attrB, 'vec2', count );
-
-				const addKernel = buildSlowAddKernel( count, busyIterations, readNode, writeNode );
-				const transposeFwdKernel = buildTransposeKernel( height, width, tile, readNode, writeNode );
-				const transposeBackKernel = buildTransposeKernel( width, height, tile, readNode, writeNode );
-
-				let current = 'A';
-
-				const dispatchPingPong = ( kernel ) => {
-
-					readNode.value = current === 'A' ? attrA : attrB;
-					writeNode.value = current === 'A' ? attrB : attrA;
-
-					renderer.compute( kernel );
-
-					current = current === 'A' ? 'B' : 'A';
-
-				};
-
-				for ( let s = 0; s < rowStages; s ++ ) dispatchPingPong( addKernel );
-
-				dispatchPingPong( transposeFwdKernel );
-
-				for ( let s = 0; s < colStages; s ++ ) dispatchPingPong( addKernel );
-
-				dispatchPingPong( transposeBackKernel );
-
-				const liveAttribute = current === 'A' ? attrA : attrB;
-				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
-
-				const expected = rowStages + colStages;
-				let firstWrong = - 1;
-
-				for ( let i = 0; i < count; i ++ ) {
-
-					if ( x[ i ] !== expected || y[ i ] !== 0 ) {
-
-						firstWrong = i;
-						break;
-
-					}
-
-				}
-
-				assert.ok( firstWrong === - 1, firstWrong === - 1
-					? `run ${ run }: all elements equal (${ expected }, 0)`
-					: `run ${ run }: element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
-				);
-
-				attrA.dispose?.();
-				attrB.dispose?.();
-
-			}
-
-		} );
-
 		// The specific case this PR fixes: a kernel binds a *texture* alongside a storage buffer
 		// in the same bind group. If the same texture object is reused unchanged across calls
 		// while only the storage buffer's node is repointed to a different attribute, a bind-group
 		// cache keyed only on the texture's identity/version could return a bind group still wired
 		// to the previous storage attribute. This isolates exactly that: one texture, reused
 		// across many calls, while the storage write target alternates every call.
-		repointTest( 'texture+storage kernel reused with the same texture object across alternating storage targets (1024x1024)', async ( assert, renderer ) => {
+		repointTest( 'texture+storage kernel reused with the same texture object across alternating storage targets', async ( assert, renderer ) => {
 
-			const width = 1024, height = 1024;
+			const width = 64, height = 64;
 			const count = width * height;
-			const calls = 64;
+			const calls = 16;
 
 			const sourceData = new Float32Array( count * 4 );
 
@@ -956,17 +273,13 @@ export default QUnit.module( 'TSL', () => {
 
 				const { x, y } = await readVec2Buffer( renderer, targetAttribute, count );
 
-				for ( let i = 0; i < count; i ++ ) {
+				firstWrong = firstMismatch( count, ( i ) => x[ i ] !== 7 || y[ i ] !== 3 );
 
-					if ( x[ i ] !== 7 || y[ i ] !== 3 ) {
+				if ( firstWrong !== - 1 ) {
 
-						firstWrong = i;
-						firstWrongCall = call;
-						firstWrongValue = { x: x[ i ], y: y[ i ] };
-						firstWrongOtherBuffer = await readVec2Buffer( renderer, otherAttribute, count );
-						break;
-
-					}
+					firstWrongCall = call;
+					firstWrongValue = { x: x[ firstWrong ], y: y[ firstWrong ] };
+					firstWrongOtherBuffer = await readVec2Buffer( renderer, otherAttribute, count );
 
 				}
 

--- a/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
+++ b/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three/webgpu';
-import { Fn, instanceIndex, storage, texture, int, uint, ivec2 } from 'three/tsl';
+import { Fn, instanceIndex, storage, texture, int, uint, ivec2, vec2, renderGroup } from 'three/tsl';
 import { getSharedRenderer } from './gpu-test-utils.js';
 
 // Minimal reproduction for a WebGPU bind-group caching bug: when a storage buffer node's
@@ -10,6 +10,27 @@ import { getSharedRenderer } from './gpu-test-utils.js';
 // sampled textures. Each test below builds a compute kernel once, then repoints its storage
 // node(s) immediately before each dispatch, with no `await` in between, and checks that every
 // dispatch actually wrote to the buffer it was pointed at.
+//
+// Two related bugs, in the same function, are also covered here:
+// - The attribute-sync/cache-key logic above was (and, for the identity-sync half, always had
+//   been) gated behind `updateGroup()`, which for a storage node explicitly assigned to a
+//   non-default group (`renderGroup`/`frameGroup` via `.setGroup()`) can permanently return
+//   `false` after the first check -- since nothing ever calls `.update()` on those shared group
+//   nodes to bump their version. That silently dropped every repoint after the first for such a
+//   node. See the "non-default group" test below.
+// - A sampler's key (built from wrap/filter/anisotropy) was only recomputed when the bound
+//   texture's `version` changed, and even then was never folded into the bind-group cache key.
+//   Sampler-only setting changes don't bump `texture.version`, so a bind group could keep
+//   serving a stale sampler indefinitely. See the "sampler settings" test below.
+//
+// The cache-key fix above also means storage-only bind groups are now actually cached (they
+// previously always rebuilt from scratch, see the note on the first two tests below), so a
+// disposed attribute needs its cached entries evicted the same way `Textures.js` already does for
+// disposed textures -- otherwise `bindingsData.groups`/`versions` grow one entry per distinct
+// attribute id forever. The "dispose eviction" test below reaches into renderer internals
+// (`renderer._bindings`) to confirm that cleanup actually runs; there's no public API surface to
+// observe it through, so a black-box test can't tell a leaked cache entry from a correctly-evicted
+// one.
 
 function makeBuffer( count, initialValue ) {
 
@@ -95,6 +116,12 @@ export default QUnit.module( 'TSL', () => {
 
 		}
 
+		// Note: this test (and the interleaved-kernels one below it) would pass even without the
+		// cache-key fix -- a storage-only bind group never had a texture/uniform buffer binding to
+		// contribute a non-empty cache key, so it was always rebuilt from scratch regardless of
+		// caching correctness. They're kept as cheap regression/soak coverage over many repointed
+		// dispatches; the "texture+storage" and "non-default group" tests further down are what
+		// actually exercise the two bugs this file fixes.
 		repointTest( 'single shared kernel survives rapid back-to-back repointed dispatches', async ( assert, renderer ) => {
 
 			const count = 64;
@@ -295,6 +322,216 @@ export default QUnit.module( 'TSL', () => {
 			attrA.dispose?.();
 			attrB.dispose?.();
 			sourceTexture.dispose();
+
+		} );
+
+		// The non-default-group case this fix covers: a storage node explicitly assigned to
+		// `renderGroup` (via `.setGroup()`) instead of the default per-object group. Nothing ever
+		// bumps `renderGroup`'s own version for a compute-only kernel like this one, so
+		// `updateGroup()` returns `true` on the very first check and `false` on every one after --
+		// meaning the storage-buffer identity/cache-key sync has to run unconditionally, not
+		// gated behind that check, or every repoint after the first is silently dropped.
+		repointTest( 'storage node assigned to a non-default group (renderGroup) still tracks repointed dispatches', async ( assert, renderer ) => {
+
+			const count = 64;
+			const iterations = 32;
+			const initialValue = 1;
+
+			const attrA = makeBuffer( count, initialValue );
+			const attrB = makeBuffer( count, 0 );
+
+			const readNode = storage( attrA, 'float', count ).toReadOnly().setGroup( renderGroup );
+			const writeNode = storage( attrB, 'float', count ).setGroup( renderGroup );
+
+			const kernel = Fn( () => {
+
+				const v = readNode.element( instanceIndex ).toVar();
+				writeNode.element( instanceIndex ).assign( v.add( 1 ) );
+
+			} )().compute( count );
+
+			let current = 'A';
+
+			for ( let i = 0; i < iterations; i ++ ) {
+
+				readNode.value = current === 'A' ? attrA : attrB;
+				writeNode.value = current === 'A' ? attrB : attrA;
+
+				renderer.compute( kernel );
+
+				current = current === 'A' ? 'B' : 'A';
+
+			}
+
+			const liveAttribute = current === 'A' ? attrA : attrB;
+			const result = await readBuffer( renderer, liveAttribute, count );
+
+			const expected = initialValue + iterations;
+			const firstWrong = firstMismatch( count, ( i ) => result[ i ] !== expected );
+
+			assert.ok( firstWrong === - 1, firstWrong === - 1
+				? `all ${ count } elements equal ${ expected } after ${ iterations } repointed dispatches on a non-default (renderGroup) storage node`
+				: `element ${ firstWrong } was ${ result[ firstWrong ] }, expected ${ expected } after ${ iterations } repointed dispatches on a non-default (renderGroup) storage node (first mismatch)`
+			);
+
+			attrA.dispose?.();
+			attrB.dispose?.();
+
+		} );
+
+		// A second, independent bug living in the same cache mechanism: a sampler's key (built
+		// from wrap/filter/anisotropy) is only recomputed when the bound texture's `version`
+		// changes, and even then wasn't folded into the bind-group cache key. Changing only
+		// `wrapS` between dispatches -- with the same texture object, same `version` -- must
+		// still produce a fresh bind group with the new sampler, not a cached one still wired to
+		// the old wrap mode.
+		repointTest( 'reused texture+sampler kernel picks up a wrap-mode-only change with no version bump', async ( assert, renderer ) => {
+
+			const width = 4, height = 1;
+
+			// four distinct texels along x, byte-encoded in the red channel: 50, 100, 150, 200
+			// (normalized on sample to roughly 0.196, 0.392, 0.588, 0.784)
+			const sourceData = new Uint8Array( width * height * 4 );
+
+			for ( let i = 0; i < width; i ++ ) {
+
+				sourceData[ i * 4 ] = ( i + 1 ) * 50;
+				sourceData[ i * 4 + 1 ] = 0;
+				sourceData[ i * 4 + 2 ] = 0;
+				sourceData[ i * 4 + 3 ] = 255;
+
+			}
+
+			// UnsignedByteType (the default) so the texture stays filterable without depending on
+			// a `float32Filterable` backend feature -- LinearFilter is required for this test since
+			// NearestFilter alone makes a texture "unfilterable" and skips creating a sampler
+			// binding entirely (see `WGSLNodeBuilder.isUnfilterable()`), which would make this test
+			// not exercise the sampler code path at all.
+			const sourceTexture = new THREE.DataTexture( sourceData, width, height, THREE.RGBAFormat );
+			sourceTexture.magFilter = THREE.LinearFilter;
+			sourceTexture.minFilter = THREE.LinearFilter;
+			sourceTexture.wrapS = THREE.RepeatWrapping;
+			sourceTexture.needsUpdate = true;
+
+			const attr = makeBuffer( 1, - 1 );
+
+			const sourceNode = texture( sourceTexture );
+			const writeNode = storage( attr, 'float', 1 );
+
+			// u = 1.125 sits exactly on texel 0's center once wrapped (1.125 mod 1 = 0.125, and
+			// texel centers are at 0.125/0.375/0.625/0.875 across 4 texels) -- so RepeatWrapping
+			// reads texel 0 (~0.196) with no bilinear blending. ClampToEdgeWrapping instead clamps
+			// the coordinate to the last texel (~0.784), also blend-free since 1.125 is well past
+			// the last texel's half-texel boundary. `sourceNode` and its texture object are never
+			// repointed -- only `wrapS` changes, with no `needsUpdate`/version bump, between calls.
+			const sampleKernel = Fn( () => {
+
+				writeNode.element( 0 ).assign( sourceNode.sample( vec2( 1.125, 0.5 ) ).r );
+
+			} )().compute( 1 );
+
+			async function sampleOnce() {
+
+				renderer.compute( sampleKernel );
+
+				const data = await readBuffer( renderer, attr, 1 );
+
+				return data[ 0 ];
+
+			}
+
+			const tolerance = 0.03;
+			const texel0 = 50 / 255;
+			const texel3 = 200 / 255;
+
+			sourceTexture.wrapS = THREE.RepeatWrapping;
+			const repeatValue = await sampleOnce();
+
+			sourceTexture.wrapS = THREE.ClampToEdgeWrapping;
+			const clampValue = await sampleOnce();
+
+			sourceTexture.wrapS = THREE.RepeatWrapping;
+			const repeatValueAgain = await sampleOnce();
+
+			assert.ok( Math.abs( repeatValue - texel0 ) < tolerance,
+				`RepeatWrapping wraps u=1.125 to texel 0 (~${ texel0.toFixed( 3 ) }), got ${ repeatValue }` );
+			assert.ok( Math.abs( clampValue - texel3 ) < tolerance,
+				`ClampToEdgeWrapping clamps u=1.125 to the last texel (~${ texel3.toFixed( 3 ) }), got ${ clampValue }; a stale sampler would still report ~${ texel0.toFixed( 3 ) }` );
+			assert.ok( Math.abs( repeatValueAgain - texel0 ) < tolerance,
+				`switching wrapS back to RepeatWrapping (again with no version bump) is picked up, got ${ repeatValueAgain }` );
+
+			attr.dispose?.();
+			sourceTexture.dispose();
+
+		} );
+
+		// White-box: confirms `Bindings._destroyStorageBufferBindGroups()` actually runs and evicts
+		// the disposed attribute's cache entries, rather than just trusting that the code exists.
+		// This reaches into `renderer._bindings` since bind-group cache state isn't exposed
+		// publicly.
+		repointTest( 'disposing a storage attribute evicts its cached bind-group entries', async ( assert, renderer ) => {
+
+			const count = 8;
+
+			const attrA = makeBuffer( count, 1 );
+			const attrB = makeBuffer( count, 0 );
+
+			const readNode = storage( attrA, 'float', count ).toReadOnly();
+			const writeNode = storage( attrB, 'float', count );
+
+			const kernel = Fn( () => {
+
+				const v = readNode.element( instanceIndex ).toVar();
+				writeNode.element( instanceIndex ).assign( v.add( 1 ) );
+
+			} )().compute( count );
+
+			// dispatch once to build the bind group, then repoint and dispatch again so at least
+			// two distinct cache-key entries accumulate for this bind group before disposal
+			renderer.compute( kernel );
+
+			readNode.value = attrB;
+			writeNode.value = attrA;
+			renderer.compute( kernel );
+
+			const bindings = renderer._bindings;
+			const bindGroups = bindings.getForCompute( kernel );
+
+			// find the bind group holding the storage binding now pointed at `attrA`
+			let storageBindGroup = null;
+
+			for ( const bindGroup of bindGroups ) {
+
+				if ( bindGroup.bindings.some( ( binding ) => binding.isStorageBuffer && binding.attribute === attrA ) ) {
+
+					storageBindGroup = bindGroup;
+
+				}
+
+			}
+
+			assert.ok( storageBindGroup !== null, 'found the bind group holding the repointed storage attribute' );
+
+			const attributeData = bindings.attributes.get( attrA );
+
+			assert.ok( attributeData.bindGroups instanceof Set && attributeData.bindGroups.has( storageBindGroup ),
+				'Bindings tracks that this bind group references attrA' );
+
+			const bindGroupData = bindings.backend.get( storageBindGroup );
+
+			assert.ok( bindGroupData.groups && Object.keys( bindGroupData.groups ).length > 0,
+				'the bind group has at least one cached GPU bind-group entry before disposal' );
+
+			attrA.dispose();
+
+			assert.strictEqual( attributeData.bindGroups.size, 0,
+				'the attribute-to-bind-group tracking set is cleared after dispose' );
+			assert.strictEqual( bindGroupData.groups, undefined,
+				'the disposed attribute\'s cached GPU bind-group entries are evicted' );
+			assert.strictEqual( bindGroupData.versions, undefined,
+				'the disposed attribute\'s cached version entries are evicted' );
+
+			attrB.dispose?.();
 
 		} );
 

--- a/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
+++ b/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
@@ -299,7 +299,7 @@ export default QUnit.module( 'TSL', () => {
 
 		[ 65536, 1048576 ].forEach( ( count ) => {
 
-			repointTest( `vec2 buffer at FFT2D scale (${ count } elements) survives 32 rapid repointed dispatches`, async ( assert, renderer ) => {
+			repointTest( `vec2 buffer at large scale (${ count } elements) survives 32 rapid repointed dispatches`, async ( assert, renderer ) => {
 
 				const iterations = 32;
 
@@ -734,15 +734,13 @@ export default QUnit.module( 'TSL', () => {
 
 		} );
 
-		// Every kernel above is cheap -- a handful of ALU ops per invocation. FFT2D's real
-		// butterfly kernels do meaningfully more work per invocation (cos/sin twiddle factors,
-		// several reads/writes), so real dispatches run measurably longer on the GPU. If the
-		// corruption is a genuine race between the CPU re-pointing nodes and what the GPU has
-		// actually consumed -- rather than a pure JS-side binding bug, which should be timing-
-		// independent -- a longer-running kernel gives that race a bigger window. This burns real
-		// GPU cycles (many `sin` calls) per invocation while keeping the arithmetic result exactly
-		// verifiable: `sin(i) - sin(i)` is exactly 0 in IEEE754 (same computed value subtracted
-		// from itself), so the busy-work never perturbs the expected total.
+		// Every kernel above is cheap -- a handful of ALU ops per invocation. A kernel that runs
+		// measurably longer on the GPU gives any CPU/GPU timing race a bigger window, ruling out
+		// a driver-timing race rather than a pure JS-side binding bug (which should be
+		// timing-independent). This burns real GPU cycles (many `sin` calls) per invocation while
+		// keeping the arithmetic result exactly verifiable: `sin(i) - sin(i)` is exactly 0 in
+		// IEEE754 (same computed value subtracted from itself), so the busy-work never perturbs
+		// the expected total.
 		function buildSlowAddKernel( count, busyIterations, readNode, writeNode ) {
 
 			return Fn( () => {
@@ -821,9 +819,7 @@ export default QUnit.module( 'TSL', () => {
 		} );
 
 		// Combines the slow kernel with the mixed global-memory/shared-memory transpose sequence
-		// from above, at hardwood's actual scale, repeated -- the most demanding single test in
-		// this file: real element count, real mixed kernel shapes, and per-invocation duration
-		// closer to the real butterfly math than anything tested so far.
+		// from above, repeated -- the most demanding single test in this file.
 		repointTest( 'slow kernels + transpose sequence sharing repointed nodes, repeated 4x (2048x1024)', async ( assert, renderer ) => {
 
 			const width = 2048, height = 1024;
@@ -896,16 +892,12 @@ export default QUnit.module( 'TSL', () => {
 
 		} );
 
-		// A different untested factor: `_load`/`_store` bind a *texture* alongside a storage
-		// buffer in the same kernel. The WebGPU backend's bind-group cache key is built ONLY from
-		// texture identity/version (`cacheKey += texture.id + ','`, `version += texture.version`
-		// in Bindings.js) -- a storage buffer's attribute changing contributes nothing to that key.
-		// So if the *same* texture object is reused across calls (exactly what happens when
-		// webgpu_fft_2d.html's `resourceCache` reuses `complexSource[c]` across preset switches of
-		// the same size) while only the storage side has been repointed, a cache lookup keyed
-		// purely on the unchanged texture could return a bind group still wired to the *previous*
-		// storage attribute. This isolates exactly that: one texture, reused across many calls,
-		// while the storage write target alternates every call.
+		// The specific case this PR fixes: a kernel binds a *texture* alongside a storage buffer
+		// in the same bind group. If the same texture object is reused unchanged across calls
+		// while only the storage buffer's node is repointed to a different attribute, a bind-group
+		// cache keyed only on the texture's identity/version could return a bind group still wired
+		// to the previous storage attribute. This isolates exactly that: one texture, reused
+		// across many calls, while the storage write target alternates every call.
 		repointTest( 'texture+storage kernel reused with the same texture object across alternating storage targets (1024x1024)', async ( assert, renderer ) => {
 
 			const width = 1024, height = 1024;
@@ -932,9 +924,9 @@ export default QUnit.module( 'TSL', () => {
 			const sourceNode = texture( sourceTexture );
 			const writeNode = storage( attrA, 'vec2', count );
 
-			// texture -> storage, exactly FFT2D._load's shape (2D-indexed texture read, flat
-			// storage write) -- built once, `sourceNode` never repointed (same texture every
-			// call), only `writeNode.value` alternates.
+			// texture -> storage: a 2D-indexed texture read, flat storage write -- built once,
+			// `sourceNode` never repointed (same texture every call), only `writeNode.value`
+			// alternates.
 			const loadKernel = Fn( () => {
 
 				const x = instanceIndex.mod( uint( width ) );

--- a/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
+++ b/test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js
@@ -1,0 +1,1020 @@
+import * as THREE from 'three/webgpu';
+import {
+	Fn, If, Loop, instanceIndex, storage, texture, uniform, vec2, float, int, uint, ivec2, sin,
+	workgroupArray, workgroupBarrier, workgroupId, globalId, localId
+} from 'three/tsl';
+import { getSharedRenderer } from './gpu-test-utils.js';
+
+// A minimal, FFT-independent repro of the mechanism suspected in FFT2D.js's ping-pong buffer
+// sharing attempt (see that file's constructor comment): a *single* compiled compute kernel,
+// built once, whose storage buffer nodes are repointed (`.value = someOtherAttribute`) at a
+// *different* buffer immediately before each of many back-to-back `renderer.compute()` calls,
+// with no `await` between them. FFT2D's version of this pattern intermittently corrupted data on
+// real hardware for large (non-fused, many-dispatch-per-transform) images; this test strips away
+// the FFT math entirely to isolate just the repointing mechanism, so a failure here would confirm
+// a genuine three.js/TSL WebGPU-backend bug rather than anything FFT-specific.
+//
+// Two ping-pong `StorageBufferAttribute`s (`bufA`/`bufB`), one `float` each, `count` elements.
+// One kernel, built once: `out[i] = in[i] + 1`. `count` iterations run back-to-back, alternating
+// which buffer is "in" and which is "out" (mirroring `FFT2D`'s reverted `_dispatchPingPong`), all
+// recorded before the first readback. If every dispatch's bind group correctly captured the
+// node values *at the time `renderer.compute()` was called*, the final live buffer holds
+// `initial + iterations` in every element; any staleness/aliasing in that repointing would show
+// up as a wrong value there.
+
+function makeBuffer( count, initialValue ) {
+
+	const data = new Float32Array( count ).fill( initialValue );
+
+	return new THREE.StorageBufferAttribute( data, 1 );
+
+}
+
+async function readBuffer( renderer, attribute, count ) {
+
+	const data = new Float32Array( await renderer.getArrayBufferAsync( attribute ) );
+
+	return data.slice( 0, count );
+
+}
+
+// `vec2`-typed buffer, matching FFT2D's actual `(real, imag)` element type (as opposed to the
+// `float` used above) and, in the tests below, FFT2D's actual `width*height` element counts.
+function makeVec2Buffer( count, initialX, initialY ) {
+
+	const data = new Float32Array( count * 2 );
+
+	for ( let i = 0; i < count; i ++ ) {
+
+		data[ i * 2 ] = initialX;
+		data[ i * 2 + 1 ] = initialY;
+
+	}
+
+	return new THREE.StorageBufferAttribute( data, 2 );
+
+}
+
+async function readVec2Buffer( renderer, attribute, count ) {
+
+	const data = new Float32Array( await renderer.getArrayBufferAsync( attribute ) );
+	const x = new Float32Array( count );
+	const y = new Float32Array( count );
+
+	for ( let i = 0; i < count; i ++ ) {
+
+		x[ i ] = data[ i * 2 ];
+		y[ i ] = data[ i * 2 + 1 ];
+
+	}
+
+	return { x, y };
+
+}
+
+export default QUnit.module( 'TSL', () => {
+
+	QUnit.module( 'Storage buffer node repointing (GPGPU, WebGPU-only)', () => {
+
+		function repointTest( name, run ) {
+
+			QUnit.test( name, async ( assert ) => {
+
+				const renderer = await getSharedRenderer( 'webgpu' );
+
+				if ( renderer === null ) {
+
+					assert.ok( true, 'SKIPPED: "webgpu" backend is not available in this environment.' );
+					return;
+
+				}
+
+				await run( assert, renderer );
+
+			} );
+
+		}
+
+		[ 8, 64, 256 ].forEach( ( iterations ) => {
+
+			repointTest( `single shared kernel survives ${ iterations } rapid back-to-back repointed dispatches`, async ( assert, renderer ) => {
+
+				const count = 64;
+				const initialValue = 1;
+
+				const attrA = makeBuffer( count, initialValue );
+				const attrB = makeBuffer( count, 0 );
+
+				// One shared, repointable read/write node pair -- exactly the pattern reverted in
+				// FFT2D.js. `readNode` is read-only, matching FFT2D's usage.
+				const readNode = storage( attrA, 'float', count ).toReadOnly();
+				const writeNode = storage( attrB, 'float', count );
+
+				// Built once; every iteration below reuses this same compiled kernel, only
+				// repointing `readNode`/`writeNode`'s `.value` beforehand -- never rebuilding it.
+				const kernel = Fn( () => {
+
+					const v = readNode.element( instanceIndex ).toVar();
+					writeNode.element( instanceIndex ).assign( v.add( 1 ) );
+
+				} )().compute( count );
+
+				let current = 'A'; // which attribute currently holds the live data
+
+				for ( let i = 0; i < iterations; i ++ ) {
+
+					readNode.value = current === 'A' ? attrA : attrB;
+					writeNode.value = current === 'A' ? attrB : attrA;
+
+					renderer.compute( kernel );
+
+					current = current === 'A' ? 'B' : 'A';
+
+				}
+
+				// After the loop, `current` names the buffer the *next* pass would read from --
+				// i.e. the one the last dispatch just wrote to, which holds the live result.
+				const liveAttribute = current === 'A' ? attrA : attrB;
+				const result = await readBuffer( renderer, liveAttribute, count );
+
+				const expected = initialValue + iterations;
+				let firstWrong = -1;
+
+				for ( let i = 0; i < count; i ++ ) {
+
+					if ( result[ i ] !== expected ) {
+
+						firstWrong = i;
+						break;
+
+					}
+
+				}
+
+				assert.ok( firstWrong === -1, firstWrong === -1
+					? `all ${ count } elements equal ${ expected } after ${ iterations } repointed dispatches`
+					: `element ${ firstWrong } was ${ result[ firstWrong ] }, expected ${ expected } after ${ iterations } repointed dispatches (first mismatch)`
+				);
+
+				attrA.dispose?.();
+				attrB.dispose?.();
+
+			} );
+
+		} );
+
+		repointTest( 'two distinct kernels sharing one repointed node pair stay correct when interleaved', async ( assert, renderer ) => {
+
+			// Closer to FFT2D's real shape: several *different* compiled kernels (not just one)
+			// all referencing the same shared read/write node pair, dispatched in an interleaved
+			// sequence -- in case cross-kernel bind-group aliasing on the shared nodes, rather
+			// than same-kernel reuse, is what matters.
+
+			const count = 64;
+			const iterations = 64;
+
+			const attrA = makeBuffer( count, 1 );
+			const attrB = makeBuffer( count, 0 );
+
+			const readNode = storage( attrA, 'float', count ).toReadOnly();
+			const writeNode = storage( attrB, 'float', count );
+
+			const incrementKernel = Fn( () => {
+
+				const v = readNode.element( instanceIndex ).toVar();
+				writeNode.element( instanceIndex ).assign( v.add( 1 ) );
+
+			} )().compute( count );
+
+			const doubleKernel = Fn( () => {
+
+				const v = readNode.element( instanceIndex ).toVar();
+				writeNode.element( instanceIndex ).assign( v.mul( 2 ) );
+
+			} )().compute( count );
+
+			let current = 'A';
+			let expected = 1;
+
+			for ( let i = 0; i < iterations; i ++ ) {
+
+				readNode.value = current === 'A' ? attrA : attrB;
+				writeNode.value = current === 'A' ? attrB : attrA;
+
+				const useDouble = ( i % 3 === 0 );
+				renderer.compute( useDouble ? doubleKernel : incrementKernel );
+				expected = useDouble ? expected * 2 : expected + 1;
+
+				current = current === 'A' ? 'B' : 'A';
+
+			}
+
+			const liveAttribute = current === 'A' ? attrA : attrB;
+			const result = await readBuffer( renderer, liveAttribute, count );
+
+			let firstWrong = -1;
+
+			for ( let i = 0; i < count; i ++ ) {
+
+				if ( result[ i ] !== expected ) {
+
+					firstWrong = i;
+					break;
+
+				}
+
+			}
+
+			assert.ok( firstWrong === -1, firstWrong === -1
+				? `all ${ count } elements equal ${ expected } after ${ iterations } interleaved dispatches across 2 kernels`
+				: `element ${ firstWrong } was ${ result[ firstWrong ] }, expected ${ expected } (first mismatch)`
+			);
+
+			attrA.dispose?.();
+			attrB.dispose?.();
+
+		} );
+
+		repointTest( 'repeated repoint-and-dispatch runs stay correct across many separate calls (not just one long chain)', async ( assert, renderer ) => {
+
+			// Runs the single-kernel repoint chain from the first test many times over, each with
+			// its own fresh buffers/kernel, to catch nondeterministic ("sometimes") corruption that
+			// a single run might not hit -- matching what was actually observed (works most of the
+			// time, occasionally doesn't).
+
+			const count = 64;
+			const iterations = 32;
+			const runs = 12;
+
+			for ( let run = 0; run < runs; run ++ ) {
+
+				const initialValue = run + 1;
+
+				const attrA = makeBuffer( count, initialValue );
+				const attrB = makeBuffer( count, 0 );
+
+				const readNode = storage( attrA, 'float', count ).toReadOnly();
+				const writeNode = storage( attrB, 'float', count );
+
+				const kernel = Fn( () => {
+
+					const v = readNode.element( instanceIndex ).toVar();
+					writeNode.element( instanceIndex ).assign( v.add( 1 ) );
+
+				} )().compute( count );
+
+				let current = 'A';
+
+				for ( let i = 0; i < iterations; i ++ ) {
+
+					readNode.value = current === 'A' ? attrA : attrB;
+					writeNode.value = current === 'A' ? attrB : attrA;
+
+					renderer.compute( kernel );
+
+					current = current === 'A' ? 'B' : 'A';
+
+				}
+
+				const liveAttribute = current === 'A' ? attrA : attrB;
+				const result = await readBuffer( renderer, liveAttribute, count );
+
+				const expected = initialValue + iterations;
+				let firstWrong = -1;
+
+				for ( let i = 0; i < count; i ++ ) {
+
+					if ( result[ i ] !== expected ) {
+
+						firstWrong = i;
+						break;
+
+					}
+
+				}
+
+				assert.ok( firstWrong === -1, firstWrong === -1
+					? `run ${ run }: all elements equal ${ expected }`
+					: `run ${ run }: element ${ firstWrong } was ${ result[ firstWrong ] }, expected ${ expected } (first mismatch)`
+				);
+
+				attrA.dispose?.();
+				attrB.dispose?.();
+
+			}
+
+		} );
+
+		// From here down: closer in *scale* and *shape* to FFT2D's actual butterfly-stage kernels
+		// (which is where the real corruption showed up), not just the mechanism in isolation --
+		// `vec2` elements at FFT2D's real `width*height` element counts, and a uniform value
+		// changed on every dispatch in lockstep with the storage-node repointing, exactly
+		// mirroring `_runAxisPass`'s non-fused fallback loop (`this._pUniform.value = 1 << s;
+		// renderer.compute(...)`). If the isolated, small-scale repoint above is safe but this
+		// isn't, that would point at scale/uniform-interaction rather than repointing itself.
+
+		[ 65536, 1048576 ].forEach( ( count ) => {
+
+			repointTest( `vec2 buffer at FFT2D scale (${ count } elements) survives 32 rapid repointed dispatches`, async ( assert, renderer ) => {
+
+				const iterations = 32;
+
+				const attrA = makeVec2Buffer( count, 1, -1 );
+				const attrB = makeVec2Buffer( count, 0, 0 );
+
+				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
+				const writeNode = storage( attrB, 'vec2', count );
+
+				const kernel = Fn( () => {
+
+					const v = readNode.element( instanceIndex ).toVar();
+					writeNode.element( instanceIndex ).assign( vec2( v.x.add( 1 ), v.y.sub( 1 ) ) );
+
+				} )().compute( count );
+
+				let current = 'A';
+
+				for ( let i = 0; i < iterations; i ++ ) {
+
+					readNode.value = current === 'A' ? attrA : attrB;
+					writeNode.value = current === 'A' ? attrB : attrA;
+
+					renderer.compute( kernel );
+
+					current = current === 'A' ? 'B' : 'A';
+
+				}
+
+				const liveAttribute = current === 'A' ? attrA : attrB;
+				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
+
+				const expectedX = 1 + iterations;
+				const expectedY = -1 - iterations;
+				let firstWrong = -1;
+
+				for ( let i = 0; i < count; i ++ ) {
+
+					if ( x[ i ] !== expectedX || y[ i ] !== expectedY ) {
+
+						firstWrong = i;
+						break;
+
+					}
+
+				}
+
+				assert.ok( firstWrong === -1, firstWrong === -1
+					? `all ${ count } elements equal (${ expectedX }, ${ expectedY }) after ${ iterations } repointed dispatches`
+					: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expectedX }, ${ expectedY }) (first mismatch)`
+				);
+
+				attrA.dispose?.();
+				attrB.dispose?.();
+
+			} );
+
+		} );
+
+		repointTest( 'uniform value changed every dispatch alongside repointed storage nodes (per-stage fallback shape, 1048576 elements x 20 stages)', async ( assert, renderer ) => {
+
+			// This is the closest analog to what actually broke: FFT2D's `buildMultiDispatchStage`
+			// fallback dispatches once per stage (`log2(N)` times) over the *whole* buffer, at real
+			// image scale, changing `_pUniform.value` and repointing the storage nodes together
+			// immediately before each `renderer.compute()` call, with zero `await` between stages.
+
+			const count = 1048576; // 1024x1024, matching the reported "brick"/"hardwood" scale
+			const stages = 20; // comfortably more than log2(1048576) = 20 for a single axis
+
+			const attrA = makeVec2Buffer( count, 0, 0 );
+			const attrB = makeVec2Buffer( count, 0, 0 );
+
+			const readNode = storage( attrA, 'vec2', count ).toReadOnly();
+			const writeNode = storage( attrB, 'vec2', count );
+			const stageUniform = uniform( 1, 'uint' );
+
+			// out[i] = in[i] + stageUniform -- mirrors `_pUniform` being read inside the real
+			// per-stage kernel body, just with trivial (but exactly verifiable) math instead of the
+			// real butterfly.
+			const kernel = Fn( () => {
+
+				const v = readNode.element( instanceIndex ).toVar();
+				const s = float( stageUniform );
+				writeNode.element( instanceIndex ).assign( vec2( v.x.add( s ), v.y ) );
+
+			} )().compute( count );
+
+			let current = 'A';
+			let expected = 0;
+
+			for ( let s = 0; s < stages; s ++ ) {
+
+				stageUniform.value = 1 << s;
+
+				readNode.value = current === 'A' ? attrA : attrB;
+				writeNode.value = current === 'A' ? attrB : attrA;
+
+				renderer.compute( kernel );
+
+				expected += 1 << s;
+				current = current === 'A' ? 'B' : 'A';
+
+			}
+
+			const liveAttribute = current === 'A' ? attrA : attrB;
+			const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
+
+			let firstWrong = -1;
+
+			for ( let i = 0; i < count; i ++ ) {
+
+				if ( x[ i ] !== expected || y[ i ] !== 0 ) {
+
+					firstWrong = i;
+					break;
+
+				}
+
+			}
+
+			assert.ok( firstWrong === -1, firstWrong === -1
+				? `all ${ count } elements equal ${ expected } after ${ stages } stages of repointed dispatches`
+				: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) after ${ stages } stages (first mismatch)`
+			);
+
+			attrA.dispose?.();
+			attrB.dispose?.();
+
+		} );
+
+		repointTest( 'per-stage fallback shape repeated across 6 separate runs (1048576 elements x 20 stages each)', async ( assert, renderer ) => {
+
+			// Same as the previous test, but repeated -- to catch nondeterministic corruption a
+			// single run might not hit, at the scale most likely to matter.
+
+			const count = 1048576;
+			const stages = 20;
+			const runs = 6;
+
+			for ( let run = 0; run < runs; run ++ ) {
+
+				const attrA = makeVec2Buffer( count, 0, 0 );
+				const attrB = makeVec2Buffer( count, 0, 0 );
+
+				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
+				const writeNode = storage( attrB, 'vec2', count );
+				const stageUniform = uniform( 1, 'uint' );
+
+				const kernel = Fn( () => {
+
+					const v = readNode.element( instanceIndex ).toVar();
+					const s = float( stageUniform );
+					writeNode.element( instanceIndex ).assign( vec2( v.x.add( s ), v.y ) );
+
+				} )().compute( count );
+
+				let current = 'A';
+				let expected = 0;
+
+				for ( let s = 0; s < stages; s ++ ) {
+
+					stageUniform.value = 1 << s;
+
+					readNode.value = current === 'A' ? attrA : attrB;
+					writeNode.value = current === 'A' ? attrB : attrA;
+
+					renderer.compute( kernel );
+
+					expected += 1 << s;
+					current = current === 'A' ? 'B' : 'A';
+
+				}
+
+				const liveAttribute = current === 'A' ? attrA : attrB;
+				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
+
+				let firstWrong = -1;
+
+				for ( let i = 0; i < count; i ++ ) {
+
+					if ( x[ i ] !== expected || y[ i ] !== 0 ) {
+
+						firstWrong = i;
+						break;
+
+					}
+
+				}
+
+				assert.ok( firstWrong === -1, firstWrong === -1
+					? `run ${ run }: all elements equal ${ expected }`
+					: `run ${ run }: element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
+				);
+
+				attrA.dispose?.();
+				attrB.dispose?.();
+
+			}
+
+		} );
+
+		// A faithful copy of FFT2D.js's `buildTransposeStage` (minus the conjugate/scale option):
+		// a tiled, workgroup-shared-memory, 2D-dispatched transpose, with an explicit
+		// `workgroupBarrier()` between the load and store phases. Every other kernel in this file
+		// is a flat, global-memory-only, 1D-dispatched kernel -- structurally nothing like this.
+		// `_runButterflyPasses` in FFT2D.js alternates between exactly these two *kinds* of kernel
+		// (global-memory row/column passes, shared-memory transpose passes) sharing the same
+		// repointed nodes throughout, which nothing above actually exercises. Since a transpose is
+		// a pure permutation (it moves values, never changes them), composing
+		// transpose-forward + transpose-back is the identity -- so a value-preserving invariant
+		// stays checkable even through the permutation.
+		function buildTransposeKernel( rows, cols, tile, readNode, writeNode ) {
+
+			const sharedTile = workgroupArray( 'vec2', tile * tile );
+
+			const numWorkgroupsX = Math.ceil( cols / tile );
+			const numWorkgroupsY = Math.ceil( rows / tile );
+
+			return Fn( () => {
+
+				const gx = globalId.x;
+				const gy = globalId.y;
+				const lx = localId.x;
+				const ly = localId.y;
+				const wx = workgroupId.x;
+				const wy = workgroupId.y;
+
+				If( gx.lessThan( uint( cols ) ).and( gy.lessThan( uint( rows ) ) ), () => {
+
+					sharedTile.element( ly.mul( uint( tile ) ).add( lx ) ).assign( readNode.element( gy.mul( uint( cols ) ).add( gx ) ) );
+
+				} );
+
+				workgroupBarrier();
+
+				const outX = wy.mul( uint( tile ) ).add( lx );
+				const outY = wx.mul( uint( tile ) ).add( ly );
+
+				If( outX.lessThan( uint( rows ) ).and( outY.lessThan( uint( cols ) ) ), () => {
+
+					const v = sharedTile.element( lx.mul( uint( tile ) ).add( ly ) ).toVar();
+					writeNode.element( outY.mul( uint( rows ) ).add( outX ) ).assign( v );
+
+				} );
+
+			} )().compute( [ numWorkgroupsX, numWorkgroupsY ], [ tile, tile ] );
+
+		}
+
+		[ [ 1024, 1024 ], [ 2048, 1024 ] ].forEach( ( [ width, height ] ) => {
+
+			repointTest( `mixed global-memory / shared-memory kernels sharing repointed nodes, matching _runButterflyPasses' shape (${ width }x${ height })`, async ( assert, renderer ) => {
+
+				// Mirrors _runButterflyPasses' literal sequence: row pass (several per-stage
+				// dispatches, global memory) -> transpose (one dispatch, shared memory + barrier)
+				// -> column pass (several per-stage dispatches, global memory) -> transpose back
+				// (one dispatch, shared memory + barrier) -- all sharing the same 2 repointed nodes,
+				// no `await` anywhere in the sequence. The row/column "butterfly" math is replaced
+				// by a simple, position-independent `x += stageValue` so the expected result stays
+				// exactly checkable regardless of how the transposes permute element positions.
+
+				const count = width * height;
+				const tile = 16;
+				const rowStages = Math.round( Math.log2( width ) );
+				const colStages = Math.round( Math.log2( height ) );
+
+				const attrA = makeVec2Buffer( count, 0, 0 );
+				const attrB = makeVec2Buffer( count, 0, 0 );
+
+				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
+				const writeNode = storage( attrB, 'vec2', count );
+				const stageUniform = uniform( 1, 'uint' );
+
+				const addKernel = Fn( () => {
+
+					const v = readNode.element( instanceIndex ).toVar();
+					const s = float( stageUniform );
+					writeNode.element( instanceIndex ).assign( vec2( v.x.add( s ), v.y ) );
+
+				} )().compute( count );
+
+				const transposeFwdKernel = buildTransposeKernel( height, width, tile, readNode, writeNode );
+				const transposeBackKernel = buildTransposeKernel( width, height, tile, readNode, writeNode );
+
+				let current = 'A';
+				let expected = 0;
+
+				const dispatchPingPong = ( kernel ) => {
+
+					readNode.value = current === 'A' ? attrA : attrB;
+					writeNode.value = current === 'A' ? attrB : attrA;
+
+					renderer.compute( kernel );
+
+					current = current === 'A' ? 'B' : 'A';
+
+				};
+
+				for ( let s = 0; s < rowStages; s ++ ) {
+
+					stageUniform.value = 1 << s;
+					dispatchPingPong( addKernel );
+					expected += 1 << s;
+
+				}
+
+				dispatchPingPong( transposeFwdKernel );
+
+				for ( let s = 0; s < colStages; s ++ ) {
+
+					stageUniform.value = 1 << s;
+					dispatchPingPong( addKernel );
+					expected += 1 << s;
+
+				}
+
+				dispatchPingPong( transposeBackKernel );
+
+				const liveAttribute = current === 'A' ? attrA : attrB;
+				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
+
+				let firstWrong = -1;
+
+				for ( let i = 0; i < count; i ++ ) {
+
+					if ( x[ i ] !== expected || y[ i ] !== 0 ) {
+
+						firstWrong = i;
+						break;
+
+					}
+
+				}
+
+				assert.ok( firstWrong === -1, firstWrong === -1
+					? `all ${ count } elements equal ${ expected } after the full row/transpose/col/transpose-back sequence`
+					: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
+				);
+
+				attrA.dispose?.();
+				attrB.dispose?.();
+
+			} );
+
+		} );
+
+		repointTest( 'mixed global-memory / shared-memory kernel sequence repeated across 6 separate runs (1024x1024)', async ( assert, renderer ) => {
+
+			// Same sequence as above, repeated -- the actual report was "fails about 1 out of 2
+			// times", so a single run is not enough to trust a pass.
+
+			const width = 1024, height = 1024;
+			const count = width * height;
+			const tile = 16;
+			const rowStages = Math.round( Math.log2( width ) );
+			const colStages = Math.round( Math.log2( height ) );
+			const runs = 6;
+
+			for ( let run = 0; run < runs; run ++ ) {
+
+				const attrA = makeVec2Buffer( count, 0, 0 );
+				const attrB = makeVec2Buffer( count, 0, 0 );
+
+				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
+				const writeNode = storage( attrB, 'vec2', count );
+				const stageUniform = uniform( 1, 'uint' );
+
+				const addKernel = Fn( () => {
+
+					const v = readNode.element( instanceIndex ).toVar();
+					const s = float( stageUniform );
+					writeNode.element( instanceIndex ).assign( vec2( v.x.add( s ), v.y ) );
+
+				} )().compute( count );
+
+				const transposeFwdKernel = buildTransposeKernel( height, width, tile, readNode, writeNode );
+				const transposeBackKernel = buildTransposeKernel( width, height, tile, readNode, writeNode );
+
+				let current = 'A';
+				let expected = 0;
+
+				const dispatchPingPong = ( kernel ) => {
+
+					readNode.value = current === 'A' ? attrA : attrB;
+					writeNode.value = current === 'A' ? attrB : attrA;
+
+					renderer.compute( kernel );
+
+					current = current === 'A' ? 'B' : 'A';
+
+				};
+
+				for ( let s = 0; s < rowStages; s ++ ) {
+
+					stageUniform.value = 1 << s;
+					dispatchPingPong( addKernel );
+					expected += 1 << s;
+
+				}
+
+				dispatchPingPong( transposeFwdKernel );
+
+				for ( let s = 0; s < colStages; s ++ ) {
+
+					stageUniform.value = 1 << s;
+					dispatchPingPong( addKernel );
+					expected += 1 << s;
+
+				}
+
+				dispatchPingPong( transposeBackKernel );
+
+				const liveAttribute = current === 'A' ? attrA : attrB;
+				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
+
+				let firstWrong = -1;
+
+				for ( let i = 0; i < count; i ++ ) {
+
+					if ( x[ i ] !== expected || y[ i ] !== 0 ) {
+
+						firstWrong = i;
+						break;
+
+					}
+
+				}
+
+				assert.ok( firstWrong === -1, firstWrong === -1
+					? `run ${ run }: all elements equal ${ expected }`
+					: `run ${ run }: element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
+				);
+
+				attrA.dispose?.();
+				attrB.dispose?.();
+
+			}
+
+		} );
+
+		// Every kernel above is cheap -- a handful of ALU ops per invocation. FFT2D's real
+		// butterfly kernels do meaningfully more work per invocation (cos/sin twiddle factors,
+		// several reads/writes), so real dispatches run measurably longer on the GPU. If the
+		// corruption is a genuine race between the CPU re-pointing nodes and what the GPU has
+		// actually consumed -- rather than a pure JS-side binding bug, which should be timing-
+		// independent -- a longer-running kernel gives that race a bigger window. This burns real
+		// GPU cycles (many `sin` calls) per invocation while keeping the arithmetic result exactly
+		// verifiable: `sin(i) - sin(i)` is exactly 0 in IEEE754 (same computed value subtracted
+		// from itself), so the busy-work never perturbs the expected total.
+		function buildSlowAddKernel( count, busyIterations, readNode, writeNode ) {
+
+			return Fn( () => {
+
+				const v = readNode.element( instanceIndex ).toVar();
+				const acc = float( 0 ).toVar();
+
+				Loop( { start: 0, end: busyIterations, type: 'int' }, ( { i } ) => {
+
+					const angle = float( i ).add( instanceIndex.toFloat() );
+					acc.assign( acc.add( sin( angle ) ).sub( sin( angle ) ) );
+
+				} );
+
+				writeNode.element( instanceIndex ).assign( vec2( v.x.add( 1 ).add( acc ), v.y.add( acc ) ) );
+
+			} )().compute( count );
+
+		}
+
+		[ 4, 64 ].forEach( ( busyIterations ) => {
+
+			repointTest( `slow kernel (${ busyIterations }x busy-work per invocation) sharing repointed nodes survives 64 rapid dispatches (1048576 elements)`, async ( assert, renderer ) => {
+
+				const count = 1048576;
+				const iterations = 64;
+
+				const attrA = makeVec2Buffer( count, 0, 0 );
+				const attrB = makeVec2Buffer( count, 0, 0 );
+
+				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
+				const writeNode = storage( attrB, 'vec2', count );
+
+				const kernel = buildSlowAddKernel( count, busyIterations, readNode, writeNode );
+
+				let current = 'A';
+
+				for ( let i = 0; i < iterations; i ++ ) {
+
+					readNode.value = current === 'A' ? attrA : attrB;
+					writeNode.value = current === 'A' ? attrB : attrA;
+
+					renderer.compute( kernel );
+
+					current = current === 'A' ? 'B' : 'A';
+
+				}
+
+				const liveAttribute = current === 'A' ? attrA : attrB;
+				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
+
+				const expectedX = iterations;
+				let firstWrong = -1;
+
+				for ( let i = 0; i < count; i ++ ) {
+
+					if ( x[ i ] !== expectedX || y[ i ] !== 0 ) {
+
+						firstWrong = i;
+						break;
+
+					}
+
+				}
+
+				assert.ok( firstWrong === -1, firstWrong === -1
+					? `all ${ count } elements equal (${ expectedX }, 0) after ${ iterations } dispatches of a slow kernel`
+					: `element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expectedX }, 0) (first mismatch)`
+				);
+
+				attrA.dispose?.();
+				attrB.dispose?.();
+
+			} );
+
+		} );
+
+		// Combines the slow kernel with the mixed global-memory/shared-memory transpose sequence
+		// from above, at hardwood's actual scale, repeated -- the most demanding single test in
+		// this file: real element count, real mixed kernel shapes, and per-invocation duration
+		// closer to the real butterfly math than anything tested so far.
+		repointTest( 'slow kernels + transpose sequence sharing repointed nodes, repeated 4x (2048x1024)', async ( assert, renderer ) => {
+
+			const width = 2048, height = 1024;
+			const count = width * height;
+			const tile = 16;
+			const busyIterations = 16;
+			const rowStages = Math.round( Math.log2( width ) );
+			const colStages = Math.round( Math.log2( height ) );
+			const runs = 4;
+
+			for ( let run = 0; run < runs; run ++ ) {
+
+				const attrA = makeVec2Buffer( count, 0, 0 );
+				const attrB = makeVec2Buffer( count, 0, 0 );
+
+				const readNode = storage( attrA, 'vec2', count ).toReadOnly();
+				const writeNode = storage( attrB, 'vec2', count );
+
+				const addKernel = buildSlowAddKernel( count, busyIterations, readNode, writeNode );
+				const transposeFwdKernel = buildTransposeKernel( height, width, tile, readNode, writeNode );
+				const transposeBackKernel = buildTransposeKernel( width, height, tile, readNode, writeNode );
+
+				let current = 'A';
+
+				const dispatchPingPong = ( kernel ) => {
+
+					readNode.value = current === 'A' ? attrA : attrB;
+					writeNode.value = current === 'A' ? attrB : attrA;
+
+					renderer.compute( kernel );
+
+					current = current === 'A' ? 'B' : 'A';
+
+				};
+
+				for ( let s = 0; s < rowStages; s ++ ) dispatchPingPong( addKernel );
+
+				dispatchPingPong( transposeFwdKernel );
+
+				for ( let s = 0; s < colStages; s ++ ) dispatchPingPong( addKernel );
+
+				dispatchPingPong( transposeBackKernel );
+
+				const liveAttribute = current === 'A' ? attrA : attrB;
+				const { x, y } = await readVec2Buffer( renderer, liveAttribute, count );
+
+				const expected = rowStages + colStages;
+				let firstWrong = -1;
+
+				for ( let i = 0; i < count; i ++ ) {
+
+					if ( x[ i ] !== expected || y[ i ] !== 0 ) {
+
+						firstWrong = i;
+						break;
+
+					}
+
+				}
+
+				assert.ok( firstWrong === -1, firstWrong === -1
+					? `run ${ run }: all elements equal (${ expected }, 0)`
+					: `run ${ run }: element ${ firstWrong } was (${ x[ firstWrong ] }, ${ y[ firstWrong ] }), expected (${ expected }, 0) (first mismatch)`
+				);
+
+				attrA.dispose?.();
+				attrB.dispose?.();
+
+			}
+
+		} );
+
+		// A different untested factor: `_load`/`_store` bind a *texture* alongside a storage
+		// buffer in the same kernel. The WebGPU backend's bind-group cache key is built ONLY from
+		// texture identity/version (`cacheKey += texture.id + ','`, `version += texture.version`
+		// in Bindings.js) -- a storage buffer's attribute changing contributes nothing to that key.
+		// So if the *same* texture object is reused across calls (exactly what happens when
+		// webgpu_fft_2d.html's `resourceCache` reuses `complexSource[c]` across preset switches of
+		// the same size) while only the storage side has been repointed, a cache lookup keyed
+		// purely on the unchanged texture could return a bind group still wired to the *previous*
+		// storage attribute. This isolates exactly that: one texture, reused across many calls,
+		// while the storage write target alternates every call.
+		repointTest( 'texture+storage kernel reused with the same texture object across alternating storage targets (1024x1024)', async ( assert, renderer ) => {
+
+			const width = 1024, height = 1024;
+			const count = width * height;
+			const calls = 64;
+
+			const sourceData = new Float32Array( count * 4 );
+
+			for ( let i = 0; i < count; i ++ ) {
+
+				sourceData[ i * 4 ] = 7;
+				sourceData[ i * 4 + 1 ] = 3;
+				sourceData[ i * 4 + 2 ] = 0;
+				sourceData[ i * 4 + 3 ] = 1;
+
+			}
+
+			const sourceTexture = new THREE.DataTexture( sourceData, width, height, THREE.RGBAFormat, THREE.FloatType );
+			sourceTexture.needsUpdate = true;
+
+			const attrA = makeVec2Buffer( count, -1, -1 );
+			const attrB = makeVec2Buffer( count, -1, -1 );
+
+			const sourceNode = texture( sourceTexture );
+			const writeNode = storage( attrA, 'vec2', count );
+
+			// texture -> storage, exactly FFT2D._load's shape (2D-indexed texture read, flat
+			// storage write) -- built once, `sourceNode` never repointed (same texture every
+			// call), only `writeNode.value` alternates.
+			const loadKernel = Fn( () => {
+
+				const x = instanceIndex.mod( uint( width ) );
+				const y = instanceIndex.div( uint( width ) );
+
+				writeNode.element( instanceIndex ).assign( sourceNode.load( ivec2( int( x ), int( y ) ) ).rg );
+
+			} )().compute( count );
+
+			let target = 'A';
+			let firstWrong = -1;
+			let firstWrongCall = -1;
+			let firstWrongValue = null;
+			let firstWrongOtherBuffer = null;
+
+			for ( let call = 0; call < calls && firstWrong === -1; call ++ ) {
+
+				// Both buffers were seeded with (-1, -1) above, so a stale bind group that
+				// silently keeps writing to the *other* buffer (or doesn't write at all) shows up
+				// here as leftover (-1, -1) instead of the freshly loaded (7, 3).
+				const targetAttribute = target === 'A' ? attrA : attrB;
+				const otherAttribute = target === 'A' ? attrB : attrA;
+
+				writeNode.value = targetAttribute;
+
+				renderer.compute( loadKernel );
+
+				const { x, y } = await readVec2Buffer( renderer, targetAttribute, count );
+
+				for ( let i = 0; i < count; i ++ ) {
+
+					if ( x[ i ] !== 7 || y[ i ] !== 3 ) {
+
+						firstWrong = i;
+						firstWrongCall = call;
+						firstWrongValue = { x: x[ i ], y: y[ i ] };
+						firstWrongOtherBuffer = await readVec2Buffer( renderer, otherAttribute, count );
+						break;
+
+					}
+
+				}
+
+				target = target === 'A' ? 'B' : 'A';
+
+			}
+
+			assert.ok( firstWrong === -1, firstWrong === -1
+				? `all ${ calls } calls (alternating storage target, same reused texture) wrote (7, 3) correctly`
+				: `call ${ firstWrongCall }: element ${ firstWrong } was (${ firstWrongValue.x }, ${ firstWrongValue.y }), expected (7, 3); other buffer's element ${ firstWrong } is (${ firstWrongOtherBuffer.x[ firstWrong ] }, ${ firstWrongOtherBuffer.y[ firstWrong ] })`
+			);
+
+			attrA.dispose?.();
+			attrB.dispose?.();
+			sourceTexture.dispose();
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/addons/tsl/gpu-test-utils.js
+++ b/test/unit/addons/tsl/gpu-test-utils.js
@@ -242,7 +242,7 @@ const BACKEND_OPTIONS = {
 // so availability is detected empirically per backend rather than assumed.
 const sharedRenderers = {};
 
-async function getSharedRenderer( backend ) {
+export async function getSharedRenderer( backend ) {
 
 	if ( BACKEND_OPTIONS[ backend ] === undefined ) {
 

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -16,6 +16,7 @@ import './addons/loaders/USDLoader.tests.js';
 import './addons/exporters/USDZExporter.tests.js';
 import './addons/tsl/WebGLNodesHandler.tests.js';
 import './addons/tsl/GPUTest.tests.js';
+import './addons/tsl/TSLStorageBufferRepoint.tests.js';
 import './addons/tsl/TSLDeterminant.tests.js';
 import './addons/tsl/TSLFaceForward.tests.js';
 import './addons/tsl/TSLGainPcurve.tests.js';


### PR DESCRIPTION
## Bug

`Bindings.js#_update()` builds a cache key/version per bind group so unchanged bind groups can be reused instead of rebuilt. Texture bindings fold their identity into that key (`cacheKey += texture.id`, `version += texture.version`); storage buffer bindings didn't. `_update()` does detect that a storage node was repointed at a different `BufferAttribute`, but the new attribute's identity never reached `cacheKey`/`version`.

For a bind group with **only** storage buffers this was harmless — `cacheKey` stayed `''`, so `WebGPUBindingUtils.createBindings()` skipped its cache lookup and always built fresh (uncached, but correct).

For a bind group mixing a **texture and a storage buffer** — e.g. a compute kernel sampling a fixed source texture while writing into a storage node that gets repointed between calls — `cacheKey` was non-empty (driven by the texture) but blind to the storage buffer. If the texture object stayed the same while the storage node repointed to a different attribute, the key/version matched the previous call, so `createBindings()` returned the **stale cached bind group**, still wired to the old attribute. The dispatch silently wrote to (or read from) the wrong GPU buffer — no error, just wrong data. Deterministic once isolated, not a timing race.

## Fix

Fold the storage buffer attribute's `id`/`version` into the cache key, the same way textures already do:

```js
if ( binding.isStorageBuffer ) {
	// ...existing attribute-change detection...
	cacheKey += attribute.id + ',';
	version  += attribute.version;
}
```

A bind group's cache key now reflects every resource actually bound to it, so repointing a storage node always changes the key and forces a fresh, correctly-bound bind group.

**Side benefit:** this also enables bind group caching for storage-buffer-only kernels for the first time (previously always `''` → always rebuilt), a modest win for compute-heavy WebGPU code generally.

## Also fixed in this pass (review feedback)

- **Non-default groups**: the storage-buffer sync/cache-key logic above was gated behind `updateGroup()`, which for a node explicitly assigned to `renderGroup`/`frameGroup` (via `.setGroup()`) can permanently return `false` after its first check — nothing ever bumps those shared groups' own version. That silently dropped every repoint after the first for such a node. The block now runs unconditionally, independent of the group's own invalidation.
- **Sampler cache key**: a sampler's key (wrap/filter/anisotropy) was only recomputed when the bound texture's `version` changed, and even then was never folded into the cache key — so a texture+sampler bind group could keep serving a stale sampler after a wrap/filter-only change (which doesn't bump `texture.version`). Now recomputed and folded in unconditionally, mirroring the texture/storage handling.
- **Cache eviction**: now that storage-only bind groups are actually cached, entries need to be evicted on dispose the same way the texture cache already is — added attribute→bindGroup tracking and a `dispose` listener that clears a bind group's cached entries when a referenced storage attribute is disposed.


## Testing

- New tests in `test/unit/addons/tsl/TSLStorageBufferRepoint.tests.js`: a shared kernel repointing its storage nodes across repeated dispatches, two kernels sharing one repointed node pair interleaved, and the texture+storage case that motivated the fix (same texture reused while the storage target alternates).
- Full core (`UnitTests.html`) and addons (`UnitTestsAddons.html`) suites: pass, no regressions.
