### PR TITLE
WebGLTextures: Fix confusing texture unit warning message.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -515,7 +515,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( textureUnit >= capabilities.maxTextures ) {
 
-			warn( 'WebGLTextures: Trying to use ' + textureUnit + ' texture units while this GPU supports only ' + capabilities.maxTextures );
+			warn( 'WebGLTextures: Trying to use ' + ( textureUnit + 1 ) + ' texture units while this GPU supports only ' + capabilities.maxTextures );
 
 		}
 


### PR DESCRIPTION
Fixed #34455.

**Description**

`allocateTextureUnit()` warns when `textureUnit >= capabilities.maxTextures`, but `textureUnit` is the 0-indexed value about to be assigned, so the message understates the actual count by one (e.g. it says "16 texture units" when a GPU that supports 16 is actually being asked for 17). The warning now reports `textureUnit + 1`.
