### PR TITLE
Nodes: More consistent `dispose()` usage.

### DIFF
--- a/examples/jsm/lighting/vxgi/VXGINode.js
+++ b/examples/jsm/lighting/vxgi/VXGINode.js
@@ -633,6 +633,8 @@ class VXGINode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._renderTarget.dispose();
 		this._material.dispose();
 		this.volume.dispose();

--- a/examples/jsm/tsl/display/AfterImageNode.js
+++ b/examples/jsm/tsl/display/AfterImageNode.js
@@ -231,6 +231,8 @@ class AfterImageNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._compRT.dispose();
 		this._oldRT.dispose();
 

--- a/examples/jsm/tsl/display/BilateralBlurNode.js
+++ b/examples/jsm/tsl/display/BilateralBlurNode.js
@@ -324,6 +324,8 @@ class BilateralBlurNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._horizontalRT.dispose();
 		this._verticalRT.dispose();
 

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -467,6 +467,8 @@ class BloomNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		for ( let i = 0; i < this._renderTargetsHorizontal.length; i ++ ) {
 
 			this._renderTargetsHorizontal[ i ].dispose();

--- a/examples/jsm/tsl/display/DenoiseNode.js
+++ b/examples/jsm/tsl/display/DenoiseNode.js
@@ -266,9 +266,9 @@ class DenoiseNode extends TempNode {
 	 */
 	dispose() {
 
-		this._noiseTexture.dispose();
-
 		super.dispose();
+
+		this._noiseTexture.dispose();
 
 	}
 

--- a/examples/jsm/tsl/display/DepthOfFieldNode.js
+++ b/examples/jsm/tsl/display/DepthOfFieldNode.js
@@ -534,6 +534,8 @@ class DepthOfFieldNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._CoCRT.dispose();
 		this._CoCBlurredRT.dispose();
 		this._blur64RT.dispose();

--- a/examples/jsm/tsl/display/FSR1Node.js
+++ b/examples/jsm/tsl/display/FSR1Node.js
@@ -454,6 +454,8 @@ class FSR1Node extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._easuRT.dispose();
 		this._rcasRT.dispose();
 

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -596,6 +596,8 @@ class GTAONode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._aoRenderTarget.dispose();
 
 		this._noiseTexture.dispose();

--- a/examples/jsm/tsl/display/GodraysNode.js
+++ b/examples/jsm/tsl/display/GodraysNode.js
@@ -593,6 +593,8 @@ class GodraysNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._godraysRenderTarget.dispose();
 
 		this._material.dispose();

--- a/examples/jsm/tsl/display/LensflareNode.js
+++ b/examples/jsm/tsl/display/LensflareNode.js
@@ -253,6 +253,8 @@ class LensflareNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._renderTarget.dispose();
 		this._material.dispose();
 

--- a/examples/jsm/tsl/display/OutlineNode.js
+++ b/examples/jsm/tsl/display/OutlineNode.js
@@ -748,6 +748,8 @@ class OutlineNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.selectedObjects.length = 0;
 
 		this._renderTargetDepthBuffer.dispose();

--- a/examples/jsm/tsl/display/RecurrentDenoiseNode.js
+++ b/examples/jsm/tsl/display/RecurrentDenoiseNode.js
@@ -890,6 +890,8 @@ class RecurrentDenoiseNode extends TempNode {
 
 	dispose() {
 
+		super.dispose();
+
 		this._renderTarget.dispose();
 		this._material.dispose();
 

--- a/examples/jsm/tsl/display/SMAANode.js
+++ b/examples/jsm/tsl/display/SMAANode.js
@@ -675,6 +675,8 @@ class SMAANode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._renderTargetEdges.dispose();
 		this._renderTargetWeights.dispose();
 		this._renderTargetBlend.dispose();

--- a/examples/jsm/tsl/display/SSAONode.js
+++ b/examples/jsm/tsl/display/SSAONode.js
@@ -409,6 +409,8 @@ class SSAONode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._aoRenderTarget.dispose();
 		this._blurRenderTarget.dispose();
 

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -665,6 +665,8 @@ class SSGINode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._ssgiRenderTarget.dispose();
 
 		this._material.dispose();

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -1317,6 +1317,8 @@ class SSRNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._ssrRenderTarget.dispose();
 		this._blurRenderTarget.dispose();
 

--- a/examples/jsm/tsl/display/SSSNode.js
+++ b/examples/jsm/tsl/display/SSSNode.js
@@ -468,6 +468,8 @@ class SSSNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._sssRenderTarget.dispose();
 
 		this._material.dispose();

--- a/examples/jsm/tsl/display/SharpenNode.js
+++ b/examples/jsm/tsl/display/SharpenNode.js
@@ -259,6 +259,8 @@ class SharpenNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._renderTarget.dispose();
 
 		if ( this._material !== null ) this._material.dispose();

--- a/examples/jsm/tsl/display/TAAUNode.js
+++ b/examples/jsm/tsl/display/TAAUNode.js
@@ -791,6 +791,8 @@ class TAAUNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._historyRenderTarget.dispose();
 		this._resolveRenderTarget.dispose();
 		this._previousDepthRenderTarget.dispose();

--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -722,6 +722,8 @@ class TRAANode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this._historyRenderTarget.dispose();
 		this._resolveRenderTarget.dispose();
 

--- a/examples/jsm/tsl/display/TemporalReprojectNode.js
+++ b/examples/jsm/tsl/display/TemporalReprojectNode.js
@@ -983,6 +983,8 @@ class TemporalReprojectNode extends TempNode {
 
 	dispose() {
 
+		super.dispose();
+
 		this._previousNormalTexture.dispose();
 
 		if ( this._previousDepthNode.value !== this._historyRenderTarget.depthTexture ) {

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -1039,6 +1039,8 @@ class PassNode extends TempNode {
 	 */
 	dispose() {
 
+		super.dispose();
+
 		this.renderTarget.dispose();
 
 	}

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -111,15 +111,6 @@ class ComputeNode extends Node {
 	}
 
 	/**
-	 * Executes the `dispose` event for this node.
-	 */
-	dispose() {
-
-		this.dispatchEvent( { type: 'dispose' } );
-
-	}
-
-	/**
 	 * Sets the {@link ComputeNode#name} property.
 	 *
 	 * @param {string} name - The name of the uniform.


### PR DESCRIPTION
Related issue: -

**Description**

The PR makes sure node classes that overwrite `dispose()` actually call `super.dispose()`. Otherwise the `dispose` event for that node is never dispatched.