### PR TITLE
WIP - TSL 16 bit precision support (sunag's design suggestion)

### DIFF
--- a/examples/files.json
+++ b/examples/files.json
@@ -305,6 +305,7 @@
 		"webgl_tsl_instancing"
 	],
 	"webgpu": [
+		"webgpu_alu_stresstest",
 		"webgpu_animation_retargeting",
 		"webgpu_animation_retargeting_readyplayer",
 		"webgpu_backdrop",

--- a/examples/webgpu_alu_stresstest.html
+++ b/examples/webgpu_alu_stresstest.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgpu - ALU stress test</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<meta property="og:title" content="three.js webgpu - ALU stress test">
+		<meta property="og:type" content="website">
+		<meta property="og:url" content="https://threejs.org/examples/webgpu_alu_stresstest.html">
+		<link type="text/css" rel="stylesheet" href="example.css">
+	</head>
+	<body>
+
+		<div id="info">
+			<a href="https://threejs.org/" target="_blank" rel="noopener" class="logo-link"></a>
+
+			<div class="title-wrapper">
+				<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a><span>ALU Stress Test</span>
+			</div>
+
+			<small>
+				Fullscreen TSL shader with configurable matrix ALU pressure.
+				<br />Cyan is fp32, yellow is fp16.
+			</small>
+		</div>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "../build/three.webgpu.js",
+					"three/webgpu": "../build/three.webgpu.js",
+					"three/tsl": "../build/three.tsl.js",
+					"three/addons/": "./jsm/"
+				}
+			}
+		</script>
+
+		<script type="module">
+
+			import * as THREE from 'three/webgpu';
+			import { Fn, Loop, float, fract, mat3, mul, screenUV, sin, time, uniform, vec3 } from 'three/tsl';
+
+			import Stats from 'three/addons/libs/stats.module.js';
+
+			import { Inspector } from 'three/addons/inspector/Inspector.js';
+
+			let camera, scene, renderer, stats;
+
+			const params = {
+				precision: '32-bit',
+				iterations: 256,
+				resolutionScale: 1
+			};
+
+			const iterations = uniform( params.iterations );
+			const getPrecision = () => params.precision === '16-bit' ? 16 : 32;
+			const precisionScope = ( node ) => node.setPrecision( getPrecision() );
+
+			init();
+
+			async function init() {
+
+				camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0.1, 10 );
+				camera.position.z = 1;
+
+				scene = new THREE.Scene();
+
+				renderer = new THREE.WebGPURenderer();
+				renderer.setPixelRatio( window.devicePixelRatio * params.resolutionScale );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
+				renderer.inspector = new Inspector();
+				document.body.appendChild( renderer.domElement );
+				document.body.appendChild( renderer.inspector.domElement );
+
+				await renderer.init();
+
+				stats = new Stats();
+				document.body.appendChild( stats.dom );
+
+				// TSL
+
+				const aluStress = Fn( ( [ seed ] ) => {
+
+					const state = seed.toVar();
+					const accumulator = float( 0 ).toVar();
+
+					Loop( { start: float( 0 ), end: iterations }, () => {
+
+						const a = mat3(
+							state.x.add( 1.11 ), state.y.mul( 0.37 ).add( 0.13 ), state.z.mul( 0.19 ).add( 0.17 ),
+							state.z.mul( 0.29 ).add( 0.23 ), state.x.add( 1.07 ), state.y.mul( 0.31 ).add( 0.11 ),
+							state.y.mul( 0.41 ).add( 0.07 ), state.z.mul( 0.43 ).add( 0.19 ), state.x.add( 1.03 )
+						);
+
+						const b = mat3(
+							state.z.add( 0.91 ), state.x.mul( 0.23 ).add( 0.29 ), state.y.mul( 0.17 ).add( 0.31 ),
+							state.y.mul( 0.37 ).add( 0.05 ), state.z.add( 0.97 ), state.x.mul( 0.13 ).add( 0.41 ),
+							state.x.mul( 0.19 ).add( 0.43 ), state.y.mul( 0.11 ).add( 0.47 ), state.z.add( 0.89 )
+						);
+
+						const mixedMatrix = mul( a, b );
+						const nextState = fract( sin( mul( mixedMatrix, state ) ).mul( 437.58 ) );
+
+						state.assign( nextState );
+						accumulator.addAssign( state.dot( vec3( 0.2126, 0.7152, 0.0722 ) ) );
+
+					} );
+
+					const stressColor = vec3(
+						fract( accumulator.mul( 0.037 ).add( state.x ) ),
+						fract( accumulator.mul( 0.021 ).add( state.y ) ),
+						fract( accumulator.mul( 0.013 ).add( state.z ) )
+					);
+					const precisionProbe = float( 2048 ).add( 1 ).sub( 2048 );
+					const precisionTint = precisionProbe.greaterThan( 0.5 ).select(
+						vec3( 0, 0.85, 1 ),
+						vec3( 1, 0.82, 0 )
+					);
+
+					return stressColor.mul( 0.35 ).add( precisionTint.mul( 0.65 ) );
+
+				} );
+
+				updatePrecisionNodes();
+
+				// debug
+
+				const gui = renderer.inspector.createParameters( 'Parameters' );
+				const precisionOptions = [ '32-bit' ];
+
+				if ( renderer.hasFeature( 'shader-f16' ) ) {
+
+					precisionOptions.push( '16-bit' );
+
+				}
+
+				gui.add( params, 'precision', precisionOptions ).name( 'precision' ).onChange( () => {
+
+					updatePrecisionNodes();
+
+				} );
+				gui.add( params, 'iterations', 1, 1024, 1 ).name( 'iterations' ).onChange( ( value ) => {
+
+					iterations.value = value;
+
+				} );
+				gui.add( params, 'resolutionScale', 0.25, 1, 0.01 ).name( 'resolutionScale' ).onChange( () => {
+
+					updateRendererSize();
+
+				} );
+
+				window.addEventListener( 'resize', onWindowResize );
+
+				function updatePrecisionNodes() {
+
+					const seed = vec3(
+						screenUV,
+						time.mul( 0.11 ).add( screenUV.x.mul( 1.7 ) ).add( screenUV.y.mul( 2.3 ) )
+					).setPrecision( 32 );
+
+					scene.backgroundNode = precisionScope( aluStress( seed ) );
+
+				}
+
+			}
+
+			function updateRendererSize() {
+
+				renderer.setPixelRatio( window.devicePixelRatio * params.resolutionScale );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			function onWindowResize() {
+
+				updateRendererSize();
+
+			}
+
+			function animate() {
+
+				renderer.render( scene, camera );
+				if ( stats ) stats.update();
+
+			}
+
+		</script>
+	</body>
+</html>

--- a/examples/webgpu_tsl_procedural_terrain.html
+++ b/examples/webgpu_tsl_procedural_terrain.html
@@ -105,19 +105,26 @@
 				const colorSnow = uniform( color( '#ffffff' ) );
 				const colorRock = uniform( color( '#bfbd8d' ) );
 
+				const params = {
+					precision: '32-bit'
+				};
+
+				const getPrecision = () => params.precision === '16-bit' ? 16 : 32;
+				const precisionScope = ( node ) => node.setPrecision( getPrecision() );
+
 				const vNormal = varying( vec3() );
 				const vPosition = varying( vec3() );
 
 				const terrainElevation = Fn( ( [ position ] ) => {
 
 					const warpedPosition = position.add( offset ).toVar();
-					warpedPosition.addAssign( mx_noise_float( warpedPosition.mul( positionFrequency ).mul( warpFrequency ), 1, 0 ).mul( warpStrength ) );
+					warpedPosition.addAssign( mx_noise_float( warpedPosition.mul( positionFrequency ).mul( warpFrequency ), 1, 0 ).setPrecision( 32 ).mul( warpStrength ) );
 			
 					const elevation = float( 0 ).toVar();
 					Loop( { type: 'float', start: float( 1 ), end: noiseIterations.toFloat(), condition: '<=' }, ( { i } ) => {
 
 						const noiseInput = warpedPosition.mul( positionFrequency ).mul( i.mul( 2 ) ).add( i.mul( 987 ) );
-						const noise = mx_noise_float( noiseInput, 1, 0 ).div( i.add( 1 ).mul( 2 ) );
+						const noise = mx_noise_float( noiseInput, 1, 0 ).setPrecision( 32 ).div( i.add( 1 ).mul( 2 ) );
 						elevation.addAssign( noise );
 			
 					} );
@@ -129,7 +136,7 @@
 			
 				} );
 
-				material.positionNode = Fn( () => {
+				const terrainPosition = Fn( () => {
 
 					// neighbours positions
 
@@ -139,11 +146,11 @@
 					// elevations
 
 					const position = positionLocal.xyz.toVar();
-					const elevation = terrainElevation( positionLocal.xz );
+					const elevation = precisionScope( terrainElevation( positionLocal.xz ) );
 					position.y.addAssign( elevation );
 			
-					neighbourA.y.addAssign( terrainElevation( neighbourA.xz ) );
-					neighbourB.y.addAssign( terrainElevation( neighbourB.xz ) );
+					neighbourA.y.addAssign( precisionScope( terrainElevation( neighbourA.xz ) ) );
+					neighbourB.y.addAssign( precisionScope( terrainElevation( neighbourB.xz ) ) );
 
 					// compute normal
 
@@ -157,11 +164,9 @@
 
 					return position;
 			
-				} )();
+				} );
 
-				material.normalNode = transformNormalToView( vNormal );
-
-				material.colorNode = Fn( () => {
+				const terrainColor = Fn( () => {
 
 					const finalColor = colorSand.toVar();
 
@@ -177,13 +182,15 @@
 
 					// snow
 
-					const snowThreshold = mx_noise_float( vPosition.xz.mul( 25 ), 1, 0 ).mul( 0.1 ).add( 0.45 );
+					const snowThreshold = mx_noise_float( vPosition.xz.mul( 25 ), 1, 0 ).setPrecision( 32 ).mul( 0.1 ).add( 0.45 );
 					const snowMix = step( snowThreshold, vPosition.y );
 					finalColor.assign( snowMix.mix( finalColor, colorSnow ) );
 
 					return finalColor;
 			
-				} )();
+				} );
+
+				updatePrecisionNodes();
 
 				const geometry = new THREE.PlaneGeometry( 10, 10, 500, 500 );
 				geometry.deleteAttribute( 'uv' );
@@ -298,6 +305,11 @@
 
 				const terrainGui = gui.addFolder( '🏔️ terrain' );
 
+				terrainGui.add( params, 'precision', [ '32-bit', '16-bit' ] ).name( 'precision' ).onChange( () => {
+
+					updatePrecisionNodes();
+
+				} );
 				terrainGui.add( noiseIterations, 'value', 0, 10, 1 ).name( 'noiseIterations' );
 				terrainGui.add( positionFrequency, 'value', 0, 1, 0.001 ).name( 'positionFrequency' );
 				terrainGui.add( strength, 'value', 0, 20, 0.001 ).name( 'strength' );
@@ -350,6 +362,15 @@
 				} );
 
 				window.addEventListener( 'resize', onWindowResize );
+
+				function updatePrecisionNodes() {
+
+					material.positionNode = terrainPosition();
+					material.normalNode = transformNormalToView( vNormal );
+					material.colorNode = terrainColor();
+					material.needsUpdate = true;
+
+				}
 
 			}
 

--- a/examples/webgpu_tsl_raging_sea.html
+++ b/examples/webgpu_tsl_raging_sea.html
@@ -78,6 +78,13 @@
 				const smallWavesMultiplier = uniform( 0.18 );
 				const normalComputeShift = uniform( 0.01 );
 
+				const params = {
+					precision: '32-bit'
+				};
+
+				const getPrecision = () => params.precision === '16-bit' ? 16 : 32;
+				const precisionScope = ( node ) => node.setPrecision( getPrecision() );
+
 				// TSL functions
 
 				const wavesElevation = Fn( ( [ position ] ) => {
@@ -101,6 +108,7 @@
 						);
 
 						const wave = mx_noise_float( noiseInput, 1, 0 )
+							.setPrecision( 32 )
 							.mul( smallWavesMultiplier )
 							.div( i )
 							.abs();
@@ -113,31 +121,7 @@
 
 				} );
 
