### PR TITLE
Bindings: Fix stale storage buffer attributes.

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -392,6 +392,8 @@ class Bindings extends DataMap {
 
 				}
 
+				cacheKey += attribute.id + ',';
+
 			}
 
 			if ( binding.isUniformBuffer ) {


### PR DESCRIPTION
Closes #34381.

**Description**

This is a minimal fix for the original bug reported in #34381. The setup is: A bind group with a texture and a storage buffer. If now the storage switches to a different attribute, the bind group isn't updated. The attribute's id is now part of the cache key, mirroring how textures are handled.

First of all the bug is real since we support switching storage buffer attributes with `storage()`, see #32847.

The other findings later reported in the PR are actually incorrect and misleading. The related review comment guided the PR in the wrong direction so inconsistent fixes were applied that break our design (the way our uniform group architecture is supposed to work).

I've verified this change with the following fiddle: https://jsfiddle.net/8yfao2rx/4/

You only see a single point cloud but should see two next to each other.