### PR TITLE
Renderer - Add autoSubmit and Scheduled Submits

### DIFF
--- a/examples/webgpu_compute_rasterizer_ibl.html
+++ b/examples/webgpu_compute_rasterizer_ibl.html
@@ -153,6 +153,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
 				renderer.inspector = new Inspector();
+				renderer.autoSubmit = false;
 				document.body.appendChild( renderer.domElement );
 
 				await renderer.init();
@@ -1764,6 +1765,7 @@
 				// Present (tone mapping + output color space apply on the canvas)
 				renderer.setRenderTarget( null );
 				blitQuad.render( renderer );
+				renderer.submit();
 
 			}
 

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -629,6 +629,12 @@ class Backend {
 	}
 
 	/**
+	 * Receives all pooled render passes and compute passes and submits them to the device's
+	 * command encoder in a single call. Currently only implemented on the WebGPUBackend.
+	 */
+	submit() {}
+
+	/**
 	 * This method performs a readback operation by moving buffer data from
 	 * a storage buffer attribute from the GPU to the CPU.
 	 *

--- a/src/renderers/common/CanvasTarget.js
+++ b/src/renderers/common/CanvasTarget.js
@@ -161,6 +161,8 @@ class CanvasTarget extends EventDispatcher {
 		// Renderer can't be resized while presenting in XR.
 		if ( this.xr && this.xr.isPresenting ) return;
 
+		this._dispatchBeforeResize();
+
 		this._width = width;
 		this._height = height;
 
@@ -186,6 +188,8 @@ class CanvasTarget extends EventDispatcher {
 
 		// Renderer can't be resized while presenting in XR.
 		if ( this.xr && this.xr.isPresenting ) return;
+
+		this._dispatchBeforeResize();
 
 		this._width = width;
 		this._height = height;
@@ -321,6 +325,17 @@ class CanvasTarget extends EventDispatcher {
 	_dispatchResize() {
 
 		this.dispatchEvent( { type: 'resize' } );
+
+	}
+
+	/**
+	 * Dispatches the before resize event.
+	 *
+	 * @private
+	 */
+	_dispatchBeforeResize() {
+
+		this.dispatchEvent( { type: 'beforeresize' } );
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -149,6 +149,17 @@ class Renderer {
 		 */
 		this.autoClearStencil = true;
 
+
+		/**
+		 * When `autoSubmit` is set to `true`, this property defines whether the renderer's
+		 * backend should automatically submit GPU passes to the command encoder on each
+		 * renderer call.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.autoSubmit = true;
+
 		/**
 		 * Whether the default framebuffer should be transparent or opaque.
 		 *
@@ -283,6 +294,14 @@ class Renderer {
 		this._onCanvasTargetResize = this._onCanvasTargetResize.bind( this );
 
 		/**
+		 * OnCanvasTargetBeforeResize callback function.
+		 *
+		 * @private
+		 * @type {Function}
+		 */
+		this._onCanvasTargetBeforeResize = this._onCanvasTargetBeforeResize.bind( this );
+
+		/**
 		 * The canvas target for rendering.
 		 *
 		 * @private
@@ -290,6 +309,7 @@ class Renderer {
 		 */
 		this._canvasTarget = new CanvasTarget( backend.getDomElement() );
 		this._canvasTarget.addEventListener( 'resize', this._onCanvasTargetResize );
+		this._canvasTarget.addEventListener( 'beforeresize', this._onCanvasTargetBeforeResize );
 		this._canvasTarget.isDefaultCanvasTarget = true;
 
 		/**
@@ -2784,6 +2804,7 @@ class Renderer {
 	setCanvasTarget( canvasTarget ) {
 
 		this._canvasTarget.removeEventListener( 'resize', this._onCanvasTargetResize );
+		this._canvasTarget.removeEventListener( 'beforeresize', this._onCanvasTargetBeforeResize );
 
 		this._canvasTarget = canvasTarget;
 		this._canvasTarget.addEventListener( 'resize', this._onCanvasTargetResize );
@@ -2994,6 +3015,20 @@ class Renderer {
 		if ( this._initialized === false ) await this.init();
 
 		this.compute( computeNodes, dispatchSize );
+
+	}
+
+	/**
+	 * Receives all pooled render passes and compute passes and submits them to the device's
+	 * command encoder in a single call.
+	 */
+	submit() {
+
+		if ( ! this.autoSubmit ) {
+
+			this.backend.submit();
+
+		}
 
 	}
 
@@ -3966,6 +4001,18 @@ class Renderer {
 	_onCanvasTargetResize() {
 
 		if ( this._initialized ) this.backend.updateSize();
+
+	}
+
+	/**
+	 * Callback for before the canvas is resized.
+	 * Submits any renderer work done with the previous canvas context.
+	 *
+	 * @private
+	 */
+	_onCanvasTargetBeforeResize() {
+
+		if ( this._initialized ) this.backend.submit();
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -6,7 +6,7 @@ import { GPUFeatureName, GPULoadOp, GPUStoreOp, GPUIndexFormat, GPUTextureViewDi
 import WGSLNodeBuilder from './nodes/WGSLNodeBuilder.js';
 import Backend from '../common/Backend.js';
 
-import WebGPUUtils, { submit } from './utils/WebGPUUtils.js';
+import WebGPUUtils from './utils/WebGPUUtils.js';
 import WebGPUAttributeUtils from './utils/WebGPUAttributeUtils.js';
 import WebGPUBindingUtils from './utils/WebGPUBindingUtils.js';
 import WebGPUCapabilities from './utils/WebGPUCapabilities.js';
@@ -188,6 +188,36 @@ class WebGPUBackend extends Backend {
 		this._compatibility = {
 			[ Compatibility.TEXTURE_COMPARE ]: compatibilityTextureCompare
 		};
+
+		/**
+		 * Command buffers finished this frame and awaiting submission. Every render/compute pass,
+		 * whether from a direct render call or from a nested render in an `updateBefore() callback,
+		 * finishes its commandBuffers into this stack. Command buffers should always be pushed in
+		 * from the lowest to highest nested render/compute call.
+		 *
+		 * @private
+		 * @type {Array<GPUCommandBuffer>}
+		 */
+		this._finishedCommandBuffers = [];
+
+		/**
+		 * Whether a microtask has already been scheduled to submit this frame.
+		 *
+		 * @private
+		 * @type {boolean}
+		 * @default false
+		 */
+		this._submitScheduled = false;
+
+		/**
+		 * GPU resources whose destruction is deferred until the command buffers that
+		 * reference them have been submitted. Destroying a texture or buffer still
+		 * recorded into an unsubmitted encoder makes the following submit fail validation.
+		 *
+		 * @private
+		 * @type {Array<(GPUTexture|GPUBuffer|GPUQuerySet)>}
+		 */
+		this._resourcesToDestroy = [];
 
 	}
 
@@ -412,6 +442,11 @@ class WebGPUBackend extends Backend {
 	 */
 	async getArrayBufferAsync( attribute, target = null, offset = 0, count = - 1 ) {
 
+		// the readback maps a buffer, so the work that produced its contents has to be
+		// submitted first
+
+		this.submit();
+
 		return await this.attributeUtils.getArrayBufferAsync( attribute, target, offset, count );
 
 	}
@@ -550,7 +585,7 @@ class WebGPUBackend extends Backend {
 
 			if ( textureData.msaaTextures !== undefined ) {
 
-				for ( const texture of textureData.msaaTextures ) texture.destroy();
+				for ( const texture of textureData.msaaTextures ) this.destroyResource( texture );
 
 				textureData.msaaTextures = undefined;
 
@@ -574,7 +609,7 @@ class WebGPUBackend extends Backend {
 
 			if ( textureData.msaaTextures !== undefined ) {
 
-				for ( const texture of textureData.msaaTextures ) texture.destroy();
+				for ( const texture of textureData.msaaTextures ) this.destroyResource( texture );
 
 			}
 
@@ -874,6 +909,106 @@ class WebGPUBackend extends Backend {
 	}
 
 	/**
+	 * Returns a command encoder for a pass or copy.
+	 *
+	 * @private
+	 * @param {string} label - A debug label for the command encoder.
+	 * @return {GPUCommandEncoder} The command encoder.
+	 */
+	_acquireCommandEncoder( label ) {
+
+		_commandEncoderDescriptor.label = label;
+
+		const commandEncoder = this.device.createCommandEncoder( _commandEncoderDescriptor );
+
+		_commandEncoderDescriptor.reset();
+
+		return commandEncoder;
+
+	}
+
+	/**
+	 * Finishes a command encoder and queues a submit task.
+	 *
+	 * @private
+	 * @param {GPUCommandEncoder} commandEncoder - The command encoder to finish.
+	 */
+	_finishCommandEncoder( commandEncoder ) {
+
+		this._finishedCommandBuffers.push( commandEncoder.finish() );
+		this._scheduleCommandEncoderSubmit();
+
+	}
+
+	/**
+	 * Schedules a microtask that submits the frame's finished command buffers.
+	 * The microtask runs once the current callback returns to the event loop.
+	 *
+	 * @private
+	 */
+	_scheduleCommandEncoderSubmit() {
+
+		// submit must be sent by user when autoSubmit = false
+
+		if ( this.renderer.autoSubmit && this._submitScheduled === false ) {
+
+			this._submitScheduled = true;
+
+			queueMicrotask( () => this.submit() );
+
+		}
+
+	}
+
+	/**
+	 * Submits the frame's finished command buffers with a single `queue.submit()`, then
+	 * releases any resources whose destruction was deferred.
+	 */
+	submit() {
+
+		this._submitScheduled = false;
+
+		if ( this._finishedCommandBuffers.length > 0 ) {
+
+			this.device.queue.submit( this._finishedCommandBuffers );
+			this._finishedCommandBuffers.length = 0;
+
+		}
+
+		if ( this._resourcesToDestroy.length > 0 ) {
+
+			for ( const resource of this._resourcesToDestroy ) resource.destroy();
+
+			this._resourcesToDestroy.length = 0;
+
+		}
+
+	}
+
+	/**
+	 * Destroys a GPU resource, deferring the destruction whenever an encoder or command
+	 * buffer of the current frame might still reference it. Deferred resources are
+	 * destroyed by {@link WebGPUBackend#submit} directly after the frame is submitted.
+	 *
+	 * @param {?(GPUTexture|GPUBuffer|GPUQuerySet)} resource - The resource to destroy.
+	 */
+	destroyResource( resource ) {
+
+		if ( ! resource ) return;
+
+		if ( this._finishedCommandBuffers.length === 0 ) {
+
+			resource.destroy();
+
+		} else {
+
+			this._resourcesToDestroy.push( resource );
+
+		}
+
+	}
+
+	/**
 	 * This method is executed at the beginning of a render call and prepares
 	 * the WebGPU state for upcoming render calls
 	 *
@@ -892,8 +1027,8 @@ class WebGPUBackend extends Backend {
 
 		if ( occlusionQueryCount > 0 ) {
 
-			if ( renderContextData.currentOcclusionQuerySet ) renderContextData.currentOcclusionQuerySet.destroy();
-			if ( renderContextData.currentOcclusionQueryBuffer ) renderContextData.currentOcclusionQueryBuffer.destroy();
+			this.destroyResource( renderContextData.currentOcclusionQuerySet );
+			this.destroyResource( renderContextData.currentOcclusionQueryBuffer );
 
 			// Get a reference to the array of objects with queries. The renderContextData property
 			// can be changed by another render pass before the buffer.mapAsyc() completes.
@@ -923,7 +1058,7 @@ class WebGPUBackend extends Backend {
 
 			renderContextData.lastOcclusionObject = undefined;
 
-			renderContextData.occlusionQuerySet.destroy();
+			this.destroyResource( renderContextData.occlusionQuerySet );
 			renderContextData.occlusionQuerySet = undefined;
 
 		}
@@ -1077,9 +1212,7 @@ class WebGPUBackend extends Backend {
 
 		//
 
-		_commandEncoderDescriptor.label = 'renderContext_' + renderContext.id;
-		const encoder = device.createCommandEncoder( _commandEncoderDescriptor );
-		_commandEncoderDescriptor.reset();
+		const encoder = this._acquireCommandEncoder( 'renderContext_' + renderContext.id );
 
 		// Layered render targets: prepare bundle encoders for each camera in the array camera.
 
@@ -1516,7 +1649,8 @@ class WebGPUBackend extends Backend {
 
 		} else if ( renderContextData.currentPass ) {
 
-		  renderContextData.currentPass.end();
+			renderContextData.currentPass.end();
+			renderContextData.currentPass = null;
 
 		}
 
@@ -1558,11 +1692,20 @@ class WebGPUBackend extends Backend {
 
 			//
 
+		}
+
+		this._finishCommandEncoder( renderContextData.encoder );
+
+		if ( occlusionQueryCount > 0 ) {
+
+			// occlusion results are read back on the CPU, so the resolve recorded above
+			// must reach the queue before mapAsync()
+
+			this.submit();
+
 			this.resolveOccludedAsync( renderContext );
 
 		}
-
-		submit( this.device, renderContextData.encoder.finish() );
 
 
 		//
@@ -1643,7 +1786,7 @@ class WebGPUBackend extends Backend {
 
 			}
 
-			currentOcclusionQueryBuffer.destroy();
+			this.destroyResource( currentOcclusionQueryBuffer );
 
 			renderContextData.occluded = occluded;
 
@@ -1713,7 +1856,6 @@ class WebGPUBackend extends Backend {
 	 */
 	clear( color, depth, stencil, renderTargetContext = null ) {
 
-		const device = this.device;
 		const renderer = this.renderer;
 
 		let colorAttachments = [];
@@ -1829,9 +1971,7 @@ class WebGPUBackend extends Backend {
 
 		//
 
-		_commandEncoderDescriptor.label = 'clear';
-		const encoder = device.createCommandEncoder( _commandEncoderDescriptor );
-		_commandEncoderDescriptor.reset();
+		const encoder = this._acquireCommandEncoder( 'clear' );
 
 		const currentPass = encoder.beginRenderPass( {
 			colorAttachments,
@@ -1840,7 +1980,7 @@ class WebGPUBackend extends Backend {
 
 		currentPass.end();
 
-		submit( device, encoder.finish() );
+		this._finishCommandEncoder( encoder );
 
 	}
 
@@ -1865,11 +2005,11 @@ class WebGPUBackend extends Backend {
 
 		this.initTimestampQuery( TimestampQuery.COMPUTE, this.getTimestampUID( computeGroup ), _computePassDescriptor );
 
-		groupGPU.cmdEncoderGPU = this.device.createCommandEncoder( _commandEncoderDescriptor );
+		groupGPU.cmdEncoderGPU = this._acquireCommandEncoder( label );
+
 		groupGPU.passEncoderGPU = groupGPU.cmdEncoderGPU.beginComputePass( _computePassDescriptor );
 		groupGPU.currentPipeline = null;
 
-		_commandEncoderDescriptor.reset();
 		_computePassDescriptor.reset();
 
 	}
@@ -1997,7 +2137,7 @@ class WebGPUBackend extends Backend {
 
 		groupData.passEncoderGPU.end();
 
-		submit( this.device, groupData.cmdEncoderGPU.finish() );
+		this._finishCommandEncoder( groupData.cmdEncoderGPU );
 
 	}
 
@@ -2799,7 +2939,7 @@ class WebGPUBackend extends Backend {
 
 		const uniformBufferData = this.get( uniformBuffer );
 
-		uniformBufferData.buffer.destroy();
+		this.destroyResource( uniformBufferData.buffer );
 
 		this.delete( uniformBuffer );
 
@@ -3016,9 +3156,7 @@ class WebGPUBackend extends Backend {
 
 		}
 
-		_commandEncoderDescriptor.label = 'copyTextureToTexture_' + srcTexture.id + '_' + dstTexture.id;
-		const encoder = this.device.createCommandEncoder( _commandEncoderDescriptor );
-		_commandEncoderDescriptor.reset();
+		const encoder = this._acquireCommandEncoder( 'copyTextureToTexture_' + srcTexture.id + '_' + dstTexture.id );
 
 		const sourceGPU = this.get( srcTexture ).texture;
 		const destinationGPU = this.get( dstTexture ).texture;
@@ -3049,7 +3187,7 @@ class WebGPUBackend extends Backend {
 		_texelCopyTextureInfoDst.reset();
 		_extent3D.reset();
 
-		submit( this.device, encoder.finish() );
+		this._finishCommandEncoder( encoder );
 
 		if ( dstLevel === 0 && dstTexture.generateMipmaps ) {
 
@@ -3141,9 +3279,7 @@ class WebGPUBackend extends Backend {
 
 		} else {
 
-			_commandEncoderDescriptor.label = 'copyFramebufferToTexture_' + texture.id;
-			encoder = this.device.createCommandEncoder( _commandEncoderDescriptor );
-			_commandEncoderDescriptor.reset();
+			encoder = this._acquireCommandEncoder( 'copyFramebufferToTexture_' + texture.id );
 
 		}
 
@@ -3183,7 +3319,7 @@ class WebGPUBackend extends Backend {
 
 		} else {
 
-			submit( this.device, encoder.finish() );
+			this._finishCommandEncoder( encoder );
 
 		}
 

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -354,7 +354,7 @@ class WebGPUAttributeUtils {
 		const backend = this.backend;
 		const data = backend.get( this._getBufferAttribute( attribute ) );
 
-		data.buffer.destroy();
+		backend.destroyResource( data.buffer );
 
 		backend.delete( attribute );
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -483,13 +483,13 @@ class WebGPUTextureUtils {
 		const backend = this.backend;
 		const textureData = backend.get( texture );
 
-		if ( textureData.texture !== undefined && isDefaultTexture === false && texture.isExternalTexture !== true && textureData.externalTexture !== true ) textureData.texture.destroy();
+		if ( textureData.texture !== undefined && isDefaultTexture === false && texture.isExternalTexture !== true && textureData.externalTexture !== true ) backend.destroyResource( textureData.texture );
 
-		if ( textureData.msaaTexture !== undefined ) textureData.msaaTexture.destroy();
+		if ( textureData.msaaTexture !== undefined ) backend.destroyResource( textureData.msaaTexture );
 
 		if ( textureData.msaaTextures !== undefined ) {
 
-			for ( const msaaTexture of textureData.msaaTextures ) msaaTexture.destroy();
+			for ( const msaaTexture of textureData.msaaTextures ) backend.destroyResource( msaaTexture );
 
 		}
 
@@ -537,7 +537,7 @@ class WebGPUTextureUtils {
 
 		let colorBuffer = colorTextureData.texture;
 
-		if ( colorBuffer ) colorBuffer.destroy();
+		if ( colorBuffer ) backend.destroyResource( colorBuffer );
 
 		_textureDescriptor.label = 'colorBuffer';
 		_textureDescriptor.size.width = width;


### PR DESCRIPTION
Related issue: #33821

**Description**

Test branch largely inspired by the discussion in this comment in the issue referenced above: https://github.com/mrdoob/three.js/issues/33821#issuecomment-4756172133

Accordingly this PR does two things:

1. Coalesce all finished commandBuffers of the render or compute calls executed by the user, only submitting when control flow returns rather than on every nested render or compute call within the Nodes.

2. Allows the user to set an autoSubmit flag on the Renderer. Setting this flag to false will cause finished commandBuffers to accumulate on the renderer in the order that they were created. Calling `render.submit()` will manually submit all those commandBuffers at once. This behavior is set on the main Renderer class but only has an effect on the WebGPURenderer.

This PR does not share commandEncoders between nested renders invoked by updateBefore nodes nor does it share the commandEncoder between multiple executions of render.render() and renderer.compute(), as those would involve more drastic changes to the Renderer. The focus of this PR is primarily on cutting down the number of submit calls, and putting pass submission into the hands of power users if it is needed for performance reasons.

@gkjohnson I was able to test your fiddle: https://jsfiddle.net/pzcsu6jt/1/ on this branch and observed a 400 ms improvement (to around 600ms for initialization). I also did a hasty test where I shared a single commandEncoder across the various render and clear passes to bring the initialization time down to 200ms. This was at the expense of breaking every example with nested render paths ( pretty much everything that calls renderer.render() in a PassNode )

Not intending to merge this in anytime soon since this currently breaks multiple examples.