### PR TITLE
Add optional compose-based containerized dev environment.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,6 +49,7 @@ If you prefer not to install Node.js on your machine, a compose file is provided
 
     docker compose up -d dev    # dev server at http://localhost:8080, rebuilds on change
     docker compose run test     # npm test (lint + unit tests) in a clean container
+    docker compose run e2e      # npm run test-e2e (see note above about CI)
     docker compose down         # stop everything
 
 The ~200 MB Chromium needed by the unit tests stays inside the container image instead of being installed on your machine. The regular `npm ci` workflow above is unaffected.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,6 +43,16 @@ If you’d like to make a build of the source files (e.g. `build/three.module.js
 
     npm run build
 
+### Containerized alternative (optional)
+
+If you prefer not to install Node.js on your machine, a compose file is provided for Docker and Podman:
+
+    docker compose up -d dev    # dev server at http://localhost:8080, rebuilds on change
+    docker compose run test     # npm test (lint + unit tests) in a clean container
+    docker compose down         # stop everything
+
+The ~200 MB Chromium needed by the unit tests stays inside the container image instead of being installed on your machine. The regular `npm ci` workflow above is unaffected.
+
 ## Making changes
 
 When you’ve decided to make changes, start with the following:

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,17 @@
+services:
+  dev:
+    image: docker.io/library/node:22-bookworm
+    working_dir: /three.js
+    volumes:
+      - .:/three.js
+    ports:
+      - "8080:8080"
+    command: bash -c "npm ci && npm start"
+
+  test:
+    image: ghcr.io/puppeteer/puppeteer:latest
+    user: root
+    working_dir: /three.js
+    volumes:
+      - .:/three.js
+    command: bash -c "npm ci && npm test"

--- a/compose.yml
+++ b/compose.yml
@@ -15,3 +15,12 @@ services:
     volumes:
       - .:/three.js
     command: bash -c "npm ci && npm test"
+
+  e2e:
+    image: ghcr.io/puppeteer/puppeteer:latest
+    user: root
+    shm_size: 2gb
+    working_dir: /three.js
+    volumes:
+      - .:/three.js
+    command: bash -c "apt-get update && apt-get install -y mesa-vulkan-drivers && npm ci && npm run test-e2e"


### PR DESCRIPTION
Related issue: #34462

**Description**

The PR adds an optional `compose.yml` (Docker / Podman) with three services: `dev` runs `npm ci && npm start` with port 8080 published, `test` runs `npm test` in the puppeteer image so the ~200 MB Chromium needed by the unit tests stays inside the container, and `e2e` runs `npm run test-e2e` in the same image with `mesa-vulkan-drivers` installed, matching the CI environment. A short section in CONTRIBUTING.md documents the commands. `package.json` and the existing `npm ci` workflow are untouched.

Verified: `docker compose up -d dev` serves the examples ([screenshot](https://raw.githubusercontent.com/clement-igonet/threejs-maplibre/main/evidence/34462/threejs-compose-dev-cube.png)), `docker compose run test` passes lint and the unit suites, and the branch runs the full CI green including all 5 e2e shards ([run](https://github.com/clement-igonet/three.js-1/actions/runs/33966210145)).
