### PR TITLE
Use native APIs to convert between ArrayBuffer and Base64

### DIFF
--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -461,6 +461,12 @@ export function getDataFromObject( object ) {
  */
 export function arrayBufferToBase64( arrayBuffer ) {
 
+	if ( typeof Uint8Array.prototype.toBase64 === 'function' ) {
+
+		return new Uint8Array( arrayBuffer ).toBase64();
+
+	}
+
 	let chars = '';
 
 	const array = new Uint8Array( arrayBuffer );
@@ -484,6 +490,12 @@ export function arrayBufferToBase64( arrayBuffer ) {
  * @return {ArrayBuffer} The array buffer.
  */
 export function base64ToArrayBuffer( base64 ) {
+
+	if ( typeof Uint8Array.fromBase64 === 'function' ) {
+
+		return Uint8Array.fromBase64( base64 ).buffer;
+
+	}
 
 	return Uint8Array.from( atob( base64 ), c => c.charCodeAt( 0 ) ).buffer;
 


### PR DESCRIPTION
**Description**

Use native APIs to convert between ArrayBuffer and Base64

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/toBase64

Since September 2025, this feature works across the latest devices and browser versions.

perf measures: https://jsfiddle.net/b6jgxw5L/

