### PR TITLE
WebGPURenderer: Fix viewport regression with array cameras.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1266,7 +1266,7 @@ class WebGLBackend extends Backend {
 
 			const renderTarget = this._currentContext.renderTarget;
 
-			const pixelRatio = renderTarget !== null ? 1 : this.renderer.getPixelRatio();
+			const pixelRatio = ( renderTarget === null || renderTarget.isPostProcessingRenderTarget === true ) ? this.renderer.getPixelRatio() : 1;
 			const isRenderCameraDepthArray = this._isRenderCameraDepthArray( this._currentContext );
 			const prevActiveCubeFace = this._currentContext.activeCubeFace;
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2257,7 +2257,8 @@ class WebGPUBackend extends Backend {
 
 			}
 
-			const pixelRatio = context.renderTarget !== null ? 1 : this.renderer.getPixelRatio();
+			const renderTarget = context.renderTarget;
+			const pixelRatio = ( renderTarget === null || renderTarget.isPostProcessingRenderTarget === true ) ? this.renderer.getPixelRatio() : 1;
 			const indexPos = cameraIndex ? bindings.indexOf( cameraIndex ) : - 1;
 
 			for ( let i = 0, len = cameras.length; i < len; i ++ ) {


### PR DESCRIPTION
Related issue: #34333

**Description**

This is a fix for #34333 which introduces a small regression. I've noticed `webgpu_camera_array` only rendered in a quarter view on my system (DPR 2) and I've eventually realized the assumptions in #34333 are incomplete. The pixel ratio scaling must be honored when rendering to the canvas and that includes the internal framebuffer target.

The E2E tests did not catch this regression because they run with a DPR of 1.
