### PR TITLE
Allow using location + date time to position sun light.

### DIFF
--- a/examples/jsm/lights/SunLight.js
+++ b/examples/jsm/lights/SunLight.js
@@ -92,25 +92,7 @@ class SunLight extends Light {
 
 }
 
-/**
- * Calculates the apparent position of the sun for a given date, time and
- * geographic location, using a low-precision solar position algorithm
- * (accurate to about 0.01° through 2099). `date`'s UTC time is used, so
- * build it with the correct time zone offset already applied.
- *
- * ```js
- * const { elevation, azimuth } = getSunPosition( new Date(), 51.5, - 0.13 ); // London
- * sunLight.position.setFromSphericalCoords( 1, MathUtils.degToRad( 90 - elevation ), MathUtils.degToRad( azimuth ) );
- * ```
- *
- * Reference: {@link https://en.wikipedia.org/wiki/Position_of_the_Sun}
- *
- * @param {Date} date - The date and time to compute the sun position for.
- * @param {number} latitude - The observer's latitude, in degrees (`-90` to `90`).
- * @param {number} longitude - The observer's longitude, in degrees (`-180` to `180`, east positive).
- * @return {{elevation: number, azimuth: number}} The sun's elevation and azimuth, in degrees.
- */
-function getSunPosition( date, latitude, longitude ) {
+function getSolarCoordinates( date ) {
 
 	const jd = date.getTime() / 86400000 + 2440587.5; // Julian date
 	const t = ( jd - 2451545.0 ) / 36525; // centuries since J2000.0
@@ -152,6 +134,12 @@ function getSunPosition( date, latitude, longitude ) {
 		1.25 * eccentricity * eccentricity * Math.sin( 2 * Mrad )
 	);
 
+	return { declination, equationOfTime };
+
+}
+
+function getHorizontalCoordinates( date, latitude, longitude, declination, equationOfTime ) {
+
 	const utcMinutes = date.getUTCHours() * 60 + date.getUTCMinutes() + date.getUTCSeconds() / 60;
 	const trueSolarTime = MathUtils.euclideanModulo( utcMinutes + equationOfTime + 4 * longitude, 1440 );
 
@@ -166,17 +154,42 @@ function getSunPosition( date, latitude, longitude ) {
 	const zenithRad = Math.acos( MathUtils.clamp( cosZenith, - 1, 1 ) );
 
 	// https://en.wikipedia.org/wiki/Solar_azimuth_angle
-	let azimuthRad = Math.acos( MathUtils.clamp(
-		( Math.sin( declination ) - Math.sin( latRad ) * Math.cos( zenithRad ) ) /
-		( Math.cos( latRad ) * Math.sin( zenithRad ) ), - 1, 1
-	) );
-
-	if ( hourAngleRad > 0 ) azimuthRad = Math.PI * 2 - azimuthRad;
+	const azimuthRad = Math.atan2(
+		Math.sin( hourAngleRad ),
+		Math.cos( hourAngleRad ) * Math.sin( latRad ) - Math.tan( declination ) * Math.cos( latRad )
+	);
 
 	return {
 		elevation: 90 - zenithRad * MathUtils.RAD2DEG,
-		azimuth: azimuthRad * MathUtils.RAD2DEG
+		azimuth: MathUtils.euclideanModulo( azimuthRad * MathUtils.RAD2DEG + 180, 360 )
 	};
+
+}
+
+
+/**
+ * Calculates the apparent position of the sun for a given date, time and
+ * geographic location, using a low-precision solar position algorithm
+ * (accurate to about 0.01° through 2099). `date`'s UTC time is used, so
+ * build it with the correct time zone offset already applied.
+ *
+ * ```js
+ * const { elevation, azimuth } = getSunPosition( new Date(), 51.5, - 0.13 ); // London
+ * sunLight.position.setFromSphericalCoords( 1, MathUtils.degToRad( 90 - elevation ), MathUtils.degToRad( azimuth ) );
+ * ```
+ *
+ * Reference: {@link https://en.wikipedia.org/wiki/Position_of_the_Sun}
+ *
+ * @param {Date} date - The date and time to compute the sun position for.
+ * @param {number} latitude - The observer's latitude, in degrees (`-90` to `90`).
+ * @param {number} longitude - The observer's longitude, in degrees (`-180` to `180`, east positive).
+ * @return {{elevation: number, azimuth: number}} The sun's elevation and azimuth, in degrees.
+ */
+function getSunPosition( date, latitude, longitude ) {
+
+	const { declination, equationOfTime } = getSolarCoordinates( date );
+
+	return getHorizontalCoordinates( date, latitude, longitude, declination, equationOfTime );
 
 }
 

--- a/examples/jsm/lights/SunLight.js
+++ b/examples/jsm/lights/SunLight.js
@@ -1,4 +1,4 @@
-import { Light, Object3D } from 'three';
+import { Light, MathUtils, Object3D } from 'three';
 import { SunLightShadow } from './SunLightShadow.js';
 
 /**
@@ -92,4 +92,92 @@ class SunLight extends Light {
 
 }
 
-export { SunLight };
+/**
+ * Calculates the apparent position of the sun for a given date, time and
+ * geographic location, using a low-precision solar position algorithm
+ * (accurate to about 0.01° through 2099). `date`'s UTC time is used, so
+ * build it with the correct time zone offset already applied.
+ *
+ * ```js
+ * const { elevation, azimuth } = getSunPosition( new Date(), 51.5, - 0.13 ); // London
+ * sunLight.position.setFromSphericalCoords( 1, MathUtils.degToRad( 90 - elevation ), MathUtils.degToRad( azimuth ) );
+ * ```
+ *
+ * Reference: {@link https://en.wikipedia.org/wiki/Position_of_the_Sun}
+ *
+ * @param {Date} date - The date and time to compute the sun position for.
+ * @param {number} latitude - The observer's latitude, in degrees (`-90` to `90`).
+ * @param {number} longitude - The observer's longitude, in degrees (`-180` to `180`, east positive).
+ * @return {{elevation: number, azimuth: number}} The sun's elevation and azimuth, in degrees.
+ */
+function getSunPosition( date, latitude, longitude ) {
+
+	const jd = date.getTime() / 86400000 + 2440587.5; // Julian date
+	const t = ( jd - 2451545.0 ) / 36525; // centuries since J2000.0
+
+	const L0 = MathUtils.euclideanModulo( 280.46646 + t * ( 36000.76983 + t * 0.0003032 ), 360 );
+	const M = 357.52911 + t * ( 35999.05029 - 0.0001537 * t ); // https://en.wikipedia.org/wiki/Mean_anomaly
+	const Mrad = M * MathUtils.DEG2RAD;
+
+	const eccentricity = 0.016708634 - t * ( 0.000042037 + 0.0000001267 * t );
+
+	// https://en.wikipedia.org/wiki/Equation_of_the_center
+	const equationOfCenter = Math.sin( Mrad ) * ( 1.914602 - t * ( 0.004817 + 0.000014 * t ) ) +
+		Math.sin( 2 * Mrad ) * ( 0.019993 - 0.000101 * t ) +
+		Math.sin( 3 * Mrad ) * 0.000289;
+
+	const trueLongitude = L0 + equationOfCenter;
+
+	const omega = 125.04 - 1934.136 * t;
+	const apparentLongitude = trueLongitude - 0.00569 - 0.00478 * Math.sin( omega * MathUtils.DEG2RAD );
+
+	// https://en.wikipedia.org/wiki/Axial_tilt
+	const meanObliquity = 23 + ( 26 + ( 21.448 - t * ( 46.815 + t * ( 0.00059 - t * 0.001813 ) ) ) / 60 ) / 60;
+	const obliquity = meanObliquity + 0.00256 * Math.cos( omega * MathUtils.DEG2RAD );
+
+	const lambdaRad = apparentLongitude * MathUtils.DEG2RAD;
+	const obliquityRad = obliquity * MathUtils.DEG2RAD;
+
+	const declination = Math.asin( Math.sin( obliquityRad ) * Math.sin( lambdaRad ) );
+
+	const y = Math.pow( Math.tan( obliquityRad / 2 ), 2 );
+	const L0rad = L0 * MathUtils.DEG2RAD;
+
+	// https://en.wikipedia.org/wiki/Equation_of_time
+	const equationOfTime = 4 * MathUtils.RAD2DEG * (
+		y * Math.sin( 2 * L0rad ) -
+		2 * eccentricity * Math.sin( Mrad ) +
+		4 * eccentricity * y * Math.sin( Mrad ) * Math.cos( 2 * L0rad ) -
+		0.5 * y * y * Math.sin( 4 * L0rad ) -
+		1.25 * eccentricity * eccentricity * Math.sin( 2 * Mrad )
+	);
+
+	const utcMinutes = date.getUTCHours() * 60 + date.getUTCMinutes() + date.getUTCSeconds() / 60;
+	const trueSolarTime = MathUtils.euclideanModulo( utcMinutes + equationOfTime + 4 * longitude, 1440 );
+
+	// https://en.wikipedia.org/wiki/Hour_angle
+	const hourAngleRad = ( trueSolarTime / 4 - 180 ) * MathUtils.DEG2RAD;
+
+	const latRad = latitude * MathUtils.DEG2RAD;
+
+	// https://en.wikipedia.org/wiki/Solar_zenith_angle
+	const cosZenith = Math.sin( latRad ) * Math.sin( declination ) +
+		Math.cos( latRad ) * Math.cos( declination ) * Math.cos( hourAngleRad );
+	const zenithRad = Math.acos( MathUtils.clamp( cosZenith, - 1, 1 ) );
+
+	// https://en.wikipedia.org/wiki/Solar_azimuth_angle
+	let azimuthRad = Math.acos( MathUtils.clamp(
+		( Math.sin( declination ) - Math.sin( latRad ) * Math.cos( zenithRad ) ) /
+		( Math.cos( latRad ) * Math.sin( zenithRad ) ), - 1, 1
+	) );
+
+	if ( hourAngleRad > 0 ) azimuthRad = Math.PI * 2 - azimuthRad;
+
+	return {
+		elevation: 90 - zenithRad * MathUtils.RAD2DEG,
+		azimuth: azimuthRad * MathUtils.RAD2DEG
+	};
+
+}
+
+export { SunLight, getSunPosition };

--- a/examples/webgl_lights_sunlight.html
+++ b/examples/webgl_lights_sunlight.html
@@ -31,20 +31,104 @@
 
 			import * as THREE from 'three';
 
-			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { getSunPosition, SunLight } from 'three/addons/lights/SunLight.js';
 			import { FirstPersonControls } from 'three/addons/controls/FirstPersonControls.js';
 			import { Sky } from 'three/addons/objects/Sky.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			let renderer, scene, camera, controls, timer, sunLight, sky, sceneEnv, pmremGenerator, renderTarget;
+			let azimuthControl, elevationControl, latitudeControl, longitudeControl, timeZoneOffsetControl, dateControl, timeOfDayControl;
+
+			const now = new Date();
 
 			const params = {
 				showCascades: false,
 				far: 1000,
 				resolution: 2048,
+				mode: 'Manual', // 'Manual' drives the sun from azimuth/elevation; 'Physical' derives them from lat/long + date/time
 				azimuth: 135,
-				elevation: 10
+				elevation: 10,
+				latitude: 0,
+				longitude: 0,
+				timeZoneOffset: - now.getTimezoneOffset() / 60,
+				date: toDateString( now ),
+				timeOfDayHours: now.getHours() + now.getMinutes() / 60, // time of day, in hours since midnight (0-24)
+				syncWithLocal: syncWithLocal
 			};
+
+			const timeZoneOffsets = [
+				- 12, - 11, - 10, - 9.5, - 9, - 8, - 7, - 6, - 5, - 4, - 3.5, - 3, - 2, - 1,
+				0,
+				1, 2, 3, 3.5, 4, 4.5, 5, 5.5, 5.75, 6, 6.5, 7, 8, 8.75, 9, 9.5, 10, 10.5, 11, 12, 12.75, 13, 14
+			];
+
+			function toDateString( date ) {
+
+				const pad = ( n ) => String( n ).padStart( 2, '0' );
+
+				return `${ date.getFullYear() }-${ pad( date.getMonth() + 1 ) }-${ pad( date.getDate() ) }`;
+
+			}
+
+			function syncPhysicalToManual() {
+
+				const [ year, month, day ] = params.date.split( '-' ).map( Number );
+				const hours = Math.floor( params.timeOfDayHours );
+				const minutes = Math.round( ( params.timeOfDayHours - hours ) * 60 );
+
+				const date = new Date( Date.UTC( year, month - 1, day, hours, minutes ) - params.timeZoneOffset * 3600000 );
+				const sunPosition = getSunPosition( date, params.latitude, params.longitude );
+
+				params.azimuth = sunPosition.azimuth;
+				params.elevation = sunPosition.elevation;
+
+			}
+
+			function onPhysicalChange() {
+
+				if ( params.mode === 'Physical' ) {
+
+					syncPhysicalToManual();
+
+				}
+
+				updateSun();
+
+			}
+
+		
+			function syncWithLocal() {
+
+				function completeSync() {
+
+					const now = new Date();
+					params.timeZoneOffset = - now.getTimezoneOffset() / 60;
+					params.date = toDateString( now );
+					params.timeOfDayHours = now.getHours() + now.getMinutes() / 60;
+
+					syncPhysicalToManual();
+					updateSun();
+
+				}
+
+				if ( navigator.geolocation ) {
+
+					navigator.geolocation.getCurrentPosition( function ( position ) {
+
+						params.latitude = position.coords.latitude;
+						params.longitude = position.coords.longitude;
+
+						completeSync();
+
+					}, completeSync );
+
+				} else {
+
+					completeSync();
+
+				}
+
+			}
 
 			const _sunDay = new THREE.Color( 0xfff2e3 ), _sunDusk = new THREE.Color( 0xff8a3d );
 			const _fogDay = new THREE.Color( 0xd8e2ea ), _fogDusk = new THREE.Color( 0xd9a273 );
@@ -73,9 +157,10 @@
 
 				sunLight.position.setFromSphericalCoords( 1, THREE.MathUtils.degToRad( 90 - params.elevation ), THREE.MathUtils.degToRad( params.azimuth ) );
 
-				// the sun light warms up and fades towards the horizon
+				// the sun light warms up and fades towards the horizon (and stays
+				// off below it, since Physical mode can drive elevation negative)
 
-				const daylight = Math.min( 1, params.elevation / 30 );
+				const daylight = THREE.MathUtils.clamp( params.elevation / 30, 0, 1 );
 
 				sunLight.color.lerpColors( _sunDusk, _sunDay, daylight );
 				sunLight.intensity = 3 + daylight * 2;
@@ -231,8 +316,43 @@
 
 				} );
 