-				// position
-
-				const elevation = wavesElevation( positionLocal );
-				const position = positionLocal.add( vec3( 0, elevation, 0 ) );
-
-				material.positionNode = position;
-
-				// normals
-
-				let positionA = positionLocal.add( vec3( normalComputeShift, 0, 0 ) );
-				let positionB = positionLocal.add( vec3( 0, 0, normalComputeShift.negate() ) );
-
-				positionA = positionA.add( vec3( 0, wavesElevation( positionA ), 0 ) );
-				positionB = positionB.add( vec3( 0, wavesElevation( positionB ), 0 ) );
-
-				const toA = positionA.sub( position ).normalize();
-				const toB = positionB.sub( position ).normalize();
-				const normal = toA.cross( toB );
-
-				material.normalNode = transformNormalToView( normal );
-
-				// emissive
-
-				const emissive = elevation.remap( emissiveHigh, emissiveLow ).pow( emissivePower );
-				material.emissiveNode = emissiveColor.mul( emissive );
+				updatePrecisionNodes();
 
 				// mesh
 
@@ -167,6 +151,11 @@
 
 				const gui = renderer.inspector.createParameters( 'Parameters' );
 
+				gui.add( params, 'precision', [ '32-bit', '16-bit' ] ).name( 'precision' ).onChange( () => {
+
+					updatePrecisionNodes();
+
+				} );
 				gui.addColor( { color: material.color.getHex( THREE.SRGBColorSpace ) }, 'color' ).name( 'color' ).onChange( value => material.color.set( value ) );
 				gui.add( material, 'roughness', 0, 1, 0.001 );
 
@@ -190,6 +179,37 @@
 				// events
 
 				window.addEventListener( 'resize', onWindowResize );
