### PR TITLE
TSL: IndexNode - Update JSDoc

### DIFF
--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -133,7 +133,7 @@ export const vertexIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.VER
  * ```js
  * // instanceIndex will equal the current mesh's instance index between 0-500
  * const material = new THREE.BasicNodeMaterial();
- * material.positionNode = vec3( instanceIndex.mul( 2 ), instanceIndex.mul( 2 ), 0 );
+ * material.positionNode = vec3( instanceIndex.mod( 10 ), instanceIndex.div( 10 ), 0 );
  * const mesh = new THREE.InstancedMesh( geometry, material, 500 );
  * ```
  *

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -219,7 +219,7 @@ export const invocationSubgroupIndex = /*@__PURE__*/ nodeImmutable( IndexNode, I
  * TSL object that represents the index of a compute invocation within the scope of a workgroup.
  *
  * ```js
- * // Execute 12 compute threads with a workgroup size of 4
+ * // Execute 12 compute threads with a workgroup size of 4.
  * const computeFn = Fn( () => {
  *
  * 	storageBufferOne.element( instanceIndex ).assign( invocationLocalIndex );

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -131,10 +131,9 @@ export const vertexIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.VER
  * In these stages, use `instanceIndex` to modify a mesh based on its instance or to select per-instance data.
  *
  * ```js
- * // Create instanced mesh
- * const material = new THREE.BasicNodeMaterial();
  * // instanceIndex will equal the current mesh's instance index between 0-500
- * material.positionNode = vec3( instanceIndex.mul(2), instanceIndex.mul( 2 ), 0 );
+ * const material = new THREE.BasicNodeMaterial();
+ * material.positionNode = vec3( instanceIndex.mul( 2 ), instanceIndex.mul( 2 ), 0 );
  * const mesh = new THREE.InstancedMesh( geometry, material, 500 );
  * ```
  *
@@ -142,12 +141,12 @@ export const vertexIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.VER
  * In this stage, use `instanceIndex` to modify or select data at a given index within a buffer, or derive values from the index itself.
  *
  * ```js
+ * // instanceIndex will equal value between 0 - 255
  * const computeFn = Fn() => {
  *
- * 	// instanceIndex will equal value between 0 - 255
- * 	storageBuffer.element( instanceIndex ).assign( instanceIndex );posX = instanceIndex.mod( width );
+ * 	storageBuffer.element( instanceIndex ).assign( instanceIndex );
  *
- * } )().compute(255)
+ * } )().compute( 255 )
  * ```
  *
  * @tsl

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -131,38 +131,23 @@ export const vertexIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.VER
  * In these stages, use `instanceIndex` to modify a mesh based on its instance or to select per-instance data.
  *
  * ```js
- * // Create instanced sprites
- * const positionAttribute = new THREE.InstancedBufferAttribute( new Float32Array( positions ), 3 );
- * const material = new THREE.SpriteNodeMaterial();
- * material.positionNode = instancedBufferAttribute( positionAttribute );
- *
- * // Offset the rotation of the sprite instance by the time uniform and the mesh instance's index.
- * material.rotationNode = time.add( instanceIndex ).sin();
- *
- * const particles = new THREE.Sprite( material );
- * particles.count = positionAttribute.count;
+ * // Create instanced mesh
+ * const material = new THREE.BasicNodeMaterial();
+ * // instanceIndex will equal the current mesh's instance index between 0-500
+ * material.positionNode = vec3( instanceIndex.mul(2), instanceIndex.mul( 2 ), 0 );
+ * const mesh = new THREE.InstancedMesh( geometry, material, 500 );
  * ```
  *
  * Within the compute stage, `instanceIndex` will represent the global index of a compute invocation within the 3-dimensional compute workgroup load.
  * In this stage, use `instanceIndex` to modify or select data at a given index within a buffer, or derive values from the index itself.
  *
  * ```js
