### PR TITLE
Dev: Improve `preview.js`.

### DIFF
--- a/utils/build/preview.js
+++ b/utils/build/preview.js
@@ -1,20 +1,23 @@
 import { spawn } from 'child_process';
+import { createRequire } from 'module';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 const rootDir = path.resolve( __dirname, '../..' );
 
+const rollupBin = createRequire( import.meta.url ).resolve( 'rollup/dist/bin/rollup' );
+
 // Start rollup in watch mode
-const rollup = spawn( 'npx', [
-	'rollup',
+const rollup = spawn( process.execPath, [
+	rollupBin,
 	'-c', 'utils/build/rollup.config.js',
 	'-w',
 	'-m', 'inline'
 ], {
 	cwd: rootDir,
 	stdio: [ 'ignore', 'pipe', 'pipe' ],
-	shell: true
+	shell: false
 } );
 
 // Start server


### PR DESCRIPTION
Related issue: -

**Description**

I've recently updated node.js on my system and see below log now when running `npm run preview`:

> (node:11600) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.

To fix this warning, `preview.js` is rewritten to avoid using `npx` and `shell: true`. The script now directly resolve rollup's bin and runs it.

I've tested this with macOS but it _should_ work under Windows as well.