### PR TITLE
KeyframeTrack: Serialize Bezier tangent settings.

### DIFF
--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -472,17 +472,30 @@ function parseKeyframeTrack( json ) {
 
 	}
 
+	let track;
+
 	// derived classes can define a static parse method
 	if ( trackType.parse !== undefined ) {
 
-		return trackType.parse( json );
+		track = trackType.parse( json );
 
 	} else {
 
 		// by default, we assume a constructor compatible with the base
-		return new trackType( json.name, json.times, json.values, json.interpolation );
+		track = new trackType( json.name, json.times, json.values, json.interpolation );
 
 	}
+
+	if ( json.settings !== undefined ) {
+
+		track.settings = {
+			inTangents: AnimationUtils.convertArray( json.settings.inTangents, Float32Array ),
+			outTangents: AnimationUtils.convertArray( json.settings.outTangents, Float32Array )
+		};
+
+	}
+
+	return track;
 
 }
 

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -95,13 +95,11 @@ class KeyframeTrack {
 
 			}
 
-			if ( track.settings !== undefined ) {
+			if ( track.settings ) {
 
 				json.settings = {
-
-					'inTangents': AnimationUtils.convertArray( track.settings.inTangents, Array ),
-					'outTangents': AnimationUtils.convertArray( track.settings.outTangents, Array )
-
+					inTangents: AnimationUtils.convertArray( track.settings.inTangents, Array ),
+					outTangents: AnimationUtils.convertArray( track.settings.outTangents, Array )
 				};
 
 			}
@@ -328,6 +326,13 @@ class KeyframeTrack {
 			for ( let i = 0, n = times.length; i !== n; ++ i ) {
 
 				times[ i ] *= timeScale;
+
+			}
+
+			if ( this.settings ) {
+
+				scaleTangentTimes( this.settings.inTangents, timeScale );
+				scaleTangentTimes( this.settings.outTangents, timeScale );
 
 			}
 
@@ -607,6 +612,18 @@ class KeyframeTrack {
 		track.createInterpolant = this.createInterpolant;
 
 		return track;
+
+	}
+
+}
+
+function scaleTangentTimes( tangents, timeScale ) {
+
+	if ( tangents === undefined ) return;
+
+	for ( let i = 0, n = tangents.length; i !== n; i += 2 ) {
+
+		tangents[ i ] *= timeScale;
 
 	}
 

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -95,6 +95,17 @@ class KeyframeTrack {
 
 			}
 
+			if ( track.settings !== undefined ) {
+
+				json.settings = {
+
+					'inTangents': AnimationUtils.convertArray( track.settings.inTangents, Array ),
+					'outTangents': AnimationUtils.convertArray( track.settings.outTangents, Array )
+
+				};
+
+			}
+
 		}
 
 		json.type = track.ValueTypeName; // mandatory

--- a/test/unit/src/animation/AnimationClip.tests.js
+++ b/test/unit/src/animation/AnimationClip.tests.js
@@ -40,13 +40,18 @@ export default QUnit.module( 'Animation', () => {
 			const parsedClip = AnimationClip.parse( JSON.parse( JSON.stringify( AnimationClip.toJSON( clip ) ) ) );
 			const parsedTrack = parsedClip.tracks[ 0 ];
 
-			assert.smartEqual( Array.from( parsedTrack.settings.inTangents ), Array.from( track.settings.inTangents ) );
-			assert.smartEqual( Array.from( parsedTrack.settings.outTangents ), Array.from( track.settings.outTangents ) );
-
+			assert.smartEqual(
+				Array.from( parsedTrack.settings.inTangents ), Array.from( track.settings.inTangents ),
+				'Bezier in tangents are restored'
+			);
+			assert.smartEqual(
+				Array.from( parsedTrack.settings.outTangents ), Array.from( track.settings.outTangents ),
+				'Bezier out tangents are restored'
+			);
 			assert.equal(
 				parsedTrack.createInterpolant().evaluate( 0.5 )[ 0 ],
 				track.createInterpolant().evaluate( 0.5 )[ 0 ],
-				'Bezier tangents survive a round trip'
+				'Bezier interpolation is preserved through serialization'
 			);
 
 		} );

--- a/test/unit/src/animation/AnimationClip.tests.js
+++ b/test/unit/src/animation/AnimationClip.tests.js
@@ -1,5 +1,8 @@
 import { AnimationClip } from '../../../../src/animation/AnimationClip.js';
 
+import { NumberKeyframeTrack } from '../../../../src/animation/tracks/NumberKeyframeTrack.js';
+import { InterpolateBezier } from '../../../../src/constants.js';
+
 export default QUnit.module( 'Animation', () => {
 
 	QUnit.module( 'AnimationClip', () => {
@@ -19,6 +22,31 @@ export default QUnit.module( 'Animation', () => {
 			assert.strictEqual(
 				clip.name === 'clip1', true,
 				'AnimationClip can be named'
+			);
+
+		} );
+
+		// STATIC
+		QUnit.test( 'parse', ( assert ) => {
+
+			const track = new NumberKeyframeTrack( '.material.opacity', [ 0, 1 ], [ 0, 10 ] );
+			track.settings = {
+				inTangents: new Float32Array( [ 0, 0, - 0.25, - 8 ] ),
+				outTangents: new Float32Array( [ 0.25, 8, 0, 0 ] )
+			};
+			track.setInterpolation( InterpolateBezier );
+
+			const clip = new AnimationClip( 'clip1', 1, [ track ] );
+			const parsedClip = AnimationClip.parse( JSON.parse( JSON.stringify( AnimationClip.toJSON( clip ) ) ) );
+			const parsedTrack = parsedClip.tracks[ 0 ];
+
+			assert.smartEqual( Array.from( parsedTrack.settings.inTangents ), Array.from( track.settings.inTangents ) );
+			assert.smartEqual( Array.from( parsedTrack.settings.outTangents ), Array.from( track.settings.outTangents ) );
+
+			assert.equal(
+				parsedTrack.createInterpolant().evaluate( 0.5 )[ 0 ],
+				track.createInterpolant().evaluate( 0.5 )[ 0 ],
+				'Bezier tangents survive a round trip'
 			);
 
 		} );

--- a/test/unit/src/animation/KeyframeTrack.tests.js
+++ b/test/unit/src/animation/KeyframeTrack.tests.js
@@ -57,6 +57,22 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
+		QUnit.test( 'scale', ( assert ) => {
+
+			const track = new NumberKeyframeTrack( '.material.opacity', [ 0, 1 ], [ 0, 10 ] );
+			track.settings = {
+				inTangents: new Float32Array( [ 0, 0, 0.75, 8 ] ),
+				outTangents: new Float32Array( [ 0.25, 8, 0, 0 ] )
+			};
+
+			track.scale( 2 );
+
+			assert.smartEqual( Array.from( track.times ), [ 0, 2 ] );
+			assert.smartEqual( Array.from( track.settings.inTangents ), [ 0, 0, 1.5, 8 ] );
+			assert.smartEqual( Array.from( track.settings.outTangents ), [ 0.5, 8, 0, 0 ] );
+
+		} );
+
 		QUnit.test( 'optimize', ( assert ) => {
 
 			const track = new NumberKeyframeTrack( '.material.opacity', [ 0, 1, 2, 3, 4 ], [ 0, 0, 0, 0, 1 ] );


### PR DESCRIPTION
Related issue: #34397

**Description**

`KeyframeTrack.toJSON()` never wrote `settings`, so the in/out tangents an `InterpolateBezier` track depends on were dropped on serialization. The parsed track still reported `InterpolateBezier` and still built a `BezierInterpolant`, but with no tangent data that interpolant falls back to linear without logging anything.

`toJSON()` now writes the tangents the same way `times` and `values` are written, and `parse()` restores them. Tangent control points are absolute times, so `scale()` now scales their time components too, otherwise `AnimationClip.parse()` on a clip with `fps` would leave them out of sync with `times`.
