### PR TITLE
TSL Bug: Fix bitcast(uint, 'int')'s GLSL polyfill return type

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -11,7 +11,7 @@ import { error } from '../../../utils.js';
 
 const glslPolyfills = {
 	bitcast_int_uint: new CodeNode( /* glsl */'uint tsl_bitcast_int_to_uint ( int x ) { return floatBitsToUint( intBitsToFloat ( x ) ); }' ),
-	bitcast_uint_int: new CodeNode( /* glsl */'uint tsl_bitcast_uint_to_int ( uint x ) { return floatBitsToInt( uintBitsToFloat ( x ) ); }' ),
+	bitcast_uint_int: new CodeNode( /* glsl */'int tsl_bitcast_uint_to_int ( uint x ) { return floatBitsToInt( uintBitsToFloat ( x ) ); }' ),
 	textureGather: new CodeNode( /* glsl */`
 vec4 tsl_textureGather( const int comp, sampler2D map, vec2 coord, ivec2 offset, bool flipY ) {
 	if ( flipY ) offset.y = - offset.y;

--- a/test/unit/addons/tsl/TSLBitOps.tests.js
+++ b/test/unit/addons/tsl/TSLBitOps.tests.js
@@ -24,6 +24,19 @@ export default QUnit.module( 'TSL', () => {
 
 		} );
 
+		gpuTest( 'bitcast() reinterprets bits between int and uint', ( { assert } ) => {
+
+			// -1's two's-complement bit pattern (0xFFFFFFFF) read as unsigned
+			// is the largest uint32 value.
+			assert.eq( bitcast( int( - 1 ), 'uint' ), uint( 4294967295 ), 'bitcast(-1, "uint") == 0xFFFFFFFF' );
+			assert.eq( bitcast( uint( 4294967295 ), 'int' ), int( - 1 ), 'bitcast(0xFFFFFFFF, "int") == -1' );
+
+			// Round trip: bitcast is lossless reinterpretation, so converting
+			// out and back must recover the exact original value.
+			assert.eq( bitcast( bitcast( int( - 42 ), 'uint' ), 'int' ), int( - 42 ), 'bitcast round trip recovers the exact int' );
+
+		} );
+
 	} );
 
 	QUnit.module( 'bit counting', () => {


### PR DESCRIPTION
## Problem

`GLSLNodeBuilder`'s `bitcast_uint_int` polyfill was declared:

```glsl
uint tsl_bitcast_uint_to_int ( uint x ) { return floatBitsToInt( uintBitsToFloat ( x ) ); }
```

`floatBitsToInt()` returns `int`, but the function is declared to return
`uint` — a type mismatch GLSL rejects outright. Any TSL code calling
`bitcast(uintValue, 'int')` on the WebGL backend fails to compile/link.

## Fix

One-character fix: declare the function `int`, matching its body.

## Verification

Added a regression test (`bitcast() reinterprets bits between int and
uint`) to `TSLBitOps.tests.js`. Confirmed it fails before this fix and
passes after, isolating it as the very first WebGL compute kernel of the
process so a stale kernel from an earlier test can't mask the failure (see
the `gpu-test-random-canary` branch this one is built on, which makes that
unnecessary for future tests). Full addons suite: 350/350 passing.

Depends on `fix/gpu-test-random-canary`. PR #34427