### PR TITLE
DenoiseNode: Dispose internal noise texture.

### DIFF
--- a/examples/jsm/tsl/display/DenoiseNode.js
+++ b/examples/jsm/tsl/display/DenoiseNode.js
@@ -57,11 +57,19 @@ class DenoiseNode extends TempNode {
 		this.normalNode = normalNode;
 
 		/**
+		 * The internal noise texture.
+		 *
+		 * @private
+		 * @type {DataTexture}
+		 */
+		this._noiseTexture = generateDefaultNoise();
+
+		/**
 		 * The node represents the internal noise texture.
 		 *
 		 * @type {TextureNode}
 		 */
-		this.noiseNode = texture( generateDefaultNoise() );
+		this.noiseNode = texture( this._noiseTexture );
 
 		/**
 		 * The luma Phi value.
@@ -249,6 +257,18 @@ class DenoiseNode extends TempNode {
 		const outputNode = output();
 
 		return outputNode;
+
+	}
+
+	/**
+	 * Frees internal resources. This method should be called
+	 * when the effect is no longer required.
+	 */
+	dispose() {
+
+		this._noiseTexture.dispose();
+
+		super.dispose();
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

`DenoiseNode` creates a private noise `DataTexture`, but previously inherited `Node.dispose()`, which only dispatches the node's `dispose` event. The owned texture therefore never received a `dispose` event when the effect was discarded.

Store the generated texture separately and dispose it before calling `super.dispose()`. This preserves the inherited node event while releasing the owned GPU texture, matching the ownership pattern used by `GTAONode` in #34369.

**Testing**

- `npm test` (1315 core tests passed, 1 todo; 348 addon tests passed)
- `npm run lint-addons`
- Verified that calling `DenoiseNode.dispose()` dispatches both the internal texture and node `dispose` events
