### PR TITLE
npm: Add export for package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "import": "./build/three.module.js",
       "require": "./build/three.cjs"
     },
+    "./package.json": "./package.json",
     "./examples/fonts/*": "./examples/fonts/*",
     "./examples/jsm/*": "./examples/jsm/*",
     "./addons": "./examples/jsm/Addons.js",


### PR DESCRIPTION
Fixed #34445.

**Description**

`three/package.json` is not listed in the `exports` map, so importing it to read the installed version fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` and the only workaround is guessing the path on disk. The file is already part of the published package via `files`, so this just makes it resolvable, for both `import` and `require`.
