### PR TITLE
Backend - Add WebGPULimits

### DIFF
--- a/examples/jsm/gpgpu/BitonicSort.js
+++ b/examples/jsm/gpgpu/BitonicSort.js
@@ -77,20 +77,17 @@ export const getBitonicDisperseIndices = /*@__PURE__*/ Fn( ( [ index, swapSpan ]
 export class BitonicSort {
 
 	/**
-	 * Constructs a new light probe helper.
+	 * A reusable GPGPU Bitonic Sort.
 	 *
-	 * @param {Renderer} renderer - The current scene's renderer.
+	 * Each compute pass executes this.count / 2 invocations that compare two data points
+	 * separated by lane counts that are decreased by a power of 2. When these spans equal the
+	 * workgroupSize, data can be shared within local workgroup buffers and synchronized via
+	 * workgroup barriers, allowing each read/write across spans to exist within the same pass.
+	 *
 	 * @param {StorageBufferNode} dataBuffer - The data buffer to sort.
 	 * @param {Object} [options={}] - Options that modify the bitonic sort.
 	 */
-	constructor( renderer, dataBuffer, options = {} ) {
-
-		/**
-		 * A reference to the renderer.
-		 *
-		 * @type {Renderer}
-		 */
-		this.renderer = renderer;
+	constructor( dataBuffer, options = {} ) {
 
 		/**
 		 * A reference to the StorageBufferNode holding the data that will be sorted  .
@@ -102,38 +99,34 @@ export class BitonicSort {
 		/**
 		 * The size of the data.
 		 *
-		 * @type {StorageBufferNode}
+		 * @type {number}
 		 */
 		this.count = dataBuffer.value.count;
 
 		/**
+		 * The maximum size of each compute dispatch.
 		 *
-		 * The size of each compute dispatch.
 		 * @type {number}
 		 */
-
-		 this.dispatchSize = this.count / 2;
+		this.dispatchSize = this.count / 2;
 
 		/**
 		 * The workgroup size of the compute shaders executed during the sort.
+		 * For practical use cases, one can typically rely on the default workgroup size.
+		 * The final value is alligned with the limits of the device when the sort is first executed.
 		 *
-		 * @type {StorageBufferNode}
+		 * @type {number}
 		*/
-		this.workgroupSize = options.workgroupSize ? Math.min( this.dispatchSize, options.workgroupSize ) : Math.min( this.dispatchSize, 64 );
+		this.workgroupSize = options.workgroupSize ? Math.min( this.dispatchSize, options.workgroupSize ) : this.dispatchSize;
 
 		/**
 		 * A node representing a workgroup scoped buffer that holds locally sorted elements.
+		 * Created when the sort is first executed, once the workgroup size has been alligned with the device.
 		 *
-		 * @type {WorkgroupInfoNode}
+		 * @type {?WorkgroupInfoNode}
+		 * @default null
 		*/
-		this.localStorage = workgroupArray( dataBuffer.nodeType, this.workgroupSize * 2 );
-
-		this._tempArray = new Uint32Array( this.count );
-		for ( let i = 0; i < this.count; i ++ ) {
-
-			this._tempArray[ i ] = 0;
-
-		}
+		this.localStorage = null;
 
 		/**
 		 * A node representing a storage buffer used for transferring the result of the global sort back to the original data buffer.
@@ -149,7 +142,6 @@ export class BitonicSort {
 		*/
 		this.infoStorage = instancedArray( new Uint32Array( [ 1, 2, 2 ] ), 'uint' ).setName( 'BitonicSortInfo' );
 
-
 		/**
 		 * The number of distinct swap operations ('flips' and 'disperses') executed in an in-place
 		 * bitonic sort of the current data buffer.
@@ -160,6 +152,7 @@ export class BitonicSort {
 
 		/**
 		 * The number of steps (i.e prepping and/or executing a swap) needed to fully execute an in-place bitonic sort of the current data buffer.
+		 * Recomputed when the sort is first executed, since it depends on the device alligned workgroup size.
 		 *
 		 * @type {number}
 		*/
@@ -174,57 +167,69 @@ export class BitonicSort {
 
 		/**
 		 * An object containing compute shaders that execute a 'flip' swap within a global address space on elements in the data buffer.
+		 * Created when the sort is first executed, once the workgroup size has been alligned with the device.
 		 *
-		 * @type {Object<string, ComputeNode>}
+		 * @type {?Object<string, ComputeNode>}
+		 * @default null
 		*/
-		this.flipGlobalNodes = {
-			'Data': this._getFlipGlobal( this.dataBuffer, this.tempBuffer ),
-			'Temp': this._getFlipGlobal( this.tempBuffer, this.dataBuffer )
-		};
+		this.flipGlobalNodes = null;
 
 		/**
 		 * An object containing compute shaders that execute a 'disperse' swap within a global address space on elements in the data buffer.
 		 *
-		 * @type {Object<string, ComputeNode>}
+		 * @type {?Object<string, ComputeNode>}
+		 * @default null
 		*/
-		this.disperseGlobalNodes = {
-			'Data': this._getDisperseGlobal( this.dataBuffer, this.tempBuffer ),
-			'Temp': this._getDisperseGlobal( this.tempBuffer, this.dataBuffer )
-		};
+		this.disperseGlobalNodes = null;
 
 		/**
 		 * A compute shader that executes a sequence of flip and disperse swaps within a local address space on elements in the data buffer.
 		 *
-		 * @type {ComputeNode}
+		 * @type {?ComputeNode}
+		 * @default null
 		*/
-		this.swapLocalFn = this._getSwapLocal();
+		this.swapLocalFn = null;
 
 		/**
 		 * A compute shader that executes a sequence of disperse swaps within a local address space on elements in the data buffer.
 		 *
-		 * @type {Object<string, ComputeNode>}
+		 * @type {?Object<string, ComputeNode>}
+		 * @default null
 		*/
-		this.disperseLocalNodes = {
-			'Data': this._getDisperseLocal( this.dataBuffer ),
-			'Temp': this._getDisperseLocal( this.tempBuffer ),
-		};
+		this.disperseLocalNodes = null;
 
 		// Utility functions
 
 		/**
 		 * A compute shader that sets up the algorithm and the swap span for the next swap operation.
 		 *
-		 * @type {ComputeNode}
+		 * @type {?ComputeNode}
+		 * @default null
 		*/
-		this.setAlgoFn = this._getSetAlgoFn();
+		this.setAlgoFn = null;
 
 		/**
 		 * A compute shader that aligns the result of the global swap operation with the current buffer.
 		 *
-		 * @type {ComputeNode}
+		 * @type {?ComputeNode}
+		 * @default null
 		*/
-		this.alignFn = this._getAlignFn();
+		this.alignFn = null;
 
+		/**
+		 * A function that takes a renderer and either runs the bitonic sort or uses the renderer
+		 * information to generate the shaders on the initial compute dispatch.
+		 *
+		 * @type {function(Renderer):void}
+		*/
+		this.compute = this._computeInitial;
+
+		/**
+		 * A function that runs a single step of the bitonic sort.
+		 *
+		 * @type {function(Renderer):void}
+		*/
+		this.computeStep = this._computeStepInitial;
 
 		/**
 		 * A compute shader that resets the algorithm and swap span information.
@@ -318,8 +323,8 @@ export class BitonicSort {
 	 */
 	_globalCompareAndSwapTSL( idxBefore, idxAfter, dataBuffer, tempBuffer ) {
 
-		const data1 = dataBuffer.element( idxBefore );
-		const data2 = dataBuffer.element( idxAfter );
+		const data1 = dataBuffer.element( idxBefore ).toVar();
+		const data2 = dataBuffer.element( idxAfter ).toVar();
 
 		tempBuffer.element( idxBefore ).assign( min( data1, data2 ) );
 		tempBuffer.element( idxAfter ).assign( max( data1, data2 ) );
@@ -617,6 +622,60 @@ export class BitonicSort {
 
 		return fnDef;
 
+	}	/**
+	 * Aligns the workgroup size with the limits of the current device, then creates
+	 * the workgroup storage and compute shaders that depend on it.
+	 *
+	 * @private
+	 * @param {Renderer} renderer - The current scene's renderer.
+	 */
+	_generateComputeShaders( renderer ) {
+
+		const { maxComputeInvocationsPerWorkgroup, maxComputeWorkgroupSizeX } = renderer.backend.computeLimits;
+
+		// A one dimensional workgroup is bound by the total number of invocations per
+		// workgroup as well as by the size of the workgroup's x dimension.
+
+		const maxWorkgroupSize = Math.min( maxComputeInvocationsPerWorkgroup, maxComputeWorkgroupSizeX );
+
+		if ( this.workgroupSize > maxWorkgroupSize ) {
+
+			// Swap spans are powers of two, so the workgroup size has to be one as well.
+
+			this.workgroupSize = 2 ** Math.floor( Math.log2( maxWorkgroupSize ) );
+
+		}
+
+		// Only create the state that depends on the workgroup size once it has been alligned with the device
+
+		this.localStorage = workgroupArray( this.dataBuffer.nodeType, this.workgroupSize * 2 );
+		this.stepCount = this._getStepCount();
+
+		this.flipGlobalNodes = {
+			'Data': this._getFlipGlobal( this.dataBuffer, this.tempBuffer ),
+			'Temp': this._getFlipGlobal( this.tempBuffer, this.dataBuffer )
+		};
+
+		this.disperseGlobalNodes = {
+			'Data': this._getDisperseGlobal( this.dataBuffer, this.tempBuffer ),
+			'Temp': this._getDisperseGlobal( this.tempBuffer, this.dataBuffer )
+		};
+
+		this.swapLocalFn = this._getSwapLocal();
+
+		this.disperseLocalNodes = {
+			'Data': this._getDisperseLocal( this.dataBuffer ),
+			'Temp': this._getDisperseLocal( this.tempBuffer ),
+		};
+
+		this.setAlgoFn = this._getSetAlgoFn();
+		this.alignFn = this._getAlignFn();
+
+		// Reset compute function to default behavior
+
+		this.compute = this._compute;
+		this.computeStep = this._computeStep;
+
 	}
 
 	/**
@@ -624,7 +683,7 @@ export class BitonicSort {
 	 *
 	 * @param {Renderer} renderer - The current scene's renderer.
 	 */
-	computeStep( renderer ) {
+	_computeStep( renderer ) {
 
 		// Swap local only runs once
 		if ( this.currentDispatch === 0 ) {
@@ -698,7 +757,7 @@ export class BitonicSort {
 	 *
 	 * @param {Renderer} renderer - The current scene's renderer.
 	 */
-	compute( renderer ) {
+	_compute( renderer ) {
 
 		this.globalOpsRemaining = 0;
 		this.globalOpsInSpan = 0;
@@ -706,9 +765,34 @@ export class BitonicSort {
 
 		for ( let i = 0; i < this.stepCount; i ++ ) {
 
-			this.computeStep( renderer );
+			this._computeStep( renderer );
 
 		}
+
+	}
+
+	/**
+	 * Resolves our compute data with the current backend device then runs compute.
+	 *
+	 * @param {Renderer} renderer - The current scene's renderer.
+	 */
+	_computeInitial( renderer ) {
+
+		// Generates shaders and sets compute to default
+		this._generateComputeShaders( renderer );
+		this.compute( renderer );
+
+	}
+
+	/**
+	 * Resolves our compute data with the current backend device then runs computeStep.
+	 *
+	 * @param {Renderer} renderer - The current scene's renderer.
+	 */
+	_computeStepInitial( renderer ) {
+
+		this._generateComputeShaders( renderer );
+		this.computeStep( renderer );
 
 	}
 

--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -327,7 +327,6 @@
 				scene.background = new THREE.Color( 0x313131 );
 
 				const bitonicSortModule = new BitonicSort(
-					renderer,
 					currentElementsStorage,
 					{
 						workgroupSize: 64,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1723,6 +1723,26 @@ export const RenderObjectRefreshType = {
 };
 
 /**
+ * The minimum viable compute limits across all compute capable backends.
+ *
+ * Backends report their actual compute limits via `Backend.computeLimits` and
+ * fall back to these values when the underlying device does not provide them.
+ * Since only the WebGPUBackend currently provides compute limits, these constants
+ * mirror the minimumn guarantees provided by a WebGPU capable device.
+ *
+ * @type {ConstantsMinimumComputeLimits}
+ * @constant
+ */
+export const MinimumComputeLimits = {
+	maxComputeWorkgroupStorageSize: 16384,
+	maxComputeInvocationsPerWorkgroup: 256,
+	maxComputeWorkgroupSizeX: 256,
+	maxComputeWorkgroupSizeY: 256,
+	maxComputeWorkgroupSizeZ: 64,
+	maxComputeWorkgroupsPerDimension: 65535
+};
+
+/**
  * This type represents mouse buttons and interaction types in context of controls.
  *
  * @typedef {Object} ConstantsMouse
@@ -1779,4 +1799,16 @@ export const RenderObjectRefreshType = {
  * @property {number} NONE - No refresh required.
  * @property {number} SHARED - Only shared uniform buffers require an update.
  * @property {number} FULL - The render object requires a full refresh.
+ */
+
+/**
+ * This type represents the compute limits of a backend.
+ *
+ * @typedef {Object} ConstantsMinimumComputeLimits
+ * @property {number} maxComputeWorkgroupStorageSize - The maximum number of bytes used for workgroup storage in a compute stage.
+ * @property {number} maxComputeInvocationsPerWorkgroup - The maximum number of invocations in a single workgroup.
+ * @property {number} maxComputeWorkgroupSizeX - The maximum size of the X dimension of a workgroup.
+ * @property {number} maxComputeWorkgroupSizeY - The maximum size of the Y dimension of a workgroup.
+ * @property {number} maxComputeWorkgroupSizeZ - The maximum size of the Z dimension of a workgroup.
+ * @property {number} maxComputeWorkgroupsPerDimension - The maximum number of workgroups dispatched per dimension.
  */

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -4,7 +4,7 @@ let _color4 = null;
 import Color4 from './Color4.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { createCanvasElement, warnOnce } from '../../utils.js';
-import { REVISION, TimestampQuery } from '../../constants.js';
+import { REVISION, TimestampQuery, MinimumComputeLimits } from '../../constants.js';
 
 /**
  * Most of the rendering related logic is implemented in the
@@ -558,6 +558,19 @@ class Backend {
 	get hasTimestamp() {
 
 		return false;
+
+	}
+
+	/**
+	 * The compute limits of the backend. Backends that can query the limits
+	 * of the underlying device should override this getter.
+	 *
+	 * @type {ConstantsMinimumComputeLimits}
+	 * @readonly
+	 */
+	get computeLimits() {
+
+		return MinimumComputeLimits;
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1,7 +1,7 @@
 // debugger tools
 // import 'https://greggman.github.io/webgpu-avoid-redundant-state-setting/webgpu-check-redundant-state-setting.js';
 
-import { GPUFeatureName, GPULoadOp, GPUStoreOp, GPUIndexFormat, GPUTextureViewDimension, GPUFeatureMap, GPUShaderStage } from './utils/WebGPUConstants.js';
+import { GPUFeatureName, GPULoadOp, GPUStoreOp, GPUIndexFormat, GPUTextureViewDimension, GPUFeatureMap, GPUShaderStage, GPUDefaultComputeLimits } from './utils/WebGPUConstants.js';
 
 import WGSLNodeBuilder from './nodes/WGSLNodeBuilder.js';
 import Backend from '../common/Backend.js';
@@ -394,6 +394,19 @@ class WebGPUBackend extends Backend {
 	get hasTimestamp() {
 
 		return true;
+
+	}
+
+	/**
+	 * The compute limits of the device. If the device has not been initialized
+	 * yet, the default limits guaranteed by the WebGPU specification are returned.
+	 *
+	 * @type {Object}
+	 * @readonly
+	 */
+	get computeLimits() {
+
+		return this.device !== null ? this.device.limits : GPUDefaultComputeLimits;
 
 	}
 

--- a/src/renderers/webgpu/utils/WebGPUConstants.js
+++ b/src/renderers/webgpu/utils/WebGPUConstants.js
@@ -345,10 +345,78 @@ export const GPUFeatureName = {
 	DualSourceBlending: 'dual-source-blending',
 	Subgroups: 'subgroups',
 	TextureFormatsTier1: 'texture-formats-tier1',
-	TextureFormatsTier2: 'texture-formats-tier2'
+	TextureFormatsTier2: 'texture-formats-tier2',
+	PrimitiveIndex: 'primitive-index',
+	TextureComponentSwizzle: 'texture-component-swizzle',
 };
 
 export const GPUFeatureMap = {
 	'texture-compression-s3tc': 'texture-compression-bc',
 	'texture-compression-etc1': 'texture-compression-etc2'
+};
+
+export const WGSLLanguageFeatures = {
+	ReadOnlyAndReadWriteStorageTextures: 'readonly_and_readwrite_storage_textures',
+	Packed4x8IntegerDotProduct: 'packed_4x8_integer_dot_product',
+	UnrestrictedPointerParameters: 'unrestricted_pointer_parameters',
+	PointerCompositeAccess: 'pointer_composite_access',
+	UniformBufferStandardLayout: 'uniform_buffer_standard_layout',
+	SubgroupID: 'subgroup_id',
+	SubgroupUniformity: 'subgroup_uniformity',
+	TextureAndSamplerLet: 'texture_and_sampler_let',
+	TextureFormatsTier1: 'texture_formats_tier1',
+	LinearIndexing: 'linear_indexing',
+	ImmediateAddressSpace: 'immediate_address_space',
+	FragmentDepth: 'fragment_depth',
+	BufferView: 'buffer_view',
+	SwizzleAssignment: 'swizzle_assignment'
+};
+
+export const GPUDefaultTextureLimits = {
+	maxTextureDimension1D: 8192,
+	maxTextureDimension2D: 8192,
+	maxTextureDimension3D: 2048,
+	maxTextureArrayLayers: 256
+};
+
+export const GPUDefaultResourceLimits = {
+	maxBindGroups: 4,
+	maxBindingsPerBindGroup: 640,
+	maxDynamicUniformBuffersPerPipelineLayout: 8,
+	maxDynamicStorageBuffersPerPipelineLayout: 4,
+	maxColorAttachments: 8,
+	maxColorAttachmentBytesPerSample: 32,
+};
+
+export const GPUDefaultShaderLimits = {
+	maxSampledTexturesPerShaderStage: 16,
+	maxSamplersPerShaderStage: 16,
+	maxStorageBuffersInFragmentStage: 8,
+	maxStorageBuffersInVertexStage: 8,
+	maxStorageBuffersPerShaderStage: 8,
+	maxStorageTexturesInFragmentStage: 4,
+	maxStorageTexturesInVertexStage: 4,
+	maxStorageTexturesPerShaderStage: 4,
+	maxUniformBuffersPerShaderStage: 12,
+	maxInterStageShaderVariables: 16,
+};
+
+export const GPUDefaultBufferLimits = {
+	maxUniformBufferBindingSize: 65536,
+	maxStorageBufferBindingSize: 134217728,
+	minUniformBufferOffsetAlignment: 256,
+	minStorageBufferOffsetAlignment: 256,
+	maxVertexBuffers: 8,
+	maxBufferSize: 268435456,
+	maxVertexAttributes: 16,
+	maxVertexBufferArrayStride: 2048,
+};
+
+export const GPUDefaultComputeLimits = {
+	maxComputeWorkgroupStorageSize: 16384,
+	maxComputeInvocationsPerWorkgroup: 256,
+	maxComputeWorkgroupSizeX: 256,
+	maxComputeWorkgroupSizeY: 256,
+	maxComputeWorkgroupSizeZ: 64,
+	maxComputeWorkgroupsPerDimension: 65535
 };


### PR DESCRIPTION
**Description**

Adds WebGPU limits as constants to the library and uses them in BitonicSort to automatically generate shaders that leverage the device's largest possible compute size.

**PR Changes**

1. Add the default/minimum limits for WebGPU compatible devices to the WebGPUConstants.js page. Use these limits as the default for querying the device's backend for its compute limits. Since we only have compute limits for the WebGPUBackend, the limits reflect the naming conventions of a WebGPU device's limits.

2. Adds missing features and constants to WebGPUConstants, such as the primitive-index feature, for later use.

3. Makes changes to the BitonicSort including
- Removing unused variables
- Creating shaders on the initial compute to align the sort's workgroup size with the WebGPU device's limitations
- Micro-optimizations to the shaders ( mostly adding toVar() to global comparisons to decrease read accesses )