+
+				function updatePrecisionNodes() {
+
+					// position
+
+					const elevation = precisionScope( wavesElevation( positionLocal ) );
+					const position = positionLocal.add( vec3( 0, elevation, 0 ) );
+
+					material.positionNode = position;
+
+					// normals
+
+					let positionA = positionLocal.add( vec3( normalComputeShift, 0, 0 ) );
+					let positionB = positionLocal.add( vec3( 0, 0, normalComputeShift.negate() ) );
+
+					positionA = positionA.add( vec3( 0, precisionScope( wavesElevation( positionA ) ), 0 ) );
+					positionB = positionB.add( vec3( 0, precisionScope( wavesElevation( positionB ) ), 0 ) );
+
+					const toA = positionA.sub( position ).normalize();
+					const toB = positionB.sub( position ).normalize();
+					const normal = toA.cross( toB );
+
+					material.normalNode = transformNormalToView( normal );
+
+					// emissive
+
+					const emissive = elevation.remap( emissiveHigh, emissiveLow ).pow( emissivePower );
+					material.emissiveNode = emissiveColor.mul( emissive );
+					material.needsUpdate = true;
+
+				}
 
 			}
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -575,13 +575,16 @@ class TextureNode extends UniformNode {
 		} else {
 
 			const nodeData = builder.getDataFromNode( this );
+			const precisionCacheKey = builder.getPrecisionCacheKey ? builder.getPrecisionCacheKey( this ) : 'default';
 
 			const nodeType = this.getNodeType( builder );
 
-			let propertyName = nodeData.propertyName;
+			const propertyNames = nodeData.propertyName || ( nodeData.propertyName = {} );
+			let propertyName = propertyNames[ precisionCacheKey ];
 
 			if ( propertyName === undefined ) {
 
+				const previousContext = builder.addContext( { precision: null } );
 				const { uvNode, levelNode, biasNode, compareNode, compareStepNode, depthNode, gradNode, gatherNode, offsetNode } = properties;
 
 				const uvSnippet = this.generateUV( builder, uvNode );
@@ -608,6 +611,7 @@ class TextureNode extends UniformNode {
 				propertyName = builder.getPropertyName( nodeVar );
 
 				let snippet = this.generateSnippet( builder, textureProperty, uvSnippet, levelSnippet, biasSnippet, finalDepthSnippet, compareSnippet, gradSnippet, gatherSnippet, offsetSnippet, flipYSnippet );
+				builder.setContext( previousContext );
 
 				let snippetType;
 
@@ -641,8 +645,9 @@ class TextureNode extends UniformNode {
 
 				builder.addLineFlowCode( `${propertyName} = ${snippet}`, this );
 
-				nodeData.snippet = snippet;
-				nodeData.propertyName = propertyName;
+				nodeData.snippet = nodeData.snippet || {};
+				nodeData.snippet[ precisionCacheKey ] = snippet;
+				propertyNames[ precisionCacheKey ] = propertyName;
 
 			}
 

--- a/src/nodes/code/FunctionCallNode.js
+++ b/src/nodes/code/FunctionCallNode.js
@@ -95,7 +95,7 @@ class FunctionCallNode extends TempNode {
 
 	}
 
-	generate( builder ) {
+	generate( builder, output ) {
 
 		const params = [];
 
@@ -106,15 +106,24 @@ class FunctionCallNode extends TempNode {
 
 		const generateInput = ( node, inputNode ) => {
 
-			const type = inputNode.type;
+			const type = builder.getBaseType ? builder.getBaseType( inputNode.type ) : inputNode.type;
 			const pointer = type === 'pointer';
 
-			let output;
+			let snippet;
 
-			if ( pointer ) output = '&' + node.build( builder );
-			else output = node.build( builder, type );
+			if ( pointer ) {
 
-			return output;
+				snippet = '&' + node.build( builder );
+
+			} else {
+
+				const previousContext = builder.addContext( { precision: null } );
+				snippet = node.build( builder, type );
+				builder.setContext( previousContext );
+
+			}
+
+			return snippet;
 
 		};
 
@@ -167,8 +176,10 @@ class FunctionCallNode extends TempNode {
 		}
 
 		const functionName = functionNode.build( builder, 'property' );
+		const type = builder.getBaseType ? builder.getBaseType( functionNode.getNodeType( builder ) ) : functionNode.getNodeType( builder );
+		const targetType = output || this.getNodeType( builder );
 
-		return `${ functionName }( ${ params.join( ', ' ) } )`;
+		return builder.format( `${ functionName }( ${ params.join( ', ' ) } )`, type, targetType );
 
 	}
 

--- a/src/nodes/core/AssignNode.js
+++ b/src/nodes/core/AssignNode.js
@@ -115,7 +115,13 @@ class AssignNode extends TempNode {
 		const needsSplitAssign = this.needsSplitAssign( builder );
 
 		const target = targetNode.build( builder );
-		const targetType = targetNode.getNodeType( builder );
+		let targetType = targetNode.getNodeType( builder );
+
+		if ( targetNode.isVarNode ) {
+
+			targetType = builder.getVarFromNode( targetNode ).type;
+
+		}
 
 		const source = sourceNode.build( builder, targetType );
 		const sourceType = sourceNode.getNodeType( builder );

--- a/src/nodes/core/ConstNode.js
+++ b/src/nodes/core/ConstNode.js
@@ -34,6 +34,8 @@ class ConstNode extends InputNode {
 		 */
 		this.isConstNode = true;
 
+		this.precisionContext = true;
+
 	}
 
 	/**
@@ -52,7 +54,10 @@ class ConstNode extends InputNode {
 
 		const type = this.getNodeType( builder );
 
-		if ( _regNum.test( type ) && _regNum.test( output ) ) {
+		const isNumericType = _regNum.test( type ) || type === 'half';
+		const isNumericOutput = _regNum.test( output ) || output === 'half';
+
+		if ( isNumericType && isNumericOutput ) {
 
 			return builder.generateConst( output, this.value );
 

--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -81,6 +81,16 @@ class ContextNode extends Node {
 	 */
 	generateNodeType( builder ) {
 
+		if ( typeof this.value.precision === 'number' ) {
+
+			const previousContext = builder.addContext( { ...this.value, precision: null } );
+			const type = builder.getBaseType( this.node.getNodeType( builder ) );
+			builder.setContext( previousContext );
+
+			return type;
+
+		}
+
 		return this.node.getNodeType( builder );
 
 	}
@@ -152,12 +162,15 @@ class ContextNode extends Node {
 	generate( builder, output ) {
 
 		const previousContext = builder.addContext( this.value );
+		const precision = builder.getContextPrecision();
+		const contextOutput = precision === 16 && output !== null ? builder.getPrecisionType( output, precision ) : output;
 
-		const snippet = this.node.build( builder, output );
+		const snippet = this.node.build( builder, contextOutput );
+		const snippetType = contextOutput || this.node.getNodeType( builder );
 
 		builder.setContext( previousContext );
 
-		return snippet;
+		return builder.format( snippet, snippetType, output );
 
 	}
 
@@ -209,6 +222,17 @@ export const uniformFlow = ( node ) => context( node, { uniformFlow: true } );
  * @returns {ContextNode}
  */
 export const setName = ( node, name ) => context( node, { nodeName: name } );
+
+/**
+ * TSL function for defining a compute precision context for a given node.
+ *
+ * @tsl
+ * @function
+ * @param {Node} node - The node whose computation precision should be modified.
+ * @param {number} precision - The compute precision to request.
+ * @returns {ContextNode}
+ */
+export const setPrecision = ( node, precision ) => context( node, { precision } );
 
 /**
  * TSL function for defining a built-in shadow context for a given node.
@@ -331,6 +355,7 @@ addMethodChaining( 'context', context );
 addMethodChaining( 'label', label );
 addMethodChaining( 'uniformFlow', uniformFlow );
 addMethodChaining( 'setName', setName );
+addMethodChaining( 'setPrecision', setPrecision );
 addMethodChaining( 'builtinShadowContext', ( node, shadowNode, light ) => builtinShadowContext( shadowNode, light, node ) );
 addMethodChaining( 'builtinAOContext', ( node, aoValue ) => builtinAOContext( aoValue, node ) );
 addMethodChaining( 'builtinGIContext', ( node, aoValue, giValue ) => builtinGIContext( aoValue, giValue, node ) );

--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -163,7 +163,7 @@ class ContextNode extends Node {
 
 		const previousContext = builder.addContext( this.value );
 		const precision = builder.getContextPrecision();
-		const contextOutput = precision === 16 && output !== null ? builder.getPrecisionType( output, precision ) : output;
+		const contextOutput = precision === 16 && output !== null ? builder.getPrecisionType( output, precision ) : ( precision === 32 && output !== null ? builder.getBaseType( output ) : output );
 
 		const snippet = this.node.build( builder, contextOutput );
 		const snippetType = contextOutput || this.node.getNodeType( builder );
@@ -171,6 +171,12 @@ class ContextNode extends Node {
 		builder.setContext( previousContext );
 
 		return builder.format( snippet, snippetType, output );
+
+	}
+
+	getPrecision() {
+
+		return this.value.precision !== undefined ? this.value.precision : this.node.getPrecision();
 
 	}
 
@@ -232,7 +238,17 @@ export const setName = ( node, name ) => context( node, { nodeName: name } );
  * @param {number} precision - The compute precision to request.
  * @returns {ContextNode}
  */
-export const setPrecision = ( node, precision ) => context( node, { precision } );
+export const setPrecision = ( node, precision ) => {
+
+	if ( precision !== 16 && precision !== 32 ) {
+
+		warn( `TSL: Unsupported precision "${ precision }". Use 16 or 32.` );
+
+	}
+
+	return context( node, { precision } );
+
+};
 
 /**
  * TSL function for defining a built-in shadow context for a given node.

--- a/src/nodes/core/InputNode.js
+++ b/src/nodes/core/InputNode.js
@@ -115,6 +115,12 @@ class InputNode extends Node {
 
 	}
 
+	getPrecision() {
+
+		return this.computePrecision || this.precision;
+
+	}
+
 	serialize( data ) {
 
 		super.serialize( data );

--- a/src/nodes/core/InputNode.js
+++ b/src/nodes/core/InputNode.js
@@ -35,6 +35,14 @@ class InputNode extends Node {
 		this.isInputNode = true;
 
 		/**
+		 * Input/resource declarations keep their logical type in precision contexts.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.precisionContext = false;
+
+		/**
 		 * The value of this node. This can be any JS primitive, functions, array buffers or even three.js objects (vector, matrices, colors).
 		 *
 		 * @type {any}
@@ -84,10 +92,22 @@ class InputNode extends Node {
 	 * overwritten in derived classes if the final precision must be computed
 	 * analytically.
 	 *
-	 * @param {('low'|'medium'|'high')} precision - The precision of the input value in the shader.
-	 * @return {InputNode} A reference to this node.
+	 * @param {('low'|'medium'|'high')|number} precision - The precision of the input value in the shader.
+	 * @return {InputNode|ContextNode} A reference to this node or a precision context node.
 	 */
 	setPrecision( precision ) {
+
+		if ( typeof precision === 'number' && this.context ) {
+
+			return this.context( { precision } );
+
+		} else if ( typeof precision === 'number' ) {
+
+			this.computePrecision = precision;
+
+			return this;
+
+		}
 
 		this.precision = precision;
 

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -485,6 +485,17 @@ class Node extends EventDispatcher {
 	}
 
 	/**
+	 * Returns the precision requested for this node, if any.
+	 *
+	 * @return {?number|string} The requested precision.
+	 */
+	getPrecision() {
+
+		return null;
+
+	}
+
+	/**
 	 * Returns the hash of the node which is used to identify the node. By default it's
 	 * the {@link Node#uuid} however derived node classes might have to overwrite this method
 	 * depending on their implementation.

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -574,32 +574,37 @@ class Node extends EventDispatcher {
 	getNodeType( builder, output = null ) {
 
 		const nodeData = builder.getDataFromNode( this );
+		const precisionCacheKey = builder.getPrecisionCacheKey ? builder.getPrecisionCacheKey( this ) : 'default';
 
 		let type;
 
 		if ( output !== null ) {
 
 			nodeData.typeFromOutput = nodeData.typeFromOutput || {};
+			nodeData.typeFromOutput[ precisionCacheKey ] = nodeData.typeFromOutput[ precisionCacheKey ] || {};
 
-			type = nodeData.typeFromOutput[ output ];
+			type = nodeData.typeFromOutput[ precisionCacheKey ][ output ];
 
 			if ( type === undefined ) {
 
 				type = this.generateNodeType( builder, output );
+				type = builder.getPrecisionType ? builder.getPrecisionType( type, builder.getNodePrecision( this ) ) : type;
 
-				nodeData.typeFromOutput[ output ] = type;
+				nodeData.typeFromOutput[ precisionCacheKey ][ output ] = type;
 
 			}
 
 		} else {
 
-			type = nodeData.type;
+			nodeData.type = nodeData.type || {};
+			type = nodeData.type[ precisionCacheKey ];
 
 			if ( type === undefined ) {
 
 				type = this.generateNodeType( builder );
+				type = builder.getPrecisionType ? builder.getPrecisionType( type, builder.getNodePrecision( this ) ) : type;
 
-				nodeData.type = type;
+				nodeData.type[ precisionCacheKey ] = type;
 
 			}
 
@@ -971,18 +976,22 @@ class Node extends EventDispatcher {
 
 				const type = this.getNodeType( builder );
 				const nodeData = builder.getDataFromNode( this );
+				const precisionCacheKey = builder.getPrecisionCacheKey ? builder.getPrecisionCacheKey( this ) : 'default';
 
-				result = nodeData.snippet;
+				nodeData.snippet = nodeData.snippet || {};
+				nodeData.generated = nodeData.generated || {};
+
+				result = nodeData.snippet[ precisionCacheKey ];
 
 				if ( result === undefined ) {
 
-					if ( nodeData.generated === undefined ) {
+					if ( nodeData.generated[ precisionCacheKey ] === undefined ) {
 
-						nodeData.generated = true;
+						nodeData.generated[ precisionCacheKey ] = true;
 
 						result = this.generate( builder ) || '';
 
-						nodeData.snippet = result;
+						nodeData.snippet[ precisionCacheKey ] = result;
 
 					} else {
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1141,6 +1141,110 @@ class NodeBuilder {
 	}
 
 	/**
+	 * Returns the current requested compute precision.
+	 *
+	 * @return {?number} The requested precision, or null when default precision is used.
+	 */
+	getContextPrecision() {
+
+		const precision = this.context.precision;
+
+		return typeof precision === 'number' ? precision : null;
+
+	}
+
+	/**
+	 * Returns whether the given type can use shader precision lowering.
+	 *
+	 * @param {?string} type - The type to check.
+	 * @return {boolean} Whether the type is a floating point scalar, vector, or matrix.
+	 */
+	isFloatType( type ) {
+
+		type = this.getVectorType( type );
+
+		return type === 'float' || type === 'half' || /^h?vec[2-4]$/.test( type ) || /^h?mat[2-4]$/.test( type );
+
+	}
+
+	/**
+	 * Returns whether the type is an internal precision-lowered float type.
+	 *
+	 * @param {?string} type - The type to check.
+	 * @return {boolean} Whether the type is an internal half-precision type.
+	 */
+	isPrecisionType( type ) {
+
+		return type === 'half' || /^hvec[2-4]$/.test( type ) || /^hmat[2-4]$/.test( type );
+
+	}
+
+	/**
+	 * Returns the logical fp32 type for an internal precision-lowered type.
+	 *
+	 * @param {string} type - The type to normalize.
+	 * @return {string} The logical type.
+	 */
+	getBaseType( type ) {
+
+		if ( type === 'half' ) return 'float';
+		if ( /^h(vec|mat)[2-4]$/.test( type ) ) return type.slice( 1 );
+
+		return type;
+
+	}
+
+	/**
+	 * Returns the internal type for a requested precision.
+	 *
+	 * @param {string} type - The logical type.
+	 * @param {?number} [precision=this.getContextPrecision()] - The requested precision.
+	 * @return {string} The precision-adjusted type.
+	 */
+	getPrecisionType( type, precision = this.getContextPrecision() ) {
+
+		if ( precision !== 16 || this.isFloatType( type ) === false ) return type;
+
+		type = this.getVectorType( type );
+
+		if ( type === 'float' ) return 'half';
+		if ( /^vec[2-4]$/.test( type ) || /^mat[2-4]$/.test( type ) ) return 'h' + type;
+
+		return type;
+
+	}
+
+	/**
+	 * Returns the precision that should affect a node's generated computation.
+	 *
+	 * @param {Node} node - The node to check.
+	 * @return {?number} The node precision.
+	 */
+	getNodePrecision( node ) {
+
+		if ( node.precisionContext === false ) return null;
+
+		const precision = this.getContextPrecision();
+
+		return precision === 16 ? precision : null;
+
+	}
+
+	/**
+	 * Returns the cache key suffix for precision-dependent generated data.
+	 *
+	 * @param {Node} node - The node to check.
+	 * @return {string} The precision cache key.
+	 */
+	getPrecisionCacheKey( node ) {
+
+		const precision = this.getNodePrecision( node );
+
+		return precision === null ? 'default' : `precision:${ precision }`;
+
+	}
+
+	/**
 	 * Returns the vertexIndex input variable as a native shader string.
 	 *
 	 * @abstract
@@ -1420,16 +1524,17 @@ class NodeBuilder {
 
 		if ( value === null ) {
 
-			if ( type === 'float' || type === 'int' || type === 'uint' ) value = 0;
+			if ( type === 'float' || type === 'int' || type === 'uint' || type === 'half' ) value = 0;
 			else if ( type === 'bool' ) value = false;
 			else if ( type === 'color' ) value = new Color();
-			else if ( type === 'vec2' || type === 'uvec2' || type === 'ivec2' ) value = new Vector2();
-			else if ( type === 'vec3' || type === 'uvec3' || type === 'ivec3' ) value = new Vector3();
-			else if ( type === 'vec4' || type === 'uvec4' || type === 'ivec4' ) value = new Vector4();
+			else if ( type === 'vec2' || type === 'uvec2' || type === 'ivec2' || type === 'hvec2' ) value = new Vector2();
+			else if ( type === 'vec3' || type === 'uvec3' || type === 'ivec3' || type === 'hvec3' ) value = new Vector3();
+			else if ( type === 'vec4' || type === 'uvec4' || type === 'ivec4' || type === 'hvec4' ) value = new Vector4();
 
 		}
 
 		if ( type === 'float' ) return _toFloat( value );
+		if ( type === 'half' ) return `${ this.getType( type ) }( ${ _toFloat( value ) } )`;
 		if ( type === 'int' ) return `${ Math.round( value ) }`;
 		if ( type === 'uint' ) return value >= 0 ? `${ Math.round( value ) }u` : '0u';
 		if ( type === 'bool' ) return value ? 'true' : 'false';
@@ -1632,9 +1737,9 @@ class NodeBuilder {
 	 */
 	getElementType( type ) {
 
-		if ( type === 'mat2' ) return 'vec2';
-		if ( type === 'mat3' ) return 'vec3';
-		if ( type === 'mat4' ) return 'vec4';
+		if ( type === 'mat2' || type === 'hmat2' ) return this.changeComponentType( 'vec2', this.getComponentType( type ) );
+		if ( type === 'mat3' || type === 'hmat3' ) return this.changeComponentType( 'vec3', this.getComponentType( type ) );
+		if ( type === 'mat4' || type === 'hmat4' ) return this.changeComponentType( 'vec4', this.getComponentType( type ) );
 
 		return this.getComponentType( type );
 
@@ -1650,15 +1755,16 @@ class NodeBuilder {
 
 		type = this.getVectorType( type );
 
-		if ( type === 'float' || type === 'bool' || type === 'int' || type === 'uint' ) return type;
+		if ( type === 'float' || type === 'bool' || type === 'int' || type === 'uint' || type === 'half' ) return type;
 
-		const componentType = /(b|i|u|)(vec|mat)([2-4])/.exec( type );
+		const componentType = /(b|i|u|h|)(vec|mat)([2-4])/.exec( type );
 
 		if ( componentType === null ) return null;
 
 		if ( componentType[ 1 ] === 'b' ) return 'bool';
 		if ( componentType[ 1 ] === 'i' ) return 'int';
 		if ( componentType[ 1 ] === 'u' ) return 'uint';
+		if ( componentType[ 1 ] === 'h' ) return 'half';
 
 		return 'float';
 
@@ -1768,7 +1874,7 @@ class NodeBuilder {
 		const vecNum = /vec([2-4])/.exec( vecType );
 
 		if ( vecNum !== null ) return Number( vecNum[ 1 ] );
-		if ( vecType === 'float' || vecType === 'bool' || vecType === 'int' || vecType === 'uint' ) return 1;
+		if ( vecType === 'float' || vecType === 'bool' || vecType === 'int' || vecType === 'uint' || vecType === 'half' ) return 1;
 		if ( /mat2/.test( type ) === true ) return 4;
 		if ( /mat3/.test( type ) === true ) return 9;
 		if ( /mat4/.test( type ) === true ) return 16;
@@ -2128,7 +2234,8 @@ class NodeBuilder {
 	getVarFromNode( node, name = null, type = node.getNodeType( this ), shaderStage = this.shaderStage, readOnly = false ) {
 
 		const nodeData = this.getDataFromNode( node, shaderStage );
-		const subBuildVariable = this.getSubBuildProperty( 'variable', nodeData.subBuilds );
+		const precisionCacheKey = this.getPrecisionCacheKey( node );
+		const subBuildVariable = this.getSubBuildProperty( 'variable', nodeData.subBuilds ) + ( precisionCacheKey === 'default' ? '' : '_' + precisionCacheKey.replace( ':', '_' ) );
 
 		let nodeVar = nodeData[ subBuildVariable ];
 
@@ -2538,7 +2645,17 @@ class NodeBuilder {
 
 		}
 
-		let fn = cache.get( shaderNode );
+		let shaderNodeCache = cache.get( shaderNode );
+
+		if ( shaderNodeCache === undefined ) {
+
+			shaderNodeCache = {};
+			cache.set( shaderNode, shaderNodeCache );
+
+		}
+
+		const precisionCacheKey = this.getPrecisionCacheKey( shaderNode );
+		let fn = shaderNodeCache[ precisionCacheKey ];
 
 		if ( fn === undefined ) {
 
@@ -2552,7 +2669,7 @@ class NodeBuilder {
 
 			this.currentFunctionNode = previous;
 
-			cache.set( shaderNode, fn );
+			shaderNodeCache[ precisionCacheKey ] = fn;
 
 		}
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2264,6 +2264,8 @@ class NodeBuilder {
 
 			//
 
+			type = this.getPrecisionType( type, this.getNodePrecision( node ) );
+
 			const count = node.getArrayCount( this );
 
 			nodeVar = new NodeVar( name, type, readOnly, count );

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -3505,6 +3505,12 @@ class NodeBuilder {
 
 		}
 
+		if ( fromTypeLength > 4 && fromTypeLength === toTypeLength && fromType !== toType ) {
+
+			return `${ this.getType( toType ) }( ${ snippet } )`;
+
+		}
+
 
 		if ( fromTypeLength > 4 ) { // fromType is matrix-like
 

--- a/src/nodes/core/ParameterNode.js
+++ b/src/nodes/core/ParameterNode.js
@@ -34,6 +34,14 @@ class ParameterNode extends PropertyNode {
 		 */
 		this.isParameterNode = true;
 
+		/**
+		 * Function parameter declarations keep their logical type in precision contexts.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.precisionContext = false;
+
 	}
 
 	/**
@@ -72,9 +80,9 @@ class ParameterNode extends PropertyNode {
 
 	}
 
-	generate() {
+	generate( builder, output ) {
 
-		return this.name;
+		return builder.format( this.name, this.getNodeType( builder ), output );
 
 	}
 

--- a/src/nodes/core/ParameterNode.js
+++ b/src/nodes/core/ParameterNode.js
@@ -80,9 +80,9 @@ class ParameterNode extends PropertyNode {
 
 	}
 
-	generate( builder, output ) {
+	generate() {
 
-		return builder.format( this.name, this.getNodeType( builder ), output );
+		return this.name;
 
 	}
 

--- a/src/nodes/core/TempNode.js
+++ b/src/nodes/core/TempNode.js
@@ -56,10 +56,12 @@ class TempNode extends Node {
 
 			const type = builder.getVectorType( this.getNodeType( builder, output ) );
 			const nodeData = builder.getDataFromNode( this );
+			const precisionCacheKey = builder.getPrecisionCacheKey ? builder.getPrecisionCacheKey( this ) : 'default';
+			const propertyNames = nodeData.propertyName || ( nodeData.propertyName = {} );
 
-			if ( nodeData.propertyName !== undefined ) {
+			if ( propertyNames[ precisionCacheKey ] !== undefined ) {
 
-				return builder.format( nodeData.propertyName, type, output );
+				return builder.format( propertyNames[ precisionCacheKey ], type, output );
 
 			} else if ( type !== 'void' && output !== 'void' && this.hasDependencies( builder ) ) {
 
@@ -70,10 +72,11 @@ class TempNode extends Node {
 
 				builder.addLineFlowCode( `${ propertyName } = ${ snippet }`, this );
 
-				nodeData.snippet = snippet;
-				nodeData.propertyName = propertyName;
+				nodeData.snippet = nodeData.snippet || {};
+				nodeData.snippet[ precisionCacheKey ] = snippet;
+				propertyNames[ precisionCacheKey ] = propertyName;
 
-				return builder.format( nodeData.propertyName, type, output );
+				return builder.format( propertyName, type, output );
 
 			}
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -153,7 +153,9 @@ class VarNode extends Node {
 
 	generateNodeType( builder ) {
 
-		return this.node.getNodeType( builder );
+		const type = this.node.getNodeType( builder );
+
+		return builder.getBaseType ? builder.getBaseType( type ) : type;
 
 	}
 
@@ -238,7 +240,7 @@ class VarNode extends Node {
 
 	}
 
-	generate( builder ) {
+	generate( builder, output ) {
 
 		const { node, name, readOnly } = this;
 		const { renderer } = builder;
@@ -273,35 +275,51 @@ class VarNode extends Node {
 		}
 
 		const vectorType = builder.getVectorType( nodeType );
-		const snippet = node.build( builder, vectorType );
-
 		const nodeVar = builder.getVarFromNode( this, name, vectorType, undefined, shouldTreatAsReadOnly );
-
+		const targetType = nodeVar.type;
 		const propertyName = builder.getPropertyName( nodeVar );
+		const nodeData = builder.getDataFromNode( this );
+		const precisionCacheKey = builder.getPrecisionCacheKey ? builder.getPrecisionCacheKey( this ) : 'default';
 
-		let declarationPrefix = propertyName;
+		nodeData.declared = nodeData.declared || {};
 
-		if ( shouldTreatAsReadOnly ) {
+		if ( nodeData.declared[ precisionCacheKey ] !== true ) {
 
-			if ( isWebGPUBackend ) {
+			nodeData.declared[ precisionCacheKey ] = true;
 
-				declarationPrefix = isDeterministic
-					? `const ${ propertyName }`
-					: `let ${ propertyName }`;
+			let snippet = node.build( builder, targetType );
 
-			} else {
+			if ( builder.isPrecisionType && builder.isPrecisionType( targetType ) ) {
 
-				const count = node.getArrayCount( builder );
-
-				declarationPrefix = `const ${ builder.getVar( nodeVar.type, propertyName, count ) }`;
+				snippet = builder.format( snippet, builder.getBaseType( targetType ), targetType );
 
 			}
 
+			let declarationPrefix = propertyName;
+
+			if ( shouldTreatAsReadOnly ) {
+
+				if ( isWebGPUBackend ) {
+
+					declarationPrefix = isDeterministic
+						? `const ${ propertyName }`
+						: `let ${ propertyName }`;
+
+				} else {
+
+					const count = node.getArrayCount( builder );
+
+					declarationPrefix = `const ${ builder.getVar( nodeVar.type, propertyName, count ) }`;
+
+				}
+
+			}
+
+			builder.addLineFlowCode( `${ declarationPrefix } = ${ snippet }`, this );
+
 		}
 
-		builder.addLineFlowCode( `${ declarationPrefix } = ${ snippet }`, this );
-
-		return propertyName;
+		return builder.format( propertyName, targetType, output );
 
 	}
 

--- a/src/nodes/core/VaryingNode.js
+++ b/src/nodes/core/VaryingNode.js
@@ -57,6 +57,14 @@ class VaryingNode extends Node {
 		this.isVaryingNode = true;
 
 		/**
+		 * Varying declarations keep their logical type in precision contexts.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.precisionContext = false;
+
+		/**
 		 * The interpolation type of the varying data.
 		 *
 		 * @type {?string}
@@ -159,7 +167,7 @@ class VaryingNode extends Node {
 
 	}
 
-	generate( builder ) {
+	generate( builder, output ) {
 
 		const propertyKey = builder.getSubBuildProperty( 'property', builder.currentStack );
 		const properties = builder.getNodeProperties( this );
@@ -187,7 +195,7 @@ class VaryingNode extends Node {
 
 		}
 
-		return builder.getPropertyName( varying );
+		return builder.format( builder.getPropertyName( varying ), this.getNodeType( builder ), output );
 
 	}
 

--- a/src/nodes/core/VaryingNode.js
+++ b/src/nodes/core/VaryingNode.js
@@ -167,7 +167,7 @@ class VaryingNode extends Node {
 
 	}
 
-	generate( builder, output ) {
+	generate( builder ) {
 
 		const propertyKey = builder.getSubBuildProperty( 'property', builder.currentStack );
 		const properties = builder.getNodeProperties( this );
@@ -195,7 +195,7 @@ class VaryingNode extends Node {
 
 		}
 
-		return builder.format( builder.getPropertyName( varying ), this.getNodeType( builder ), output );
+		return builder.getPropertyName( varying );
 
 	}
 

--- a/src/nodes/math/ConditionalNode.js
+++ b/src/nodes/math/ConditionalNode.js
@@ -127,10 +127,12 @@ class ConditionalNode extends Node {
 		const type = this.getNodeType( builder );
 
 		const nodeData = builder.getDataFromNode( this );
+		const precisionCacheKey = builder.getPrecisionCacheKey ? builder.getPrecisionCacheKey( this ) : 'default';
+		const nodeProperties = nodeData.nodeProperty || ( nodeData.nodeProperty = {} );
 
-		if ( nodeData.nodeProperty !== undefined ) {
+		if ( nodeProperties[ precisionCacheKey ] !== undefined ) {
 
-			return nodeData.nodeProperty;
+			return nodeProperties[ precisionCacheKey ];
 
 		}
 
@@ -140,7 +142,7 @@ class ConditionalNode extends Node {
 		const needsOutput = output !== 'void';
 		const nodeProperty = needsOutput ? property( type ).build( builder ) : '';
 
-		nodeData.nodeProperty = nodeProperty;
+		nodeProperties[ precisionCacheKey ] = nodeProperty;
 
 		const nodeSnippet = condNode.build( builder, 'bool' );
 		const isUniformFlow = builder.context.uniformFlow;

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -225,8 +225,17 @@ class MathNode extends TempNode {
 
 		let method = this.method;
 
-		const type = this.getNodeType( builder );
-		const inputType = this.getInputType( builder );
+		let type = this.getNodeType( builder );
+		let inputType = this.getInputType( builder );
+
+		if ( builder.getPrecisionType ) {
+
+			const precision = builder.getContextPrecision() || ( builder.isPrecisionType( output ) ? 16 : null );
+
+			type = builder.getPrecisionType( type, precision );
+			inputType = builder.getPrecisionType( inputType, precision );
+
+		}
 
 		const a = this.aNode;
 		const b = this.bNode;

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -200,7 +200,7 @@ class OperatorNode extends TempNode {
 
 		const { aNode, bNode } = this;
 
-		const type = this.getNodeType( builder, output );
+		let type = this.getNodeType( builder, output );
 
 		let typeA = null;
 		let typeB = null;
@@ -287,6 +287,16 @@ class OperatorNode extends TempNode {
 
 			}
 
+			if ( builder.getPrecisionType ) {
+
+				const precision = builder.getContextPrecision() || ( builder.isPrecisionType( output ) ? 16 : null );
+
+				type = builder.getPrecisionType( type, precision );
+				typeA = builder.getPrecisionType( typeA, precision );
+				typeB = typeB !== null ? builder.getPrecisionType( typeB, precision ) : null;
+
+			}
+
 		} else {
 
 			typeA = typeB = type;
@@ -295,6 +305,44 @@ class OperatorNode extends TempNode {
 
 		const a = aNode.build( builder, typeA );
 		const b = bNode ? bNode.build( builder, typeB ) : null;
+
+		const coercePrecisionOperand = ( snippet, fromType, node ) => {
+
+			if ( snippet === null ) return snippet;
+
+			let sourceType = fromType;
+
+			if ( node && node.isVarNode ) {
+
+				sourceType = builder.getVarFromNode( node ).type;
+
+			}
+
+			if ( sourceType !== type ) {
+
+				return builder.format( snippet, sourceType, type );
+
+			}
+
+			// Same TSL type can still disagree with the WGSL declaration for vars and loop iterators.
+			return `${ builder.getType( type ) }( ${ snippet } )`;
+
+		};
+
+		const needsPrecisionCoerce = builder.isFloatType && builder.isFloatType( type ) && (
+			builder.getContextPrecision() === 16 ||
+			( builder.isPrecisionType && ( builder.isPrecisionType( type ) || builder.isPrecisionType( typeA ) || ( typeB !== null && builder.isPrecisionType( typeB ) ) ) )
+		);
+
+		let aSnippet = a;
+		let bSnippet = b;
+
+		if ( needsPrecisionCoerce ) {
+
+			aSnippet = coercePrecisionOperand( a, typeA, aNode );
+			bSnippet = coercePrecisionOperand( b, typeB, bNode );
+
+		}
 
 		const fnOpSnippet = builder.getFunctionOperator( op );
 
@@ -308,11 +356,11 @@ class OperatorNode extends TempNode {
 
 					if ( builder.isVector( typeA ) ) {
 
-						return builder.format( `${ this.getOperatorMethod( builder, output ) }( ${ a }, ${ b } )`, type, output );
+						return builder.format( `${ this.getOperatorMethod( builder, output ) }( ${ aSnippet }, ${ bSnippet } )`, type, output );
 
 					} else {
 
-						return builder.format( `( ${ a } ${ op } ${ b } )`, type, output );
+						return builder.format( `( ${ aSnippet } ${ op } ${ bSnippet } )`, type, output );
 
 					}
 
@@ -320,7 +368,7 @@ class OperatorNode extends TempNode {
 
 					// WGSL
 
-					return builder.format( `( ${ a } ${ op } ${ b } )`, type, output );
+					return builder.format( `( ${ aSnippet } ${ op } ${ bSnippet } )`, type, output );
 
 				}
 
@@ -328,11 +376,11 @@ class OperatorNode extends TempNode {
 
 				if ( builder.isInteger( typeB ) ) {
 
-					return builder.format( `( ${ a } % ${ b } )`, type, output );
+					return builder.format( `( ${ aSnippet } % ${ bSnippet } )`, type, output );
 
 				} else {
 
-					return builder.format( `${ this.getOperatorMethod( builder, type ) }( ${ a }, ${ b } )`, type, output );
+					return builder.format( `${ this.getOperatorMethod( builder, type ) }( ${ aSnippet }, ${ bSnippet } )`, type, output );
 
 				}
 
@@ -340,23 +388,23 @@ class OperatorNode extends TempNode {
 
 				if ( isGLSL && builder.isVector( typeA ) ) {
 
-					return builder.format( `not( ${a} )`, output );
+					return builder.format( `not( ${ aSnippet } )`, output );
 
 				} else {
 
 					// WGSL and scalars on GLSL
 
-					return builder.format( `( ${op} ${a} )`, typeA, output );
+					return builder.format( `( ${ op } ${ aSnippet } )`, typeA, output );
 
 				}
 
 			} else if ( op === '~' ) {
 
-				return builder.format( `( ${op} ${a} )`, typeA, output );
+				return builder.format( `( ${ op } ${ aSnippet } )`, typeA, output );
 
 			} else if ( fnOpSnippet ) {
 
-				return builder.format( `${ fnOpSnippet }( ${ a }, ${ b } )`, type, output );
+				return builder.format( `${ fnOpSnippet }( ${ aSnippet }, ${ bSnippet } )`, type, output );
 
 			} else {
 
@@ -364,15 +412,15 @@ class OperatorNode extends TempNode {
 
 				if ( builder.isMatrix( typeA ) && typeB === 'float' ) {
 
-					return builder.format( `( ${ b } ${ op } ${ a } )`, type, output );
+					return builder.format( `( ${ bSnippet } ${ op } ${ aSnippet } )`, type, output );
 
 				} else if ( typeA === 'float' && builder.isMatrix( typeB ) ) {
 
-					return builder.format( `${ a } ${ op } ${ b }`, type, output );
+					return builder.format( `${ aSnippet } ${ op } ${ bSnippet }`, type, output );
 
 				} else {
 
-					let snippet = `( ${ a } ${ op } ${ b } )`;
+					let snippet = `( ${ aSnippet } ${ op } ${ bSnippet } )`;
 
 					if ( ! isGLSL && type === 'bool' && builder.isVector( typeA ) && builder.isVector( typeB ) ) {
 
@@ -390,17 +438,24 @@ class OperatorNode extends TempNode {
 
 			if ( fnOpSnippet ) {
 
-				return builder.format( `${ fnOpSnippet }( ${ a }, ${ b } )`, type, output );
+				return builder.format( `${ fnOpSnippet }( ${ aSnippet }, ${ bSnippet } )`, type, output );
 
 			} else {
 
-				if ( builder.isMatrix( typeA ) && typeB === 'float' ) {
+				if ( bNode === null && builder.isPrecisionType && builder.isPrecisionType( typeA ) ) {
 
-					return builder.format( `${ b } ${ op } ${ a }`, type, output );
+					const baseTypeA = builder.getBaseType( typeA );
+					const baseA = aNode.build( builder, baseTypeA );
+
+					return builder.format( `( ${ op } ${ baseA } )`, baseTypeA, output || typeA );
+
+				} else if ( builder.isMatrix( typeA ) && typeB === 'float' ) {
+
+					return builder.format( `${ bSnippet } ${ op } ${ aSnippet }`, type, output );
 
 				} else {
 
-					return builder.format( `${ a } ${ op } ${ b }`, type, output );
+					return builder.format( `${ aSnippet } ${ op } ${ bSnippet }`, type, output );
 
 				}
 

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -150,7 +150,7 @@ class OperatorNode extends TempNode {
 
 			if ( builder.isMatrix( typeA ) ) {
 
-				if ( typeB === 'float' ) {
+				if ( typeB === 'float' || typeB === 'half' ) {
 
 					return typeA; // matrix * scalar = matrix
 
@@ -166,7 +166,7 @@ class OperatorNode extends TempNode {
 
 			} else if ( builder.isMatrix( typeB ) ) {
 
-				if ( typeA === 'float' ) {
+				if ( typeA === 'float' || typeA === 'half' ) {
 
 					return typeB; // scalar * matrix = matrix
 
@@ -238,11 +238,11 @@ class OperatorNode extends TempNode {
 
 			} else if ( builder.isMatrix( typeA ) ) {
 
-				if ( typeB === 'float' ) {
+				if ( typeB === 'float' || typeB === 'half' ) {
 
 					// Keep matrix type for typeA, but ensure typeB stays float
 
-					typeB = 'float';
+					typeB = builder.getComponentType( typeA );
 
 				} else if ( builder.isVector( typeB ) ) {
 
@@ -261,11 +261,11 @@ class OperatorNode extends TempNode {
 
 			} else if ( builder.isMatrix( typeB ) ) {
 
-				if ( typeA === 'float' ) {
+				if ( typeA === 'float' || typeA === 'half' ) {
 
 					// Keep matrix type for typeB, but ensure typeA stays float
 
-					typeA = 'float';
+					typeA = builder.getComponentType( typeB );
 
 				} else if ( builder.isVector( typeA ) ) {
 

--- a/src/nodes/utils/ConvertNode.js
+++ b/src/nodes/utils/ConvertNode.js
@@ -88,10 +88,11 @@ class ConvertNode extends Node {
 
 		const node = this.node;
 		const type = this.getNodeType( builder );
+		const inputType = builder.getBaseType ? builder.getBaseType( type ) : type;
 
-		const snippet = node.build( builder, type );
+		const snippet = node.build( builder, inputType );
 
-		return builder.format( snippet, type, output );
+		return builder.format( snippet, inputType, output || type );
 
 	}
 

--- a/src/nodes/utils/FunctionOverloadingNode.js
+++ b/src/nodes/utils/FunctionOverloadingNode.js
@@ -112,7 +112,11 @@ class FunctionOverloadingNode extends Node {
 						const param = params[ i ];
 						const input = inputs[ i ];
 
-						if ( param.getNodeType( builder ) === input.type ) {
+						const paramType = param.getNodeType( builder );
+						const baseParamType = builder.getBaseType ? builder.getBaseType( paramType ) : paramType;
+						const baseInputType = builder.getBaseType ? builder.getBaseType( input.type ) : input.type;
+
+						if ( baseParamType === baseInputType ) {
 
 							currentScore ++;
 

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -96,8 +96,9 @@ class LoopNode extends Node {
 
 			const name = ( param.isNode !== true && param.name ) || this.getVarName( i );
 			const type = ( param.isNode !== true && param.type ) || 'int';
+			const loopType = builder.getPrecisionType ? builder.getPrecisionType( type ) : type;
 
-			inputs[ name ] = expression( name, type );
+			inputs[ name ] = expression( name, loopType );
 
 		}
 
@@ -188,6 +189,13 @@ class LoopNode extends Node {
 
 				type = param.type || 'int';
 				name = param.name || this.getVarName( i );
+
+				if ( builder.getPrecisionType ) {
+
+					type = builder.getPrecisionType( type );
+
+				}
+
 				start = param.start;
 				end = param.end;
 				condition = param.condition;

--- a/src/nodes/utils/SplitNode.js
+++ b/src/nodes/utils/SplitNode.js
@@ -114,7 +114,8 @@ class SplitNode extends Node {
 	generate( builder, output ) {
 
 		const node = this.node;
-		const nodeTypeLength = builder.getTypeLength( node.getNodeType( builder ) );
+		const nodeType = node.getNodeType( builder );
+		const nodeTypeLength = builder.getTypeLength( nodeType );
 
 		let snippet = null;
 
@@ -133,16 +134,19 @@ class SplitNode extends Node {
 			}
 
 			const nodeSnippet = node.build( builder, type );
+			const snippetType = type || nodeType;
 
 			if ( this.components.length === nodeTypeLength && this.components === _stringVectorComponents.slice( 0, this.components.length ) ) {
 
 				// unnecessary swizzle
 
-				snippet = builder.format( nodeSnippet, type, output );
+				snippet = builder.format( nodeSnippet, snippetType, output );
 
 			} else {
 
-				snippet = builder.format( `${nodeSnippet}.${this.components}`, this.getNodeType( builder ), output );
+				const splitType = builder.getTypeFromLength( this.components.length, builder.getComponentType( snippetType ) );
+
+				snippet = builder.format( `${nodeSnippet}.${this.components}`, splitType, output );
 
 			}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -280,8 +280,6 @@ class GLSLNodeBuilder extends NodeBuilder {
 
 	getType( type ) {
 
-		type = this.getPrecisionType( type );
-
 		return glslHalfFallbackTypeLib[ type ] || super.getType( type );
 
 	}
@@ -370,12 +368,15 @@ class GLSLNodeBuilder extends NodeBuilder {
 		const flowData = this.flowShaderNode( shaderNode );
 
 		const parameters = [];
+		const previousContext = this.addContext( { precision: null } );
 
 		for ( const input of layout.inputs ) {
 
 			parameters.push( this.getType( input.type ) + ' ' + input.name );
 
 		}
+
+		this.setContext( previousContext );
 
 		//
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -98,6 +98,16 @@ const glslMethods = {
 	floatunpack_unorm_4x8: 'tsl_unpackUnorm4x8'
 };
 
+const glslHalfFallbackTypeLib = {
+	half: 'float',
+	hvec2: 'vec2',
+	hvec3: 'vec3',
+	hvec4: 'vec4',
+	hmat2: 'mat2',
+	hmat3: 'mat3',
+	hmat4: 'mat4'
+};
+
 const precisionLib = {
 	low: 'lowp',
 	medium: 'mediump',
@@ -265,6 +275,22 @@ class GLSLNodeBuilder extends NodeBuilder {
 		}
 
 		return glslMethods[ method ] || method;
+
+	}
+
+	getType( type ) {
+
+		type = this.getPrecisionType( type );
+
+		return glslHalfFallbackTypeLib[ type ] || super.getType( type );
+
+	}
+
+	getVar( type, name, count = null ) {
+
+		const qualifier = this.isPrecisionType( type ) ? 'mediump ' : '';
+
+		return qualifier + super.getVar( type, name, count );
 
 	}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1530,12 +1530,15 @@ class WGSLNodeBuilder extends NodeBuilder {
 		const flowData = this.flowShaderNode( shaderNode );
 
 		const parameters = [];
+		const previousContext = this.addContext( { precision: null } );
 
 		for ( const input of layout.inputs ) {
 
 			parameters.push( input.name + ' : ' + this.getType( input.type ) );
 
 		}
+
+		this.setContext( previousContext );
 
 		//
 
@@ -2526,7 +2529,7 @@ ${ flowData.code }
 	 */
 	getType( type ) {
 
-		type = this.getPrecisionType( type );
+		type = this.getVectorType( type );
 
 		if ( wgslHalfFallbackTypeLib[ type ] !== undefined ) {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -73,7 +73,25 @@ const wgslTypeLib = {
 
 	mat2: 'mat2x2<f32>',
 	mat3: 'mat3x3<f32>',
-	mat4: 'mat4x4<f32>'
+	mat4: 'mat4x4<f32>',
+
+	half: 'f16',
+	hvec2: 'vec2<f16>',
+	hvec3: 'vec3<f16>',
+	hvec4: 'vec4<f16>',
+	hmat2: 'mat2x2<f16>',
+	hmat3: 'mat3x3<f16>',
+	hmat4: 'mat4x4<f16>'
+};
+
+const wgslHalfFallbackTypeLib = {
+	half: 'float',
+	hvec2: 'vec2',
+	hvec3: 'vec3',
+	hvec4: 'vec4',
+	hmat2: 'mat2',
+	hmat3: 'mat3',
+	hmat4: 'mat4'
 };
 
 const wgslCodeCache = {};
@@ -359,6 +377,8 @@ class WGSLNodeBuilder extends NodeBuilder {
 		 * @default true
 		 */
 		this.allowGlobalVariables = true;
+
+		this._supports = { ...supports };
 
 	}
 
@@ -2506,6 +2526,22 @@ ${ flowData.code }
 	 */
 	getType( type ) {
 
+		type = this.getPrecisionType( type );
+
+		if ( wgslHalfFallbackTypeLib[ type ] !== undefined ) {
+
+			if ( this.isAvailable( 'shaderF16' ) ) {
+
+				this.enableShaderF16();
+
+			} else {
+
+				type = wgslHalfFallbackTypeLib[ type ];
+
+			}
+
+		}
+
 		return wgslTypeLib[ type ] || type;
 
 	}
@@ -2518,7 +2554,7 @@ ${ flowData.code }
 	 */
 	isAvailable( name ) {
 
-		let result = supports[ name ];
+		let result = this._supports[ name ];
 
 		if ( result === undefined ) {
 
@@ -2530,9 +2566,13 @@ ${ flowData.code }
 
 				result = this.renderer.hasFeature( 'clip-distances' );
 
+			} else if ( name === 'shaderF16' ) {
+
+				result = this.renderer.hasFeature( 'shader-f16' );
+
 			}
 
-			supports[ name ] = result;
+			this._supports[ name ] = result;
 
 		}
 
@@ -2630,6 +2670,9 @@ fn main( ${shaderData.attributes} ) -> VaryingsStruct {
 	_getWGSLFragmentCode( shaderData ) {
 
 		return `${ this.getSignature() }
+// directives
+${shaderData.directives}
+
 // global
 ${ diagnostics }
 

--- a/test/unit/addons/tsl/TSLPrecision.tests.js
+++ b/test/unit/addons/tsl/TSLPrecision.tests.js
@@ -1,6 +1,21 @@
 import { DataTexture, DataUtils, HalfFloatType, NearestFilter, RedFormat } from 'three';
-import { Fn, float, mat3, mul, texture, uniform, vec2, vec3 } from 'three/tsl';
+import { Fn, cos, cross, distance, dot, float, length, mat2, mat3, mat4, mix, mul, normalize, reflect, refract, sin, tan, texture, uniform, vec2, vec3, vec4 } from 'three/tsl';
 import { gpuTest } from './gpu-test-utils.js';
+
+const HALF_ULP_QUARTER_AT_ONE = 1 / 4096;
+const NATIVE_F16_OPTIONS = { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] };
+
+function assertHalfEquals( assert, actual, expected, message, tolerance = 1e-5 ) {
+
+	assert.closeAbs( actual.setPrecision( 16 ), expected, tolerance, message );
+
+}
+
+function assertFp32KeepsDelta( assert, deltaNode, message, threshold = 1e-4 ) {
+
+	assert.greaterThan( deltaNode.setPrecision( 32 ), float( threshold ), message );
+
+}
 
 export default QUnit.module( 'TSL', () => {
 
@@ -36,7 +51,15 @@ export default QUnit.module( 'TSL', () => {
 
 			assert.closeAbs( expression.setPrecision( 16 ), float( 0 ), 1e-3, '2048 + 1 rounds before subtracting in fp16' );
 
-		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'native 16-bit context reaches temporaries', ( { assert } ) => {
+
+			const rounded = float( 2048 ).add( 1 ).toVar();
+
+			assertHalfEquals( assert, rounded.sub( 2048 ), float( 0 ), 'temporary stores rounded fp16 value', 1e-3 );
+
+		}, NATIVE_F16_OPTIONS );
 
 		gpuTest( 'precision scope returns to fp32 outside the scoped expression', ( { assert } ) => {
 
@@ -46,7 +69,7 @@ export default QUnit.module( 'TSL', () => {
 			assert.closeAbs( fp32, float( 1 ), 1e-3, 'unscoped expression keeps fp32 precision' );
 			assert.closeAbs( fp16ThenFp32, float( 0 ), 1e-3, 'precision context result is promoted before surrounding fp32 math' );
 
-		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
+		}, NATIVE_F16_OPTIONS );
 
 		gpuTest( '32-bit context overrides an outer 16-bit context', ( { assert } ) => {
 
@@ -56,16 +79,182 @@ export default QUnit.module( 'TSL', () => {
 			assert.closeAbs( fp32Scoped, float( 1 ), 1e-3, 'setPrecision( 32 ) keeps fp32 arithmetic' );
 			assert.closeAbs( nested, float( 1 ), 1e-3, 'inner fp32 scope is preserved inside outer fp16 scope' );
 
-		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( '32-bit context preserves sub-half-ulp scalar differences', ( { assert } ) => {
+
+			const x = float( 1 ).add( HALF_ULP_QUARTER_AT_ONE );
+
+			assertFp32KeepsDelta( assert, x.sub( 1 ), 'setPrecision( 32 ) keeps fp32 scalar difference' );
+			assertHalfEquals( assert, x.sub( 1 ), float( 0 ), 'setPrecision( 16 ) rounds same scalar difference away' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'native 16-bit context rounds trigonometric inputs', ( { assert } ) => {
+
+			const x = float( 1 ).add( HALF_ULP_QUARTER_AT_ONE );
+			const one = float( 1 );
+			const sinDelta = sin( x ).sub( sin( one ) );
+			const cosDelta = cos( one ).sub( cos( x ) );
+			const tanDelta = tan( x ).sub( tan( one ) );
+
+			assertHalfEquals( assert, sinDelta, float( 0 ), 'sin input is evaluated at fp16 precision' );
+			assertHalfEquals( assert, cosDelta, float( 0 ), 'cos input is evaluated at fp16 precision', 1e-3 );
+			assertHalfEquals( assert, tanDelta, float( 0 ), 'tan input is evaluated at fp16 precision' );
+
+			assertFp32KeepsDelta( assert, sinDelta, 'sin keeps the sub-half-ulp input delta in fp32' );
+			assertFp32KeepsDelta( assert, cosDelta, 'cos keeps the sub-half-ulp input delta in fp32' );
+			assertFp32KeepsDelta( assert, tanDelta, 'tan keeps the sub-half-ulp input delta in fp32' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'native 16-bit context rounds vector operation inputs', ( { assert } ) => {
+
+			const delta = HALF_ULP_QUARTER_AT_ONE;
+			const x = float( 1 ).add( delta );
+			const v = vec3( x, 1, 0 );
+			const base = vec3( 1, 1, 0 );
+			const z = vec3( 0, 0, 1 );
+			const normal = vec3( 0, 1, 0 );
+			const dotDelta = dot( v, vec3( 1, 0, 0 ) ).sub( 1 );
+			const lengthDelta = length( vec3( x, 0, 0 ) ).sub( 1 );
+			const distanceDelta = distance( vec3( x, 0, 0 ), vec3( 0, 0, 0 ) ).sub( 1 );
+			const crossDelta = cross( v, z ).sub( cross( base, z ) );
+			const normalizeDelta = normalize( v ).sub( normalize( base ) );
+			const reflectDelta = reflect( vec3( x, - 1, 0 ), normal ).sub( reflect( vec3( 1, - 1, 0 ), normal ) );
+			const refractDelta = refract( vec3( x, - 1, 0 ), normal, 1 ).sub( refract( vec3( 1, - 1, 0 ), normal, 1 ) );
+
+			assertHalfEquals( assert, dotDelta, float( 0 ), 'dot rounds vector components to fp16' );
+			assertHalfEquals( assert, lengthDelta, float( 0 ), 'length rounds vector components to fp16' );
+			assertHalfEquals( assert, distanceDelta, float( 0 ), 'distance rounds vector components to fp16' );
+			assertHalfEquals( assert, crossDelta, vec3( 0, 0, 0 ), 'cross rounds vector components to fp16' );
+			assertHalfEquals( assert, normalizeDelta, vec3( 0, 0, 0 ), 'normalize rounds vector components to fp16' );
+			assertHalfEquals( assert, reflectDelta, vec3( 0, 0, 0 ), 'reflect rounds vector components to fp16' );
+			assertHalfEquals( assert, refractDelta, vec3( 0, 0, 0 ), 'refract rounds vector components to fp16' );
+
+			assertFp32KeepsDelta( assert, dotDelta, 'dot keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, lengthDelta, 'length keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, distanceDelta, 'distance keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, crossDelta.y.negate(), 'cross keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, reflectDelta.x, 'reflect keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, refractDelta.x, 'refract keeps fp32 delta in 32-bit scope' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'native 16-bit context converts vector widths at precision boundaries', ( { assert } ) => {
+
+			const x = float( 1 ).add( HALF_ULP_QUARTER_AT_ONE );
+
+			const v2 = vec2( x, 1 );
+			const v3 = vec3( x, 1, 1 );
+			const v4 = vec4( x, 1, 1, 1 );
+
+			assertHalfEquals( assert, v2, vec2( 1, 1 ), 'vec2 converts to hvec2 and promotes back to vec2' );
+			assertHalfEquals( assert, v3, vec3( 1, 1, 1 ), 'vec3 converts to hvec3 and promotes back to vec3' );
+			assertHalfEquals( assert, v4, vec4( 1, 1, 1, 1 ), 'vec4 converts to hvec4 and promotes back to vec4' );
+
+			assertFp32KeepsDelta( assert, v2.x.sub( 1 ), 'vec2 keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, v3.x.sub( 1 ), 'vec3 keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, v4.x.sub( 1 ), 'vec4 keeps fp32 delta in 32-bit scope' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'native 16-bit context converts matrix widths at precision boundaries', ( { assert } ) => {
+
+			const x = float( 1 ).add( HALF_ULP_QUARTER_AT_ONE );
+			const m2 = mat2(
+				x, 0,
+				0, 1
+			);
+			const i2 = mat2(
+				1, 0,
+				0, 1
+			);
+			const m3 = mat3(
+				x, 0, 0,
+				0, 1, 0,
+				0, 0, 1
+			);
+			const i3 = mat3(
+				1, 0, 0,
+				0, 1, 0,
+				0, 0, 1
+			);
+			const m4 = mat4(
+				x, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, 1
+			);
+			const i4 = mat4(
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, 1
+			);
+
+			assertHalfEquals( assert, m2, i2, 'mat2 converts to hmat2 and promotes back to mat2' );
+			assertHalfEquals( assert, m3, i3, 'mat3 converts to hmat3 and promotes back to mat3' );
+			assertHalfEquals( assert, m4, i4, 'mat4 converts to hmat4 and promotes back to mat4' );
+
+			assertFp32KeepsDelta( assert, m2.element( 0 ).x.sub( 1 ), 'mat2 keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, m3.element( 0 ).x.sub( 1 ), 'mat3 keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, m4.element( 0 ).x.sub( 1 ), 'mat4 keeps fp32 delta in 32-bit scope' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'native 16-bit context rounds vector-matrix operation inputs', ( { assert } ) => {
+
+			const x = float( 1 ).add( HALF_ULP_QUARTER_AT_ONE );
+			const matrix = mat3(
+				x, 0, 0,
+				0, 1, 0,
+				0, 0, 1
+			);
+			const identity = mat3(
+				1, 0, 0,
+				0, 1, 0,
+				0, 0, 1
+			);
+			const axis = vec3( 1, 0, 0 );
+
+			assertHalfEquals( assert, mul( matrix, axis ), axis, 'matrix-vector multiplication rounds matrix input to fp16' );
+			assertHalfEquals( assert, mul( axis, matrix ), axis, 'vector-matrix multiplication rounds matrix input to fp16' );
+			assertHalfEquals( assert, mul( matrix, identity ), identity, 'matrix-matrix multiplication rounds matrix input to fp16' );
+
+			assertFp32KeepsDelta( assert, mul( matrix, axis ).x.sub( 1 ), 'matrix-vector multiplication keeps fp32 input delta in fp32 scope' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'native 16-bit context reaches mix and select branches', ( { assert } ) => {
+
+			const x = float( 1 ).add( HALF_ULP_QUARTER_AT_ONE );
+			const condition = x.greaterThan( 0 );
+			const mixedScalar = mix( float( 1 ), x, float( 1 ) ).sub( 1 );
+			const selectedScalar = condition.select( x, float( 0 ) ).sub( 1 );
+			const mixedVector = mix( vec3( 1 ), vec3( x, 1, 1 ), vec3( 1 ) ).sub( vec3( 1 ) );
+			const selectedVector = condition.select( vec3( x, 1, 1 ), vec3( 0 ) ).sub( vec3( 1 ) );
+
+			assertHalfEquals( assert, mixedScalar, float( 0 ), 'mix scalar inputs round in fp16 scope' );
+			assertHalfEquals( assert, selectedScalar, float( 0 ), 'select scalar branch rounds in fp16 scope' );
+			assertHalfEquals( assert, mixedVector, vec3( 0, 0, 0 ), 'mix vector inputs round in fp16 scope' );
+			assertHalfEquals( assert, selectedVector, vec3( 0, 0, 0 ), 'select vector branch rounds in fp16 scope' );
+
+			assertFp32KeepsDelta( assert, mixedScalar, 'mix scalar keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, selectedScalar, 'select scalar keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, mixedVector.x, 'mix vector keeps fp32 delta in 32-bit scope' );
+			assertFp32KeepsDelta( assert, selectedVector.x, 'select vector keeps fp32 delta in 32-bit scope' );
+
+		}, NATIVE_F16_OPTIONS );
 
 		gpuTest( 'shared node can be used in fp32 and fp16 contexts', ( { assert } ) => {
 
 			const shared = float( 2048 ).add( 1 ).sub( 2048 );
 
 			assert.closeAbs( shared, float( 1 ), 1e-3, 'shared node in default fp32 context' );
-			assert.closeAbs( shared.setPrecision( 16 ), float( 0 ), 1e-3, 'same shared node in fp16 context' );
+			assertHalfEquals( assert, shared, float( 0 ), 'same shared node in fp16 context', 1e-3 );
 
-		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
+		}, NATIVE_F16_OPTIONS );
 
 		gpuTest( 'Fn call can be evaluated in a 16-bit context', ( { assert } ) => {
 
@@ -75,9 +264,9 @@ export default QUnit.module( 'TSL', () => {
 
 			} );
 
-			assert.closeAbs( compute().setPrecision( 16 ), float( 0 ), 1e-3, 'whole function call uses fp16 intermediates' );
+			assertHalfEquals( assert, compute(), float( 0 ), 'whole function call uses fp16 intermediates', 1e-3 );
 
-		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
+		}, NATIVE_F16_OPTIONS );
 
 		gpuTest( 'normally typed uniform feeds contextual fp16 math', ( { assert } ) => {
 

--- a/test/unit/addons/tsl/TSLPrecision.tests.js
+++ b/test/unit/addons/tsl/TSLPrecision.tests.js
@@ -1,0 +1,90 @@
+import { DataTexture, DataUtils, HalfFloatType, NearestFilter, RedFormat } from 'three';
+import { Fn, float, mat3, mul, texture, uniform, vec2, vec3 } from 'three/tsl';
+import { gpuTest } from './gpu-test-utils.js';
+
+export default QUnit.module( 'TSL', () => {
+
+	QUnit.module( 'contextual precision', () => {
+
+		gpuTest( '16-bit context preserves ordinary arithmetic for exactly representable values', ( { assert } ) => {
+
+			assert.closeAbs( float( 1.5 ).add( 2.5 ).setPrecision( 16 ), float( 4.0 ), 1e-3, 'scalar addition' );
+			assert.closeAbs( vec3( 1, 2, 3 ).mul( vec3( 2, 3, 4 ) ).setPrecision( 16 ), vec3( 2, 6, 12 ), 1e-3, 'vector multiplication' );
+
+			const scale = mat3(
+				2, 0, 0,
+				0, 3, 0,
+				0, 0, 4
+			);
+
+			assert.closeAbs( mul( scale, vec3( 1, 1, 1 ) ).setPrecision( 16 ), vec3( 2, 3, 4 ), 1e-3, 'matrix-vector multiplication' );
+
+		} );
+
+		gpuTest( 'native 16-bit context rounds intermediate values', ( { assert } ) => {
+
+			const expression = float( 2048 ).add( 1 ).sub( 2048 );
+
+			assert.closeAbs( expression.setPrecision( 16 ), float( 0 ), 1e-3, '2048 + 1 rounds before subtracting in fp16' );
+
+		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
+
+		gpuTest( 'precision scope returns to fp32 outside the scoped expression', ( { assert } ) => {
+
+			const fp32 = float( 2048 ).add( 1 ).sub( 2048 );
+			const fp16ThenFp32 = float( 2048 ).add( 1 ).setPrecision( 16 ).sub( 2048 );
+
+			assert.closeAbs( fp32, float( 1 ), 1e-3, 'unscoped expression keeps fp32 precision' );
+			assert.closeAbs( fp16ThenFp32, float( 0 ), 1e-3, 'precision context result is promoted before surrounding fp32 math' );
+
+		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
+
+		gpuTest( 'shared node can be used in fp32 and fp16 contexts', ( { assert } ) => {
+
+			const shared = float( 2048 ).add( 1 ).sub( 2048 );
+
+			assert.closeAbs( shared, float( 1 ), 1e-3, 'shared node in default fp32 context' );
+			assert.closeAbs( shared.setPrecision( 16 ), float( 0 ), 1e-3, 'same shared node in fp16 context' );
+
+		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
+
+		gpuTest( 'Fn call can be evaluated in a 16-bit context', ( { assert } ) => {
+
+			const compute = Fn( () => {
+
+				return float( 2048 ).add( 1 ).sub( 2048 );
+
+			} );
+
+			assert.closeAbs( compute().setPrecision( 16 ), float( 0 ), 1e-3, 'whole function call uses fp16 intermediates' );
+
+		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
+
+		gpuTest( 'normally typed uniform feeds contextual fp16 math', ( { assert } ) => {
+
+			const value = uniform( 2, 'float' );
+
+			assert.closeAbs( value.add( 2 ).setPrecision( 16 ), float( 4 ), 1e-3, 'uniform remains normally declared and converts at the computation boundary' );
+
+		} );
+
+		gpuTest( 'HalfFloatType texture can feed contextual fp16 math', ( { assert } ) => {
+
+			const data = new Uint16Array( 1 );
+			data[ 0 ] = DataUtils.toHalfFloat( 2 );
+
+			const tex = new DataTexture( data, 1, 1, RedFormat, HalfFloatType );
+			tex.minFilter = NearestFilter;
+			tex.magFilter = NearestFilter;
+			tex.generateMipmaps = false;
+			tex.needsUpdate = true;
+
+			const sampled = texture( tex, vec2( 0, 0 ) ).x;
+
+			assert.closeAbs( sampled.add( 2 ).setPrecision( 16 ), float( 4 ), 1e-3, 'half-float texture format remains independent from compute precision' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/addons/tsl/TSLPrecision.tests.js
+++ b/test/unit/addons/tsl/TSLPrecision.tests.js
@@ -6,6 +6,15 @@ export default QUnit.module( 'TSL', () => {
 
 	QUnit.module( 'contextual precision', () => {
 
+		QUnit.test( 'getPrecision reports explicit precision scopes', ( assert ) => {
+
+			assert.strictEqual( float( 1 ).getPrecision(), null, 'nodes use default precision unless a scope is requested' );
+			assert.strictEqual( float( 1 ).add( 2 ).setPrecision( 16 ).getPrecision(), 16, 'setPrecision( 16 ) reports a 16-bit scope' );
+			assert.strictEqual( float( 1 ).add( 2 ).setPrecision( 32 ).getPrecision(), 32, 'setPrecision( 32 ) reports a 32-bit scope' );
+			assert.strictEqual( uniform( 1, 'float' ).setPrecision( 'high' ).getPrecision(), 'high', 'input declaration precision is preserved' );
+
+		} );
+
 		gpuTest( '16-bit context preserves ordinary arithmetic for exactly representable values', ( { assert } ) => {
 
 			assert.closeAbs( float( 1.5 ).add( 2.5 ).setPrecision( 16 ), float( 4.0 ), 1e-3, 'scalar addition' );
@@ -36,6 +45,16 @@ export default QUnit.module( 'TSL', () => {
 
 			assert.closeAbs( fp32, float( 1 ), 1e-3, 'unscoped expression keeps fp32 precision' );
 			assert.closeAbs( fp16ThenFp32, float( 0 ), 1e-3, 'precision context result is promoted before surrounding fp32 math' );
+
+		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
+
+		gpuTest( '32-bit context overrides an outer 16-bit context', ( { assert } ) => {
+
+			const fp32Scoped = float( 2048 ).add( 1 ).sub( 2048 ).setPrecision( 32 );
+			const nested = fp32Scoped.setPrecision( 16 );
+
+			assert.closeAbs( fp32Scoped, float( 1 ), 1e-3, 'setPrecision( 32 ) keeps fp32 arithmetic' );
+			assert.closeAbs( nested, float( 1 ), 1e-3, 'inner fp32 scope is preserved inside outer fp16 scope' );
 
 		}, { backends: [ 'webgpu' ], requiredFeatures: [ 'shader-f16' ] } );
 

--- a/test/unit/addons/tsl/TSLPrecision.tests.js
+++ b/test/unit/addons/tsl/TSLPrecision.tests.js
@@ -1,5 +1,5 @@
 import { DataTexture, DataUtils, HalfFloatType, NearestFilter, RedFormat } from 'three';
-import { Fn, cos, cross, distance, dot, float, length, mat2, mat3, mat4, mix, mul, normalize, reflect, refract, sin, tan, texture, uniform, vec2, vec3, vec4 } from 'three/tsl';
+import { Fn, Loop, cos, cross, distance, dot, float, length, mat2, mat3, mat4, mix, mul, mx_noise_float, normalize, reflect, refract, sin, tan, texture, uniform, vec2, vec3, vec4 } from 'three/tsl';
 import { gpuTest } from './gpu-test-utils.js';
 
 const HALF_ULP_QUARTER_AT_ONE = 1 / 4096;
@@ -265,6 +265,95 @@ export default QUnit.module( 'TSL', () => {
 			} );
 
 			assertHalfEquals( assert, compute(), float( 0 ), 'whole function call uses fp16 intermediates', 1e-3 );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'swizzled vector resources convert at a 16-bit operator boundary', ( { assert } ) => {
+
+			const position = uniform( vec3( 1, 0, 1 ), 'vec3' );
+			const offset = uniform( vec2( 2, 3 ), 'vec2' );
+
+			assert.closeAbs( position.xz.add( offset ).setPrecision( 16 ), vec2( 3, 4 ), 1e-3, 'fp32 vector swizzles and uniforms convert before the operator emits code' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'Fn call converts swizzled vector inputs and uniforms in a 16-bit context', ( { assert } ) => {
+
+			const offset = uniform( vec2( 2, 3 ), 'vec2' );
+			const compute = Fn( ( [ position ] ) => {
+
+				return position.xz.add( offset );
+
+			} );
+
+			assert.closeAbs( compute( vec3( 1, 0, 1 ) ).setPrecision( 16 ), vec2( 3, 4 ), 1e-3, 'fp32 vector swizzles and uniforms convert at the operator boundary' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'Fn call converts nested scalar resource operations in a 16-bit context', ( { assert } ) => {
+
+			const frequency = uniform( vec2( 3, 1 ), 'vec2' );
+			const speed = uniform( 1.25, 'float' );
+			const multiplier = uniform( 0.15, 'float' );
+			const compute = Fn( ( [ position ] ) => {
+
+				return sin( position.x.mul( frequency.x ).add( float( 1 ).mul( speed ) ) ).mul( multiplier );
+
+			} );
+
+			assert.closeAbs( compute( vec3( 1, 0, 1 ) ).setPrecision( 16 ), compute( vec3( 1, 0, 1 ) ).setPrecision( 32 ), 1e-2, 'nested fp32 scalar resource operations convert before mixing with fp16 terms' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( '16-bit addAssign converts a nested 32-bit term', ( { assert } ) => {
+
+			const compute = Fn( () => {
+
+				const sum = float( 1 ).toVar();
+
+				sum.addAssign( float( 1 ).setPrecision( 32 ) );
+
+				return sum;
+
+			} );
+
+			assert.closeAbs( compute().setPrecision( 16 ), float( 2 ), 1e-2, 'nested fp32 addend converts before addAssign in an fp16 scope' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( '16-bit loop addAssign converts a nested 32-bit term', ( { assert } ) => {
+
+			const compute = Fn( () => {
+
+				const elevation = float( 0 ).toVar();
+
+				Loop( { type: 'float', start: float( 1 ), end: float( 2 ), condition: '<' }, ( { i } ) => {
+
+					elevation.addAssign( mx_noise_float( vec2( i, 1.25 ), 1, 0 ).setPrecision( 32 ).div( i.add( 1 ) ) );
+
+				} );
+
+				return elevation;
+
+			} );
+
+			assert.closeAbs( compute().setPrecision( 16 ), compute().setPrecision( 32 ), 1, 'loop addAssign converts nested fp32 noise into the surrounding fp16 temporary' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'constructor converts unary uniform operands in a 16-bit context', ( { assert } ) => {
+
+			const shift = uniform( 0.25, 'float' );
+
+			assert.closeAbs( vec3( 0, 0, shift.negate() ).setPrecision( 16 ), vec3( 0, 0, - 0.25 ), 1e-3, 'unary uniform operands convert before entering an fp16 vector constructor' );
+
+		}, NATIVE_F16_OPTIONS );
+
+		gpuTest( 'overloaded functions match precision-lowered vector inputs by base type', ( { assert } ) => {
+
+			const noise = mx_noise_float( vec3( 1.25, 2.5, 3.75 ) );
+
+			assert.closeAbs( noise.setPrecision( 16 ), noise.setPrecision( 32 ), 1, 'hvec3 input selects the vec3 overload instead of the vec2 overload' );
 
 		}, NATIVE_F16_OPTIONS );
 

--- a/test/unit/addons/tsl/gpu-test-utils.js
+++ b/test/unit/addons/tsl/gpu-test-utils.js
@@ -28,9 +28,9 @@
 // compiles down to a tiny custom Node (AssertWriteNode) whose setup() asks
 // the builder for the real type.
 //
-// Matrix support (mat3/mat4): a single `vec4` row can't hold 9 or 16 floats.
-// A matrix value is represented as `columns` column-vectors (mat3: 3 x vec3,
-// mat4: 4 x vec4 -- see `MATRIX_LAYOUT`/NodeBuilder.getElementType), each
+// Matrix support (mat2/mat3/mat4): a single `vec4` row can't hold all matrix values.
+// A matrix value is represented as `columns` column-vectors (mat2: 2 x vec2,
+// mat3: 3 x vec3, mat4: 4 x vec4 -- see `MATRIX_LAYOUT`/NodeBuilder.getElementType), each
 // zero-padded to a vec4 exactly like a plain vector value. `AssertWriteNode`
 // resolves this layout once real type info exists (`setup(builder)`) and
 // then, for each column, calls a `writeColumn(c, actualVec4, expectedVec4)`
@@ -81,9 +81,10 @@ export const Kind = {
 const SWIZZLE = [ 'x', 'y', 'z', 'w' ];
 
 // Matrix types are represented as `columns` column-vectors of `columnLength`
-// components each (mat3: 3 x vec3, mat4: 4 x vec4) -- see gpu-test-utils.js
+// components each (mat2: 2 x vec2, mat3: 3 x vec3, mat4: 4 x vec4) -- see gpu-test-utils.js
 // file header and NodeBuilder.getTypeLength/getElementType.
 const MATRIX_LAYOUT = {
+	mat2: { columns: 2, columnLength: 2 },
 	mat3: { columns: 3, columnLength: 3 },
 	mat4: { columns: 4, columnLength: 4 }
 };
@@ -113,7 +114,7 @@ function toVec4( value, count ) {
 }
 
 // Resolves how many "columns" a type needs and how long each column is.
-// Vectors/scalars are a single column of their own length; mat3/mat4 are
+// Vectors/scalars are a single column of their own length; matrices are
 // `MATRIX_LAYOUT`-many columns of their own (shorter) length.
 function resolveLayout( type, builder ) {
 
@@ -129,7 +130,7 @@ function resolveLayout( type, builder ) {
 
 	if ( count > 4 ) {
 
-		throw new Error( `gpuTest: type "${ type }" (${ count } components) is not supported -- only scalars, vecN, mat3 and mat4 are.` );
+		throw new Error( `gpuTest: type "${ type }" (${ count } components) is not supported -- only scalars, vecN, mat2, mat3 and mat4 are.` );
 
 	}
 
@@ -140,7 +141,7 @@ function resolveLayout( type, builder ) {
 // A statement node: at real shader-build time (setup(builder), when a real
 // NodeBuilder -- and therefore real type information -- exists) it asks the
 // builder what type `value1`/`value2` resolved to, then hands each column
-// (1 for scalars/vectors, 3 or 4 for mat3/mat4), zero-padded to a vec4, to
+// (1 for scalars/vectors, 2 to 4 for matrices), zero-padded to a vec4, to
 // the caller-supplied `writeColumn(columnIndex, actualVec4, expectedVec4)`.
 // How -- and at what addressing cost -- a column actually gets written to a
 // buffer is entirely up to `writeColumn`; see `gpuTest`/`gpuFuzzTest` for the
@@ -204,7 +205,7 @@ class AssertWriteNode extends Node {
 		// instead of re-evaluating it. `.toVar()` sidesteps this by forcing
 		// the evaluation to happen up front, outside every branch, so each
 		// column's branch only ever *reads* an already-computed variable.
-		// (Recall multi-column values only arise for mat3/mat4 here since
+		// (Recall multi-column values only arise for matrices here since
 		// scalars/vectors are always a single column -- but `.toVar()` is
 		// cheap and correct for those too, so it's applied unconditionally.)
 		const v1 = this.value1.toVar();
@@ -571,7 +572,7 @@ function assertKernelRan( assert, data, row, name, kind = 'gpuTest' ) {
  * `maxAssertions * MAX_COLUMNS` rows -- every assertion reserves a fixed
  * `MAX_COLUMNS`-row stride (`row = assertionIndex * MAX_COLUMNS`), and only
  * uses as many of those rows as its resolved type needs (1 for a scalar/
- * vector, up to `MAX_COLUMNS` for a mat3/mat4). Each row is still written
+ * vector, up to `MAX_COLUMNS` for a matrix). Each row is still written
  * only via the bare `instanceIndex` node, guarded by
  * `If( instanceIndex.equal( row ), ... )`, per the file header's WebGL2
  * addressing constraint. This costs a larger (but cheap: still just 2
@@ -579,7 +580,7 @@ function assertKernelRan( assert, data, row, name, kind = 'gpuTest' ) {
  * invocations -- rather than more simultaneously-bound buffers, which is
  * the resource that's actually scarce on the WebGL2 fallback.
  *
- * Supports scalars, vecN and mat3/mat4 -- see the file header's "Matrix
+ * Supports scalars, vecN and mat2/mat3/mat4 -- see the file header's "Matrix
  * support" section.
  *
  * `maxAssertions` (default 64) sizes the backing buffers and dispatch count
@@ -719,7 +720,7 @@ export function gpuTest( name, buildFn, { maxAssertions = 64, backends = [ 'webg
  * `maxSitesPerInstance` (default 4) bounds how many `assert.*` calls buildFn
  * may make per invocation. `maxColumnsPerSite` (default 1) bounds how wide a
  * single site's value may be: 1 covers every scalar/vector type; pass 3 or 4
- * to allow a site to assert on a mat3/mat4. Both knobs spend the same scarce
+ * to allow a site to assert on a matrix. Both knobs spend the same scarce
  * resource -- WebGL2's fallback guarantees only a handful of simultaneously-
  * bound output buffers (spec minimum is 4) -- so `maxSitesPerInstance *
  * maxColumnsPerSite` total buffer pairs is a real budget, not just memory;
@@ -790,7 +791,7 @@ export function gpuFuzzTest( name, count, buildFn, { maxSitesPerInstance = 4, ma
 
 					if ( c >= maxColumnsPerSite ) {
 
-						throw new Error( `gpuFuzzTest "${ name }": a value at site ${ site } needs column ${ c + 1 }, more than maxColumnsPerSite (${ maxColumnsPerSite }); raise that option to assert on wider values (e.g. mat3/mat4).` );
+						throw new Error( `gpuFuzzTest "${ name }": a value at site ${ site } needs column ${ c + 1 }, more than maxColumnsPerSite (${ maxColumnsPerSite }); raise that option to assert on wider values (e.g. matrices).` );
 
 					}
 

--- a/test/unit/addons/tsl/gpu-test-utils.js
+++ b/test/unit/addons/tsl/gpu-test-utils.js
@@ -432,7 +432,13 @@ function buildAssertAPI( makeNode ) {
 // one, each gets a `[backend]` suffix so failures say which backend failed.
 // Backend availability is detected at runtime (see getSharedRenderer) rather
 // than assumed, so no static "skip this backend" flag is needed here.
-function declareTest( name, backends, run ) {
+function rendererHasFeature( renderer, feature ) {
+
+	return typeof renderer.hasFeature === 'function' && renderer.hasFeature( feature );
+
+}
+
+function declareTest( name, backends, requiredFeatures, run ) {
 
 	for ( const backend of backends ) {
 
@@ -450,6 +456,15 @@ function declareTest( name, backends, run ) {
 				// practical equivalent: it never fails the build, and the
 				// console.warn from getSharedRenderer explains why.
 				assert.ok( true, `SKIPPED: "${ backend }" backend is not available in this environment.` );
+				return;
+
+			}
+
+			const missingFeature = requiredFeatures.find( feature => rendererHasFeature( renderer, feature ) === false );
+
+			if ( missingFeature !== undefined ) {
+
+				assert.ok( true, `SKIPPED: "${ backend }" backend does not support "${ missingFeature }".` );
 				return;
 
 			}
@@ -576,9 +591,9 @@ function assertKernelRan( assert, data, row, name, kind = 'gpuTest' ) {
  * regression can't slip by unnoticed; narrow it (e.g. `[ 'webgpu' ]`) only
  * for a node that's deliberately WebGPU-only.
  */
-export function gpuTest( name, buildFn, { maxAssertions = 64, backends = [ 'webgpu', 'webgl' ] } = {} ) {
+export function gpuTest( name, buildFn, { maxAssertions = 64, backends = [ 'webgpu', 'webgl' ], requiredFeatures = [] } = {} ) {
 
-	declareTest( name, backends, async ( assert, renderer ) => {
+	declareTest( name, backends, requiredFeatures, async ( assert, renderer ) => {
 
 		const nodes = [];
 		const totalRows = maxAssertions * MAX_COLUMNS;
@@ -651,7 +666,7 @@ export function gpuTest( name, buildFn, { maxAssertions = 64, backends = [ 'webg
 
 			};
 
-			buildFn( { assert: buildAssertAPI( makeNode ) } );
+			buildFn( { assert: buildAssertAPI( makeNode ), renderer, hasFeature: feature => rendererHasFeature( renderer, feature ) } );
 
 		} )().compute( totalRows );
 
@@ -723,9 +738,9 @@ export function gpuTest( name, buildFn, { maxAssertions = 64, backends = [ 'webg
  *
  * `backends` (default `[ 'webgpu', 'webgl' ]`) -- see `gpuTest`.
  */
-export function gpuFuzzTest( name, count, buildFn, { maxSitesPerInstance = 4, maxColumnsPerSite = 1, backends = [ 'webgpu', 'webgl' ] } = {} ) {
+export function gpuFuzzTest( name, count, buildFn, { maxSitesPerInstance = 4, maxColumnsPerSite = 1, backends = [ 'webgpu', 'webgl' ], requiredFeatures = [] } = {} ) {
 
-	declareTest( name, backends, async ( assert, renderer ) => {
+	declareTest( name, backends, requiredFeatures, async ( assert, renderer ) => {
 
 		const nodes = []; // one entry per call site (not per instance)
 		const actualBuffers = []; // actualBuffers[site][column]
@@ -818,7 +833,7 @@ export function gpuFuzzTest( name, count, buildFn, { maxSitesPerInstance = 4, ma
 
 				nodes.length = 0;
 
-				buildFn( { instanceIndex, assert: buildAssertAPI( makeNode ) } );
+				buildFn( { instanceIndex, assert: buildAssertAPI( makeNode ), renderer, hasFeature: feature => rendererHasFeature( renderer, feature ) } );
 
 			} );
 

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -25,6 +25,7 @@ import './addons/tsl/TSLBRDF.tests.js';
 import './addons/tsl/TSLDepthConversion.tests.js';
 import './addons/tsl/TSLColorSpaceConversion.tests.js';
 import './addons/tsl/TSLTypeConstructors.tests.js';
+import './addons/tsl/TSLPrecision.tests.js';
 import './addons/tsl/TSLBitOps.tests.js';
 import './addons/tsl/TSLNoise.tests.js';
 import './addons/tsl/TSLMath.tests.js';


### PR DESCRIPTION
### Description

This PR adds contextual FP16 support to TSL through `setPrecision( 16 )`, while keeping the public TSL type surface as `float`, `vec*`, and `mat*`.  This is based on @sunag's suggestion here: https://github.com/mrdoob/three.js/issues/34335#issuecomment-5377138194

Precision now acts as a scoped compute policy. TSL expressions, temporaries, and function calls can lower to native WGSL `f16` when the WebGPU device supports `shader-f16`. Uniforms, storage buffers, attributes, and textures keep their existing declarations and layouts; their values convert only when they enter a scoped FP16 expression.

The PR also adds `setPrecision( 32 )` as an explicit fp32 scope and `getPrecision()` for reading an active precision request.

### Examples

```js
// The whole expression runs in the scoped FP16 compute context.
material.colorNode = sin( normalWorld ).mul( 0.5 ).add( 0.5 ).setPrecision( 16 );
```

```js
// `expensiveTerm()` stays FP32, then converts when it enters the outer FP16 expression.
const fp32Term = expensiveTerm().setPrecision( 32 );

material.colorNode = fp32Term.add( halfPrecisionTerm ).setPrecision( 16 );
```

### Testing

- Added `TSLPrecision.tests.js` for scoped FP16 arithmetic, nested 16/32-bit scopes, shared-node cache isolation, `Fn()` propagation, and resource inputs.
- Added feature gating to the GPU test helper for tests that require `shader-f16`.
- `npm test`

