### PR TITLE
WebGLRenderer: Only apply pixel ratio to the canvas in setViewport() and setScissor().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -817,7 +817,7 @@ class WebGLRenderer {
 
 			}
 
-			state.viewport( _currentViewport.copy( _viewport ).multiplyScalar( _pixelRatio ).round() );
+			state.viewport( _currentViewport.copy( _viewport ).multiplyScalar( getTargetPixelRatio() ).round() );
 
 		};
 
@@ -854,7 +854,7 @@ class WebGLRenderer {
 
 			}
 
-			state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ).round() );
+			state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( getTargetPixelRatio() ).round() );
 
 		};
 


### PR DESCRIPTION
Related issue: supersedes #25436

**Description**

`setViewport()` and `setScissor()` multiply by the pixel ratio unconditionally, even while a render target is bound. Pixel ratio only applies to the canvas: `setRenderTarget()` already copies a render target's viewport and scissor unscaled, and `WebGPURenderer` uses a pixel ratio of `1` whenever a render target is active. This PR makes the two setters use the existing `getTargetPixelRatio()` helper so `WebGLRenderer` follows the same rule.

With `setPixelRatio( 2 )`, a `100x100` render target bound and `setViewport( 0, 0, 100, 100 )`:

| | current viewport |
|---|---|
| before | 200 x 200 |
| after | 100 x 100 |

The canvas case is unchanged (`200 x 200`), and so is the state restored by `setRenderTarget( null )`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hiak2i5BkymorxmUQTKapR
