### PR TITLE
WebGPURenderer: Fix integer array texture bindings

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -873,21 +873,8 @@ ${ flowData.code }
 				const textureNode = uniform.node;
 				const texture = textureNode.value;
 
-				let typePrefix = '';
-
-				if ( texture.isDataTexture === true || texture.isData3DTexture === true ) {
-
-					if ( texture.type === UnsignedIntType ) {
-
-						typePrefix = 'u';
-
-					} else if ( texture.type === IntType ) {
-
-						typePrefix = 'i';
-
-					}
-
-				}
+				const componentType = this.getComponentTypeFromTexture( texture );
+				const typePrefix = componentType === 'float' ? '' : componentType.charAt( 0 );
 
 				if ( uniform.type === 'texture3D' && texture.isArrayTexture === false ) {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -2168,8 +2168,6 @@ ${ flowData.code }
 
 				}
 
-				const componentPrefix = this.getComponentTypeFromTexture( texture ).charAt( 0 );
-
 				if ( texture.isCubeTexture === true && texture.isDepthTexture === true ) {
 
 					textureType = 'texture_depth_cube';
@@ -2204,10 +2202,12 @@ ${ flowData.code }
 
 				} else if ( texture.isArrayTexture === true || texture.isDataArrayTexture === true || texture.isCompressedArrayTexture === true ) {
 
+					const componentPrefix = this.getComponentTypeFromTexture( texture ).charAt( 0 );
 					textureType = `texture_2d_array<${ componentPrefix }32>`;
 
 				} else if ( texture.is3DTexture === true || texture.isData3DTexture === true ) {
 
+					const componentPrefix = this.getComponentTypeFromTexture( texture ).charAt( 0 );
 					textureType = `texture_3d<${ componentPrefix }32>`;
 
 				} else {

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -2202,7 +2202,9 @@ ${ flowData.code }
 
 				} else if ( texture.isArrayTexture === true || texture.isDataArrayTexture === true || texture.isCompressedArrayTexture === true ) {
 
-					textureType = 'texture_2d_array<f32>';
+					const componentPrefix = this.getComponentTypeFromTexture( texture ).charAt( 0 );
+
+					textureType = `texture_2d_array<${ componentPrefix }32>`;
 
 				} else if ( texture.is3DTexture === true || texture.isData3DTexture === true ) {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -2168,6 +2168,8 @@ ${ flowData.code }
 
 				}
 
+				const componentPrefix = this.getComponentTypeFromTexture( texture ).charAt( 0 );
+
 				if ( texture.isCubeTexture === true && texture.isDepthTexture === true ) {
 
 					textureType = 'texture_depth_cube';
@@ -2202,13 +2204,11 @@ ${ flowData.code }
 
 				} else if ( texture.isArrayTexture === true || texture.isDataArrayTexture === true || texture.isCompressedArrayTexture === true ) {
 
-					const componentPrefix = this.getComponentTypeFromTexture( texture ).charAt( 0 );
-
 					textureType = `texture_2d_array<${ componentPrefix }32>`;
 
 				} else if ( texture.is3DTexture === true || texture.isData3DTexture === true ) {
 
-					textureType = 'texture_3d<f32>';
+					textureType = `texture_3d<${ componentPrefix }32>`;
 
 				} else {
 


### PR DESCRIPTION
Fixed #34420

**Description**

Uses the existing texture component type detection when declaring sampled array texture bindings in WGSL.

Unsigned and signed integer array textures now generate `texture_2d_array<u32>` and `texture_2d_array<i32>` respectively instead of always generating `texture_2d_array<f32>`.

Validation:

- `npm run lint`
- `npm run build`