-				gui.add( params, 'azimuth', 0, 360 ).onChange( updateSun );
-				gui.add( params, 'elevation', 5, 80 ).onChange( updateSun );
+				function updateModeVisibility() {
+
+					const manual = params.mode === 'Manual';
+
+					azimuthControl[ manual ? 'show' : 'hide' ]();
+					elevationControl[ manual ? 'show' : 'hide' ]();
+
+					for ( const control of [ latitudeControl, longitudeControl, timeZoneOffsetControl, dateControl, timeOfDayControl ] ) {
+
+						control[ manual ? 'hide' : 'show' ]();
+
+					}
+
+				}
+
+				gui.add( params, 'mode', [ 'Manual', 'Physical' ] ).onChange( function () {
+
+					updateModeVisibility();
+					if ( params.mode === 'Physical' ) onPhysicalChange();
+
+				} );
+
+				azimuthControl = gui.add( params, 'azimuth', 0, 360 ).onChange( updateSun ).listen();
+				elevationControl = gui.add( params, 'elevation', - 90, 90 ).onChange( updateSun ).listen();
+
+				latitudeControl = gui.add( params, 'latitude', - 90, 90 ).onChange( onPhysicalChange ).listen();
+				longitudeControl = gui.add( params, 'longitude', - 180, 180 ).onChange( onPhysicalChange ).listen();
+				dateControl = gui.add( params, 'date' ).name( 'date (YYYY-MM-DD)' ).onChange( onPhysicalChange ).listen();
+				timeZoneOffsetControl = gui.add( params, 'timeZoneOffset', timeZoneOffsets ).name( 'time zone (UTC offset)' ).onChange( onPhysicalChange ).listen();
+				timeOfDayControl = gui.add( params, 'timeOfDayHours', 0, 24, 1 / 60 ).name( 'time of day (hours)' ).onChange( onPhysicalChange ).listen();
+
+				// always visible, in both modes: only requests geolocation (and
+				// thus a permission prompt) when explicitly clicked
+
+				gui.add( params, 'syncWithLocal' ).name( 'Sync with Local' );
+
+				updateModeVisibility();
 
 				window.addEventListener( 'resize', function () {
 

--- a/examples/webgpu_lights_sunlight.html
+++ b/examples/webgpu_lights_sunlight.html
@@ -42,18 +42,104 @@
 			import { FirstPersonControls } from 'three/addons/controls/FirstPersonControls.js';
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 			import { SkyMesh } from 'three/addons/objects/SkyMesh.js';
-			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { getSunPosition, SunLight } from 'three/addons/lights/SunLight.js';
 			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 
 			let renderer, scene, camera, controls, timer, sunLight, sky, sceneEnv, pmremGenerator, renderTarget;
+			let azimuthControl, elevationControl, latitudeControl, longitudeControl, timeZoneOffsetControl, dateControl, timeOfDayControl;
+
+			const now = new Date();
 
 			const params = {
 				showCascades: false,
 				far: 1000,
 				resolution: 2048,
+				mode: 'Manual', // 'Manual' drives the sun from azimuth/elevation; 'Physical' derives them from lat/long + date/time
 				azimuth: 135,
-				elevation: 10
+				elevation: 10,
+				latitude: 0,
+				longitude: 0,
+				timeZoneOffset: - now.getTimezoneOffset() / 60,
+				date: toDateString( now ),
+				timeOfDayHours: now.getHours() + now.getMinutes() / 60, // time of day, in hours since midnight (0-24)
+				syncWithLocal: syncWithLocal
 			};
+
+			const timeZoneOffsets = [
+				- 12, - 11, - 10, - 9.5, - 9, - 8, - 7, - 6, - 5, - 4, - 3.5, - 3, - 2, - 1,
+				0,
+				1, 2, 3, 3.5, 4, 4.5, 5, 5.5, 5.75, 6, 6.5, 7, 8, 8.75, 9, 9.5, 10, 10.5, 11, 12, 12.75, 13, 14
+			];
+
+			function toDateString( date ) {
+
+				const pad = ( n ) => String( n ).padStart( 2, '0' );
+
+				return `${ date.getFullYear() }-${ pad( date.getMonth() + 1 ) }-${ pad( date.getDate() ) }`;
+
+			}
+
+
+			function syncPhysicalToManual() {
+
+				const [ year, month, day ] = params.date.split( '-' ).map( Number );
+				const hours = Math.floor( params.timeOfDayHours );
+				const minutes = Math.round( ( params.timeOfDayHours - hours ) * 60 );
+
+				const date = new Date( Date.UTC( year, month - 1, day, hours, minutes ) - params.timeZoneOffset * 3600000 );
+				const sunPosition = getSunPosition( date, params.latitude, params.longitude );
+
+				params.azimuth = sunPosition.azimuth;
+				params.elevation = sunPosition.elevation;
+
+			}
+
+			function onPhysicalChange() {
+
+				if ( params.mode === 'Physical' ) {
+
+					syncPhysicalToManual();
+
+				}
+
+				updateSun();
+
+			}
+
+
+			function syncWithLocal() {
+
+				function completeSync() {
+
+					const now = new Date();
+					params.timeZoneOffset = - now.getTimezoneOffset() / 60;
+					params.date = toDateString( now );
+					params.timeOfDayHours = now.getHours() + now.getMinutes() / 60;
+				
+					syncPhysicalToManual();
+					updateSun();
+
+				}
+
+					
+				if ( navigator.geolocation ) {
+
+					navigator.geolocation.getCurrentPosition( function ( position ) {
+
+						params.latitude = position.coords.latitude;
+						params.longitude = position.coords.longitude;
+
+						completeSync();
+
+					}, completeSync );
+
+				} else {
+
+					completeSync();
+
+				}
+
+			}
 
 			const _sunDay = new THREE.Color( 0xfff2e3 ), _sunDusk = new THREE.Color( 0xff8a3d );
 			const _fogDay = new THREE.Color( 0xd8e2ea ), _fogDusk = new THREE.Color( 0xd9a273 );
@@ -86,9 +172,10 @@
 
 				sunLight.position.setFromSphericalCoords( 1, THREE.MathUtils.degToRad( 90 - params.elevation ), THREE.MathUtils.degToRad( params.azimuth ) );
 
-				// the sun light warms up and fades towards the horizon
+				// the sun light warms up and fades towards the horizon (and stays
+				// off below it, since Physical mode can drive elevation negative)
 
-				const daylight = Math.min( 1, params.elevation / 30 );
+				const daylight = THREE.MathUtils.clamp( params.elevation / 30, 0, 1 );
 
 				sunLight.color.lerpColors( _sunDusk, _sunDay, daylight );
 				sunLight.intensity = 3 + daylight * 2;
@@ -123,7 +210,6 @@
 				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 0.6;
@@ -155,8 +241,13 @@
 				sunLight.shadow.mapSize.setScalar( params.resolution );
 				sunLight.shadow.normalBias = 0.05;
 				scene.add( sunLight );
+			
+				renderer.init().then( () => {
 
-				renderer.init().then( updateSun );
+					updateSun();
+					renderer.setAnimationLoop( animate );
+
+				} );
 
 				// ground
 
@@ -238,8 +329,43 @@
 
 				} );
 