- * // Write a storage texture with one compute invocation per texel
- * const width = 512, height = 512;
- * const storageTexture = new THREE.StorageTexture( width, height );
+ * const computeFn = Fn() => {
  *
- * const computeTexture = Fn( ( { storageTexture } ) => {
+ * 	// instanceIndex will equal value between 0 - 255
+ * 	storageBuffer.element( instanceIndex ).assign( instanceIndex );posX = instanceIndex.mod( width );
  *
- * 	// Derive 2D texel coordinates from the flat invocation index
- * 	const posX = instanceIndex.mod( width );
- * 	const posY = instanceIndex.div( width );
- * 	const indexUV = uvec2( posX, posY );
- *
- * 	textureStore( storageTexture, indexUV, vec4( 1, 0, 0, 1 ) ).toWriteOnly();
- *
- * } );
- *
- * const computeNode = computeTexture( { storageTexture } ).compute( width * height );
+ * } )().compute(255)
  * ```
  *
  * @tsl

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -172,7 +172,7 @@ export const instanceIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.I
 
 /**
  * TSL object that represents the index of the subgroup the current compute invocation belongs to.
- * Subgroup indices only exist local within the workgroups to which they belong.
+ * Subgroup indices are local to the workgroups to which they belong.
  *
  * ```js
  * // Execute 12 compute threads with a workgroup size of 9. Example assumes a subgroup size of 3.

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -179,7 +179,7 @@ export const instanceIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.I
  * const computeFn = Fn( () => {
  *
  * 	storageBufferOne.element( instanceIndex ).assign( subgroupIndex );
- *  storageBufferTwo.element( instanceIndex ).assign( workgroupId.x )
+ * 	storageBufferTwo.element( instanceIndex ).assign( workgroupId.x );
  *
  * } )().compute( 12, [ 9 ] );
  *
@@ -201,7 +201,7 @@ export const subgroupIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.S
  * const computeFn = Fn( () => {
  *
  * 	storageBufferOne.element( instanceIndex ).assign( invocationSubgroupIndex );
- *  storageBufferTwo.element( instanceIndex ).assign( subgroupIndex );
+ * 	storageBufferTwo.element( instanceIndex ).assign( subgroupIndex );
  *
  * } )().compute( 12, [ 12 ] );
  *

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -9,7 +9,7 @@ import { varying } from './VaryingNode.js';
  * - `vertexIndex`: The index of a vertex within a mesh.
  * - `instanceIndex`: The index of either a mesh instance or an invocation of a compute shader.
  * - `drawIndex`: The index of a draw call.
- * - `invocationLocalIndex`: The index of a compute invocation within the scope of a workgroup load.
+ * - `invocationLocalIndex`: The index of a compute invocation within the scope of a workgroup.
  * - `invocationSubgroupIndex`: The index of a compute invocation within the scope of a subgroup.
  * - `subgroupIndex`: The index of a compute invocation's subgroup within its workgroup.
  *
