### PR TITLE
DevTools: Object details, box highlight and 1.18.

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -13,7 +13,7 @@ The toolbar icon shows the three.js revision found on the page. Clicking it scro
 ## Features
 
 - **Scenes**: a collapsible tree of every scene and its objects, with geometry and material types for meshes, and object and light counts per scene.
-- **Objects**: hover an object to see its position, rotation and scale, and to highlight it in the page with a yellow wireframe.
+- **Objects**: click an object to expand it: a preview of the object rendered with its own material, its position, rotation and scale, and a dropdown of properties for its geometry and each material. Hovering draws a box around it over the page.
 - **Renderers**: properties, render stats and memory usage of every `WebGLRenderer` and `WebGPURenderer`, with a button to scroll to its canvas.
 
 ## How it works
@@ -24,7 +24,8 @@ three.js has built-in support for the extension: when `window.__THREE_DEVTOOLS__
 
 - `manifest.json`: injects the page scripts into every frame at `document_start`.
 - `bridge.js`: runs in the page's main world. Creates `window.__THREE_DEVTOOLS__`, collects data from the observed renderers and scenes, and answers the panel's requests.
-- `highlight.js`: runs alongside the bridge. Adds a yellow wireframe clone of the hovered object to its scene.
+- `highlight.js`: runs alongside the bridge. Draws a box around the hovered object in an overlay above the page, projected through the camera and viewport the scene is shown with (one per sub camera of an ArrayCamera).
+- `preview.js`: runs alongside the bridge. Renders an expanded object with its own material, using a renderer created from the page's own three.js, lit by the page's environment and by studio lights of its own (the page's lights on WebGPU).
 - `content-script.js`: runs in the isolated world. Relays messages between the bridge and the background script.
 - `background.js`: service worker. Routes messages between the panel and the content script of the inspected tab, and manages the toolbar badge.
 - `devtools.js`: creates the "Three.js" panel.
@@ -42,9 +43,13 @@ The panel opens a port to the background script and identifies the inspected tab
 
 Events from the page: `register`, `renderer`, `scene`, `scene-removed`, `object-details`. Requests from the panel: `request-state`, `request-object-details`, `scroll-to-canvas`, `highlight-object`, `unhighlight-object`.
 
+### Views
+
+The highlight and the preview need the renderer, camera and viewport a scene is shown with, which the bridge records in `scene.onAfterRender`. A scene is drawn many times a frame (shadow maps, reflections, post processing), so only a pass to the canvas, or to a texture shaped like it, counts, and since passes are seen as they finish, one rendered from inside another is followed by the pass it served. A pass to the canvas also records its viewport.
+
 ### State
 
-The panel requests the state when it opens and then once a second. On each request the bridge resends every renderer (their stats change every frame), and a scene only when its object count changed. Scenes have no `dispose()`, so a scene that stays empty for several requests is removed from the panel, and brought back if it gains children again.
+The panel requests the state when it opens and then once a second, along with the details of the expanded objects. Rendering a preview costs the page a frame, so it is only asked for when a row is expanded and when its geometry or material changes. On each request the bridge resends every renderer (their stats change every frame), and a scene only when its object count changed. Scenes have no `dispose()`, so a scene that stays empty for several requests is removed from the panel, and brought back if it gains children again.
 
 The background script tags every message with the frame it came from and reports navigations, so the panel drops the renderers and scenes of a navigated frame (all of them for a top-level navigation).
 

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -25,7 +25,7 @@ three.js has built-in support for the extension: when `window.__THREE_DEVTOOLS__
 - `manifest.json`: injects the page scripts into every frame at `document_start`.
 - `bridge.js`: runs in the page's main world. Creates `window.__THREE_DEVTOOLS__`, collects data from the observed renderers and scenes, and answers the panel's requests.
 - `highlight.js`: runs alongside the bridge. Draws a box around the hovered object in an overlay above the page, projected through the camera and viewport the scene is shown with (one per sub camera of an ArrayCamera).