-				gui.add( params, 'azimuth', 0, 360 ).onChange( updateSun );
-				gui.add( params, 'elevation', 5, 80 ).onChange( updateSun );
+				function updateModeVisibility() {
+
+					const manual = params.mode === 'Manual';
+
+					azimuthControl[ manual ? 'show' : 'hide' ]();
+					elevationControl[ manual ? 'show' : 'hide' ]();
+
+					for ( const control of [ latitudeControl, longitudeControl, timeZoneOffsetControl, dateControl, timeOfDayControl ] ) {
+
+						control[ manual ? 'hide' : 'show' ]();
+
+					}
+
+				}
+
+				gui.add( params, 'mode', [ 'Manual', 'Physical' ] ).onChange( function () {
+
+					updateModeVisibility();
+					if ( params.mode === 'Physical' ) onPhysicalChange();
+
+				} );
+
+				azimuthControl = gui.add( params, 'azimuth', 0, 360 ).onChange( updateSun ).listen();
+				elevationControl = gui.add( params, 'elevation', - 90, 90 ).onChange( updateSun ).listen();
+
+				latitudeControl = gui.add( params, 'latitude', - 90, 90 ).onChange( onPhysicalChange ).listen();
+				longitudeControl = gui.add( params, 'longitude', - 180, 180 ).onChange( onPhysicalChange ).listen();
+				dateControl = gui.add( params, 'date' ).name( 'date (YYYY-MM-DD)' ).onChange( onPhysicalChange ).listen();
+				timeZoneOffsetControl = gui.add( params, 'timeZoneOffset', timeZoneOffsets ).name( 'time zone (UTC offset)' ).onChange( onPhysicalChange ).listen();
+				timeOfDayControl = gui.add( params, 'timeOfDayHours', 0, 24, 1 / 60 ).name( 'time of day (hours)' ).onChange( onPhysicalChange ).listen();
+
+				// always visible, in both modes: only requests geolocation (and
+				// thus a permission prompt) when explicitly clicked
+
+				gui.add( params, 'syncWithLocal' ).name( 'Sync with Local' );
+
+				updateModeVisibility();
 
 				window.addEventListener( 'resize', function () {
 

--- a/test/unit/addons/lights/SunLight.tests.js
+++ b/test/unit/addons/lights/SunLight.tests.js
@@ -1,0 +1,55 @@
+import { getSunPosition } from '../../../../examples/jsm/lights/SunLight.js';
+
+export default QUnit.module( 'Addons', () => {
+
+	QUnit.module( 'Lights', () => {
+
+		QUnit.module( 'SunLight', () => {
+
+			QUnit.test( 'getSunPosition', ( assert ) => {
+
+				// NREL SPA reference case, adapted to geometric elevation without atmospheric refraction.
+				const position = getSunPosition(
+					new Date( '2003-10-17T19:30:30Z' ),
+					39.742476,
+					- 105.1786
+				);
+
+				assert.ok(
+					Math.abs( position.elevation - 39.8721 ) < 0.01,
+					'Calculates the reference elevation'
+				);
+				assert.ok(
+					Math.abs( position.azimuth - 194.3402 ) < 0.01,
+					'Calculates the reference azimuth'
+				);
+
+			} );
+
+			QUnit.test( 'getSunPosition cardinal directions', ( assert ) => {
+
+				const morning = getSunPosition( new Date( '2025-03-20T06:00:00Z' ), 0, 0 );
+				const evening = getSunPosition( new Date( '2025-03-20T18:00:00Z' ), 0, 0 );
+
+				assert.ok( Math.abs( morning.azimuth - 90 ) < 2, 'The morning sun is in the east' );
+				assert.ok( Math.abs( evening.azimuth - 270 ) < 2, 'The evening sun is in the west' );
+
+			} );
+
+			QUnit.test( 'getSunPosition polar coordinates', ( assert ) => {
+
+				const northPole = getSunPosition( new Date( '2025-06-21T12:00:00Z' ), 90, 0 );
+				const southPole = getSunPosition( new Date( '2025-12-21T12:00:00Z' ), - 90, 0 );
+
+				assert.ok( Number.isFinite( northPole.elevation ), 'North-pole elevation is finite' );
+				assert.ok( Number.isFinite( northPole.azimuth ), 'North-pole azimuth is finite' );
+				assert.ok( Number.isFinite( southPole.elevation ), 'South-pole elevation is finite' );
+				assert.ok( Number.isFinite( southPole.azimuth ), 'South-pole azimuth is finite' );
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -5,6 +5,7 @@ import './addons/utils/ColorUtils.tests.js';
 import './addons/utils/GaussianSplatUtils.tests.js';
 import './addons/math/ColorSpaces.tests.js';
 import './addons/curves/NURBSCurve.tests.js';
+import './addons/lights/SunLight.tests.js';
 import './addons/loaders/FBXLoader.tests.js';
 import './addons/loaders/GLTFLoader.tests.js';
 import './addons/loaders/HDRLoader.tests.js';


### PR DESCRIPTION
Added a "physical" mode to the sunlight examples that allows you to set the latitude-longitude of the location and the date and time and then see what the sun would be doing.   You can also sync to your local location + date time.

Lastly, I made it easy to adjust the time of day to see the sun rise and set realistically.

This makes it much much easier to simulate day/night cycles than trying to figure out how to move the sun via manual azimuth/elevation modification.

This is achieved via the new  ```getSunPosition( date, latitude, longitude ) => { azimuth, elevation }``` function in SunLight.js.  It takes in the date, and location and returns the azimuth and elevation expected by SunLight.  It is fully tree-shakable if you are not using it.

 
<img width="1127" height="525" alt="Screenshot 2026-08-31 at 10 39 39 AM" src="https://github.com/user-attachments/assets/64d5656e-4ffe-455a-80fe-424323b53aa7" />


https://github.com/user-attachments/assets/112c6416-4edb-406b-8c1b-f0805ec3e4a8



@mrdoob 