### PR TITLE
MathUtils: Fix large isPowerOfTwo values

### DIFF
--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -287,7 +287,7 @@ function radToDeg( radians ) {
  */
 function isPowerOfTwo( value ) {
 
-	return ( value & ( value - 1 ) ) === 0 && value !== 0;
+	return value > 0 && Number.isInteger( value ) && 2 ** Math.round( Math.log2( value ) ) === value;
 
 }
 

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -280,10 +280,10 @@ function radToDeg( radians ) {
 }
 
 /**
- * Returns `true` if the given number is a power of two.
+ * Returns `true` if the given integer is a power of two.
  *
  * @param {number} value - The value to check.
- * @return {boolean} Whether the given number is a power of two or not.
+ * @return {boolean} Whether the given integer is a power of two or not.
  */
 function isPowerOfTwo( value ) {
 

--- a/test/unit/src/math/MathUtils.tests.js
+++ b/test/unit/src/math/MathUtils.tests.js
@@ -153,6 +153,8 @@ export default QUnit.module( 'Maths', () => {
 			assert.strictEqual( MathUtils.isPowerOfTwo( 2 ), true, '2 is a PoT' );
 			assert.strictEqual( MathUtils.isPowerOfTwo( 3 ), false, '3 is not a PoT' );
 			assert.strictEqual( MathUtils.isPowerOfTwo( 4 ), true, '4 is a PoT' );
+			assert.strictEqual( MathUtils.isPowerOfTwo( 2 ** 40 ), true, 'Large PoT' );
+			assert.strictEqual( MathUtils.isPowerOfTwo( 3 * 2 ** 32 ), false, 'Large non-PoT' );
 
 		} );
 


### PR DESCRIPTION
## Problem

`MathUtils.isPowerOfTwo()` uses bitwise operators, which coerce numbers to 32 bits. Large non-powers such as `3 * 2 ** 32` therefore return `true`, despite the public API documenting a general `number` input.

## Fix

Check for a positive integer and compare it exactly with the nearest numeric power of two. This avoids 32-bit truncation while keeping existing behavior.

## Tests

- `npm run test-unit` - 1315 passed, 1 todo
- `npm run test-unit-addons` - 385 passed
- `npm run lint-core` - passed
- `npm run build` - passed
- `git diff --check` - passed

## Compatibility

The signature is unchanged. Behavior changes only for values the previous 32-bit coercion classified incorrectly.

## Related issue

Independently reproduced on current `dev`; no matching issue or pull request was found.

