### PR TITLE
PassNode: Fix pixel ratio in derived passes.

### DIFF
--- a/examples/jsm/tsl/display/SSAAPassNode.js
+++ b/examples/jsm/tsl/display/SSAAPassNode.js
@@ -99,9 +99,7 @@ class SSAAPassNode extends PassNode {
 
 		//
 
-		this._pixelRatio = renderer.getPixelRatio();
-
-		const size = renderer.getSize( _size );
+		const size = renderer.getDrawingBufferSize( _size );
 
 		this.setSize( size.width, size.height );
 		this._sampleRenderTarget.setSize( this.renderTarget.width, this.renderTarget.height );

--- a/examples/jsm/tsl/display/StereoCompositePassNode.js
+++ b/examples/jsm/tsl/display/StereoCompositePassNode.js
@@ -139,11 +139,9 @@ class StereoCompositePassNode extends PassNode {
 
 		//
 
-		this._pixelRatio = renderer.getPixelRatio();
-
 		this.updateStereoCamera( renderer.coordinateSystem );
 
-		const size = renderer.getSize( _size );
+		const size = renderer.getDrawingBufferSize( _size );
 		this.setSize( size.width, size.height );
 
 		// left

--- a/examples/jsm/tsl/display/StereoPassNode.js
+++ b/examples/jsm/tsl/display/StereoPassNode.js
@@ -61,13 +61,11 @@ class StereoPassNode extends PassNode {
 
 		//
 
-		this._pixelRatio = renderer.getPixelRatio();
-
 		stereo.cameraL.coordinateSystem = renderer.coordinateSystem;
 		stereo.cameraR.coordinateSystem = renderer.coordinateSystem;
 		stereo.update( camera );
 
-		const size = renderer.getSize( _size );
+		const size = renderer.getDrawingBufferSize( _size );
 		this.setSize( size.width, size.height );
 
 		renderer.autoClear = false;

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -45,7 +45,7 @@
 			let gui, stats;
 
 			const params = {
-				sampleLevel: 4,
+				sampleLevel: 3,
 				unbiased: true,
 				camera: 'perspective',
 				clearColor: 'black',
@@ -174,7 +174,6 @@
 				// postprocessing
 
 				composer = new EffectComposer( renderer );
-				composer.setPixelRatio( 1 ); // ensure pixel ratio is always 1 for performance reasons
 				ssaaRenderPassP = new SSAARenderPass( scene, cameraP );
 				composer.addPass( ssaaRenderPassP );
 				ssaaRenderPassO = new SSAARenderPass( scene, cameraO );
@@ -194,7 +193,7 @@
 
 				cameraP.aspect = aspect;
 				cameraP.setViewOffset( width, height, params.viewOffsetX, 0, width, height );
-				cameraO.updateProjectionMatrix();
+				cameraP.updateProjectionMatrix();
 
 				cameraO.left = - height * aspect;
 				cameraO.right = height * aspect;


### PR DESCRIPTION
Fixed #34452.

**Description**

The PR fixes a small regression of #33606. When `PassNode` was refactored, it's was necessary to update derived classes as well. So they must be migrated to `getDrawingBufferSize()` usage (the `_pixelRatio` assignments are dead code).
