### PR TITLE
StorageTextureNode: Preserve integer store values

### DIFF
--- a/src/nodes/accessors/StorageTextureNode.js
+++ b/src/nodes/accessors/StorageTextureNode.js
@@ -260,7 +260,8 @@ class StorageTextureNode extends TextureNode {
 
 		const textureProperty = super.generate( builder, 'property' );
 		const uvSnippet = uvNode.build( builder, this.value.is3DTexture === true ? 'uvec3' : 'uvec2' );
-		const storeSnippet = storeNode.build( builder, 'vec4' );
+		const storeType = builder.getTypeFromLength( 4, builder.getComponentTypeFromTexture( this.value ) );
+		const storeSnippet = storeNode.build( builder, storeType );
 		const depthSnippet = depthNode ? depthNode.build( builder, 'int' ) : null;
 
 		const snippet = builder.generateTextureStore( this.value, textureProperty, uvSnippet, depthSnippet, storeSnippet );


### PR DESCRIPTION
Fixed #34421

**Description**

Builds storage texture store values using the component type of the target texture.

Integer storage textures now preserve `uvec4` or `ivec4` values instead of coercing every store value to `vec4`, which generated an invalid WGSL `textureStore()` call.

Validation:

- `npm run lint`
- `npm run build`