### PR TITLE
Inspector: Implement disposal support and improve split screen handling

### DIFF
--- a/examples/jsm/inspector/Inspector.js
+++ b/examples/jsm/inspector/Inspector.js
@@ -10,7 +10,7 @@ import { Viewer } from './tabs/Viewer.js';
 import { Timeline } from './tabs/Timeline.js';
 import { setText } from './ui/utils.js';
 
-import { setConsoleFunction, REVISION } from 'three/webgpu';
+import { setConsoleFunction, getConsoleFunction, REVISION } from 'three/webgpu';
 
 class Inspector extends RendererInspector {
 
@@ -70,6 +70,8 @@ class Inspector extends RendererInspector {
 		this.settings = settings;
 		this.once = {};
 		this.extensionsData = new WeakMap();
+		this.previousConsoleFunction = null;
+		this._domObserver = null;
 
 		this.displayCycle = {
 			text: {
@@ -274,66 +276,33 @@ class Inspector extends RendererInspector {
 
 	}
 
-	init() {
-
-		const renderer = this.getRenderer();
-
-		let sign = `THREE.WebGPURenderer: ${ REVISION } [ "`;
-
-		if ( renderer.backend.isWebGPUBackend ) {
-
-			sign += 'WebGPU';
-
-		} else if ( renderer.backend.isWebGLBackend ) {
-
-			sign += 'WebGL2';
-
-		}
-
-		sign += '" ]';
-
-		this.console.addMessage( 'info', sign );
-
-		//
-
-		if ( renderer.inspector.domElement.parentElement === null ) {
-
-			if ( renderer.domElement.parentElement !== null ) {
-
-				renderer.domElement.parentElement.appendChild( renderer.inspector.domElement );
-
-			} else {
-
-				const observer = new MutationObserver( () => {
-
-					if ( renderer.domElement.parentElement !== null ) {
-
-						renderer.domElement.parentElement.appendChild( renderer.inspector.domElement );
-						observer.disconnect();
-
-					}
-
-				} );
-
-				observer.observe( document.body || document.documentElement, { childList: true, subtree: true } );
-
-			}
-
-		}
-
-	}
-
 	setRenderer( renderer ) {
 
 		super.setRenderer( renderer );
 
 		if ( renderer !== null ) {
 
-			setConsoleFunction( this.resolveConsole.bind( this ) );
+			const previousConsoleFunction = getConsoleFunction();
+
+			this.previousConsoleFunction = previousConsoleFunction;
+
+			setConsoleFunction( ( type, message, ...params ) => {
+
+				if ( previousConsoleFunction ) {
+
+					previousConsoleFunction( type, message, ...params );
+
+				}
+
+				this.resolveConsole( type, message, ...params );
+
+			} );
 
 			if ( this.isAvailable ) {
 
-				renderer.init().then( () => {
+				const init = async () => {
+
+					if ( renderer.hasInitialized() === false ) await renderer.init();
 
 					renderer.backend.trackTimestamp = true;
 
@@ -343,11 +312,92 @@ class Inspector extends RendererInspector {
 
 					}
 
-				} );
+					let sign = `THREE.WebGPURenderer: ${ REVISION } [ "`;
+
+					if ( renderer.backend.isWebGPUBackend ) {
+
+						sign += 'WebGPU';
+
+					} else if ( renderer.backend.isWebGLBackend ) {
+
+						sign += 'WebGL2';
+
+					}
+
+					sign += '" ]';
+
+					this.console.addMessage( 'info', sign );
+
+					//
+
+					const domElement = this.domElement;
+
+					if ( domElement.parentElement === null ) {
+
+						if ( renderer.domElement.parentElement !== null ) {
+
+							renderer.domElement.parentElement.appendChild( domElement );
+
+						} else {
+
+							if ( this._domObserver !== null ) {
+
+								this._domObserver.disconnect();
+
+							}
+
+							this._domObserver = new MutationObserver( () => {
+
+								if ( renderer.domElement && renderer.domElement.parentElement !== null ) {
+
+									renderer.domElement.parentElement.appendChild( domElement );
+
+									if ( this._domObserver !== null ) {
+
+										this._domObserver.disconnect();
+										this._domObserver = null;
+
+									}
+
+								}
+
+							} );
+
+							this._domObserver.observe( document.body || document.documentElement, { childList: true, subtree: true } );
+
+						}
+
+					}
+
+				};
+
+				init();
 
 				this.timeline.setRenderer( renderer );
 
 			}
+
+		} else {
+
+			if ( this.previousConsoleFunction ) {
+
+				setConsoleFunction( this.previousConsoleFunction );
+				this.previousConsoleFunction = undefined;
+
+			}
+
+			if ( this._domObserver !== null ) {
+
+				this._domObserver.disconnect();
+				this._domObserver = null;
+
+			}
+
+			this.profiler.dispose();
+
+			this.statsData.clear();
+
+			super.dispose();
 
 		}
 
@@ -572,6 +622,14 @@ class Inspector extends RendererInspector {
 			cycle.time = 0;
 
 		}
+
+	}
+
+	dispose() {
+
+		super.dispose();
+
+		this.setRenderer( null );
 
 	}
 

--- a/examples/jsm/inspector/RendererInspector.js
+++ b/examples/jsm/inspector/RendererInspector.js
@@ -84,6 +84,7 @@ export class RendererInspector extends InspectorBase {
 
 		this._lastFinishTime = 0;
 		this._resolveTimestampPromise = null;
+		this._rAFId = null;
 
 		this.overdraw = false;
 		this._overdrawMaterial = null;
@@ -262,14 +263,32 @@ export class RendererInspector extends InspectorBase {
 
 		this._resolveTimestampPromise = new Promise( ( resolve ) => {
 
-			requestAnimationFrame( async () => {
+			this._rAFId = requestAnimationFrame( async () => {
+
+				this._rAFId = null;
 
 				const renderer = this.getRenderer();
+
+				if ( renderer === null ) {
+
+					this._resolveTimestampPromise = null;
+					resolve();
+					return;
+
+				}
 
 				if ( renderer.backend.hasTimestamp ) {
 
 					await renderer.resolveTimestampsAsync( TimestampQuery.COMPUTE );
 					await renderer.resolveTimestampsAsync( TimestampQuery.RENDER );
+
+					if ( renderer !== this.getRenderer() ) {
+
+						this._resolveTimestampPromise = null;
+						resolve();
+						return;
+
+					}
 
 					const computeFrames = renderer.backend.getTimestampFrames( TimestampQuery.COMPUTE );
 					const renderFrames = renderer.backend.getTimestampFrames( TimestampQuery.RENDER );
@@ -548,6 +567,28 @@ export class RendererInspector extends InspectorBase {
 		currentRender.cpu = performance.now() - currentRender.timestamp;
 
 		this.currentRender = currentRender.parent;
+
+	}
+
+	dispose() {
+
+		if ( this._rAFId !== null ) {
+
+			cancelAnimationFrame( this._rAFId );
+			this._rAFId = null;
+
+		}
+
+		this._resolveTimestampPromise = null;
+
+		if ( this._overdrawMaterial !== null ) {
+
+			this._overdrawMaterial.dispose();
+			this._overdrawMaterial = null;
+
+		}
+
+		super.dispose();
 
 	}
 

--- a/examples/jsm/inspector/tabs/Viewer.js
+++ b/examples/jsm/inspector/tabs/Viewer.js
@@ -675,6 +675,7 @@ class Viewer extends Tab {
 				const onPointerDown = ( e ) => {
 
 					isDragging = true;
+					line.classList.add( 'active' );
 					e.preventDefault();
 
 				};
@@ -700,6 +701,7 @@ class Viewer extends Tab {
 				const onPointerUp = () => {
 
 					isDragging = false;
+					line.classList.remove( 'active' );
 
 				};
 

--- a/examples/jsm/inspector/tabs/Viewer.js
+++ b/examples/jsm/inspector/tabs/Viewer.js
@@ -948,6 +948,13 @@ class Viewer extends Tab {
 
 			const mainCanvas = renderer.domElement;
 			const rect = mainCanvas.getBoundingClientRect();
+
+			if ( rect.width <= 0 || rect.height <= 0 ) {
+
+				return;
+
+			}
+
 			const targetParent = document.fullscreenElement || this.profiler.domElement;
 			const parentRect = targetParent.getBoundingClientRect();
 			const localLeft = rect.left - parentRect.left;
@@ -1021,7 +1028,7 @@ class Viewer extends Tab {
 
 			if ( ! renderer.backend.isWebGPUBackend ) {
 
-				inspector.resolveConsoleOnce( 'warn', 'Inspector: Viewer is only available with WebGPU.' );
+				// Viewer is only available with WebGPU.
 
 				return;
 
@@ -1312,6 +1319,53 @@ class Viewer extends Tab {
 			}
 
 		}
+
+	}
+
+	dispose() {
+
+		if ( this.splitActive ) {
+
+			this.stopSplitMode();
+
+		}
+
+		if ( this.splitCanvas ) {
+
+			if ( this.splitCanvas.parentElement ) {
+
+				this.splitCanvas.parentElement.removeChild( this.splitCanvas );
+
+			}
+
+			this.splitCanvas = null;
+
+		}
+
+		if ( this.splitCanvasTarget ) {
+
+			this.splitCanvasTarget.dispose();
+			this.splitCanvasTarget = null;
+
+		}
+
+		if ( this.splitMaterial ) {
+
+			this.splitMaterial.dispose();
+			this.splitMaterial = null;
+
+		}
+
+		for ( const canvasData of this.canvasNodes.values() ) {
+
+			canvasData.canvasTarget.dispose();
+			canvasData.material.dispose();
+
+		}
+
+		this.canvasNodes.clear();
+
+		super.dispose();
 
 	}
 

--- a/examples/jsm/inspector/ui/Profiler.js
+++ b/examples/jsm/inspector/ui/Profiler.js
@@ -2243,4 +2243,24 @@ export class Profiler extends EventDispatcher {
 
 	}
 
+	dispose() {
+
+		for ( const tab of Object.values( this.tabs ) ) {
+
+			tab.dispose();
+
+		}
+
+		this.domElement.remove();
+
+		for ( const detachedWindow of this.detachedWindows ) {
+
+			detachedWindow.panel.remove();
+
+		}
+
+		this.toggleGraph.dispose();
+
+	}
+
 }

--- a/examples/jsm/inspector/ui/Style.js
+++ b/examples/jsm/inspector/ui/Style.js
@@ -2112,14 +2112,20 @@ export class Style {
 		position: absolute;
 		top: 0;
 		bottom: 0;
-		width: 0;
+		width: 1px;
 		left: 50%;
-		background: transparent;
+		background-color: transparent;
 		cursor: ew-resize;
 		pointer-events: auto !important;
 		z-index: 10;
 		touch-action: none;
-		transform: translateX(-50%);
+		transition: background-color 0.15s ease-out;
+	}
+
+	.split-screen-line:hover,
+	.split-screen-line:active,
+	.split-screen-line.active {
+		background-color: var(--color-accent);
 	}
 
 	.split-screen-line::before {
@@ -2128,7 +2134,7 @@ export class Style {
 		top: 0;
 		bottom: 0;
 		left: -12px;
-		width: 24px;
+		width: 25px;
 		background: transparent;
 		cursor: ew-resize;
 	}
@@ -2136,27 +2142,27 @@ export class Style {
 	.split-screen-line::after {
 		content: '';
 		position: absolute;
-		top: 0;
-		bottom: 0;
-		left: -7px;
-		width: 14px;
+		top: -1px;
+		bottom: -1px;
+		left: -5px;
+		width: 11px;
 		pointer-events: none;
 		background-image:
-			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M0 0 L14 0 L7 8 Z' fill='%239a9aab'/%3E%3C/svg%3E"),
-			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M0 8 L14 8 L7 0 Z' fill='%239a9aab'/%3E%3C/svg%3E");
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='7' viewBox='0 0 11 7'%3E%3Cpath d='M-0.5 -1 L5.5 7 L11.5 -1 Z' fill='rgba(30,30,36,0.85)' stroke='%234a4a5a' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E"),
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='7' viewBox='0 0 11 7'%3E%3Cpath d='M-0.5 8 L5.5 0 L11.5 8 Z' fill='rgba(30,30,36,0.85)' stroke='%234a4a5a' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E");
 		background-position: top center, bottom center;
 		background-repeat: no-repeat;
-		opacity: 0.8;
-		filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.6));
-		transition: opacity 0.2s, filter 0.2s;
+		opacity: 1;
+		transition: opacity 0.15s ease-out;
 	}
 
-	.split-screen-line:hover::after {
+	.split-screen-line:hover::after,
+	.split-screen-line:active::after,
+	.split-screen-line.active::after {
 		opacity: 1;
 		background-image:
-			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M0 0 L14 0 L7 8 Z' fill='%2300aaff'/%3E%3C/svg%3E"),
-			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3E%3Cpath d='M0 8 L14 8 L7 0 Z' fill='%2300aaff'/%3E%3C/svg%3E");
-		filter: drop-shadow(0 0 4px rgba(0, 170, 255, 0.8));
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='7' viewBox='0 0 11 7'%3E%3Cpath d='M-0.5 -1 L5.5 7 L11.5 -1 Z' fill='%2300aaff' stroke='%2300aaff' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E"),
+			url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='7' viewBox='0 0 11 7'%3E%3Cpath d='M-0.5 8 L5.5 0 L11.5 8 Z' fill='%2300aaff' stroke='%2300aaff' stroke-width='1' stroke-linejoin='round'/%3E%3C/svg%3E");
 	}
 
 	/* Grid Mode styles for List component */

--- a/src/renderers/common/InspectorBase.js
+++ b/src/renderers/common/InspectorBase.js
@@ -84,11 +84,6 @@ class InspectorBase extends EventDispatcher {
 	}
 
 	/**
-	 * Initializes the inspector.
-	 */
-	init() { }
-
-	/**
 	 * Called when a frame begins.
 	 */
 	begin() {
@@ -168,6 +163,17 @@ class InspectorBase extends EventDispatcher {
 	 * @param {Texture} framebufferTexture - The texture associated with the framebuffer.
 	 */
 	copyFramebufferToTexture( /*framebufferTexture*/ ) { }
+
+	/**
+	 * Frees all internal resources of the inspector.
+	 */
+	dispose() {
+
+		if ( this.isRunning === true ) this.finish();
+
+		this.dispatchEvent( { type: 'dispose' } );
+
+	}
 
 }
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -842,12 +842,6 @@ class Renderer {
 			this._animation.start();
 			this._initialized = true;
 
-			//
-
-			this._inspector.init();
-
-			//
-
 			resolve( this );
 
 		} );
@@ -2702,6 +2696,7 @@ class Renderer {
 
 			this.info.dispose();
 
+			this._inspector.dispose();
 			this._animation.dispose();
 			this._objects.dispose();
 			this._geometries.dispose();


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/34085

**Description**

After calling `renderer.dispose()`, manually removing the inspector was previously required; now, we can switch inspectors during rendering and dispose of the renderer along with the inspector.

There has been a slight improvement in the split-screen UX, with a hover effect added to assist with the tab following the latest updates.