### PR TITLE
TextureNode: allow for non-mergeable uniforms

### DIFF
--- a/src/nodes/accessors/CubeTextureNode.js
+++ b/src/nodes/accessors/CubeTextureNode.js
@@ -205,11 +205,19 @@ export const cubeTexture = ( value = EmptyTexture, uvNode = null, levelNode = nu
 };
 
 /**
- * TSL function for creating a uniform cube texture node.
+ * TSL function for creating a non-mergeable uniform cube texture node.
  *
  * @tsl
  * @function
  * @param {?CubeTexture} [value=EmptyTexture] - The cube texture.
  * @returns {CubeTextureNode}
  */
-export const uniformCubeTexture = ( value = EmptyTexture ) => cubeTextureBase( value );
+export const uniformCubeTexture = ( value = EmptyTexture ) => {
+
+	const textureNode = cubeTextureBase( value );
+
+	textureNode.mergeable = false;
+
+	return textureNode;
+
+};

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -155,6 +155,15 @@ class TextureNode extends UniformNode {
 		this.referenceNode = null;
 
 		/**
+		 * The mergeable value is stored in a private property.
+		 *
+		 * @private
+		 * @type {boolean}
+		 * @default true
+		 */
+		this._mergeable = true;
+
+		/**
 		 * The texture value is stored in a private property.
 		 *
 		 * @private
@@ -193,6 +202,32 @@ class TextureNode extends UniformNode {
 
 	}
 
+	set mergeable( value ) {
+
+		if ( this.referenceNode ) {
+
+			this.referenceNode.mergeable = value;
+
+		} else {
+
+			this._mergeable = value;
+
+		}
+
+	}
+
+	/**
+	 * Whether the uniform may be merged with other uniforms at compile-time.
+	 *
+	 * @type {boolean}
+	 * @default true
+	 */
+	get mergeable() {
+
+		return this.referenceNode ? this.referenceNode.mergeable : this._mergeable;
+
+	}
+
 	set value( value ) {
 
 		if ( this.referenceNode ) {
@@ -219,12 +254,24 @@ class TextureNode extends UniformNode {
 	}
 
 	/**
-	 * Overwritten since the uniform hash is defined by the texture's UUID.
+	 * Overwritten since the uniform hash is defined by the texture's UUID - if mergeable - and the hash of its reference node otherwise.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
 	 * @return {string} The uniform hash.
 	 */
-	getUniformHash( /*builder*/ ) {
+	getUniformHash( builder ) {
+
+		if ( this.referenceNode && ! this.referenceNode.mergeable ) {
+
+			return this.referenceNode.getHash( builder );
+
+		}
+
+		if ( ! this._mergeable ) {
+
+			return this.getHash( builder );
+
+		}
 
 		return this.value.uuid;
 
@@ -1011,14 +1058,22 @@ export const texture = ( value = EmptyTexture, uvNode = null, levelNode = null, 
 };
 
 /**
- * TSL function for creating a uniform texture node.
+ * TSL function for creating a non-mergeable uniform texture node.
  *
  * @tsl
  * @function
  * @param {?Texture} value - The texture.
  * @returns {TextureNode}
  */
-export const uniformTexture = ( value = EmptyTexture ) => texture( value );
+export const uniformTexture = ( value = EmptyTexture ) => {
+
+	const textureNode = texture( value );
+
+	textureNode.mergeable = false;
+
+	return textureNode;
+
+};
 
 /**
  * TSL function for creating a texture node that fetches/loads texels without interpolation.


### PR DESCRIPTION
Related issue: #34393

**Description**

Right now two texture uniforms always will be merged if they use the same texture at compile-time.
This means that a material might need to be rebuilt whenever a texture uniform changes, since two uniforms that share the same texture suddenly might not.

I think the best solution here is to optionally merge texture uniforms based on a shared reference node instead of a shared texture. This allows for changing texture uniforms without needing a rebuild and enables better program reuse in some cases. 

This PR introduces a `mergeable` flag on `TextureNode` (default is true). It also changes `uniformTexture()` and `uniformCubeTexture()` to create non-mergeable uniforms. I figured this made sense given the names and that `texture()` and `cubeTexture()` already exist to directly sample textures or create mergeable uniform (the way it works right now).

Would love feedback regarding if the change makes sense to begin with, the name of the new property and if `uniformTexture()` / `uniformCubeTexture()` behaviour should be changed or not.

*This contribution is funded by [BitReality](https://bitreality.com)*
