### PR TITLE
KeyframeTrack: Serialize/deserialize tangent data.

### DIFF
--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -472,17 +472,30 @@ function parseKeyframeTrack( json ) {
 
 	}
 
+	let track;
+
 	// derived classes can define a static parse method
 	if ( trackType.parse !== undefined ) {
 
-		return trackType.parse( json );
+		track = trackType.parse( json );
 
 	} else {
 
 		// by default, we assume a constructor compatible with the base
-		return new trackType( json.name, json.times, json.values, json.interpolation );
+		track = new trackType( json.name, json.times, json.values, json.interpolation );
 
 	}
+
+	if ( json.settings !== undefined && json.settings.inTangents !== undefined && json.settings.outTangents !== undefined ) {
+
+		track.settings = {
+			inTangents: AnimationUtils.convertArray( json.settings.inTangents, Float32Array ),
+			outTangents: AnimationUtils.convertArray( json.settings.outTangents, Float32Array )
+		};
+
+	}
+
+	return track;
 
 }
 

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -486,7 +486,7 @@ function parseKeyframeTrack( json ) {
 
 	}
 
-	if ( json.settings !== undefined && json.settings.inTangents !== undefined && json.settings.outTangents !== undefined ) {
+	if ( AnimationUtils.hasTangents( json.settings ) ) {
 
 		track.settings = {
 			inTangents: AnimationUtils.convertArray( json.settings.inTangents, Float32Array ),

--- a/src/animation/AnimationUtils.js
+++ b/src/animation/AnimationUtils.js
@@ -24,6 +24,18 @@ function convertArray( array, type ) {
 }
 
 /**
+ * Returns `true` if the given keyframe track settings hold Bezier tangent data.
+ *
+ * @param {?Object} settings - The settings of a keyframe track.
+ * @return {boolean} Whether both tangent arrays are defined or not.
+ */
+function hasTangents( settings ) {
+
+	return settings !== undefined && settings.inTangents !== undefined && settings.outTangents !== undefined;
+
+}
+
+/**
  * Returns an array by which times and values can be sorted.
  *
  * @param {Array<number>} times - The keyframe time values.
@@ -406,6 +418,19 @@ class AnimationUtils {
 	}
 
 	/**
+	 * Returns `true` if the given keyframe track settings hold Bezier tangent data.
+	 *
+	 * @static
+	 * @param {?Object} settings - The settings of a keyframe track.
+	 * @return {boolean} Whether both tangent arrays are defined or not.
+	 */
+	static hasTangents( settings ) {
+
+		return hasTangents( settings );
+
+	}
+
+	/**
 	 * Returns an array by which times and values can be sorted.
 	 *
 	 * @static
@@ -486,6 +511,7 @@ class AnimationUtils {
 export {
 	convertArray,
 	isTypedArray,
+	hasTangents,
 	getKeyframeOrder,
 	sortedArray,
 	flattenJSON,

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -95,7 +95,7 @@ class KeyframeTrack {
 
 			}
 
-			if ( hasTangents( track.settings ) ) {
+			if ( AnimationUtils.hasTangents( track.settings ) ) {
 
 				json.settings = {
 					inTangents: AnimationUtils.convertArray( track.settings.inTangents, Array ),
@@ -329,7 +329,7 @@ class KeyframeTrack {
 
 			}
 
-			if ( hasTangents( this.settings ) ) {
+			if ( AnimationUtils.hasTangents( this.settings ) ) {
 
 				scaleTangentTimes( this.settings.inTangents, timeScale );
 				scaleTangentTimes( this.settings.outTangents, timeScale );
@@ -611,7 +611,7 @@ class KeyframeTrack {
 		// Interpolant argument to constructor is not saved, so copy the factory method directly.
 		track.createInterpolant = this.createInterpolant;
 
-		if ( hasTangents( this.settings ) ) {
+		if ( AnimationUtils.hasTangents( this.settings ) ) {
 
 			track.settings = {
 				inTangents: this.settings.inTangents.slice(),
@@ -623,12 +623,6 @@ class KeyframeTrack {
 		return track;
 
 	}
-
-}
-
-function hasTangents( settings ) {
-
-	return settings !== undefined && settings.inTangents !== undefined && settings.outTangents !== undefined;
 
 }
 

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -95,6 +95,15 @@ class KeyframeTrack {
 
 			}
 
+			if ( hasTangents( track.settings ) ) {
+
+				json.settings = {
+					inTangents: AnimationUtils.convertArray( track.settings.inTangents, Array ),
+					outTangents: AnimationUtils.convertArray( track.settings.outTangents, Array )
+				};
+
+			}
+
 		}
 
 		json.type = track.ValueTypeName; // mandatory
@@ -317,6 +326,13 @@ class KeyframeTrack {
 			for ( let i = 0, n = times.length; i !== n; ++ i ) {
 
 				times[ i ] *= timeScale;
+
+			}
+
+			if ( hasTangents( this.settings ) ) {
+
+				scaleTangentTimes( this.settings.inTangents, timeScale );
+				scaleTangentTimes( this.settings.outTangents, timeScale );
 
 			}
 
@@ -595,7 +611,34 @@ class KeyframeTrack {
 		// Interpolant argument to constructor is not saved, so copy the factory method directly.
 		track.createInterpolant = this.createInterpolant;
 
+		if ( hasTangents( this.settings ) ) {
+
+			track.settings = {
+				inTangents: this.settings.inTangents.slice(),
+				outTangents: this.settings.outTangents.slice()
+			};
+
+		}
+
 		return track;
+
+	}
+
+}
+
+function hasTangents( settings ) {
+
+	return settings !== undefined && settings.inTangents !== undefined && settings.outTangents !== undefined;
+
+}
+
+function scaleTangentTimes( tangents, timeScale ) {
+
+	// tangents are [ time, value ] pairs, so only every second entry is a time
+
+	for ( let i = 0, n = tangents.length; i !== n; i += 2 ) {
+
+		tangents[ i ] *= timeScale;
 
 	}
 


### PR DESCRIPTION
Fixed #34397.

**Description**

The PR makes sure `KeyframeTrack` properly serializes tangent data and `AnimationClip` restores them.

Also fixes two related bugs: `clone()` and `scale()` now correctly honor tangent data as well.