### PR TITLE
Nodes: Add `updateBefore` and `updateAfter` support for compute stage

### DIFF
--- a/examples/jsm/inspector/RendererInspector.js
+++ b/examples/jsm/inspector/RendererInspector.js
@@ -76,6 +76,7 @@ export class RendererInspector extends InspectorBase {
 		super();
 
 		this.currentFrame = null;
+		this.currentContext = null;
 		this.currentRender = null;
 		this.currentCompute = null;
 		this.currentNodes = null;
@@ -98,13 +99,7 @@ export class RendererInspector extends InspectorBase {
 
 	getParent() {
 
-		if ( this.currentCompute !== null && this.currentRender !== null ) {
-
-			return this.currentCompute.timestamp > this.currentRender.timestamp ? this.currentCompute : this.currentRender;
-
-		}
-
-		return this.currentRender || this.currentCompute || this.getFrame();
+		return this.currentContext || this.getFrame();
 
 	}
 
@@ -113,6 +108,7 @@ export class RendererInspector extends InspectorBase {
 		super.begin();
 
 		this.currentFrame = this._createFrame();
+		this.currentContext = this.currentFrame;
 		this.currentRender = null;
 		this.currentCompute = null;
 		this.currentNodes = [];
@@ -136,6 +132,7 @@ export class RendererInspector extends InspectorBase {
 		this.lastFrame = frame;
 
 		this.currentFrame = null;
+		this.currentContext = null;
 		this.currentRender = null;
 		this.currentCompute = null;
 		this.currentNodes = null;
@@ -517,6 +514,7 @@ export class RendererInspector extends InspectorBase {
 		currentCompute.parent.children.push( currentCompute );
 
 		this.currentCompute = currentCompute;
+		this.currentContext = currentCompute;
 
 	}
 
@@ -529,6 +527,7 @@ export class RendererInspector extends InspectorBase {
 		const currentCompute = this.currentCompute;
 		currentCompute.cpu = performance.now() - currentCompute.timestamp;
 
+		this.currentContext = currentCompute.parent;
 		this.currentCompute = currentCompute.parent && currentCompute.parent.isComputeStats ? currentCompute.parent : null;
 
 	}
@@ -547,6 +546,7 @@ export class RendererInspector extends InspectorBase {
 		currentRender.parent.children.push( currentRender );
 
 		this.currentRender = currentRender;
+		this.currentContext = currentRender;
 
 	}
 
@@ -559,6 +559,7 @@ export class RendererInspector extends InspectorBase {
 		const currentRender = this.currentRender;
 		currentRender.cpu = performance.now() - currentRender.timestamp;
 
+		this.currentContext = currentRender.parent;
 		this.currentRender = currentRender.parent && currentRender.parent.isRenderStats ? currentRender.parent : null;
 
 	}

--- a/examples/jsm/inspector/RendererInspector.js
+++ b/examples/jsm/inspector/RendererInspector.js
@@ -57,7 +57,9 @@ class ComputeStats extends ObjectStats {
 
 	constructor( uid, computeNode ) {
 
-		super( uid, computeNode.name );
+		const name = computeNode.name || ( computeNode.isComputeNode ? 'Compute' : 'Compute Group' );
+
+		super( uid, name );
 
 		this.computeNode = computeNode;
 
@@ -75,6 +77,7 @@ export class RendererInspector extends InspectorBase {
 
 		this.currentFrame = null;
 		this.currentRender = null;
+		this.currentCompute = null;
 		this.currentNodes = null;
 		this.lastFrame = null;
 
@@ -95,7 +98,13 @@ export class RendererInspector extends InspectorBase {
 
 	getParent() {
 
-		return this.currentRender || this.getFrame();
+		if ( this.currentCompute !== null && this.currentRender !== null ) {
+
+			return this.currentCompute.timestamp > this.currentRender.timestamp ? this.currentCompute : this.currentRender;
+
+		}
+
+		return this.currentRender || this.currentCompute || this.getFrame();
 
 	}
 
@@ -104,7 +113,8 @@ export class RendererInspector extends InspectorBase {
 		super.begin();
 
 		this.currentFrame = this._createFrame();
-		this.currentRender = this.currentFrame;
+		this.currentRender = null;
+		this.currentCompute = null;
 		this.currentNodes = [];
 
 	}
@@ -127,6 +137,7 @@ export class RendererInspector extends InspectorBase {
 
 		this.currentFrame = null;
 		this.currentRender = null;
+		this.currentCompute = null;
 		this.currentNodes = null;
 
 		this._lastFinishTime = now;
@@ -500,19 +511,10 @@ export class RendererInspector extends InspectorBase {
 
 		const currentCompute = new ComputeStats( uid, computeNode );
 		currentCompute.timestamp = performance.now();
-		currentCompute.parent = this.currentCompute || this.getParent();
+		currentCompute.parent = this.getParent();
 
 		frame.computes.push( currentCompute );
-
-		if ( this.currentRender !== null ) {
-
-			this.currentRender.children.push( currentCompute );
-
-		} else {
-
-			frame.children.push( currentCompute );
-
-		}
+		currentCompute.parent.children.push( currentCompute );
 
 		this.currentCompute = currentCompute;
 
@@ -527,7 +529,7 @@ export class RendererInspector extends InspectorBase {
 		const currentCompute = this.currentCompute;
 		currentCompute.cpu = performance.now() - currentCompute.timestamp;
 
-		this.currentCompute = currentCompute.parent.isComputeStats ? currentCompute.parent : null;
+		this.currentCompute = currentCompute.parent && currentCompute.parent.isComputeStats ? currentCompute.parent : null;
 
 	}
 
@@ -542,16 +544,7 @@ export class RendererInspector extends InspectorBase {
 		currentRender.parent = this.getParent();
 
 		frame.renders.push( currentRender );
-
-		if ( this.currentRender !== null ) {
-
-			this.currentRender.children.push( currentRender );
-
-		} else {
-
-			frame.children.push( currentRender );
-
-		}
+		currentRender.parent.children.push( currentRender );
 
 		this.currentRender = currentRender;
 
@@ -566,7 +559,7 @@ export class RendererInspector extends InspectorBase {
 		const currentRender = this.currentRender;
 		currentRender.cpu = performance.now() - currentRender.timestamp;
 
-		this.currentRender = currentRender.parent;
+		this.currentRender = currentRender.parent && currentRender.parent.isRenderStats ? currentRender.parent : null;
 
 	}
 

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -501,9 +501,10 @@ class Node extends EventDispatcher {
 	/**
 	 * Returns the update type of {@link Node#update}.
 	 *
+	 * @param {NodeFrame} [frame] - The current node frame.
 	 * @return {NodeUpdateType} The update type.
 	 */
-	getUpdateType() {
+	getUpdateType( /*frame*/ ) {
 
 		return this.updateType;
 
@@ -512,9 +513,10 @@ class Node extends EventDispatcher {
 	/**
 	 * Returns the update type of {@link Node#updateBefore}.
 	 *
+	 * @param {NodeFrame} [frame] - The current node frame.
 	 * @return {NodeUpdateType} The update type.
 	 */
-	getUpdateBeforeType() {
+	getUpdateBeforeType( /*frame*/ ) {
 
 		return this.updateBeforeType;
 
@@ -523,9 +525,10 @@ class Node extends EventDispatcher {
 	/**
 	 * Returns the update type of {@link Node#updateAfter}.
 	 *
+	 * @param {NodeFrame} [frame] - The current node frame.
 	 * @return {NodeUpdateType} The update type.
 	 */
-	getUpdateAfterType() {
+	getUpdateAfterType( /*frame*/ ) {
 
 		return this.updateAfterType;
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -3464,7 +3464,7 @@ class NodeBuilder {
 
 		const mrt = this.renderer.getMRT();
 
-		return ( mrt && mrt.has( 'velocity' ) ) || getDataFromObject( this.object ).useVelocity === true;
+		return ( mrt && mrt.has( 'velocity' ) ) || ( this.object !== null && getDataFromObject( this.object ).useVelocity === true );
 
 	}
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -124,6 +124,14 @@ class NodeBuilder {
 		this.geometry = ( object && object.geometry ) || null;
 
 		/**
+		 * The compute node, if building for compute.
+		 *
+		 * @type {?ComputeNode}
+		 * @default null
+		 */
+		this.compute = null;
+
+		/**
 		 * The current renderer.
 		 *
 		 * @type {Renderer}
@@ -830,8 +838,8 @@ class NodeBuilder {
 	 */
 	addSequentialNode( node ) {
 
-		const updateBeforeType = node.getUpdateBeforeType();
-		const updateAfterType = node.getUpdateAfterType();
+		const updateBeforeType = node.updateBeforeType;
+		const updateAfterType = node.updateAfterType;
 
 		if ( updateBeforeType !== NodeUpdateType.NONE || updateAfterType !== NodeUpdateType.NONE ) {
 
@@ -848,7 +856,7 @@ class NodeBuilder {
 
 		for ( const node of this.nodes ) {
 
-			const updateType = node.getUpdateType();
+			const updateType = node.updateType;
 
 			if ( updateType !== NodeUpdateType.NONE ) {
 
@@ -860,8 +868,8 @@ class NodeBuilder {
 
 		for ( const node of this.sequentialNodes ) {
 
-			const updateBeforeType = node.getUpdateBeforeType();
-			const updateAfterType = node.getUpdateAfterType();
+			const updateBeforeType = node.updateBeforeType;
+			const updateAfterType = node.updateAfterType;
 
 			if ( updateBeforeType !== NodeUpdateType.NONE ) {
 
@@ -3110,7 +3118,7 @@ class NodeBuilder {
 	 */
 	prebuild() {
 
-		const { object, renderer, material } = this;
+		const { renderer, material } = this;
 
 		// < renderer.contextNode >
 
@@ -3158,7 +3166,7 @@ class NodeBuilder {
 
 		} else {
 
-			this.addFlow( 'compute', object );
+			this.addFlow( 'compute', this.compute );
 
 		}
 

--- a/src/nodes/core/NodeFrame.js
+++ b/src/nodes/core/NodeFrame.js
@@ -106,6 +106,14 @@ class NodeFrame {
 		 */
 		this.scene = null;
 
+		/**
+		 * A reference to the current compute node.
+		 *
+		 * @type {?ComputeNode}
+		 * @default null
+		 */
+		this.compute = null;
+
 	}
 
 	/**
@@ -146,7 +154,7 @@ class NodeFrame {
 	 */
 	updateBeforeNode( node ) {
 
-		const updateType = node.getUpdateBeforeType();
+		const updateType = node.getUpdateBeforeType( this );
 		const reference = node.updateReference( this );
 
 		if ( updateType === NodeUpdateType.FRAME ) {
@@ -203,7 +211,7 @@ class NodeFrame {
 	 */
 	updateAfterNode( node ) {
 
-		const updateType = node.getUpdateAfterType();
+		const updateType = node.getUpdateAfterType( this );
 		const reference = node.updateReference( this );
 
 		if ( updateType === NodeUpdateType.FRAME ) {
@@ -252,7 +260,7 @@ class NodeFrame {
 	 */
 	updateNode( node ) {
 
-		const updateType = node.getUpdateType();
+		const updateType = node.getUpdateType( this );
 		const reference = node.updateReference( this );
 
 		if ( updateType === NodeUpdateType.FRAME ) {

--- a/src/nodes/display/ScreenNode.js
+++ b/src/nodes/display/ScreenNode.js
@@ -68,27 +68,6 @@ class ScreenNode extends Node {
 	}
 
 	/**
-	 * This method is overwritten since the node's update type depends on the selected scope.
-	 *
-	 * @return {NodeUpdateType} The update type.
-	 */
-	getUpdateType() {
-
-		let updateType = NodeUpdateType.NONE;
-
-		if ( this.scope === ScreenNode.SIZE || this.scope === ScreenNode.VIEWPORT ) {
-
-			updateType = NodeUpdateType.RENDER;
-
-		}
-
-		this.updateType = updateType;
-
-		return updateType;
-
-	}
-
-	/**
 	 * `ScreenNode` implements {@link Node#update} to retrieve viewport and size information
 	 * from the current renderer.
 	 *
@@ -148,6 +127,20 @@ class ScreenNode extends Node {
 			output = vec2( screenCoordinate.div( screenSize ) );
 
 		}
+
+		//
+
+		let updateType = NodeUpdateType.NONE;
+
+		if ( this.scope === ScreenNode.SIZE || this.scope === ScreenNode.VIEWPORT ) {
+
+			updateType = NodeUpdateType.RENDER;
+
+		}
+
+		this.updateType = updateType;
+
+		//
 
 		return output;
 

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -99,6 +99,15 @@ class ComputeNode extends Node {
 		 */
 		this.countNode = null;
 
+		/**
+		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node computes
+		 * once per frame.
+		 *
+		 * @type {string}
+		 * @default 'frame'
+		 */
+		this.updateBeforeType = NodeUpdateType.FRAME;
+
 	}
 
 	/**
@@ -154,6 +163,18 @@ class ComputeNode extends Node {
 	}
 
 	/**
+	 * Returns the update type of {@link Node#updateBefore}.
+	 *
+	 * @param {NodeFrame} [frame] - The current node frame.
+	 * @return {NodeUpdateType} The update type.
+	 */
+	getUpdateBeforeType( frame ) {
+
+		return frame.compute !== this ? this.updateBeforeType : NodeUpdateType.NONE;
+
+	}
+
+	/**
 	 * The method execute the compute for this node.
 	 *
 	 * @param {NodeFrame} frame - A reference to the current node frame.
@@ -165,8 +186,6 @@ class ComputeNode extends Node {
 	}
 
 	setup( builder ) {
-
-		this.updateBeforeType = ( builder.object !== this ) ? NodeUpdateType.FRAME : NodeUpdateType.NONE;
 
 		if ( this.count !== null && this.countNode === null ) {
 

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -85,15 +85,6 @@ class ComputeNode extends Node {
 		this.name = '';
 
 		/**
-		 * The `updateBeforeType` is set to `NodeUpdateType.OBJECT` since {@link ComputeNode#updateBefore}
-		 * is executed once per object by default.
-		 *
-		 * @type {string}
-		 * @default 'object'
-		 */
-		this.updateBeforeType = NodeUpdateType.OBJECT;
-
-		/**
 		 * A callback executed when the compute node finishes initialization.
 		 *
 		 * @type {?Function}
@@ -174,6 +165,8 @@ class ComputeNode extends Node {
 	}
 
 	setup( builder ) {
+
+		this.updateBeforeType = ( builder.object !== this ) ? NodeUpdateType.FRAME : NodeUpdateType.NONE;
 
 		if ( this.count !== null && this.countNode === null ) {
 

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -470,7 +470,7 @@ class Backend {
 	 * Updates a unique identifier for the given render context that can be used
 	 * to allocate resources like occlusion queries or timestamp queries.
 	 *
-	 * @param {RenderContext|ComputeNode} abstractRenderContext - The render context.
+	 * @param {RenderContext|ComputeNode|Array<ComputeNode>} abstractRenderContext - The render context.
 	 */
 	updateTimeStampUID( abstractRenderContext ) {
 
@@ -479,7 +479,15 @@ class Backend {
 
 		let prefix;
 
-		if ( abstractRenderContext.isComputeNode === true ) {
+		let id = abstractRenderContext.id;
+
+		if ( Array.isArray( abstractRenderContext ) ) {
+
+			id = abstractRenderContext.map( c => c.id ).join( ',' );
+
+			prefix = 'c:' + this.renderer.info.compute.frameCalls;
+
+		} else if ( abstractRenderContext.isComputeNode === true ) {
 
 			prefix = 'c:' + this.renderer.info.compute.frameCalls;
 
@@ -489,7 +497,7 @@ class Backend {
 
 		}
 
-		contextData.timestampUID = prefix + ':' + abstractRenderContext.id + ':f' + frame;
+		contextData.timestampUID = prefix + ':' + id + ':f' + frame;
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2880,7 +2880,7 @@ class Renderer {
 
 		if ( this._initialized === false ) {
 
-			warn( 'Renderer: .compute() called before the backend is initialized. Try using .computeAsync() instead.' );
+			warn( 'Renderer: ".compute()" called before the backend is initialized. Try using ".computeAsync()" instead.' );
 
 			return this.computeAsync( computeNodes, dispatchSize );
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1163,6 +1163,7 @@ class Renderer {
 
 			await nodes.getForComputeAsync( computeNode );
 
+			nodes.updateBeforeForCompute( computeNode );
 			nodes.updateForCompute( computeNode );
 			bindings.updateForCompute( computeNode );
 
@@ -1171,6 +1172,8 @@ class Renderer {
 
 			pipelines.getForCompute( computeNode, computeBindings, compilationPromises );
 			await Promise.all( compilationPromises );
+
+			nodes.updateAfterForCompute( computeNode );
 
 			loaded ++;
 
@@ -2950,6 +2953,7 @@ class Renderer {
 
 			}
 
+			nodes.updateBeforeForCompute( computeNode );
 			nodes.updateForCompute( computeNode );
 			bindings.updateForCompute( computeNode );
 
@@ -2957,6 +2961,8 @@ class Renderer {
 			const computePipeline = pipelines.getForCompute( computeNode, computeBindings );
 
 			backend.compute( computeNodes, computeNode, computeBindings, computePipeline, dispatchSize );
+
+			nodes.updateAfterForCompute( computeNode );
 
 		}
 

--- a/src/renderers/common/nodes/NodeManager.js
+++ b/src/renderers/common/nodes/NodeManager.js
@@ -1028,6 +1028,44 @@ class NodeManager extends DataMap {
 	}
 
 	/**
+	 * Triggers the call of `updateBefore()` methods
+	 * for all nodes of the given compute node.
+	 *
+	 * @param {Node} computeNode - The compute node.
+	 */
+	updateBeforeForCompute( computeNode ) {
+
+		const nodeFrame = this.getNodeFrame();
+		const nodeBuilder = this.getForCompute( computeNode );
+
+		for ( const node of nodeBuilder.updateBeforeNodes ) {
+
+			nodeFrame.updateBeforeNode( node );
+
+		}
+
+	}
+
+	/**
+	 * Triggers the call of `updateAfter()` methods
+	 * for all nodes of the given compute node.
+	 *
+	 * @param {Node} computeNode - The compute node.
+	 */
+	updateAfterForCompute( computeNode ) {
+
+		const nodeFrame = this.getNodeFrame();
+		const nodeBuilder = this.getForCompute( computeNode );
+
+		for ( const node of nodeBuilder.updateAfterNodes ) {
+
+			nodeFrame.updateAfterNode( node );
+
+		}
+
+	}
+
+	/**
 	 * Triggers the call of `update()` methods
 	 * for all nodes of the given compute node.
 	 *

--- a/src/renderers/common/nodes/NodeManager.js
+++ b/src/renderers/common/nodes/NodeManager.js
@@ -461,7 +461,9 @@ class NodeManager extends DataMap {
 
 		if ( nodeBuilderState === undefined || computeData.version !== computeNode.version ) {
 
-			const nodeBuilder = this.backend.createNodeBuilder( computeNode, this.renderer );
+			const nodeBuilder = this.backend.createNodeBuilder( null, this.renderer );
+			nodeBuilder.compute = computeNode;
+
 			const onNodeBuilderCreated = this.renderer.debug.onNodeBuilderCreated;
 
 			if ( onNodeBuilderCreated !== null ) onNodeBuilderCreated( nodeBuilder, computeNode );
@@ -908,7 +910,18 @@ class NodeManager extends DataMap {
 
 	}
 
-	getNodeFrame( renderer = this.renderer, scene = null, object = null, camera = null, material = null ) {
+	/**
+	 * Returns a node frame configured with the given parameters.
+	 *
+	 * @param {Renderer} [renderer=this.renderer] - The renderer.
+	 * @param {?Scene} [scene=null] - The scene.
+	 * @param {?Object3D} [object=null] - The object.
+	 * @param {?Camera} [camera=null] - The camera.
+	 * @param {?Material} [material=null] - The material.
+	 * @param {?Node} [compute=null] - The compute node.
+	 * @return {NodeFrame} The node frame.
+	 */
+	getNodeFrame( renderer = this.renderer, scene = null, object = null, camera = null, material = null, compute = null ) {
 
 		const nodeFrame = this.nodeFrame;
 		nodeFrame.renderer = renderer;
@@ -916,14 +929,33 @@ class NodeManager extends DataMap {
 		nodeFrame.object = object;
 		nodeFrame.camera = camera;
 		nodeFrame.material = material;
+		nodeFrame.compute = compute;
 
 		return nodeFrame;
 
 	}
 
+	/**
+	 * Returns a node frame configured for the given render object.
+	 *
+	 * @param {RenderObject} renderObject - The render object.
+	 * @return {NodeFrame} The node frame.
+	 */
 	getNodeFrameForRender( renderObject ) {
 
 		return this.getNodeFrame( renderObject.renderer, renderObject.scene, renderObject.object, renderObject.camera, renderObject.material );
+
+	}
+
+	/**
+	 * Returns a node frame configured for the given compute node.
+	 *
+	 * @param {Node} computeNode - The compute node.
+	 * @return {NodeFrame} The node frame.
+	 */
+	getNodeFrameForCompute( computeNode ) {
+
+		return this.getNodeFrame( this.renderer, null, null, null, null, computeNode );
 
 	}
 
@@ -1035,12 +1067,13 @@ class NodeManager extends DataMap {
 	 */
 	updateBeforeForCompute( computeNode ) {
 
-		const nodeFrame = this.getNodeFrame();
 		const nodeBuilder = this.getForCompute( computeNode );
 
 		for ( const node of nodeBuilder.updateBeforeNodes ) {
 
-			nodeFrame.updateBeforeNode( node );
+			// update frame state for each node
+
+			this.getNodeFrameForCompute( computeNode ).updateBeforeNode( node );
 
 		}
 
@@ -1054,12 +1087,13 @@ class NodeManager extends DataMap {
 	 */
 	updateAfterForCompute( computeNode ) {
 
-		const nodeFrame = this.getNodeFrame();
 		const nodeBuilder = this.getForCompute( computeNode );
 
 		for ( const node of nodeBuilder.updateAfterNodes ) {
 
-			nodeFrame.updateAfterNode( node );
+			// update frame state for each node
+
+			this.getNodeFrameForCompute( computeNode ).updateAfterNode( node );
 
 		}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -1257,7 +1257,7 @@ ${ flowData.code }
 	 */
 	getInvocationLocalIndex() {
 
-		const workgroupSize = this.object.workgroupSize;
+		const workgroupSize = this.compute.workgroupSize;
 
 		const size = workgroupSize.reduce( ( acc, curr ) => acc * curr, 1 );
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -2409,8 +2409,7 @@ ${ flowData.code }
 		} else {
 
 			// Early strictly validated in computeNode
-
-			const workgroupSize = this.object.workgroupSize;
+			const workgroupSize = this.compute.workgroupSize;
 
 			this.computeShader = this._getWGSLComputeCode( shadersData.compute, workgroupSize );
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR introduces support for `updateBefore` and `updateAfter` lifecycle hooks during compute pass execution (`renderer.compute()`), enabling nodes that require preparatory operations (such as `GaussianBlurNode`, render-to-texture passes, or nested computes) to execute before and after compute shaders.

<img width="648" height="822" alt="image" src="https://github.com/user-attachments/assets/e7b1ced2-d6d5-45a3-abb7-5acb15aec369" />

```js
const computeTexture = Fn( ( { storageTexture, inputTexture } ) => {

	const indexUV = uvec2( instanceIndex.mod( width ), instanceIndex.div( width ) );
	const uv = vec2( indexUV ).div( vec2( width, height ) );

	const texColor = gaussianBlur( texture( inputTexture ), 3 ).getTextureNode().sample( uv );

	textureStore( storageTexture, indexUV, texColor ).toWriteOnly();

} );
```
