### PR TITLE
TSL Bug: Fix subgroup broadcast first param length

### DIFF
--- a/src/nodes/gpgpu/SubgroupFunctionNode.js
+++ b/src/nodes/gpgpu/SubgroupFunctionNode.js
@@ -481,10 +481,9 @@ export const subgroupAny = /*@__PURE__*/ nodeProxyIntent( SubgroupFunctionNode, 
  * @tsl
  * @method
  * @param {number} e - The value to broadcast from the lowest subgroup invocation.
- * @param {number} id - The subgroup invocation to broadcast from.
  * @return {number} The broadcast value.
  */
-export const subgroupBroadcastFirst = /*@__PURE__*/ nodeProxyIntent( SubgroupFunctionNode, SubgroupFunctionNode.SUBGROUP_BROADCAST_FIRST ).setParameterLength( 2 );
+export const subgroupBroadcastFirst = /*@__PURE__*/ nodeProxyIntent( SubgroupFunctionNode, SubgroupFunctionNode.SUBGROUP_BROADCAST_FIRST ).setParameterLength( 1 );
 
 /**
  * Swaps e between invocations in the quad in the X direction.

--- a/test/unit/addons/tsl/GPUSubgroupBroadcastFirst.tests.js
+++ b/test/unit/addons/tsl/GPUSubgroupBroadcastFirst.tests.js
@@ -1,0 +1,58 @@
+import {
+	Fn,
+	instanceIndex, invocationSubgroupIndex,
+	instancedArray, subgroupBroadcastFirst,
+	uint
+} from 'three/tsl';
+import { rawComputeTest, readUintBuffer } from './gpu-raw-test-utils.js';
+
+// Regression test for a bug fixed alongside this file: subgroupBroadcastFirst()
+// was declared with `setParameterLength(2)` in SubgroupFunctionNode.js, but
+// per the WGSL spec it takes exactly one argument
+// (`subgroupBroadcastFirst(e: T) -> T` -- no lane id, unlike
+// subgroupBroadcast). Calling it correctly (one argument) made three.js
+// auto-pad a bogus second argument, producing invalid WGSL ("no matching
+// call to 'subgroupBroadcastFirst(f32, abstract-float)'"). See
+// GPUSubgroup.tests.js for the rest of this codebase's subgroup coverage and
+// the general approach.
+
+const WORKGROUP_SIZE = 64;
+const WORKGROUP_COUNT = 4;
+const DISPATCH_COUNT = WORKGROUP_SIZE * WORKGROUP_COUNT;
+
+// See GPUSubgroup.tests.js's matching comment: a plain numeric `count` in
+// `.compute(count, ws)` auto-inserts a bounds-check branch that violates
+// WGSL's "subgroup functions need uniform control flow" rule.
+const DISPATCH_SIZE = [ WORKGROUP_COUNT, 1, 1 ];
+
+export default QUnit.module( 'TSL', () => {
+
+	QUnit.module( 'subgroup functions', () => {
+
+		rawComputeTest( 'subgroupBroadcastFirst reads the first active lane\'s value', { requiredFeature: 'subgroups' }, async ( { assert, renderer } ) => {
+
+			const output = instancedArray( DISPATCH_COUNT, 'uint' );
+
+			const kernel = Fn( () => {
+
+				const value = invocationSubgroupIndex.add( uint( 100 ) ); // 100, 101, 102, ...
+
+				output.element( instanceIndex ).assign( subgroupBroadcastFirst( value ) );
+
+			} )().compute( DISPATCH_SIZE, [ WORKGROUP_SIZE ] );
+
+			await renderer.computeAsync( kernel );
+
+			const data = await readUintBuffer( renderer, output );
+
+			for ( let i = 0; i < DISPATCH_COUNT; i ++ ) {
+
+				assert.strictEqual( data[ i ], 100, `invocation ${ i }: subgroupBroadcastFirst(value) should read back the first lane's value (100)` );
+
+			}
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -21,6 +21,7 @@ import './addons/tsl/GPUComputeBuiltins.tests.js';
 import './addons/tsl/GPUBarriers.tests.js';
 import './addons/tsl/GPUSubgroup.tests.js';
 import './addons/tsl/GPUWorkgroupAtomic.tests.js';
+import './addons/tsl/GPUSubgroupBroadcastFirst.tests.js';
 import './addons/tsl/TSLDeterminant.tests.js';
 import './addons/tsl/TSLFaceForward.tests.js';
 import './addons/tsl/TSLGainPcurve.tests.js';


### PR DESCRIPTION
`subgroupBroadcastFirst()` is declared with `setParameterLength(2)` in `SubgroupFunctionNode.js`, but per the WGSL spec it takes exactly one argument (`subgroupBroadcastFirst(e: T) -> T` — no lane id, unlike `subgroupBroadcast`, which does take one). Calling it the correct, TSL spec-compliant way (one argument) makes three.js auto-pad a bogus second argument to satisfy the declared minimum, producing invalid WGSL (`no matching call to 'subgroupBroadcastFirst(f32, abstract-float)'`).

Fixes it to `setParameterLength(1)` and removes an erroneous `@param id` doc line that had been copy-pasted from `subgroupBroadcast`. Includes a regression test (`GPUSubgroupBroadcastFirst.tests.js`) that fails without this fix and passes with it.

Built on https://github.com/mrdoob/three.js/pull/34431 (the GPU compute test coverage PR) — rebase onto `dev` directly if that one lands first.