@@ -26,7 +26,7 @@ class IndexNode extends Node {
 	/**
 	 * Constructs a new index node.
 	 *
-	 * @param {('vertex'|'instance'|'subgroup'|'invocationLocal'|'invocationGlobal'|'invocationSubgroup'|'draw')} scope - The scope of the index node.
+	 * @param {('vertex'|'instance'|'subgroup'|'invocationLocal'|'invocationSubgroup'|'draw')} scope - The scope of the index node.
 	 */
 	constructor( scope ) {
 
@@ -125,7 +125,45 @@ export default IndexNode;
 export const vertexIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.VERTEX );
 
 /**
- * TSL object that represents the index of either a mesh instance or an invocation of a compute shader.
+ * TSL object that contextually represents specific index data depending on the shader stage.
+ *
+ * Within the vertex and fragment stages, `instanceIndex` will represent the index of the current mesh instance being evaluated by the shader.
+ * In these stages, use `instanceIndex` to modify a mesh based on its instance or to select per-instance data.
+ *
+ * ```js
+ * // Create instanced sprites
+ * const positionAttribute = new THREE.InstancedBufferAttribute( new Float32Array( positions ), 3 );
+ * const material = new THREE.SpriteNodeMaterial();
+ * material.positionNode = instancedBufferAttribute( positionAttribute );
+ *
+ * // Offset the rotation of the sprite instance by the time uniform and the mesh instance's index.
+ * material.rotationNode = time.add( instanceIndex ).sin();
+ *
+ * const particles = new THREE.Sprite( material );
+ * particles.count = positionAttribute.count;
+ * ```
+ *
+ * Within the compute stage, `instanceIndex` will represent the global index of a compute invocation within the 3-dimensional compute workgroup load.
+ * In this stage, use `instanceIndex` to modify or select data at a given index within a buffer, or derive values from the index itself.
+ *
+ * ```js
+ * // Write a storage texture with one compute invocation per texel
+ * const width = 512, height = 512;
+ * const storageTexture = new THREE.StorageTexture( width, height );
+ *
+ * const computeTexture = Fn( ( { storageTexture } ) => {
+ *
+ * 	// Derive 2D texel coordinates from the flat invocation index
+ * 	const posX = instanceIndex.mod( width );
+ * 	const posY = instanceIndex.div( width );
+ * 	const indexUV = uvec2( posX, posY );
+ *
+ * 	textureStore( storageTexture, indexUV, vec4( 1, 0, 0, 1 ) ).toWriteOnly();
+ *
+ * } );
+ *
+ * const computeNode = computeTexture( { storageTexture } ).compute( width * height );
+ * ```
  *
  * @tsl
  * @type {IndexNode}
@@ -134,6 +172,21 @@ export const instanceIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.I
 
 /**
  * TSL object that represents the index of the subgroup the current compute invocation belongs to.
+ * Subgroup indices only exist local within the workgroups to which they belong.
+ *
+ * ```js
+ * // Execute 12 compute threads with a workgroup size of 9. Example assumes a subgroup size of 3.
+ * const computeFn = Fn( () => {
+ *
+ * 	storageBufferOne.element( instanceIndex ).assign( subgroupIndex );
+ *  storageBufferTwo.element( instanceIndex ).assign( workgroupId.x )
+ *
+ * } )().compute( 12, [ 9 ] );
+ *
+ * // instanceIndex =  [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ];
+ * // Buffer One ( Subgroup Index ) =  [ 0, 0, 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 ];
+ * // Buffer Two ( Workgroup ID )   =  [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1 ];
+ * ```
  *
  * @tsl
  * @type {IndexNode}
@@ -143,13 +196,41 @@ export const subgroupIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.S
 /**
  * TSL object that represents the index of a compute invocation within the scope of a subgroup.
  *
+ * ```js
+ * // Execute 12 compute threads with a workgroup size of 12. Example assumes a subgroup size of 3.
+ * const computeFn = Fn( () => {
+ *
+ * 	storageBufferOne.element( instanceIndex ).assign( invocationSubgroupIndex );
+ *  storageBufferTwo.element( instanceIndex ).assign( subgroupIndex );
+ *
+ * } )().compute( 12, [ 12 ] );
+ *
+ * // instanceIndex =  [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ];
+ * // Buffer One ( Invocation Subgroup Index ) =  [ 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2 ];
+ * // Buffer Two ( Subgroup Index )            =  [ 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3 ];
+ * ```
+ *
  * @tsl
  * @type {IndexNode}
  */
 export const invocationSubgroupIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.INVOCATION_SUBGROUP );
 
 /**
- * TSL object that represents the index of a compute invocation within the scope of a workgroup load.
+ * TSL object that represents the index of a compute invocation within the scope of a workgroup.
+ *
+ * ```js
+ * // Execute 12 compute threads with a workgroup size of 4
+ * const computeFn = Fn( () => {
+ *
+ * 	storageBufferOne.element( instanceIndex ).assign( invocationLocalIndex );
+ * 	storageBufferTwo.element( instanceIndex ).assign( workgroupId.x );
+ *
+ * } )().compute( 12, [ 4 ] );
+ *
+ * // instanceIndex =  [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ];
+ * // Buffer One ( Invocation Local Index ) =     [ 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3 ];
+ * // Buffer Two ( Workgroup ID )           =     [ 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2 ];
+ * ```
  *
  * @tsl
  * @type {IndexNode}


### PR DESCRIPTION
**Description**

Updates the JSDoc for IndexNode to better clarify how use instanceIndex and how a user should infer what the value of an invocation built-in might be depending on the parameters of the compute dispatch being run.