-- `preview.js`: runs alongside the bridge. Renders an expanded object with its own material, using a renderer created from the page's own three.js, lit by the page's environment and by studio lights of its own (the page's lights on WebGPU).
+- `preview.js`: runs alongside the bridge. Renders an expanded object with its own material, using a renderer created from the page's own three.js, lit by the page's environment and by studio lights of its own (the page's lights on WebGPU). Materials with custom shaders are skipped, their uniforms belong to the page's renderer.
 - `content-script.js`: runs in the isolated world. Relays messages between the bridge and the background script.
 - `background.js`: service worker. Routes messages between the panel and the content script of the inspected tab, and manages the toolbar badge.
 - `devtools.js`: creates the "Three.js" panel.

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -49,7 +49,7 @@ The highlight and the preview need the renderer, camera and viewport a scene is 
 
 ### State
 
-The panel requests the state when it opens and then once a second, along with the details of the expanded objects. Rendering a preview costs the page a frame, so it is only asked for when a row is expanded and when its geometry or material changes. On each request the bridge resends every renderer (their stats change every frame), and a scene only when its object count changed. Scenes have no `dispose()`, so a scene that stays empty for several requests is removed from the panel, and brought back if it gains children again.
+The panel requests the state when it opens and then once a second, along with the details of the expanded objects. While there is nothing to show it says whether three.js was found, so the bridge repeats the revision three.js registered with on every request (versions before r106 do not register). Rendering a preview costs the page a frame, so it is only asked for when a row is expanded and when its geometry or material changes. On each request the bridge resends every renderer (their stats change every frame), and a scene only when its object count changed. Scenes have no `dispose()`, so a scene that stays empty for several requests is removed from the panel, and brought back if it gains children again.
 
 The background script tags every message with the frame it came from and reports navigations, so the panel drops the renderers and scenes of a navigated frame (all of them for a top-level navigation).
 

--- a/devtools/background.js
+++ b/devtools/background.js
@@ -1,4 +1,4 @@
-/* global chrome, importScripts, MESSAGE_ID, MESSAGE_INIT, MESSAGE_REQUEST_STATE, MESSAGE_REQUEST_OBJECT_DETAILS, MESSAGE_SCROLL_TO_CANVAS, MESSAGE_HIGHLIGHT_OBJECT, MESSAGE_UNHIGHLIGHT_OBJECT, EVENT_REGISTER, EVENT_COMMITTED */
+/* global chrome, importScripts, MESSAGE_INIT, MESSAGE_REQUEST_STATE, MESSAGE_REQUEST_OBJECT_DETAILS, MESSAGE_SCROLL_TO_CANVAS, MESSAGE_HIGHLIGHT_OBJECT, MESSAGE_UNHIGHLIGHT_OBJECT, EVENT_REGISTER, EVENT_COMMITTED */
 
 importScripts( 'constants.js' );
 
@@ -29,6 +29,24 @@ function clearBadge( tabId ) {
 
 }
 
+// The panel inspecting a tab, if one is open. A port that just closed throws, which is fine.
+function postToPanel( tabId, message ) {
+
+	const port = connections.get( tabId );
+	if ( port === undefined ) return;
+
+	try {
+
+		port.postMessage( message );
+
+	} catch ( error ) {
+
+		// Port already disconnected
+
+	}
+
+}
+
 // Toolbar icon click scrolls the page to its first canvas
 chrome.action.onClicked.addListener( ( tab ) => {
 
@@ -51,7 +69,7 @@ chrome.runtime.onConnect.addListener( ( port ) => {
 
 		} else if ( FORWARDABLE_MESSAGES.has( message.name ) ) {
 
-			chrome.tabs.sendMessage( tabId, message );
+			chrome.tabs.sendMessage( tabId, message ).catch( () => {} );
 
 		}
 
@@ -77,6 +95,8 @@ chrome.runtime.onMessage.addListener( ( message, sender ) => {
 			}
 		} );
 
+		return;
+
 	}
 
 	if ( sender.tab === undefined ) return;
@@ -93,24 +113,9 @@ chrome.runtime.onMessage.addListener( ( message, sender ) => {
 
 	}
 
-	const port = connections.get( tabId );
-
-	if ( port !== undefined ) {
-
-		// The panel keeps track of which frame each renderer and scene came from
-		message.frameId = sender.frameId;
-
-		try {
-
-			port.postMessage( message );
-
-		} catch ( error ) {
-
-			// Port already disconnected
-
-		}
-
-	}
+	// The panel keeps track of which frame each renderer and scene came from
+	message.frameId = sender.frameId;
+	postToPanel( tabId, message );
 
 } );
 
@@ -119,12 +124,6 @@ chrome.webNavigation.onCommitted.addListener( ( { tabId, frameId } ) => {
 
 	if ( frameId === 0 ) clearBadge( tabId );
 
-	const port = connections.get( tabId );
-
-	if ( port !== undefined ) {
-
-		port.postMessage( { id: MESSAGE_ID, name: EVENT_COMMITTED, frameId: frameId } );
-
-	}
+	postToPanel( tabId, { name: EVENT_COMMITTED, frameId: frameId } );
 
 } );

--- a/devtools/bridge.js
+++ b/devtools/bridge.js
@@ -1,4 +1,4 @@
-/* global MESSAGE_ID, HIGHLIGHT_NAME, MESSAGE_REQUEST_STATE, MESSAGE_REQUEST_OBJECT_DETAILS, MESSAGE_SCROLL_TO_CANVAS, MESSAGE_HIGHLIGHT_OBJECT, MESSAGE_UNHIGHLIGHT_OBJECT, EVENT_REGISTER, EVENT_OBSERVE, EVENT_RENDERER, EVENT_SCENE, EVENT_SCENE_REMOVED, EVENT_OBJECT_DETAILS */
+/* global MESSAGE_ID, MESSAGE_REQUEST_STATE, MESSAGE_REQUEST_OBJECT_DETAILS, MESSAGE_SCROLL_TO_CANVAS, MESSAGE_HIGHLIGHT_OBJECT, MESSAGE_UNHIGHLIGHT_OBJECT, EVENT_REGISTER, EVENT_OBSERVE, EVENT_RENDERER, EVENT_SCENE, EVENT_SCENE_REMOVED, EVENT_OBJECT_DETAILS */
 
 /**
  * Injected into the page by the three.js DevTools extension. Exposes
@@ -11,34 +11,37 @@
 	if ( window.__THREE_DEVTOOLS__ ) return;
 
 	const CANVAS_FLASH_DURATION = 1000;
-	const SCENE_EMPTY_TICKS_THRESHOLD = 5; // ~5s at 1s polling - hide empty scene from the panel
+	const SCENE_EMPTY_TICKS_THRESHOLD = 5; // Polls before an empty scene is hidden from the panel, ~5s
 
 	const observedScenes = [];
 	const observedRenderers = [];
 	const sceneObjectCountCache = new Map(); // Object count per scene at the last batch sent, absent while hidden from the panel
 	const sceneEmptyTicks = new Map(); // Consecutive sendState ticks each scene has been empty
+	const sceneViews = new Map(); // Where each scene is shown: the renderer, camera and viewport of the pass that put it on screen
 
 	// three.js reports its renderers and scenes by dispatching events on this
 	const devTools = new EventTarget();
 	Object.defineProperty( window, '__THREE_DEVTOOLS__', { value: devTools, enumerable: true } );
 
-	// Expose utilities for highlight.js
-	devTools.utils = { findObjectInScenes };
+	// Shared with highlight.js and preview.js, which add their own functions here
+	devTools.utils = { findObjectInScenes, unobserved, getSceneView };
 
-	// Renderers have no uuid of their own
-	function generateUUID() {
+	// Create an object without reporting it to the panel, for the renderer and scene of preview.js
+	let observing = true;
 
-		const array = new Uint8Array( 16 );
-		crypto.getRandomValues( array );
-		array[ 6 ] = ( array[ 6 ] & 0x0f ) | 0x40; // Set version to 4
-		array[ 8 ] = ( array[ 8 ] & 0x3f ) | 0x80; // Set variant to 10
-		return [ ...array ].map( ( b, i ) => ( i === 4 || i === 6 || i === 8 || i === 10 ? '-' : '' ) + b.toString( 16 ).padStart( 2, '0' ) ).join( '' );
+	function unobserved( create ) {
 
-	}
+		observing = false;
 
-	function xyz( vector ) {
+		try {
 
-		return { x: vector.x, y: vector.y, z: vector.z };
+			return create();
+
+		} finally {
+
+			observing = true;
+
+		}
 
 	}
 
@@ -49,11 +52,53 @@
 
 	}
 
+	// --- Scene views ---
+
+	// The renderer copies its viewport into a Vector4 and returns that, so a stand-in returning the numbers will do
+	const readViewport = { copy: ( v ) => [ v.x, v.y, v.z, v.w ] };
+
+	// A scene is drawn many times a frame: shadow maps, reflections, post processing. Passes are seen
+	// as they finish, so one rendered from inside another is followed by the pass it served, and only
+	// a pass to the canvas, or to a texture shaped like it, can be what the page shows.
+	function watchScene( scene ) {
+
+		const pageHook = scene.onAfterRender;
+
+		function hook( renderer, scene, camera ) {
+
+			const target = renderer.getRenderTarget();
+			const canvas = renderer.domElement;
+			const onCanvas = target === null;
+
+			if ( onCanvas || Math.abs( target.width / target.height - canvas.width / canvas.height ) < 0.01 ) {
+
+				sceneViews.set( scene, { scene: scene, renderer: renderer, camera: camera, viewport: onCanvas ? renderer.getViewport( readViewport ) : null } );
+
+			}
+
+			pageHook.apply( this, arguments );
+
+		}
+
+		hook.isDevToolsHook = true;
+		scene.onAfterRender = hook;
+
+	}
+
+	function getSceneView( object ) {
+
+		while ( object.parent !== null ) object = object.parent;
+
+		return sceneViews.get( object ) || null;
+
+	}
+
 	// --- Data extraction ---
 
 	function getRendererProperties( renderer ) {
 
-		const parameters = renderer.getContextAttributes ? renderer.getContextAttributes() : {};
+		// WebGL reports its context attributes, WebGPU exposes them directly
+		const parameters = renderer.getContextAttributes?.() || { alpha: renderer.alpha, antialias: renderer.samples > 0 };
 
 		return {
 			width: renderer.domElement.clientWidth,
@@ -80,91 +125,112 @@
 				memory: {
 					geometries: renderer.info.memory.geometries,
 					textures: renderer.info.memory.textures,
-					programs: renderer.info.programs ? renderer.info.programs.length : 0
+					// WebGPU counts its programs instead of listing them
+					programs: renderer.info.programs ? renderer.info.programs.length : renderer.info.memory.programs
 				}
 			}
 		};
 
 	}
 
-	function getRendererData( renderer ) {
-
-		try {
-
-			return {
-				uuid: renderer.uuid,
-				type: renderer.isWebGLRenderer ? 'WebGLRenderer' : 'WebGPURenderer',
-				properties: getRendererProperties( renderer ),
-				canvasInDOM: document.contains( renderer.domElement )
-			};
-
-		} catch ( error ) {
-
-			console.warn( 'DevTools: Error getting renderer data:', error );
-			return null;
-
-		}
-
-	}
-
 	function getObjectData( object ) {
 
-		try {
+		const data = {
+			uuid: object.uuid,
+			name: object.name,
+			type: object.isInstancedMesh ? 'InstancedMesh' : object.type, // InstancedMesh doesn't set its own type
+			visible: object.visible,
+			isScene: object.isScene === true,
+			isCamera: object.isCamera === true,
+			isLight: object.isLight === true,
+			isGroup: object.isGroup === true,
+			isMesh: object.isMesh === true,
+			isInstancedMesh: object.isInstancedMesh === true,
+			children: object.children.map( child => child.uuid )
+		};
 
-			const data = {
-				uuid: object.uuid,
-				name: object.name,
-				type: object.isInstancedMesh ? 'InstancedMesh' : object.type, // InstancedMesh doesn't set its own type
-				visible: object.visible,
-				isScene: object.isScene === true,
-				isCamera: object.isCamera === true,
-				isLight: object.isLight === true,
-				isGroup: object.isGroup === true,
-				isMesh: object.isMesh === true,
-				isInstancedMesh: object.isInstancedMesh === true,
-				children: object.children.map( child => child.uuid )
-			};
+		if ( object.isMesh ) {
 
-			if ( object.isMesh ) {
+			data.geometryType = object.geometry.type;
+			data.materialType = [].concat( object.material ).map( material => material.type ).join( ', ' );
 
-				data.geometryType = object.geometry.type;
-				data.materialType = Array.isArray( object.material ) ? object.material.map( m => m.type ).join( ', ' ) : object.material.type;
+		}
 
-			}
+		if ( object.isInstancedMesh ) {
 
-			if ( object.isInstancedMesh ) {
+			data.count = object.count;
 
-				data.count = object.count;
+		}
 
-			}
+		return data;
 
-			return data;
+	}
 
-		} catch ( error ) {
+	function getGeometryData( geometry ) {
 
-			console.warn( 'DevTools: Error getting object data:', error );
-			return null;
+		const properties = {};
+
+		for ( const [ name, attribute ] of Object.entries( geometry.attributes ) ) {
+
+			properties[ name ] = `${attribute.count} × ${attribute.itemSize}`;
+
+		}
+
+		if ( geometry.index !== null ) properties.index = geometry.index.count;
+		if ( geometry.groups.length > 0 ) properties.groups = geometry.groups.length;
+
+		return { type: geometry.type, name: geometry.name, properties: properties };
+
+	}
+
+	// Identity, shader sources and the blend/stencil/clip/polygon offset plumbing would drown the interesting properties
+	const HIDDEN_MATERIAL_PROPERTIES = /^(is|blend[A-Z]|stencil|clip|polygonOffset)|^(uuid|name|type|version|userData|defines|vertexShader|fragmentShader|depthFunc|shadowSide|colorWrite|precision|dithering|premultipliedAlpha|forceSinglePass|allowOverride)$/;
+
+	function getMaterialData( material ) {
+
+		const properties = {};
+
+		for ( const [ key, value ] of Object.entries( material ) ) {
+
+			// alphaTest, clearcoat, transmission and friends are stored in an underscored field behind a getter
+			const name = key.startsWith( '_' ) && key.slice( 1 ) in material ? key.slice( 1 ) : key;
+
+			if ( HIDDEN_MATERIAL_PROPERTIES.test( name ) ) continue;
+
+			const formatted = formatMaterialValue( value );
+			if ( formatted !== undefined ) properties[ name ] = formatted;
+
+		}
+
+		return { type: material.type, name: material.name, properties: properties };
+
+	}
+
+	// Plain values pass through, colors, textures, nodes and math objects are summarized, everything else is skipped
+	function formatMaterialValue( value ) {
+
+		if ( value === null || typeof value === 'function' ) return undefined;
+		if ( typeof value !== 'object' ) return value;
+		if ( value.isColor ) return '#' + value.getHexString();
+		if ( value.isTexture ) return value.name || ( value.image && value.image.width ? `${value.image.width} × ${value.image.height}` : 'Texture' );
+		if ( value.isNode ) return value.type;
+
+		// Vectors, Eulers and matrices. A TSL node answers to any property, so the result has to be checked
+		if ( typeof value.toArray === 'function' ) {
+
+			const array = value.toArray();
+			if ( Array.isArray( array ) ) return array;
 
 		}
 
 	}
 
-	// Collect data for a scene and all of its descendants
-	function collectSceneObjects( scene ) {
+	// Collect data for an object and all of its descendants
+	function collectSceneObjects( object, objects = [] ) {
 
-		const objects = [];
+		objects.push( getObjectData( object ) );
 
-		( function traverse( object ) {
-
-			// Skip the highlight clone added by highlight.js
-			if ( object.name === HIGHLIGHT_NAME ) return;
-
-			const data = getObjectData( object );
-			if ( data !== null ) objects.push( data );
-
-			object.children.forEach( traverse );
-
-		} )( scene );
+		for ( const child of object.children ) collectSceneObjects( child, objects );
 
 		return objects;
 
@@ -185,33 +251,27 @@
 
 	// --- Three.js events ---
 
-	devTools.addEventListener( EVENT_REGISTER, ( event ) => {
-
-		postToPanel( EVENT_REGISTER, event.detail );
-
-	} );
+	devTools.addEventListener( EVENT_REGISTER, ( event ) => postToPanel( EVENT_REGISTER, event.detail ) );
 
 	devTools.addEventListener( EVENT_OBSERVE, ( event ) => {
+
+		if ( observing === false ) return;
 
 		const object = event.detail;
 
 		if ( object.isWebGLRenderer || object.isWebGPURenderer ) {
 
-			if ( object.uuid === undefined ) object.uuid = generateUUID();
+			// Renderers have no uuid of their own
+			object.uuid = [ ...crypto.getRandomValues( new Uint8Array( 16 ) ) ].map( b => b.toString( 16 ).padStart( 2, '0' ) ).join( '' );
 
-			const data = getRendererData( object );
-
-			if ( data !== null ) {
-
-				observedRenderers.push( object );
-				postToPanel( EVENT_RENDERER, data );
-
-			}
+			observedRenderers.push( object );
+			sendRenderer( object );
 
 		} else if ( object.isScene ) {
 
 			observedScenes.push( object );
-			reloadSceneObjects( object );
+			watchScene( object );
+			sendSceneObjects( object );
 
 		}
 
@@ -220,11 +280,7 @@
 	// Old three.js versions don't register themselves, detect the global instead
 	window.addEventListener( 'load', () => {
 
-		if ( window.THREE && window.THREE.REVISION ) {
-
-			postToPanel( EVENT_REGISTER, { revision: window.THREE.REVISION } );
-
-		}
+		if ( window.THREE && window.THREE.REVISION ) postToPanel( EVENT_REGISTER, { revision: window.THREE.REVISION } );
 
 	} );
 
@@ -245,7 +301,7 @@
 				break;
 
 			case MESSAGE_REQUEST_OBJECT_DETAILS:
-				sendObjectDetails( message.uuid );
+				sendObjectDetails( message.uuid, message.preview );
 				break;
 
 			case MESSAGE_SCROLL_TO_CANVAS:
@@ -253,11 +309,11 @@
 				break;
 
 			case MESSAGE_HIGHLIGHT_OBJECT:
-				devTools.dispatchEvent( new CustomEvent( MESSAGE_HIGHLIGHT_OBJECT, { detail: { uuid: message.uuid } } ) );
+				devTools.utils.highlight( message.uuid );
 				break;
 
 			case MESSAGE_UNHIGHLIGHT_OBJECT:
-				devTools.dispatchEvent( new CustomEvent( MESSAGE_UNHIGHLIGHT_OBJECT ) );
+				devTools.utils.unhighlight();
 				break;
 
 		}
@@ -266,49 +322,56 @@
 
 	function sendState() {
 
-		for ( const renderer of observedRenderers ) {
-
-			const data = getRendererData( renderer );
-			if ( data !== null ) postToPanel( EVENT_RENDERER, data );
-
-		}
+		for ( const renderer of observedRenderers ) sendRenderer( renderer );
 
 		// Scenes have no dispose(), so one that stays empty for several polls is
 		// hidden from the panel, and brought back if it gains children again
 		for ( const scene of observedScenes ) {
 
-			if ( scene.children.length === 0 ) {
+			// The page may have replaced the hook since the scene was observed
+			if ( scene.onAfterRender.isDevToolsHook !== true ) watchScene( scene );
 
-				// Already hidden, nothing to send until children come back
-				if ( ! sceneObjectCountCache.has( scene.uuid ) ) continue;
+			const ticks = scene.children.length === 0 ? ( sceneEmptyTicks.get( scene.uuid ) || 0 ) + 1 : 0;
 
-				const ticks = ( sceneEmptyTicks.get( scene.uuid ) || 0 ) + 1;
+			sceneEmptyTicks.set( scene.uuid, ticks );
 
-				if ( ticks >= SCENE_EMPTY_TICKS_THRESHOLD ) {
+			if ( ticks < SCENE_EMPTY_TICKS_THRESHOLD ) {
 
-					sceneEmptyTicks.delete( scene.uuid );
-					sceneObjectCountCache.delete( scene.uuid );
-					postToPanel( EVENT_SCENE_REMOVED, { uuid: scene.uuid } );
-					continue;
+				sendSceneObjects( scene );
 
-				}
+			} else if ( ticks === SCENE_EMPTY_TICKS_THRESHOLD ) {
 
-				sceneEmptyTicks.set( scene.uuid, ticks );
-
-			} else {
-
-				sceneEmptyTicks.delete( scene.uuid );
+				// Dropping the count as well brings the scene back with a full batch
+				sceneObjectCountCache.delete( scene.uuid );
+				postToPanel( EVENT_SCENE_REMOVED, { uuid: scene.uuid } );
 
 			}
 
-			reloadSceneObjects( scene );
+		}
+
+	}
+
+	function sendRenderer( renderer ) {
+
+		try {
+
+			postToPanel( EVENT_RENDERER, {
+				uuid: renderer.uuid,
+				type: renderer.isWebGLRenderer ? 'WebGLRenderer' : 'WebGPURenderer',
+				properties: getRendererProperties( renderer ),
+				canvasInDOM: document.contains( renderer.domElement )
+			} );
+
+		} catch ( error ) {
+
+			console.warn( 'DevTools: Error getting renderer data:', error );
 
 		}
 
 	}
 
 	// Send a scene batch when its object count changed (a hidden scene has no count, so it comes back)
-	function reloadSceneObjects( scene ) {
+	function sendSceneObjects( scene ) {
 
 		const objects = collectSceneObjects( scene );
 
@@ -321,19 +384,20 @@
 
 	}
 
-	function sendObjectDetails( uuid ) {
+	function sendObjectDetails( uuid, preview ) {
 
 		const object = findObjectInScenes( uuid );
+		if ( object === null ) return;
 
-		if ( object ) {
-
-			postToPanel( EVENT_OBJECT_DETAILS, {
-				position: xyz( object.position ),
-				rotation: xyz( object.rotation ),
-				scale: xyz( object.scale )
-			} );
-
-		}
+		postToPanel( EVENT_OBJECT_DETAILS, {
+			uuid: uuid,
+			position: object.position.toArray(),
+			rotation: object.rotation.toArray(),
+			scale: object.scale.toArray(),
+			geometry: object.geometry ? getGeometryData( object.geometry ) : null,
+			materials: object.material ? [].concat( object.material ).map( getMaterialData ) : [],
+			preview: preview ? devTools.utils.renderPreview( object ) : null
+		} );
 
 	}
 
@@ -341,44 +405,26 @@
 
 		// Without a uuid, pick the first renderer whose canvas is in the DOM
 		const renderer = uuid ?
-			observedRenderers.find( r => r.uuid === uuid ) :
-			observedRenderers.find( r => document.contains( r.domElement ) );
+			observedRenderers.find( candidate => candidate.uuid === uuid ) :
+			observedRenderers.find( candidate => document.contains( candidate.domElement ) );
 
-		if ( renderer ) {
+		if ( renderer === undefined ) return;
 
-			renderer.domElement.scrollIntoView( { behavior: 'smooth', block: 'center', inline: 'center' } );
-
-			flashCanvas( renderer.domElement );
-
-		}
+		renderer.domElement.scrollIntoView( { behavior: 'smooth', block: 'center', inline: 'center' } );
+		flashCanvas( renderer.domElement );
 
 	}
 
 	// Brief blue overlay on top of the canvas
 	function flashCanvas( canvas ) {
 
+		const bounds = canvas.getBoundingClientRect();
+
 		const overlay = document.createElement( 'div' );
-		overlay.style.cssText = `
-			position: absolute;
-			top: 0;
-			left: 0;
-			width: 100%;
-			height: 100%;
-			background-color: rgba(0, 122, 204, 0.3);
-			pointer-events: none;
-			z-index: 999999;
-		`;
+		overlay.style.cssText = `position: absolute; top: ${bounds.top + window.scrollY}px; left: ${bounds.left + window.scrollX}px; width: ${bounds.width}px; height: ${bounds.height}px; background: rgba(0, 122, 204, 0.3); pointer-events: none; z-index: 999999;`;
 
-		// Position the overlay relative to the canvas
-		const parent = canvas.parentElement || document.body;
-
-		if ( getComputedStyle( parent ).position === 'static' ) {
-
-			parent.style.position = 'relative';
-
-		}
-
-		parent.appendChild( overlay );
+		// On <html>, so a positioned <body> cannot offset the document coordinates above
+		document.documentElement.appendChild( overlay );
 
 		setTimeout( () => overlay.remove(), CANVAS_FLASH_DURATION );
 

--- a/devtools/bridge.js
+++ b/devtools/bridge.js
@@ -384,20 +384,24 @@
 
 	}
 
-	function sendObjectDetails( uuid, preview ) {
+	async function sendObjectDetails( uuid, preview ) {
 
 		const object = findObjectInScenes( uuid );
 		if ( object === null ) return;
 
-		postToPanel( EVENT_OBJECT_DETAILS, {
+		const details = {
 			uuid: uuid,
 			position: object.position.toArray(),
 			rotation: object.rotation.toArray(),
 			scale: object.scale.toArray(),
 			geometry: object.geometry ? getGeometryData( object.geometry ) : null,
-			materials: object.material ? [].concat( object.material ).map( getMaterialData ) : [],
-			preview: preview ? devTools.utils.renderPreview( object ) : null
-		} );
+			materials: object.material ? [].concat( object.material ).map( getMaterialData ) : []
+		};
+
+		// A preview costs the page a frame, so it comes along only when asked for
+		if ( preview ) details.preview = await devTools.utils.renderPreview( object );
+
+		postToPanel( EVENT_OBJECT_DETAILS, details );
 
 	}
 

--- a/devtools/bridge.js
+++ b/devtools/bridge.js
@@ -251,7 +251,17 @@
 
 	// --- Three.js events ---
 
-	devTools.addEventListener( EVENT_REGISTER, ( event ) => postToPanel( EVENT_REGISTER, event.detail ) );
+	// Kept, since the panel may open after three.js registered and asks for the state then
+	let revision = null;
+
+	function register( value ) {
+
+		revision = value;
+		postToPanel( EVENT_REGISTER, { revision: revision } );
+
+	}
+
+	devTools.addEventListener( EVENT_REGISTER, ( event ) => register( event.detail.revision ) );
 
 	devTools.addEventListener( EVENT_OBSERVE, ( event ) => {
 
@@ -280,7 +290,7 @@
 	// Old three.js versions don't register themselves, detect the global instead
 	window.addEventListener( 'load', () => {
 
-		if ( window.THREE && window.THREE.REVISION ) postToPanel( EVENT_REGISTER, { revision: window.THREE.REVISION } );
+		if ( window.THREE && window.THREE.REVISION ) register( window.THREE.REVISION );
 
 	} );
 
@@ -321,6 +331,8 @@
 	} );
 
 	function sendState() {
+
+		if ( revision !== null ) postToPanel( EVENT_REGISTER, { revision: revision } );
 
 		for ( const renderer of observedRenderers ) sendRenderer( renderer );
 

--- a/devtools/constants.js
+++ b/devtools/constants.js
@@ -4,11 +4,10 @@ Object.assign( globalThis, {
 
 	MESSAGE_ID: 'three-devtools',
 
-	// Name of the highlight clone highlight.js adds to the scene
-	HIGHLIGHT_NAME: '__THREE_DEVTOOLS_HIGHLIGHT__',
+	// Tells the background script which tab this panel inspects
+	MESSAGE_INIT: 'init',
 
 	// Requests from the panel (panel -> background -> content script -> bridge)
-	MESSAGE_INIT: 'init',
 	MESSAGE_REQUEST_STATE: 'request-state',
 	MESSAGE_REQUEST_OBJECT_DETAILS: 'request-object-details',
 	MESSAGE_SCROLL_TO_CANVAS: 'scroll-to-canvas',

--- a/devtools/content-script.js
+++ b/devtools/content-script.js
@@ -12,6 +12,9 @@ window.addEventListener( 'message', ( event ) => {
 
 	if ( ! event.data || event.data.id !== MESSAGE_ID ) return;
 
+	// Only bridge messages carry a detail, the panel requests relayed below must not bounce back
+	if ( event.data.detail === undefined ) return;
+
 	try {
 
 		chrome.runtime.sendMessage( event.data );

--- a/devtools/highlight.js
+++ b/devtools/highlight.js
@@ -1,118 +1,193 @@
-/* global HIGHLIGHT_NAME, MESSAGE_HIGHLIGHT_OBJECT, MESSAGE_UNHIGHLIGHT_OBJECT */
-
-// Highlights the object hovered in the panel with a yellow wireframe clone
+// Draws a box around the object hovered in the panel, over the page's canvas
 
 ( function () {
 
-	let highlightObject = null;
+	const utils = __THREE_DEVTOOLS__.utils;
 
-	function cloneMaterial( material ) {
+	// The 12 edges of a box, as pairs of indices into its 8 corners
+	const EDGES = [[ 0, 1 ], [ 1, 3 ], [ 3, 2 ], [ 2, 0 ], [ 4, 5 ], [ 5, 7 ], [ 7, 6 ], [ 6, 4 ], [ 0, 4 ], [ 1, 5 ], [ 2, 6 ], [ 3, 7 ]];
 
-		// MeshNormalMaterial has no color to override
-		if ( material.isMeshNormalMaterial ) return material;
+	let overlay = null;
+	let object = null;
+	let frame = null;
 
-		const cloned = new material.constructor();
+	function createOverlay() {
 
-		if ( material.isShaderMaterial ) {
+		overlay = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
+		overlay.style.cssText = 'position: fixed; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; z-index: 999999;';
+		document.documentElement.appendChild( overlay );
 
-			// Replace the shaders with a flat yellow output
-			const raw = material.isRawShaderMaterial;
+	}
 
-			cloned.vertexShader = `
-				${ raw ? `attribute vec3 position;
-				uniform mat4 modelViewMatrix;
-				uniform mat4 projectionMatrix;
-				` : '' }void main() {
-					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-				}
-			`;
+	function createLine() {
 
-			cloned.fragmentShader = `
-				${ raw ? `precision highp float;
-				` : '' }void main() {
-					gl_FragColor = vec4( 1.0, 1.0, 0.0, 1.0 );
-				}
-			`;
+		const line = document.createElementNS( 'http://www.w3.org/2000/svg', 'line' );
+		line.setAttribute( 'stroke', '#ffff00' );
+		overlay.appendChild( line );
 
-		} else {
+	}
 
-			if ( cloned.color ) cloned.color.setRGB( 1, 1, 0 );
-			if ( cloned.emissive ) cloned.emissive.setRGB( 1, 1, 0 );
+	// A point through a Matrix4, from its column major elements, keeping w for the perspective divide
+	function transform( elements, point ) {
+
+		const [ x, y, z ] = point;
+
+		return [
+			elements[ 0 ] * x + elements[ 4 ] * y + elements[ 8 ] * z + elements[ 12 ],
+			elements[ 1 ] * x + elements[ 5 ] * y + elements[ 9 ] * z + elements[ 13 ],
+			elements[ 2 ] * x + elements[ 6 ] * y + elements[ 10 ] * z + elements[ 14 ],
+			elements[ 3 ] * x + elements[ 7 ] * y + elements[ 11 ] * z + elements[ 15 ]
+		];
+
+	}
+
+	// A skinned, instanced or batched mesh keeps its own box, since it is drawn in a pose
+	// or at positions its geometry alone knows nothing about
+	function getBoundingBox( object ) {
+
+		if ( object.computeBoundingBox !== undefined ) {
+
+			object.computeBoundingBox();
+			return object.boundingBox;
 
 		}
 
-		// Yellow wireframe drawn on top of everything
-		cloned.wireframe = true;
-		cloned.depthTest = false;
-		cloned.depthWrite = false;
-		cloned.transparent = true;
-		cloned.toneMapped = false;
-		cloned.fog = false;
+		const geometry = object.geometry;
+		if ( geometry.boundingBox === null ) geometry.computeBoundingBox();
 
-		return cloned;
+		return geometry.boundingBox;
+
+	}
+
+	// The part of the page a camera draws into. A sub camera of an ArrayCamera carries its viewport in
+	// canvas pixels, any other draws into the renderer's viewport in logical pixels, or fills the canvas
+	// when the scene reaches it through a texture. GL viewports are measured from the bottom left corner.
+	function getArea( view, camera ) {
+
+		const canvas = view.renderer.domElement;
+		const rect = canvas.getBoundingClientRect();
+		const viewport = camera.viewport !== undefined ? camera.viewport.toArray() : view.viewport?.map( value => value * view.renderer.getPixelRatio() );
+
+		if ( viewport === undefined ) return rect;
+
+		const [ x, y, width, height ] = viewport;
+		const scaleX = rect.width / canvas.width;
+		const scaleY = rect.height / canvas.height;
+
+		return { left: rect.left + x * scaleX, top: rect.bottom - ( y + height ) * scaleY, width: width * scaleX, height: height * scaleY };
+
+	}
+
+	// The corners of the object's bounding box, projected onto the area the camera draws into.
+	// A corner behind the camera has no place on screen, so it comes back as null.
+	function getCorners( object, camera, rect ) {
+
+		const box = getBoundingBox( object );
+		const corners = [];
+
+		for ( let i = 0; i < 8; i ++ ) {
+
+			const local = [ i & 1 ? box.max.x : box.min.x, i & 2 ? box.max.y : box.min.y, i & 4 ? box.max.z : box.min.z ];
+			const world = transform( object.matrixWorld.elements, local );
+			const eye = transform( camera.matrixWorldInverse.elements, world );
+			const [ x, y, , w ] = transform( camera.projectionMatrix.elements, eye );
+
+			corners.push( w > 0 ? [ rect.left + ( x / w * 0.5 + 0.5 ) * rect.width, rect.top + ( 0.5 - y / w * 0.5 ) * rect.height ] : null );
+
+		}
+
+		// An object scaled to nothing, or too far away to cover a pixel, has no box worth drawing
+		const onScreen = corners.filter( corner => corner !== null );
+		const spread = ( axis ) => Math.max( ...onScreen.map( corner => corner[ axis ] ) ) - Math.min( ...onScreen.map( corner => corner[ axis ] ) );
+
+		if ( onScreen.length === 0 || ( spread( 0 ) < 1 && spread( 1 ) < 1 ) ) return null;
+
+		return corners;
+
+	}
+
+	// A box for every camera the object is drawn with: an ArrayCamera draws one view per sub camera
+	function getBoxes( object, view ) {
+
+		const cameras = view.camera.isArrayCamera ? view.camera.cameras : [ view.camera ];
+
+		return cameras
+			.filter( camera => object.layers.test( camera.layers ) )
+			.map( camera => getCorners( object, camera, getArea( view, camera ) ) )
+			.filter( corners => corners !== null );
+
+	}
+
+	function update() {
+
+		frame = requestAnimationFrame( update );
+
+		const view = object === null ? null : utils.getSceneView( object );
+		const boxes = view === null ? [] : getBoxes( object, view );
+		const lines = overlay.children;
+
+		while ( lines.length < boxes.length * EDGES.length ) createLine();
+
+		let drawn = 0;
+
+		for ( let i = 0; i < lines.length; i ++ ) {
+
+			const corners = boxes[ Math.floor( i / EDGES.length ) ];
+			const [ a, b ] = EDGES[ i % EDGES.length ];
+			const from = corners === undefined ? null : corners[ a ];
+			const to = corners === undefined ? null : corners[ b ];
+			const hidden = from === null || to === null;
+
+			lines[ i ].style.display = hidden ? 'none' : '';
+			if ( hidden ) continue;
+
+			lines[ i ].setAttribute( 'x1', from[ 0 ] );
+			lines[ i ].setAttribute( 'y1', from[ 1 ] );
+			lines[ i ].setAttribute( 'x2', to[ 0 ] );
+			lines[ i ].setAttribute( 'y2', to[ 1 ] );
+			drawn ++;
+
+		}
+
+		overlay.style.display = drawn === 0 ? 'none' : '';
+
+	}
+
+	function isVisible( object ) {
+
+		for ( let parent = object; parent !== null; parent = parent.parent ) {
+
+			if ( parent.visible === false ) return false;
+
+		}
+
+		return true;
 
 	}
 
 	function highlight( uuid ) {
 
-		const object = __THREE_DEVTOOLS__.utils.findObjectInScenes( uuid );
+		const target = utils.findObjectInScenes( uuid );
 
-		// Renderers, helpers, the highlight itself and objects without geometry can't be highlighted
-		if ( ! object || object.type.includes( 'Helper' ) || object.name === HIGHLIGHT_NAME || ! object.geometry ) {
+		// Helpers, hidden objects and objects without geometry have no box to draw
+		object = target !== null && ! target.type.includes( 'Helper' ) && target.geometry !== undefined && isVisible( target ) ? target : null;
 
-			unhighlight();
-			return;
-
-		}
-
-		if ( highlightObject ) highlightObject.removeFromParent();
-
-		// Clone the object to preserve all properties (skeleton, bindMatrix, etc)
-		highlightObject = object.clone();
-		highlightObject.name = HIGHLIGHT_NAME;
-		highlightObject.castShadow = false;
-		highlightObject.receiveShadow = false;
-		highlightObject.renderOrder = Infinity;
-		highlightObject.visible = true;
-
-		if ( highlightObject.material ) {
-
-			highlightObject.material = Array.isArray( highlightObject.material )
-				? highlightObject.material.map( cloneMaterial )
-				: cloneMaterial( highlightObject.material );
-
-		}
-
-		// Follow the original by sharing its matrixWorld
-		highlightObject.matrixAutoUpdate = false;
-		highlightObject.matrixWorldAutoUpdate = false;
-		highlightObject.matrixWorld = object.matrixWorld;
-
-		// Add at the scene root
-		let scene = object;
-		while ( scene.parent ) scene = scene.parent;
-
-		scene.add( highlightObject );
+		if ( overlay === null ) createOverlay();
+		if ( frame === null ) update();
 
 	}
 
 	function unhighlight() {
 
-		if ( highlightObject ) {
+		object = null;
+		cancelAnimationFrame( frame );
+		frame = null;
 
-			highlightObject.visible = false;
-
-		}
+		if ( overlay !== null ) overlay.style.display = 'none';
 
 	}
 
-	// Listen for highlight events from bridge.js
-	__THREE_DEVTOOLS__.addEventListener( MESSAGE_HIGHLIGHT_OBJECT, ( event ) => {
-
-		highlight( event.detail.uuid );
-
-	} );
-
-	__THREE_DEVTOOLS__.addEventListener( MESSAGE_UNHIGHLIGHT_OBJECT, unhighlight );
+	// bridge.js calls these when the panel asks
+	Object.assign( utils, { highlight, unhighlight } );
 
 } )();

--- a/devtools/manifest.json
+++ b/devtools/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Three.js DevTools",
-	"version": "1.17",
+	"version": "1.18",
 	"description": "Developer tools extension for Three.js",
 	"icons": {
 		"128": "icons/128-light.png"
@@ -13,7 +13,7 @@
 	},
 	"content_scripts": [{
 		"matches": ["<all_urls>"],
-		"js": ["constants.js", "bridge.js", "highlight.js"],
+		"js": ["constants.js", "bridge.js", "highlight.js", "preview.js"],
 		"all_frames": true,
 		"run_at": "document_start",
 		"world": "MAIN",
@@ -26,7 +26,6 @@
 		"match_about_blank": true
 	}],
 	"permissions": [
-		"activeTab",
 		"webNavigation"
 	]
 }

--- a/devtools/panel/panel.css
+++ b/devtools/panel/panel.css
@@ -33,6 +33,13 @@ body {
 	opacity: 0.5;
 }
 
+/* Shown while there is nothing else to show */
+#notice {
+	padding: 24px 12px;
+	text-align: center;
+	color: light-dark( #666, #aaa );
+}
+
 /* Side by side while both fit, stacked when the panel is narrow */
 .sections-container {
 	display: flex;
@@ -158,13 +165,21 @@ details[open] > summary .tree-toggle::before {
 	font: inherit;
 	max-width: 80px; /* as wide as its longest option otherwise */
 }
-/* The tile is the placeholder too, so the size lives here and preview.js renders to match */
+/* The tile is the placeholder too, so the size lives here and preview.js renders to match.
+   It holds the render as its background, or the reason there is none as text. */
 .preview {
-	display: block;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-sizing: border-box;
 	width: 160px;
 	height: 160px;
+	padding: 0 12px;
 	border-radius: 4px;
-	background: #eee; /* shows until the transparent render arrives, light in both themes */
+	background: #eee center / contain no-repeat; /* light in both themes, the render is transparent */
+	color: #aaa;
+	font-size: 11px;
+	text-align: center;
 }
 
 /* Scroll to canvas button */

--- a/devtools/panel/panel.css
+++ b/devtools/panel/panel.css
@@ -9,6 +9,7 @@ body {
 	padding: 10px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 	font-size: 12px;
+	font-variant-numeric: tabular-nums; /* stats and transforms change every poll, so digits must not jitter */
 }
 
 .header {
@@ -22,7 +23,7 @@ body {
 	color: light-dark( #666, #aaa );
 }
 .header a {
-	color: light-dark( #666, #aaa );
+	color: inherit;
 	text-decoration: none;
 }
 .header a:hover {
@@ -32,8 +33,16 @@ body {
 	opacity: 0.5;
 }
 
+/* Side by side while both fit, stacked when the panel is narrow */
+.sections-container {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	gap: 24px 20px;
+}
 .section {
-	margin-bottom: 24px;
+	flex: 1 1 480px;
+	min-width: 0;
 }
 .section:empty {
 	display: none;
@@ -65,6 +74,9 @@ details > summary {
 .tree-item.invisible {
 	opacity: 0.5;
 }
+.tree-item.expanded {
+	background: light-dark( #dbe9ff, #2b4a6f );
+}
 .tree-item .icon {
 	margin-right: 4px;
 	opacity: 0.7;
@@ -75,9 +87,10 @@ details > summary {
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
-.tree-item .label .object-details {
+.object-details {
 	color: #aaa;
 	margin-left: 4px;
+	font-weight: normal;
 }
 .tree-item .type {
 	margin-left: 8px;
@@ -87,7 +100,7 @@ details > summary {
 
 .tree-toggle,
 .tree-toggle-placeholder {
-	width: 1em;
+	width: 1.5em;
 	margin-right: 2px;
 	text-align: center;
 	flex-shrink: 0;
@@ -101,27 +114,57 @@ details[open] > summary .tree-toggle::before {
 	content: '▼';
 }
 
-/* Renderer properties */
+/* Properties of an expanded renderer or object: content-sized columns, wrapping when the panel is narrow */
 .properties-list {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-	gap: 10px 20px;
-	padding-left: 20px;
-}
-.properties-list h4:not(:first-child) {
-	margin-top: 10px;
-}
-.property-row {
 	display: flex;
-	justify-content: space-between;
-	margin-bottom: 2px;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	gap: 12px 16px;
+	padding: 8px 4px 12px 16px;
 }
-.property-label {
-	margin-right: 10px;
-	white-space: nowrap;
+.property-group {
+	display: grid;
+	grid-template-columns: max-content minmax(0, max-content);
+	gap: 2px 16px;
+}
+.property-group h4 {
+	grid-column: 1 / -1;
+	margin: 12px 0 4px;
+}
+.property-group h4:first-child {
+	margin-top: 0;
+}
+.property-column .property-group + .property-group {
+	margin-top: 12px;
+}
+.property-row,
+.transform {
+	display: contents;
 }
 .property-value {
 	text-align: right;
+	overflow-wrap: anywhere;
+}
+
+/* The type headings are wider than their rows, so the value column takes the extra width
+   and every value stays next to the label it belongs to */
+.object-properties {
+	grid-template-columns: max-content minmax(0, 1fr);
+}
+.object-properties .property-value {
+	text-align: left;
+}
+.picker select {
+	font: inherit;
+	max-width: 80px; /* as wide as its longest option otherwise */
+}
+/* The tile is the placeholder too, so the size lives here and preview.js renders to match */
+.preview {
+	display: block;
+	width: 160px;
+	height: 160px;
+	border-radius: 4px;
+	background: #eee; /* shows until the transparent render arrives, light in both themes */
 }
 
 /* Scroll to canvas button */
@@ -144,43 +187,4 @@ details[open] > summary .tree-toggle::before {
 	margin-left: 8px;
 	padding: 2px 4px;
 	opacity: 0.3;
-}
-
-/* Floating object details panel */
-.floating-details {
-	position: fixed;
-	z-index: 1000;
-	background: light-dark( #fff, #2a2a2a );
-	border: 1px solid light-dark( #ccc, #555 );
-	border-radius: 6px;
-	padding: 12px;
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-	pointer-events: none; /* Prevent interfering with mouse interactions */
-	opacity: 0;
-	transform: translateY(10px);
-	transition: opacity 0.2s ease, transform 0.2s ease;
-}
-.floating-details.visible {
-	opacity: 1;
-	transform: translateY(0);
-}
-.floating-details .vector-row {
-	margin-bottom: 2px;
-	font-family: monospace;
-	font-size: 10px;
-	white-space: pre;
-}
-
-/* Two-column layout for wide panel */
-@media (min-width: 1000px) {
-	.sections-container {
-		display: flex;
-		gap: 20px;
-		align-items: flex-start;
-	}
-	.sections-container .section {
-		flex: 1;
-		min-width: 0;
-		margin-bottom: 0;
-	}
 }

--- a/devtools/panel/panel.html
+++ b/devtools/panel/panel.html
@@ -6,6 +6,14 @@
 	<link rel="stylesheet" href="panel.css">
 </head>
 <body>
+	<div class="header">
+		<a href="https://docs.google.com/forms/d/e/1FAIpQLSdw1QcgXNiECYiPx6k0vSQRiRe0FmByrrojV4fgeL5zzXIiCw/viewform?usp=preview" target="_blank">+</a>
+		<span class="version"></span>
+	</div>
+	<div class="sections-container">
+		<div class="section" id="renderers"></div>
+		<div class="section" id="scenes"></div>
+	</div>
 	<script src="../constants.js"></script>
 	<script src="panel.js"></script>
 </body>

--- a/devtools/panel/panel.html
+++ b/devtools/panel/panel.html
@@ -10,6 +10,7 @@
 		<a href="https://docs.google.com/forms/d/e/1FAIpQLSdw1QcgXNiECYiPx6k0vSQRiRe0FmByrrojV4fgeL5zzXIiCw/viewform?usp=preview" target="_blank">+</a>
 		<span class="version"></span>
 	</div>
+	<div id="notice" hidden></div>
 	<div class="sections-container">
 		<div class="section" id="renderers"></div>
 		<div class="section" id="scenes"></div>

--- a/devtools/panel/panel.js
+++ b/devtools/panel/panel.js
@@ -16,9 +16,6 @@ const openState = new Map();
 // Objects expanded in the tree (uuid -> its details block, kept across rebuilds so the selection and the image survive)
 const expanded = new Map();
 
-// Objects waiting for a render, so a slow round trip is not asked to repeat it
-const pendingPreviews = new Set();
-
 // Static DOM from panel.html
 const renderersSection = document.getElementById( 'renderers' );
 const scenesSection = document.getElementById( 'scenes' );
@@ -49,20 +46,8 @@ function poll() {
 
 	send( MESSAGE_REQUEST_STATE );
 
-	for ( const [ uuid, block ] of expanded ) {
-
-		// Rendering a preview costs the page a frame, so only ask again while the tile is empty
-		requestDetails( uuid, block.firstChild.src === '' && ! pendingPreviews.has( uuid ) );
-
-	}
-
-}
-
-function requestDetails( uuid, preview ) {
-
-	if ( preview ) pendingPreviews.add( uuid );
-
-	send( MESSAGE_REQUEST_OBJECT_DETAILS, { uuid: uuid, preview: preview } );
+	// A preview costs the page a frame, so it is only asked for on expand and when the geometry or material changes
+	for ( const uuid of expanded.keys() ) send( MESSAGE_REQUEST_OBJECT_DETAILS, { uuid: uuid, preview: false } );
 
 }
 
@@ -89,7 +74,6 @@ port.onMessage.addListener( ( message ) => {
 			break;
 
 		case EVENT_OBJECT_DETAILS:
-			pendingPreviews.delete( detail.uuid );
 			if ( expanded.has( detail.uuid ) ) renderObjectDetails( expanded.get( detail.uuid ), detail );
 			break;
 
@@ -504,7 +488,7 @@ function toggleDetails( uuid ) {
 		block.appendChild( image );
 
 		expanded.set( uuid, block );
-		requestDetails( uuid, true );
+		send( MESSAGE_REQUEST_OBJECT_DETAILS, { uuid: uuid, preview: true } );
 
 	}
 
@@ -532,7 +516,7 @@ function renderObjectDetails( block, details ) {
 		block.dataset.signature = signature;
 
 		// The render that arrived with these details is of what the object used to be
-		if ( swapped ) requestDetails( details.uuid, true );
+		if ( swapped ) send( MESSAGE_REQUEST_OBJECT_DETAILS, { uuid: details.uuid, preview: true } );
 
 		const transform = document.createElement( 'div' );
 		transform.className = 'transform';
@@ -559,9 +543,13 @@ function renderObjectDetails( block, details ) {
 	const pickers = block.querySelectorAll( '.picker' );
 	groups.forEach( ( [ , rows ], i ) => updatePropertyPicker( pickers[ i ], rows ) );
 
-	// Only an object with a geometry can be rendered, the rest keep no tile at all
-	image.hidden = details.geometry === null;
-	if ( details.preview && image.src !== details.preview ) image.src = details.preview;
+	// A preview comes with the details when one was asked for, an object that has none keeps no tile
+	if ( 'preview' in details ) {
+
+		image.hidden = details.preview === null;
+		if ( details.preview !== null ) image.src = details.preview;
+
+	}
 
 	block.querySelector( '.transform' ).replaceChildren(
 		createPropertyRow( 'Position', details.position ),
@@ -591,12 +579,7 @@ function updateSceneTree() {
 
 	for ( const uuid of expanded.keys() ) {
 
-		if ( ! state.objects.has( uuid ) ) {
-
-			expanded.delete( uuid );
-			pendingPreviews.delete( uuid );
-
-		}
+		if ( ! state.objects.has( uuid ) ) expanded.delete( uuid );
 
 	}
 

--- a/devtools/panel/panel.js
+++ b/devtools/panel/panel.js
@@ -1,4 +1,4 @@
-/* global chrome, MESSAGE_ID, MESSAGE_INIT, MESSAGE_REQUEST_STATE, MESSAGE_REQUEST_OBJECT_DETAILS, MESSAGE_SCROLL_TO_CANVAS, MESSAGE_HIGHLIGHT_OBJECT, MESSAGE_UNHIGHLIGHT_OBJECT, EVENT_RENDERER, EVENT_OBJECT_DETAILS, EVENT_SCENE, EVENT_SCENE_REMOVED, EVENT_COMMITTED */
+/* global chrome, MESSAGE_INIT, MESSAGE_REQUEST_STATE, MESSAGE_REQUEST_OBJECT_DETAILS, MESSAGE_SCROLL_TO_CANVAS, MESSAGE_HIGHLIGHT_OBJECT, MESSAGE_UNHIGHLIGHT_OBJECT, EVENT_RENDERER, EVENT_OBJECT_DETAILS, EVENT_SCENE, EVENT_SCENE_REMOVED, EVENT_COMMITTED */
 
 const STATE_POLLING_INTERVAL = 1000;
 
@@ -13,17 +13,22 @@ const state = {
 // Open/closed state of collapsible nodes (uuid -> boolean), kept across rebuilds
 const openState = new Map();
 
-// Static DOM elements (created once in initUI)
-let renderersSection = null;
-let scenesSection = null;
-let floatingPanel = null;
+// Objects expanded in the tree (uuid -> its details block, kept across rebuilds so the selection and the image survive)
+const expanded = new Map();
 
-const mousePosition = { x: 0, y: 0 };
+// Objects waiting for a render, so a slow round trip is not asked to repeat it
+const pendingPreviews = new Set();
+
+// Static DOM from panel.html
+const renderersSection = document.getElementById( 'renderers' );
+const scenesSection = document.getElementById( 'scenes' );
+
+document.querySelector( '.version' ).textContent = chrome.runtime.getManifest().version;
 
 // --- Connection ---
 
 const port = chrome.runtime.connect();
-const intervalId = setInterval( () => send( MESSAGE_REQUEST_STATE ), STATE_POLLING_INTERVAL );
+const intervalId = setInterval( poll, STATE_POLLING_INTERVAL );
 
 function send( name, data ) {
 
@@ -40,6 +45,27 @@ function send( name, data ) {
 
 }
 
+function poll() {
+
+	send( MESSAGE_REQUEST_STATE );
+
+	for ( const [ uuid, block ] of expanded ) {
+
+		// Rendering a preview costs the page a frame, so only ask again while the tile is empty
+		requestDetails( uuid, block.firstChild.src === '' && ! pendingPreviews.has( uuid ) );
+
+	}
+
+}
+
+function requestDetails( uuid, preview ) {
+
+	if ( preview ) pendingPreviews.add( uuid );
+
+	send( MESSAGE_REQUEST_OBJECT_DETAILS, { uuid: uuid, preview: preview } );
+
+}
+
 send( MESSAGE_INIT, { tabId: chrome.devtools.inspectedWindow.tabId } );
 send( MESSAGE_REQUEST_STATE );
 
@@ -52,8 +78,6 @@ port.onDisconnect.addListener( () => {
 
 port.onMessage.addListener( ( message ) => {
 
-	if ( message.id !== MESSAGE_ID ) return;
-
 	const detail = message.detail;
 
 	switch ( message.name ) {
@@ -65,7 +89,8 @@ port.onMessage.addListener( ( message ) => {
 			break;
 
 		case EVENT_OBJECT_DETAILS:
-			showFloatingDetails( detail );
+			pendingPreviews.delete( detail.uuid );
+			if ( expanded.has( detail.uuid ) ) renderObjectDetails( expanded.get( detail.uuid ), detail );
 			break;
 
 		case EVENT_SCENE:
@@ -89,15 +114,12 @@ port.onMessage.addListener( ( message ) => {
 
 } );
 
-// Replace the objects of a scene with a new batch from the bridge
-function processSceneBatch( sceneUuid, objects, frameId ) {
+// Drop a scene's objects, except the ones a new batch still lists
+function forgetObjects( sceneUuid, keep = new Set() ) {
 
-	const uuids = new Set( objects.map( object => object.uuid ) );
-
-	// Drop objects that are no longer in the scene
 	state.objects.forEach( ( object, uuid ) => {
 
-		if ( object._sceneUuid === sceneUuid && ! uuids.has( uuid ) ) {
+		if ( object._sceneUuid === sceneUuid && ! keep.has( uuid ) ) {
 
 			state.objects.delete( uuid );
 			openState.delete( uuid );
@@ -105,6 +127,13 @@ function processSceneBatch( sceneUuid, objects, frameId ) {
 		}
 
 	} );
+
+}
+
+// Replace the objects of a scene with a new batch from the bridge
+function processSceneBatch( sceneUuid, objects, frameId ) {
+
+	forgetObjects( sceneUuid, new Set( objects.map( object => object.uuid ) ) );
 
 	for ( const object of objects ) {
 
@@ -123,17 +152,7 @@ function processSceneBatch( sceneUuid, objects, frameId ) {
 function removeScene( sceneUuid ) {
 
 	state.scenes.delete( sceneUuid );
-
-	state.objects.forEach( ( object, uuid ) => {
-
-		if ( object._sceneUuid === sceneUuid ) {
-
-			state.objects.delete( uuid );
-			openState.delete( uuid );
-
-		}
-
-	} );
+	forgetObjects( sceneUuid );
 
 }
 
@@ -166,41 +185,64 @@ function clearState() {
 	state.renderers.clear();
 	state.objects.clear();
 	openState.clear();
-
-	floatingPanel.classList.remove( 'visible' );
+	expanded.clear();
 
 }
 
 // --- Rendering ---
 
-function getObjectIcon( obj ) {
+function getObjectIcon( object ) {
 
-	if ( obj.isScene ) return '🌍';
-	if ( obj.isCamera ) return '📷';
-	if ( obj.isLight ) return '💡';
-	if ( obj.isInstancedMesh ) return '🔸';
-	if ( obj.isMesh ) return '🔷';
-	if ( obj.isGroup ) return '📁';
+	if ( object.isScene ) return '🌍';
+	if ( object.isCamera ) return '📷';
+	if ( object.isLight ) return '💡';
+	if ( object.isInstancedMesh ) return '🔸';
+	if ( object.isMesh ) return '🔷';
+	if ( object.isGroup ) return '📁';
 	return '📦';
 
 }
 
 // Sort order of children in the tree
-function getObjectOrder( obj ) {
+function getObjectOrder( object ) {
 
-	if ( obj.isCamera ) return 1;
-	if ( obj.isLight ) return 2;
-	if ( obj.isGroup ) return 3;
-	if ( obj.isMesh ) return 4;
+	if ( object.isCamera ) return 1;
+	if ( object.isLight ) return 2;
+	if ( object.isGroup ) return 3;
+	if ( object.isMesh ) return 4;
 	return 5;
+
+}
+
+// A dimmer detail after a row's name or a heading's type. Text comes from the page, so it is set as text.
+function appendDetail( element, text ) {
+
+	const detail = document.createElement( 'span' );
+	detail.className = 'object-details';
+	detail.textContent = text;
+
+	element.append( ' ', detail );
 
 }
 
 function createLabel( name, details ) {
 
-	if ( details.length === 0 ) return name;
+	const label = document.createElement( 'span' );
+	label.className = 'label';
+	label.textContent = name;
 
-	return `${name} <span class="object-details">${details.join( ' ・ ' )}</span>`;
+	if ( details.length > 0 ) appendDetail( label, details.join( ' ・ ' ) );
+
+	return label;
+
+}
+
+function formatValue( value ) {
+
+	if ( value === undefined || value === null ) return '–';
+	if ( Array.isArray( value ) ) return value.map( formatValue ).join( ', ' );
+	if ( typeof value === 'number' ) return value.toLocaleString();
+	return value;
 
 }
 
@@ -210,50 +252,68 @@ function createPropertyRow( label, value ) {
 	row.className = 'property-row';
 
 	const labelSpan = document.createElement( 'span' );
-	labelSpan.className = 'property-label';
 	labelSpan.textContent = label;
 
 	const valueSpan = document.createElement( 'span' );
 	valueSpan.className = 'property-value';
-	valueSpan.textContent = ( value === undefined || value === null )
-		? '–'
-		: ( typeof value === 'number' ? value.toLocaleString() : value );
+	valueSpan.textContent = formatValue( value );
 
-	row.appendChild( labelSpan );
-	row.appendChild( valueSpan );
+	row.append( labelSpan, valueSpan );
+
 	return row;
 
 }
 
-// A titled group of property rows
-function createPropertyGroup( title, rows ) {
+// A column of titled property groups ([ title, rows ] pairs)
+function createPropertyColumn( ...groups ) {
 
-	const fragment = document.createDocumentFragment();
+	const column = document.createElement( 'div' );
+	column.className = 'property-column';
 
-	const heading = document.createElement( 'h4' );
-	heading.textContent = title;
-	fragment.appendChild( heading );
+	for ( const [ title, rows ] of groups ) {
 
-	for ( const [ label, value ] of rows ) {
+		const group = document.createElement( 'div' );
+		group.className = 'property-group';
 
-		fragment.appendChild( createPropertyRow( label, value ) );
+		const heading = document.createElement( 'h4' );
+		heading.textContent = title;
+		group.appendChild( heading );
+
+		for ( const [ label, value ] of rows ) group.appendChild( createPropertyRow( label, value ) );
+
+		column.appendChild( group );
 
 	}
 
-	return fragment;
+	return column;
 
 }
 
-function createVectorRow( label, vector ) {
+// A dropdown of an item's properties, the selected one shown beside it
+function createPropertyPicker( rows ) {
 
-	const row = document.createElement( 'div' );
-	row.className = 'vector-row';
+	const select = document.createElement( 'select' );
+	for ( const [ label ] of rows ) select.appendChild( new Option( label ) );
 
-	// Pad label to ensure consistent alignment
-	const paddedLabel = label.padEnd( 16 );
-	row.textContent = `${paddedLabel} ${vector.x.toFixed( 3 )}\t${vector.y.toFixed( 3 )}\t${vector.z.toFixed( 3 )}`;
+	const value = document.createElement( 'span' );
+	value.className = 'property-value';
+	select.addEventListener( 'change', () => value.textContent = select.value );
 
-	return row;
+	const picker = document.createElement( 'div' );
+	picker.className = 'property-row picker';
+	picker.append( select, value );
+
+	return picker;
+
+}
+
+// The options carry the current values, so the selected one is simply select.value
+function updatePropertyPicker( picker, rows ) {
+
+	const select = picker.firstChild;
+
+	rows.forEach( ( [ , value ], i ) => select.options[ i ].value = formatValue( value ) );
+	picker.lastChild.textContent = select.value;
 
 }
 
@@ -272,25 +332,39 @@ function renderRenderer( renderer, container ) {
 		`${info.render.triangles.toLocaleString()} triangles`
 	] );
 
-	const scrollButton = renderer.canvasInDOM
-		? '<button class="scroll-to-canvas-btn" title="Scroll to canvas">🙂</button>'
-		: '<span class="scroll-to-canvas-placeholder" title="Canvas not in DOM">🫥</span>';
+	const toggle = document.createElement( 'span' );
+	toggle.className = 'tree-toggle';
 
 	const summary = document.createElement( 'summary' );
 	summary.className = 'tree-item';
-	summary.innerHTML = `<span class="tree-toggle"></span><span class="label">${label}</span>${scrollButton}`;
-	node.appendChild( summary );
+	summary.append( toggle, label );
 
-	const button = summary.querySelector( '.scroll-to-canvas-btn' );
+	if ( renderer.canvasInDOM ) {
 
-	if ( button !== null ) {
-
+		const button = document.createElement( 'button' );
+		button.className = 'scroll-to-canvas-btn';
+		button.title = 'Scroll to canvas';
+		button.textContent = '🙂';
 		button.addEventListener( 'click', () => send( MESSAGE_SCROLL_TO_CANVAS, { uuid: renderer.uuid } ) );
+
+		summary.appendChild( button );
+
+	} else {
+
+		const placeholder = document.createElement( 'span' );
+		placeholder.className = 'scroll-to-canvas-placeholder';
+		placeholder.title = 'Canvas not in DOM';
+		placeholder.textContent = '🫥';
+
+		summary.appendChild( placeholder );
 
 	}
 
-	const propertiesColumn = document.createElement( 'div' );
-	propertiesColumn.appendChild( createPropertyGroup( 'Properties', [
+	node.appendChild( summary );
+
+	const properties = document.createElement( 'div' );
+	properties.className = 'properties-list';
+	properties.appendChild( createPropertyColumn( [ 'Properties', [
 		[ 'Size', `${props.width}x${props.height}` ],
 		[ 'Alpha', props.alpha ],
 		[ 'Antialias', props.antialias ],
@@ -303,26 +377,18 @@ function renderRenderer( renderer, container ) {
 		[ 'Auto Clear Depth', props.autoClearDepth ],
 		[ 'Auto Clear Stencil', props.autoClearStencil ],
 		[ 'Local Clipping', props.localClipping ]
-	] ) );
-
-	const statsColumn = document.createElement( 'div' );
-	statsColumn.appendChild( createPropertyGroup( 'Render Stats', [
+	]] ) );
+	properties.appendChild( createPropertyColumn( [ 'Render Stats', [
 		[ 'Frame', info.render.frame ],
 		[ 'Draw Calls', info.render.calls ],
 		[ 'Triangles', info.render.triangles ],
 		[ 'Points', info.render.points ],
 		[ 'Lines', info.render.lines ]
-	] ) );
-	statsColumn.appendChild( createPropertyGroup( 'Memory', [
+	]], [ 'Memory', [
 		[ 'Geometries', info.memory.geometries ],
 		[ 'Textures', info.memory.textures ],
 		[ 'Shader Programs', info.memory.programs ]
-	] ) );
-
-	const properties = document.createElement( 'div' );
-	properties.className = 'properties-list';
-	properties.appendChild( propertiesColumn );
-	properties.appendChild( statsColumn );
+	]] ) );
 	node.appendChild( properties );
 
 	container.appendChild( node );
@@ -330,114 +396,178 @@ function renderRenderer( renderer, container ) {
 }
 
 // Render an object and its children
-function renderObject( obj, container, level = 0, parentInvisible = false ) {
+function renderObject( object, container, level = 0, parentInvisible = false ) {
 
-	const children = obj.children
+	// A batch can arrive while the tree is rendering, so a listed child is not always in state yet
+	const children = object.children
 		.map( uuid => state.objects.get( uuid ) )
 		.filter( child => child !== undefined )
 		.sort( ( a, b ) => getObjectOrder( a ) - getObjectOrder( b ) );
 
 	const hasChildren = children.length > 0;
-	const invisible = parentInvisible || obj.visible === false;
+	const invisible = parentInvisible || object.visible === false;
 
-	let name = obj.name || obj.type;
+	let name = object.name || object.type;
 	const details = [];
 
-	if ( obj.isInstancedMesh ) name += ` [${obj.count}]`;
-	if ( obj.isMesh ) details.push( `${obj.geometryType} ${obj.materialType}` );
+	if ( object.isInstancedMesh ) name += ` [${object.count}]`;
+	if ( object.isMesh ) details.push( `${object.geometryType} ${object.materialType}` );
 
-	if ( obj.isScene ) {
+	if ( object.isScene ) {
 
-		let objectCount = 0;
-		let lightCount = 0;
+		const objects = [ ...state.objects.values() ].filter( item => item._sceneUuid === object.uuid && ! item.isScene );
+		const lights = objects.filter( item => item.isLight );
 
-		state.objects.forEach( object => {
-
-			if ( object._sceneUuid !== obj.uuid || object.isScene ) return;
-
-			objectCount ++;
-			if ( object.isLight ) lightCount ++;
-
-		} );
-
-		details.push( `${objectCount} objects` );
-		if ( lightCount > 0 ) details.push( `${lightCount} lights` );
+		details.push( `${objects.length} objects` );
+		if ( lights.length > 0 ) details.push( `${lights.length} lights` );
 
 	}
 
-	const toggle = hasChildren
-		? '<span class="tree-toggle"></span>'
-		: '<span class="tree-toggle-placeholder"></span>';
+	const toggle = document.createElement( 'span' );
+	toggle.className = hasChildren ? 'tree-toggle' : 'tree-toggle-placeholder';
+
+	const icon = document.createElement( 'span' );
+	icon.className = 'icon';
+	icon.textContent = getObjectIcon( object );
+
+	const type = document.createElement( 'span' );
+	type.className = 'type';
+	type.textContent = object.type;
 
 	const item = document.createElement( hasChildren ? 'summary' : 'div' );
 	item.className = 'tree-item';
 	item.style.paddingLeft = `${level * 20}px`;
 	if ( invisible ) item.classList.add( 'invisible' );
-	item.innerHTML = `${toggle}<span class="icon">${getObjectIcon( obj )}</span>
-		<span class="label">${createLabel( name, details )}</span>
-		<span class="type">${obj.type}</span>`;
+	if ( expanded.has( object.uuid ) ) item.classList.add( 'expanded' );
+	item.append( toggle, icon, createLabel( name, details ), type );
 
-	item.addEventListener( 'mouseenter', () => {
+	// The arrow toggles the children, the rest of the row toggles the details
+	item.addEventListener( 'click', ( event ) => {
 
-		send( MESSAGE_REQUEST_OBJECT_DETAILS, { uuid: obj.uuid } );
+		if ( event.target.classList.contains( 'tree-toggle' ) ) return;
 
-		// Only highlight if object and all parents are visible
-		if ( ! invisible ) send( MESSAGE_HIGHLIGHT_OBJECT, { uuid: obj.uuid } );
+		event.preventDefault();
+		toggleDetails( object.uuid );
 
 	} );
 
+	item.addEventListener( 'mouseenter', () => send( MESSAGE_HIGHLIGHT_OBJECT, { uuid: object.uuid } ) );
 	item.addEventListener( 'mouseleave', () => send( MESSAGE_UNHIGHLIGHT_OBJECT ) );
+
+	// Objects with children are a collapsible node, the row being its summary
+	let parent = container;
 
 	if ( hasChildren ) {
 
-		const node = document.createElement( 'details' );
+		parent = document.createElement( 'details' );
 
-		// Default to expanded unless the user has collapsed this node before
-		node.open = openState.get( obj.uuid ) ?? true;
-		node.addEventListener( 'toggle', () => openState.set( obj.uuid, node.open ) );
+		// Default to open unless the user has collapsed this node before
+		parent.open = openState.get( object.uuid ) ?? true;
+		parent.addEventListener( 'toggle', () => openState.set( object.uuid, parent.open ) );
 
-		node.appendChild( item );
+		container.appendChild( parent );
 
-		for ( const child of children ) {
+	}
 
-			renderObject( child, node, level + 1, invisible );
+	parent.appendChild( item );
 
-		}
+	if ( expanded.has( object.uuid ) ) {
 
-		container.appendChild( node );
+		const block = expanded.get( object.uuid );
+		block.style.marginLeft = `${level * 20}px`;
+		parent.appendChild( block );
 
-	} else {
+	}
 
-		container.appendChild( item );
+	for ( const child of children ) {
+
+		renderObject( child, parent, level + 1, invisible );
 
 	}
 
 }
 
-// Build the static DOM shell (called once)
-function initUI() {
+// Expand or collapse an object's details under its row
+function toggleDetails( uuid ) {
 
-	const header = document.createElement( 'div' );
-	header.className = 'header';
-	header.innerHTML = `<a href="https://docs.google.com/forms/d/e/1FAIpQLSdw1QcgXNiECYiPx6k0vSQRiRe0FmByrrojV4fgeL5zzXIiCw/viewform?usp=preview" target="_blank">+</a>
-		<span class="version">${chrome.runtime.getManifest().version}</span>`;
-	document.body.appendChild( header );
+	if ( expanded.has( uuid ) ) {
 
-	const sections = document.createElement( 'div' );
-	sections.className = 'sections-container';
-	document.body.appendChild( sections );
+		expanded.delete( uuid );
 
-	renderersSection = document.createElement( 'div' );
-	renderersSection.className = 'section';
-	sections.appendChild( renderersSection );
+	} else {
 
-	scenesSection = document.createElement( 'div' );
-	scenesSection.className = 'section';
-	sections.appendChild( scenesSection );
+		const image = document.createElement( 'img' );
+		image.className = 'preview';
 
-	floatingPanel = document.createElement( 'div' );
-	floatingPanel.className = 'floating-details';
-	document.body.appendChild( floatingPanel );
+		const block = document.createElement( 'div' );
+		block.className = 'properties-list';
+		block.appendChild( image );
+
+		expanded.set( uuid, block );
+		requestDetails( uuid, true );
+
+	}
+
+	updateSceneTree();
+
+}
+
+// The object rendered with its own material in one column, its transform, geometry and materials in the other.
+// Built once, then only refreshed, so the selections stay and the image does not flicker.
+function renderObjectDetails( block, details ) {
+
+	const groups = details.materials.map( material => [ material, Object.entries( material.properties ) ] );
+	if ( details.geometry !== null ) groups.unshift( [ details.geometry, Object.entries( details.geometry.properties ) ] );
+
+	// A swapped geometry or material changes a type, a name or the number of properties
+	const signature = groups.map( ( [ item, rows ] ) => item.type + item.name + rows.length ).join();
+
+	const image = block.firstChild;
+
+	// The first details fill an empty block, any later change is a swapped geometry or material
+	const swapped = block.dataset.signature !== undefined && block.dataset.signature !== signature;
+
+	if ( block.dataset.signature !== signature ) {
+
+		block.dataset.signature = signature;
+
+		// The render that arrived with these details is of what the object used to be
+		if ( swapped ) requestDetails( details.uuid, true );
+
+		const transform = document.createElement( 'div' );
+		transform.className = 'transform';
+
+		const column = document.createElement( 'div' );
+		column.className = 'property-group object-properties';
+		column.appendChild( transform );
+
+		for ( const [ item, rows ] of groups ) {
+
+			// The type in bold, then the name the page gave it
+			const heading = document.createElement( 'h4' );
+			heading.textContent = item.type;
+			if ( item.name ) appendDetail( heading, item.name );
+
+			column.append( heading, createPropertyPicker( rows ) );
+
+		}
+
+		block.replaceChildren( image, column );
+
+	}
+
+	const pickers = block.querySelectorAll( '.picker' );
+	groups.forEach( ( [ , rows ], i ) => updatePropertyPicker( pickers[ i ], rows ) );
+
+	// Only an object with a geometry can be rendered, the rest keep no tile at all
+	image.hidden = details.geometry === null;
+	if ( details.preview && image.src !== details.preview ) image.src = details.preview;
+
+	block.querySelector( '.transform' ).replaceChildren(
+		createPropertyRow( 'Position', details.position ),
+		createPropertyRow( 'Rotation', details.rotation ),
+		createPropertyRow( 'Scale', details.scale )
+	);
 
 }
 
@@ -456,65 +586,20 @@ function updateRenderers() {
 
 }
 
+// Rebuild the scene tree, forgetting expanded objects that are gone
 function updateSceneTree() {
+
+	for ( const uuid of expanded.keys() ) {
+
+		if ( ! state.objects.has( uuid ) ) {
+
+			expanded.delete( uuid );
+			pendingPreviews.delete( uuid );
+
+		}
+
+	}
 
 	renderSection( scenesSection, 'Scenes', state.scenes, renderObject );
 
 }
-
-// --- Floating details panel ---
-
-function showFloatingDetails( details ) {
-
-	floatingPanel.innerHTML = '';
-	floatingPanel.appendChild( createVectorRow( 'Position', details.position ) );
-	floatingPanel.appendChild( createVectorRow( 'Rotation', details.rotation ) );
-	floatingPanel.appendChild( createVectorRow( 'Scale', details.scale ) );
-
-	floatingPanel.classList.add( 'visible' );
-	updateFloatingPanelPosition();
-
-}
-
-function updateFloatingPanelPosition() {
-
-	if ( ! floatingPanel.classList.contains( 'visible' ) ) return;
-
-	const offset = 15; // Offset from cursor
-	let x = mousePosition.x + offset;
-	let y = mousePosition.y + offset;
-
-	// Prevent panel from going off-screen
-	const panelRect = floatingPanel.getBoundingClientRect();
-	const maxX = window.innerWidth - panelRect.width - 10;
-	const maxY = window.innerHeight - panelRect.height - 10;
-
-	if ( x > maxX ) x = mousePosition.x - panelRect.width - offset;
-	if ( y > maxY ) y = mousePosition.y - panelRect.height - offset;
-
-	floatingPanel.style.left = `${Math.max( 10, x )}px`;
-	floatingPanel.style.top = `${Math.max( 10, y )}px`;
-
-}
-
-// Track mouse position
-document.addEventListener( 'mousemove', ( event ) => {
-
-	mousePosition.x = event.clientX;
-	mousePosition.y = event.clientY;
-	updateFloatingPanelPosition();
-
-} );
-
-// Hide panel when mouse leaves the tree area
-document.addEventListener( 'mouseover', ( event ) => {
-
-	if ( ! event.target.closest( '.tree-item' ) ) {
-
-		floatingPanel.classList.remove( 'visible' );
-
-	}
-
-} );
-
-initUI();

--- a/devtools/panel/panel.js
+++ b/devtools/panel/panel.js
@@ -1,4 +1,4 @@
-/* global chrome, MESSAGE_INIT, MESSAGE_REQUEST_STATE, MESSAGE_REQUEST_OBJECT_DETAILS, MESSAGE_SCROLL_TO_CANVAS, MESSAGE_HIGHLIGHT_OBJECT, MESSAGE_UNHIGHLIGHT_OBJECT, EVENT_RENDERER, EVENT_OBJECT_DETAILS, EVENT_SCENE, EVENT_SCENE_REMOVED, EVENT_COMMITTED */
+/* global chrome, MESSAGE_INIT, MESSAGE_REQUEST_STATE, MESSAGE_REQUEST_OBJECT_DETAILS, MESSAGE_SCROLL_TO_CANVAS, MESSAGE_HIGHLIGHT_OBJECT, MESSAGE_UNHIGHLIGHT_OBJECT, EVENT_REGISTER, EVENT_RENDERER, EVENT_OBJECT_DETAILS, EVENT_SCENE, EVENT_SCENE_REMOVED, EVENT_COMMITTED */
 
 const STATE_POLLING_INTERVAL = 1000;
 
@@ -7,7 +7,8 @@ const STATE_POLLING_INTERVAL = 1000;
 const state = {
 	scenes: new Map(),
 	renderers: new Map(),
-	objects: new Map()
+	objects: new Map(),
+	revision: null
 };
 
 // Open/closed state of collapsible nodes (uuid -> boolean), kept across rebuilds
@@ -19,6 +20,7 @@ const expanded = new Map();
 // Static DOM from panel.html
 const renderersSection = document.getElementById( 'renderers' );
 const scenesSection = document.getElementById( 'scenes' );
+const notice = document.getElementById( 'notice' );
 
 document.querySelector( '.version' ).textContent = chrome.runtime.getManifest().version;
 
@@ -53,6 +55,7 @@ function poll() {
 
 send( MESSAGE_INIT, { tabId: chrome.devtools.inspectedWindow.tabId } );
 send( MESSAGE_REQUEST_STATE );
+updateNotice();
 
 port.onDisconnect.addListener( () => {
 
@@ -66,6 +69,11 @@ port.onMessage.addListener( ( message ) => {
 	const detail = message.detail;
 
 	switch ( message.name ) {
+
+		case EVENT_REGISTER:
+			state.revision = detail.revision;
+			updateNotice();
+			break;
 
 		case EVENT_RENDERER:
 			detail._frameId = message.frameId;
@@ -168,6 +176,7 @@ function clearState() {
 	state.scenes.clear();
 	state.renderers.clear();
 	state.objects.clear();
+	state.revision = null;
 	openState.clear();
 	expanded.clear();
 
@@ -480,12 +489,12 @@ function toggleDetails( uuid ) {
 
 	} else {
 
-		const image = document.createElement( 'img' );
-		image.className = 'preview';
+		const tile = document.createElement( 'div' );
+		tile.className = 'preview';
 
 		const block = document.createElement( 'div' );
 		block.className = 'properties-list';
-		block.appendChild( image );
+		block.appendChild( tile );
 
 		expanded.set( uuid, block );
 		send( MESSAGE_REQUEST_OBJECT_DETAILS, { uuid: uuid, preview: true } );
@@ -506,7 +515,7 @@ function renderObjectDetails( block, details ) {
 	// A swapped geometry or material changes a type, a name or the number of properties
 	const signature = groups.map( ( [ item, rows ] ) => item.type + item.name + rows.length ).join();
 
-	const image = block.firstChild;
+	const tile = block.firstChild;
 
 	// The first details fill an empty block, any later change is a swapped geometry or material
 	const swapped = block.dataset.signature !== undefined && block.dataset.signature !== signature;
@@ -536,18 +545,22 @@ function renderObjectDetails( block, details ) {
 
 		}
 
-		block.replaceChildren( image, column );
+		block.replaceChildren( tile, column );
 
 	}
 
 	const pickers = block.querySelectorAll( '.picker' );
 	groups.forEach( ( [ , rows ], i ) => updatePropertyPicker( pickers[ i ], rows ) );
 
-	// A preview comes with the details when one was asked for, an object that has none keeps no tile
+	// A preview comes with the details when one was asked for: the image, or the reason there is
+	// none, shown in its place. An object with nothing to draw keeps no tile at all.
 	if ( 'preview' in details ) {
 
-		image.hidden = details.preview === null;
-		if ( details.preview !== null ) image.src = details.preview;
+		const rendered = details.preview !== null && details.preview.startsWith( 'data:' );
+
+		tile.hidden = details.preview === null;
+		tile.style.backgroundImage = rendered ? `url(${details.preview})` : '';
+		tile.textContent = rendered ? '' : details.preview;
 
 	}
 
@@ -568,9 +581,31 @@ function renderSection( section, title, items, render ) {
 
 }
 
+// While there is nothing to show, say whether three.js was found at all
+function updateNotice() {
+
+	notice.hidden = state.renderers.size > 0 || state.scenes.size > 0;
+
+	if ( state.revision === null ) {
+
+		notice.textContent = 'No instance of three.js found in this page.';
+
+	} else if ( parseInt( state.revision ) < 106 ) {
+
+		notice.textContent = `three.js r${state.revision} found, but versions before r106 do not report to the DevTools.`;
+
+	} else {
+
+		notice.textContent = `three.js r${state.revision} found, but it has no renderer or scene yet.`;
+
+	}
+
+}
+
 function updateRenderers() {
 
 	renderSection( renderersSection, 'Renderers', state.renderers, renderRenderer );
+	updateNotice();
 
 }
 
@@ -584,5 +619,6 @@ function updateSceneTree() {
 	}
 
 	renderSection( scenesSection, 'Scenes', state.scenes, renderObject );
+	updateNotice();
 
 }

--- a/devtools/preview.js
+++ b/devtools/preview.js
@@ -7,16 +7,27 @@
 	const utils = __THREE_DEVTOOLS__.utils;
 
 	let renderer = null;
-	let ready = false;
+	let ready = null;
 	let scene = null;
 
 	// The three.js base class of an instance, found right below the root class that defines rootMethod:
-	// Mesh below Object3D (traverse) for an InstancedMesh, Scene below Object3D for a page's own scene class
+	// Mesh below Object3D (traverse) for a SkinnedMesh, Scene below Object3D for a page's own scene class
 	function getBaseClass( instance, rootMethod ) {
 
 		let prototype = Object.getPrototypeOf( instance );
 
 		while ( ! Object.hasOwn( Object.getPrototypeOf( prototype ), rootMethod ) ) prototype = Object.getPrototypeOf( prototype );
+
+		return prototype.constructor;
+
+	}
+
+	// The class of an instance that defines a method: InstancedMesh for setMatrixAt, LineSegments or Line for computeLineDistances
+	function getClass( instance, method ) {
+
+		let prototype = Object.getPrototypeOf( instance );
+
+		while ( ! Object.hasOwn( prototype, method ) ) prototype = Object.getPrototypeOf( prototype );
 
 		return prototype.constructor;
 
@@ -31,8 +42,8 @@
 		// Scene itself, not a page subclass, since addLights derives Object3D from this class
 		scene = utils.unobserved( () => new ( getBaseClass( view.scene, 'traverse' ) )() );
 
-		// WebGPURenderer initializes asynchronously, previews start with the next request
-		if ( renderer.init ) renderer.init().then( () => ready = true ); else ready = true;
+		// WebGPURenderer initializes asynchronously, the first preview waits for it
+		ready = renderer.init ? renderer.init() : null;
 
 	}
 
@@ -112,34 +123,48 @@
 
 	}
 
-	utils.renderPreview = function ( object ) {
+	// A plain three.js object of the object's kind, so a page subclass's constructor and the object's own
+	// transform stay out of the way. An InstancedMesh keeps a single instance at the origin, so a material
+	// written for instancing still compiles. Skinning and batching are left out, the geometry previews well enough.
+	function createPreviewObject( object ) {
+
+		if ( object.isInstancedMesh ) return new ( getClass( object, 'setMatrixAt' ) )( object.geometry, object.material, 1 );
+
+		const Class = object.isLine ? getClass( object, 'computeLineDistances' ) : getBaseClass( object, 'traverse' );
+
+		return new Class( object.geometry, object.material );
+
+	}
+
+	utils.renderPreview = async function ( object ) {
 
 		// Only meshes, lines and points have something to preview
 		if ( ! object.isMesh && ! object.isLine && ! object.isPoints ) return null;
+
+		// A ShaderMaterial shares its uniforms with the page's renderer, which wires its light uniforms
+		// into them, so drawing it with another renderer breaks the page
+		if ( [].concat( object.material ).some( material => material.isShaderMaterial ) ) return null;
 
 		// The scene has to have been drawn once, so its renderer and camera are known
 		const view = utils.getSceneView( object );
 		if ( view === null ) return null;
 
-		if ( renderer === null ) setup( view );
-		if ( ready === false ) return null;
-
-		renderer.toneMapping = view.renderer.toneMapping;
-		renderer.toneMappingExposure = view.renderer.toneMappingExposure;
-		renderer.outputColorSpace = view.renderer.outputColorSpace;
-
-		scene.clear();
-		addLights( view.scene );
-
-		const geometry = object.geometry;
-		if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
-
-		// A plain Mesh, Line or Points, so instancing, skinning and the object's own transform stay out of the way
-		const Class = getBaseClass( object, 'traverse' );
-
 		try {
 
-			return snapshot( new Class( geometry, object.material ), view.camera, geometry.boundingSphere.center, geometry.boundingSphere.radius );
+			if ( renderer === null ) setup( view );
+			await ready;
+
+			renderer.toneMapping = view.renderer.toneMapping;
+			renderer.toneMappingExposure = view.renderer.toneMappingExposure;
+			renderer.outputColorSpace = view.renderer.outputColorSpace;
+
+			scene.clear();
+			addLights( view.scene );
+
+			const geometry = object.geometry;
+			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
+
+			return snapshot( createPreviewObject( object ), view.camera, geometry.boundingSphere.center, geometry.boundingSphere.radius );
 
 		} catch ( error ) {
 

--- a/devtools/preview.js
+++ b/devtools/preview.js
@@ -1,0 +1,154 @@
+// Renders an expanded object with its own material, using a renderer created from the page's own three.js
+
+( function () {
+
+	const SIZE = 160;
+	const FOV = 40;
+	const utils = __THREE_DEVTOOLS__.utils;
+
+	let renderer = null;
+	let ready = false;
+	let scene = null;
+
+	// The three.js base class of an instance, found right below the root class that defines rootMethod:
+	// Mesh below Object3D (traverse) for an InstancedMesh, Scene below Object3D for a page's own scene class
+	function getBaseClass( instance, rootMethod ) {
+
+		let prototype = Object.getPrototypeOf( instance );
+
+		while ( ! Object.hasOwn( Object.getPrototypeOf( prototype ), rootMethod ) ) prototype = Object.getPrototypeOf( prototype );
+
+		return prototype.constructor;
+
+	}
+
+	function setup( view ) {
+
+		renderer = utils.unobserved( () => new view.renderer.constructor( { canvas: document.createElement( 'canvas' ), alpha: true, antialias: true } ) );
+		renderer.setPixelRatio( 2 );
+		renderer.setSize( SIZE, SIZE );
+
+		// Scene itself, not a page subclass, since addLights derives Object3D from this class
+		scene = utils.unobserved( () => new ( getBaseClass( view.scene, 'traverse' ) )() );
+
+		// WebGPURenderer initializes asynchronously, previews start with the next request
+		if ( renderer.init ) renderer.init().then( () => ready = true ); else ready = true;
+
+	}
+
+	// Studio lighting of our own, duck-typed since the page may not have light classes to borrow.
+	// WebGL identifies lights by type, WebGPU by class, so there the page's own lights are cloned instead.
+	function addLights( root ) {
+
+		if ( renderer.isWebGLRenderer ) {
+
+			const Object3D = Object.getPrototypeOf( scene.constructor );
+			const key = Object.assign( new Object3D(), { isLight: true, isDirectionalLight: true, type: 'DirectionalLight', color: { r: 1, g: 1, b: 1 }, intensity: 3, target: new Object3D() } );
+			const fill = Object.assign( new Object3D(), { isLight: true, isHemisphereLight: true, type: 'HemisphereLight', color: { r: 1, g: 1, b: 1 }, groundColor: { r: 0.3, g: 0.3, b: 0.3 }, intensity: 1 } );
+			key.position.set( 1, 2, 3 );
+			fill.position.set( 0, 1, 0 );
+			scene.add( key, fill );
+
+		} else {
+
+			root.traverse( ( child ) => {
+
+				if ( child.isLight ) scene.add( child.clone() );
+
+			} );
+
+		}
+
+		// A render target texture (PMREM) can't be shared with another renderer
+		scene.environment = root.environment && ! root.environment.isRenderTargetTexture ? root.environment : null;
+		scene.environmentIntensity = root.environmentIntensity;
+
+	}
+
+	// Frame the object from a three quarter view and return the rendered image. The page's camera is
+	// pointed at it for this one render and put back afterwards. Its matrices are written directly,
+	// so none of its own settings, lens and zoom included, can reframe the preview.
+	function snapshot( object, camera, center, radius ) {
+
+		const Vector3 = center.constructor;
+		const distance = radius / Math.sin( FOV * Math.PI / 360 ) * 1.1;
+		const eye = new Vector3( 1, 0.6, 1.5 ).normalize().multiplyScalar( distance ).add( center );
+		const near = distance / 100;
+		const half = near * Math.tan( FOV * Math.PI / 360 );
+
+		const saved = [ camera.projectionMatrix.clone(), camera.matrixWorld.clone(), camera.matrixWorldInverse.clone() ];
+		const autoUpdate = camera.matrixWorldAutoUpdate;
+		const isArrayCamera = camera.isArrayCamera;
+
+		camera.projectionMatrix.makePerspective( - half, half, half, - half, near, distance * 10, renderer.coordinateSystem );
+		camera.matrixWorld.lookAt( eye, center, new Vector3( 0, 1, 0 ) ).setPosition( eye );
+		camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
+
+		// The renderer recomputes the world matrix of a camera that has no parent
+		camera.matrixWorldAutoUpdate = false;
+
+		// An XR camera draws one view per eye, and a preview is a single square view
+		if ( isArrayCamera ) camera.isArrayCamera = false;
+
+		scene.add( object );
+
+		try {
+
+			renderer.render( scene, camera );
+
+		} finally {
+
+			scene.remove( object );
+
+			camera.projectionMatrix.copy( saved[ 0 ] );
+			camera.matrixWorld.copy( saved[ 1 ] );
+			camera.matrixWorldInverse.copy( saved[ 2 ] );
+			camera.matrixWorldAutoUpdate = autoUpdate;
+			if ( isArrayCamera ) camera.isArrayCamera = true;
+
+		}
+
+		return renderer.domElement.toDataURL();
+
+	}
+
+	utils.renderPreview = function ( object ) {
+
+		// Only meshes, lines and points have something to preview
+		if ( ! object.isMesh && ! object.isLine && ! object.isPoints ) return null;
+
+		// The scene has to have been drawn once, so its renderer and camera are known
+		const view = utils.getSceneView( object );
+		if ( view === null ) return null;
+
+		if ( renderer === null ) setup( view );
+		if ( ready === false ) return null;
+
+		renderer.toneMapping = view.renderer.toneMapping;
+		renderer.toneMappingExposure = view.renderer.toneMappingExposure;
+		renderer.outputColorSpace = view.renderer.outputColorSpace;
+
+		scene.clear();
+		addLights( view.scene );
+
+		const geometry = object.geometry;
+		if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
+
+		// A plain Mesh, Line or Points, so instancing, skinning and the object's own transform stay out of the way
+		const Class = getBaseClass( object, 'traverse' );
+
+		try {
+
+			return snapshot( new Class( geometry, object.material ), view.camera, geometry.boundingSphere.center, geometry.boundingSphere.radius );
+
+		} catch ( error ) {
+
+			// A material the page's renderer can draw is not always one another renderer can
+			console.warn( 'DevTools: Preview failed:', error );
+			return null;
+
+		}
+
+	};
+
+} )();

--- a/devtools/preview.js
+++ b/devtools/preview.js
@@ -1,4 +1,5 @@
-// Renders an expanded object with its own material, using a renderer created from the page's own three.js
+// Renders an expanded object with its own material, using a renderer created from the page's own three.js.
+// The preview is the image, or the reason there is none.
 
 ( function () {
 
@@ -143,7 +144,7 @@
 
 		// A ShaderMaterial shares its uniforms with the page's renderer, which wires its light uniforms
 		// into them, so drawing it with another renderer breaks the page
-		if ( [].concat( object.material ).some( material => material.isShaderMaterial ) ) return null;
+		if ( [].concat( object.material ).some( material => material.isShaderMaterial ) ) return 'ShaderMaterial preview not supported';
 
 		// The scene has to have been drawn once, so its renderer and camera are known
 		const view = utils.getSceneView( object );
@@ -170,7 +171,7 @@
 
 			// A material the page's renderer can draw is not always one another renderer can
 			console.warn( 'DevTools: Preview failed:', error );
-			return null;
+			return 'Preview failed';
 
 		}
 


### PR DESCRIPTION
**Description**

Click an object to expand a preview rendered with its own material, its transform, and a dropdown of properties for its geometry and materials. The preview uses a renderer created from the page's own three.js.

Hovering now draws a box overlay above the page instead of adding a clone to the scene. The camera and viewport come from scene.onAfterRender.

<img width="1100" height="823" alt="Screenshot 2026-08-29 at 16 35 46" src="https://github.com/user-attachments/assets/6efac4fd-20a7-4772-8056-eaa1e76970df" />