### PR TITLE
ModelNode: Support `ArrayCamera` in highp matrix nodes.

### DIFF
--- a/examples/jsm/objects/GaussianSplat.js
+++ b/examples/jsm/objects/GaussianSplat.js
@@ -17,6 +17,7 @@ import {
 	If,
 	atan,
 	cameraProjectionMatrix,
+	cameraViewport,
 	cos,
 	dot,
 	exp,
@@ -27,7 +28,6 @@ import {
 	min,
 	normalize,
 	positionGeometry,
-	screenSize,
 	sin,
 	sqrt,
 	storage,
@@ -753,7 +753,7 @@ function createMaterialNodes( buffers, sort, localCameraPosition ) {
 		const z = min( viewCenter.z, - 0.01 ).toVar( 'z' );
 		const invZ = float( 1 ).div( z ).toVar( 'invZ' );
 		const invZ2 = invZ.mul( invZ ).toVar( 'invZ2' );
-		const focal = screenSize.mul( 0.5 ).mul( vec2( cameraProjectionMatrix[ 0 ].x, cameraProjectionMatrix[ 1 ].y ) ).toVar( 'focal' );
+		const focal = cameraViewport.zw.mul( 0.5 ).mul( vec2( cameraProjectionMatrix[ 0 ].x, cameraProjectionMatrix[ 1 ].y ) ).toVar( 'focal' );
 
 		const j00 = focal.x.negate().mul( invZ ).toVar( 'j00' );
 		const j11 = focal.y.negate().mul( invZ ).toVar( 'j11' );
@@ -799,7 +799,7 @@ function createMaterialNodes( buffers, sort, localCameraPosition ) {
 		const scale1 = min( sqrt( lambda1 ), MAX_SCREEN_SPACE_SPLAT_SIZE ).toVar( 'scale1' );
 		const scale2 = min( sqrt( lambda2 ), MAX_SCREEN_SPACE_SPLAT_SIZE ).toVar( 'scale2' );
 		const offsetPixels = axis1.mul( positionGeometry.x ).mul( scale1 ).add( axis2.mul( positionGeometry.y ).mul( scale2 ) ).toVar( 'offsetPixels' );
-		const offsetNdc = offsetPixels.mul( 2 ).div( screenSize ).toVar( 'offsetNdc' );
+		const offsetNdc = offsetPixels.mul( 2 ).div( cameraViewport.zw ).toVar( 'offsetNdc' );
 		const clip = centerClip.add( vec4( offsetNdc.mul( centerClip.w ), 0, 0 ) ).toVar( 'clip' );
 
 		const clipLimit = centerClip.w.mul( CLIP_XY ).toVar( 'clipLimit' );

--- a/src/nodes/accessors/ModelNode.js
+++ b/src/nodes/accessors/ModelNode.js
@@ -3,8 +3,12 @@ import { Fn, nodeImmutable } from '../tsl/TSLBase.js';
 import { uniform } from '../core/UniformNode.js';
 
 import { Matrix4 } from '../../math/Matrix4.js';
-import { cameraViewMatrix } from './Camera.js';
+import { builtin } from './BuiltinNode.js';
+import { cameraIndex, cameraViewMatrix } from './Camera.js';
+import { uniformArray } from './UniformArrayNode.js';
 import { Matrix3 } from '../../math/Matrix3.js';
+
+const _modelViewMatrix = /*@__PURE__*/ new Matrix4();
 
 /**
  * This type of node is a specialized version of `Object3DNode`
@@ -150,11 +154,45 @@ export const highpModelViewMatrix = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	builder.context.isHighPrecisionModelViewMatrix = true;
 
-	return uniform( 'mat4' ).onObjectUpdate( ( { object, camera } ) => {
+	const camera = builder.camera;
 
-		return object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
+	let highpModelViewMatrix;
 
-	} );
+	if ( camera.isArrayCamera && camera.cameras.length > 0 ) {
+
+		const matrices = [];
+
+		for ( let i = 0; i < camera.cameras.length; i ++ ) {
+
+			matrices.push( new Matrix4() );
+
+		}
+
+		const modelViewMatrices = uniformArray( matrices ).onObjectUpdate( ( { object, camera } ) => {
+
+			const cameras = camera.cameras;
+
+			for ( let i = 0; i < matrices.length; i ++ ) {
+
+				matrices[ i ].multiplyMatrices( cameras[ i ].matrixWorldInverse, object.matrixWorld );
+
+			}
+
+		} );
+
+		highpModelViewMatrix = modelViewMatrices.element( camera.isMultiViewCamera ? builtin( 'gl_ViewID_OVR' ) : cameraIndex );
+
+	} else {
+
+		highpModelViewMatrix = uniform( 'mat4' ).onObjectUpdate( ( { object, camera } ) => {
+
+			return object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
+
+		} );
+
+	}
+
+	return highpModelViewMatrix;
 
 } ).once() )().toVar( 'highpModelViewMatrix' );
 
@@ -169,16 +207,52 @@ export const highpModelNormalViewMatrix = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	const isHighPrecisionModelViewMatrix = builder.context.isHighPrecisionModelViewMatrix;
 
-	return uniform( 'mat3' ).onObjectUpdate( ( { object, camera } ) => {
+	const camera = builder.camera;
 
-		if ( isHighPrecisionModelViewMatrix !== true ) {
+	let highpModelNormalViewMatrix;
 
-			object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
+	if ( camera.isArrayCamera && camera.cameras.length > 0 ) {
+
+		const matrices = [];
+
+		for ( let i = 0; i < camera.cameras.length; i ++ ) {
+
+			matrices.push( new Matrix3() );
 
 		}
 
-		return object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
+		const normalViewMatrices = uniformArray( matrices ).onObjectUpdate( ( { object, camera } ) => {
 
-	} );
+			const cameras = camera.cameras;
+
+			for ( let i = 0; i < matrices.length; i ++ ) {
+
+				_modelViewMatrix.multiplyMatrices( cameras[ i ].matrixWorldInverse, object.matrixWorld );
+
+				matrices[ i ].getNormalMatrix( _modelViewMatrix );
+
+			}
+
+		} );
+
+		highpModelNormalViewMatrix = normalViewMatrices.element( camera.isMultiViewCamera ? builtin( 'gl_ViewID_OVR' ) : cameraIndex );
+
+	} else {
+
+		highpModelNormalViewMatrix = uniform( 'mat3' ).onObjectUpdate( ( { object, camera } ) => {
+
+			if ( isHighPrecisionModelViewMatrix !== true ) {
+
+				object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
+
+			}
+
+			return object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
+
+		} );
+
+	}
+
+	return highpModelNormalViewMatrix;
 
 } ).once() )().toVar( 'highpModelNormalViewMatrix' );

--- a/src/nodes/accessors/ModelNode.js
+++ b/src/nodes/accessors/ModelNode.js
@@ -168,13 +168,14 @@ export const highpModelViewMatrix = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 		}
 
-		const modelViewMatrices = uniformArray( matrices ).onObjectUpdate( ( { object, camera } ) => {
+		const modelViewMatrices = uniformArray( matrices ).onObjectUpdate( ( { object, camera }, self ) => {
 
-			const cameras = camera.cameras;
+			const subCameras = camera.cameras;
+			const array = self.array;
 
-			for ( let i = 0; i < matrices.length; i ++ ) {
+			for ( let i = 0, l = subCameras.length; i < l; i ++ ) {
 
-				matrices[ i ].multiplyMatrices( cameras[ i ].matrixWorldInverse, object.matrixWorld );
+				array[ i ].multiplyMatrices( subCameras[ i ].matrixWorldInverse, object.matrixWorld );
 
 			}
 
@@ -221,15 +222,16 @@ export const highpModelNormalViewMatrix = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 		}
 
-		const normalViewMatrices = uniformArray( matrices ).onObjectUpdate( ( { object, camera } ) => {
+		const normalViewMatrices = uniformArray( matrices ).onObjectUpdate( ( { object, camera }, self ) => {
 
-			const cameras = camera.cameras;
+			const subCameras = camera.cameras;
+			const array = self.array;
 
-			for ( let i = 0; i < matrices.length; i ++ ) {
+			for ( let i = 0, l = subCameras.length; i < l; i ++ ) {
 
-				_modelViewMatrix.multiplyMatrices( cameras[ i ].matrixWorldInverse, object.matrixWorld );
+				_modelViewMatrix.multiplyMatrices( subCameras[ i ].matrixWorldInverse, object.matrixWorld );
 
-				matrices[ i ].getNormalMatrix( _modelViewMatrix );
+				array[ i ].getNormalMatrix( _modelViewMatrix );
 
 			}
 


### PR DESCRIPTION
Fixed #34373.

**Description**

The PR supports `ArrayCamera` in `highpModelViewMatrix` and `highpModelNormalViewMatrix`.

Because the PR is a replacement for #34373, it also carries the `screenSize` fix for `GaussianSpat`.
