### PR TITLE
Examples: Use SunLight in WebGPU examples.

### DIFF
--- a/examples/jsm/lighting/LightProbeGrid.js
+++ b/examples/jsm/lighting/LightProbeGrid.js
@@ -32,6 +32,7 @@ import {
 } from 'three/tsl';
 
 import { LightProbeGridNode, ATLAS_PADDING } from '../tsl/lighting/LightProbeGridNode.js';
+import { replaceSunLights, restoreSunLights } from './LightProbeGridUtils.js';
 
 // Shared fullscreen-quad for the bake passes.
 const _quad = /*@__PURE__*/ new QuadMesh();
@@ -434,6 +435,10 @@ class LightProbeGrid extends Light {
 	 * then repeat with `pass: 1`, etc. Start each pass at index 0 to snapshot the
 	 * previous pass before updating its cells.
 	 *
+	 * Shadow-casting instances of `SunLight` are temporarily replaced with
+	 * equivalent directional lights, since their view-fitted shadow cascades
+	 * cannot be frozen across probe renders.
+	 *
 	 * @param {WebGPURenderer} renderer - The renderer.
 	 * @param {Scene} scene - The scene to render.
 	 * @param {Object} [options] - Bake options.
@@ -531,6 +536,7 @@ class LightProbeGrid extends Light {
 		const renderTarget = this._renderTarget;
 		const currentViewport = renderTarget.viewport.clone();
 		const shadowStates = [];
+		let replacedSunLights = null;
 
 		try {
 
@@ -545,6 +551,8 @@ class LightProbeGrid extends Light {
 				scene.matrixWorldAutoUpdate = false;
 
 			}
+
+			replacedSunLights = replaceSunLights( scene );
 
 			// Render each shadow map once, not once per cube face.
 
@@ -580,6 +588,8 @@ class LightProbeGrid extends Light {
 			scene.matrixWorldAutoUpdate = currentMatrixWorldAutoUpdate;
 
 			for ( const { shadow, autoUpdate } of shadowStates ) shadow.autoUpdate = autoUpdate;
+
+			if ( replacedSunLights !== null ) restoreSunLights( scene, replacedSunLights );
 
 			this.visible = currentVisible;
 			if ( this._bounceGrid !== null ) this._bounceGrid.removeFromParent();

--- a/examples/jsm/lighting/LightProbeGridUtils.js
+++ b/examples/jsm/lighting/LightProbeGridUtils.js
@@ -1,0 +1,107 @@
+import { Box3, DirectionalLight, Sphere, Vector3 } from 'three';
+
+const _casterBox = /*@__PURE__*/ new Box3();
+const _casterSphere = /*@__PURE__*/ new Sphere();
+const _sunDirection = /*@__PURE__*/ new Vector3();
+
+// One bake light per SunLight: WebGPU pipelines are keyed by light identity,
+// so a fresh light per ranged bake would recompile every material each call.
+const _bakeLights = /*@__PURE__*/ new WeakMap();
+
+/**
+ * Replaces every visible, shadow-casting `SunLight` in the scene with a
+ * directional light fitted to the shadow casters. SunLight shadow cascades are
+ * fitted to the active camera every render, which the frozen shadow maps of a
+ * bake cannot provide.
+ *
+ * @param {Scene} scene - The scene to bake.
+ * @return {?Array<Object>} The replacements to pass to {@link restoreSunLights}, or `null` if the scene has no such lights.
+ */
+function replaceSunLights( scene ) {
+
+	const sunLights = [];
+
+	scene.traverse( ( object ) => {
+
+		if ( object.isSunLight === true && object.visible === true && object.castShadow === true ) sunLights.push( object );
+
+	} );
+
+	if ( sunLights.length === 0 ) return null;
+
+	_casterBox.makeEmpty();
+
+	scene.traverse( ( object ) => {
+
+		if ( object.isMesh === true && object.castShadow === true ) _casterBox.expandByObject( object );
+
+	} );
+
+	_casterBox.getBoundingSphere( _casterSphere );
+
+	const center = _casterSphere.center;
+	const radius = Math.max( _casterSphere.radius, 1 );
+
+	const replacements = [];
+
+	for ( const sunLight of sunLights ) {
+
+		let bakeLight = _bakeLights.get( sunLight );
+
+		if ( bakeLight === undefined ) {
+
+			bakeLight = new DirectionalLight();
+			bakeLight.castShadow = true;
+			_bakeLights.set( sunLight, bakeLight );
+
+		}
+
+		bakeLight.color.copy( sunLight.color );
+		bakeLight.intensity = sunLight.intensity;
+		bakeLight.shadow.mapSize.copy( sunLight.shadow.mapSize );
+
+		const shadowCamera = bakeLight.shadow.camera;
+		shadowCamera.left = - radius;
+		shadowCamera.right = radius;
+		shadowCamera.top = radius;
+		shadowCamera.bottom = - radius;
+		shadowCamera.near = radius * 0.5;
+		shadowCamera.far = radius * 3.5;
+		shadowCamera.updateProjectionMatrix();
+
+		_sunDirection.setFromMatrixPosition( sunLight.matrixWorld ).normalize();
+		bakeLight.target.position.copy( center );
+		bakeLight.position.copy( center ).addScaledVector( _sunDirection, radius * 2 );
+
+		scene.add( bakeLight, bakeLight.target );
+		bakeLight.target.updateMatrixWorld();
+		bakeLight.updateMatrixWorld();
+
+		sunLight.visible = false;
+
+		replacements.push( { sunLight, bakeLight } );
+
+	}
+
+	return replacements;
+
+}
+
+/**
+ * Restores the sun lights replaced by {@link replaceSunLights}.
+ *
+ * @param {Scene} scene - The baked scene.
+ * @param {Array<Object>} replacements - The replacements to undo.
+ */
+function restoreSunLights( scene, replacements ) {
+
+	for ( const { sunLight, bakeLight } of replacements ) {
+
+		scene.remove( bakeLight, bakeLight.target );
+		sunLight.visible = true;
+
+	}
+
+}
+
+export { replaceSunLights, restoreSunLights };

--- a/examples/jsm/lighting/LightProbeGridWebGL.js
+++ b/examples/jsm/lighting/LightProbeGridWebGL.js
@@ -2,7 +2,6 @@ import {
 	Box3,
 	CubeCamera,
 	Data3DTexture,
-	DirectionalLight,
 	FloatType,
 	HalfFloatType,
 	LinearFilter,
@@ -15,12 +14,13 @@ import {
 	RGBAFormat,
 	Scene,
 	ShaderMaterial,
-	Sphere,
 	Vector3,
 	WebGL3DRenderTarget,
 	WebGLCubeRenderTarget,
 	WebGLRenderTarget
 } from 'three';
+
+import { replaceSunLights, restoreSunLights } from './LightProbeGridUtils.js';
 
 // Shared fullscreen-quad scene / camera
 let _scene = null;
@@ -52,82 +52,6 @@ const _copyRegion = /*@__PURE__*/ new Box3();
 
 // Direct-light captures use a black atlas without changing the light layout.
 let _emptyAtlas = null;
-const _casterBox = /*@__PURE__*/ new Box3();
-const _casterSphere = /*@__PURE__*/ new Sphere();
-const _sunDirection = /*@__PURE__*/ new Vector3();
-
-// SunLight shadow cascades are fitted to the active camera every render, which
-// the frozen shadow maps of a bake cannot provide: each shadow-casting SunLight
-// is swapped for an equivalent DirectionalLight fitted to the shadow casters.
-
-function _replaceSunLights( scene ) {
-
-	const sunLights = [];
-
-	scene.traverse( ( object ) => {
-
-		if ( object.isSunLight === true && object.visible === true && object.castShadow === true ) sunLights.push( object );
-
-	} );
-
-	if ( sunLights.length === 0 ) return null;
-
-	_casterBox.makeEmpty();
-
-	scene.traverse( ( object ) => {
-
-		if ( object.isMesh === true && object.castShadow === true ) _casterBox.expandByObject( object );
-
-	} );
-
-	_casterBox.getBoundingSphere( _casterSphere );
-
-	const center = _casterSphere.center;
-	const radius = Math.max( _casterSphere.radius, 1 );
-
-	const replacements = [];
-
-	for ( const sunLight of sunLights ) {
-
-		const bakeLight = new DirectionalLight( sunLight.color, sunLight.intensity );
-		bakeLight.castShadow = true;
-		bakeLight.shadow.mapSize.copy( sunLight.shadow.mapSize );
-		bakeLight.shadow.camera.left = - radius;
-		bakeLight.shadow.camera.right = radius;
-		bakeLight.shadow.camera.top = radius;
-		bakeLight.shadow.camera.bottom = - radius;
-		bakeLight.shadow.camera.near = radius * 0.5;
-		bakeLight.shadow.camera.far = radius * 3.5;
-
-		_sunDirection.setFromMatrixPosition( sunLight.matrixWorld ).normalize();
-		bakeLight.target.position.copy( center );
-		bakeLight.position.copy( center ).addScaledVector( _sunDirection, radius * 2 );
-
-		scene.add( bakeLight, bakeLight.target );
-		bakeLight.target.updateMatrixWorld();
-		bakeLight.updateMatrixWorld();
-
-		sunLight.visible = false;
-
-		replacements.push( { sunLight, bakeLight } );
-
-	}
-
-	return replacements;
-
-}
-
-function _restoreSunLights( scene, replacements ) {
-
-	for ( const { sunLight, bakeLight } of replacements ) {
-
-		scene.remove( bakeLight, bakeLight.target );
-		bakeLight.dispose();
-		sunLight.visible = true;
-
-	}
-
-}
 
 // Number of padding texels added at each boundary of every sub-volume in the atlas.
 const ATLAS_PADDING = 1;
@@ -386,7 +310,7 @@ class LightProbeGridWebGL extends Object3D {
 
 			}
 
-			replacedSunLights = _replaceSunLights( scene );
+			replacedSunLights = replaceSunLights( scene );
 
 			// Render shadow maps once, not once per cube face.
 
@@ -409,7 +333,7 @@ class LightProbeGridWebGL extends Object3D {
 			renderer.xr.enabled = currentXrEnabled;
 			renderer.shadowMap.autoUpdate = currentShadowAutoUpdate;
 
-			if ( replacedSunLights !== null ) _restoreSunLights( scene, replacedSunLights );
+			if ( replacedSunLights !== null ) restoreSunLights( scene, replacedSunLights );
 
 			scene.matrixWorldAutoUpdate = currentMatrixWorldAutoUpdate;
 			this.visible = currentVisible;

--- a/examples/webgpu_clipping.html
+++ b/examples/webgpu_clipping.html
@@ -36,6 +36,8 @@
 
 			import * as THREE from 'three/webgpu';
 
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
@@ -68,20 +70,11 @@
 				spotLight.shadow.radius = 4;
 				scene.add( spotLight );
 
-				const dirLight = new THREE.DirectionalLight( 0x55505a, 3 );
-				dirLight.position.set( 0, 3, 0 );
-				dirLight.castShadow = true;
-				dirLight.shadow.camera.near = 1;
-				dirLight.shadow.camera.far = 10;
-
-				dirLight.shadow.camera.right = 1;
-				dirLight.shadow.camera.left = - 1;
-				dirLight.shadow.camera.top	= 1;
-				dirLight.shadow.camera.bottom = - 1;
-
-				dirLight.shadow.mapSize.width = 1024;
-				dirLight.shadow.mapSize.height = 1024;
-				scene.add( dirLight );
+				const sunLight = new SunLight( 0x55505a, 3 );
+				sunLight.position.set( 0, 3, 0 );
+				sunLight.castShadow = true;
+				sunLight.shadow.camera.far = 10;
+				scene.add( sunLight );
 
 				// Clipping planes
 
@@ -128,6 +121,7 @@
 				// Renderer
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.shadowMap.enabled = true;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );

--- a/examples/webgpu_clipping_stencil.html
+++ b/examples/webgpu_clipping_stencil.html
@@ -36,6 +36,8 @@
 
 			import * as THREE from 'three/webgpu';
 
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
@@ -112,17 +114,12 @@
 
 				scene.add( new THREE.AmbientLight( 0xffffff, 1.5 ) );
 
-				const dirLight = new THREE.DirectionalLight( 0xffffff, 3 );
-				dirLight.position.set( 5, 10, 7.5 );
-				dirLight.castShadow = true;
-				dirLight.shadow.camera.right = 2;
-				dirLight.shadow.camera.left = - 2;
-				dirLight.shadow.camera.top	= 2;
-				dirLight.shadow.camera.bottom = - 2;
-
-				dirLight.shadow.mapSize.width = 1024;
-				dirLight.shadow.mapSize.height = 1024;
-				scene.add( dirLight );
+				const sunLight = new SunLight( 0xffffff, 3 );
+				sunLight.position.set( 5, 10, 7.5 );
+				sunLight.castShadow = true;
+				sunLight.shadow.mapSize.set( 2048, 2048 );
+				sunLight.shadow.camera.far = 15;
+				scene.add( sunLight );
 
 				planes = [
 					new THREE.Plane( new THREE.Vector3( - 1, 0, 0 ), 0 ),
@@ -221,6 +218,7 @@
 				// Renderer
 
 				renderer = new THREE.WebGPURenderer( { antialias: true, stencil: true } );
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/examples/webgpu_generator_building.html
+++ b/examples/webgpu_generator_building.html
@@ -39,6 +39,8 @@
 			import * as THREE from 'three/webgpu';
 			import { uniform } from 'three/tsl';
 
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { SkyMesh } from 'three/addons/objects/SkyMesh.js';
@@ -74,6 +76,7 @@
 			async function init() {
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
@@ -117,16 +120,14 @@
 				controls.autoRotateSpeed = 0.3;
 				controls.update();
 
-				// a single directional key aligned with the sky's sun, for the crisp
-				// relief shadows the IBL alone can't give. updateSun() and
-				// fitShadowCamera() drive its colour, intensity and shadow frustum
+				// sunlight aligned with the sky, with shadows fitted to the view camera
 
-				sunLight = new THREE.DirectionalLight();
+				sunLight = new SunLight();
 				sunLight.castShadow = true;
+				sunLight.shadow.camera.far = 1000;
 				sunLight.shadow.mapSize.set( 2048, 2048 );
 				sunLight.shadow.bias = - 0.0004;
 				scene.add( sunLight );
-				scene.add( sunLight.target );
 
 				// place the sun ( sky, IBL, key light and shadow ) for the current time
 				updateSun();
@@ -182,8 +183,6 @@
 				building.castShadow = building.receiveShadow = true;
 				scene.add( building );
 
-				fitShadowCamera();
-
 			}
 
 			function updateSun() {
@@ -208,6 +207,7 @@
 				const transmittance = Math.sqrt( Math.max( sinElevation, 0 ) ); // 0 at the horizon → 1 at the zenith
 				sunLight.color.copy( sunHorizonColor ).lerp( sunMiddayColor, transmittance );
 				sunLight.intensity = 6 * transmittance; // illuminance perpendicular to the rays; the renderer applies N·L per surface
+				sunLight.position.copy( sun );
 
 				// re-bake the sky ( without the sun disc ) into the environment map for IBL
 
@@ -218,37 +218,6 @@
 				scene.environment = env;
 				sky.showSunDisc.value = true;
 				scene.add( sky );
-
-				fitShadowCamera();
-
-			}
-
-			function fitShadowCamera() {
-
-				// fit the directional light's shadow frustum to the tower and the full
-				// ground shadow it casts, so a low sun's long shadow isn't clipped
-
-				const height = parameters.height;
-				const tipDistance = height / Math.max( sun.y, 0.05 ); // shadow tip on the ground
-				const centerX = - sun.x * tipDistance * 0.5;
-				const centerZ = - sun.z * tipDistance * 0.5;
-
-				const radius = Math.hypot( parameters.width, parameters.depth ) * 0.5;
-				const half = Math.hypot( centerX, centerZ ) + radius + 20;
-				const distance = half + height; // place the light clear of the whole scene
-
-				sunLight.target.position.set( centerX, 0, centerZ );
-				sunLight.target.updateMatrixWorld();
-				sunLight.position.set( centerX + sun.x * distance, sun.y * distance, centerZ + sun.z * distance );
-
-				const shadowCamera = sunLight.shadow.camera;
-				shadowCamera.left = - half;
-				shadowCamera.right = half;
-				shadowCamera.top = half;
-				shadowCamera.bottom = - half;
-				shadowCamera.near = 1;
-				shadowCamera.far = distance * 2;
-				shadowCamera.updateProjectionMatrix();
 
 			}
 

--- a/examples/webgpu_geometry_loft.html
+++ b/examples/webgpu_geometry_loft.html
@@ -40,6 +40,8 @@
 			import * as THREE from 'three/webgpu';
 			import { bumpMap, color, cos, float, mix, mx_fractal_noise_float, mx_noise_float, mx_worley_noise_float, positionLocal, screenUV, sin, smoothstep, uv, vec3 } from 'three/tsl';
 
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
@@ -53,6 +55,7 @@
 			async function init() {
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
@@ -120,13 +123,9 @@
 
 				// light
 
-				const light = new THREE.DirectionalLight( 0xffffff, 3 );
+				const light = new SunLight( 0xffffff, 3 );
 				light.position.set( 18, 30, 12 );
 				light.castShadow = true;
-				light.shadow.camera.left = - 60;
-				light.shadow.camera.right = 60;
-				light.shadow.camera.top = 60;
-				light.shadow.camera.bottom = - 60;
 				light.shadow.camera.far = 110;
 				light.shadow.mapSize.set( 4096, 4096 );
 				light.shadow.bias = - 0.0005;

--- a/examples/webgpu_instancing_morph.html
+++ b/examples/webgpu_instancing_morph.html
@@ -39,6 +39,8 @@
 
 			import * as THREE from 'three/webgpu';
 
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 
@@ -72,21 +74,14 @@
 
 				//
 
-				const light = new THREE.DirectionalLight( 0xffffff, 1 );
+				const light = new SunLight( 0xffffff, 1 );
 
 				light.position.set( 200, 1000, 50 );
 
 				light.shadow.mapSize.width = 2048;
 				light.shadow.mapSize.height = 2048;
 				light.castShadow = true;
-
-				light.shadow.camera.left = - 5000;
-				light.shadow.camera.right = 5000;
-				light.shadow.camera.top = 5000;
-				light.shadow.camera.bottom = - 5000;
-				light.shadow.camera.far = 2000;
-
-				light.shadow.camera.updateProjectionMatrix();
+				light.shadow.camera.far = 10000;
 
 				scene.add( light );
 
@@ -150,6 +145,7 @@
 				// renderer
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.setAnimationLoop( animate );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );

--- a/examples/webgpu_postprocessing_fog.html
+++ b/examples/webgpu_postprocessing_fog.html
@@ -61,6 +61,8 @@
 				vec4
 			} from 'three/tsl';
 
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 			import { gaussianBlur } from 'three/addons/tsl/display/GaussianBlurNode.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
@@ -170,22 +172,17 @@
 				const ambient = new THREE.HemisphereLight( 0xffffff, 0x8d8d8d, 0.5 );
 				scene.add( ambient );
 
-				const dirLight = new THREE.DirectionalLight( 0xffffff, 2.5 );
-				dirLight.position.set( 5, 10, 5 );
-				dirLight.castShadow = true;
-				dirLight.shadow.mapSize.width = 1024;
-				dirLight.shadow.mapSize.height = 1024;
-				dirLight.shadow.camera.near = 1;
-				dirLight.shadow.camera.far = 25;
-				dirLight.shadow.camera.left = - 3;
-				dirLight.shadow.camera.right = 3;
-				dirLight.shadow.camera.top = 3;
-				dirLight.shadow.camera.bottom = - 3;
-				scene.add( dirLight );
+				const sunLight = new SunLight( 0xffffff, 2.5 );
+				sunLight.position.set( 5, 10, 5 );
+				sunLight.castShadow = true;
+				sunLight.shadow.mapSize.set( 2048, 2048 );
+				sunLight.shadow.camera.far = 25;
+				scene.add( sunLight );
 
 				// Renderer
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/examples/webgpu_postprocessing_motion_blur.html
+++ b/examples/webgpu_postprocessing_motion_blur.html
@@ -37,6 +37,8 @@
 
 			import * as THREE from 'three/webgpu';
 			import { pass, texture, uniform, output, mrt, velocity, uv, screenUV, vec4 } from 'three/tsl';
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 			import { motionBlur } from 'three/addons/tsl/display/MotionBlur.js';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
@@ -64,16 +66,9 @@
 				scene = new THREE.Scene();
 				scene.fog = new THREE.Fog( 0x0487e2, 7, 25 );
 
-				const sunLight = new THREE.DirectionalLight( 0xFFE499, 5 );
+				const sunLight = new SunLight( 0xFFE499, 5 );
 				sunLight.castShadow = true;
-				sunLight.shadow.camera.near = .1;
 				sunLight.shadow.camera.far = 10;
-				sunLight.shadow.camera.right = 2;
-				sunLight.shadow.camera.left = - 2;
-				sunLight.shadow.camera.top = 2;
-				sunLight.shadow.camera.bottom = - 2;
-				sunLight.shadow.mapSize.width = 1024;
-				sunLight.shadow.mapSize.height = 1024;
 				sunLight.position.set( 4, 4, 2 );
 
 				const waterAmbientLight = new THREE.HemisphereLight( 0x333366, 0x74ccf4, 5 );
@@ -161,6 +156,7 @@
 				// renderer
 
 				renderer = new THREE.WebGPURenderer();
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/examples/webgpu_postprocessing_outline.html
+++ b/examples/webgpu_postprocessing_outline.html
@@ -37,6 +37,8 @@
 
 			import * as THREE from 'three/webgpu';
 			import { pass, uniform, time, oscSine } from 'three/tsl';
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 			import { outline } from 'three/addons/tsl/display/OutlineNode.js';
 
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
@@ -63,6 +65,7 @@
 				const height = window.innerHeight;
 
 				renderer = new THREE.WebGPURenderer();
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( width, height );
 				renderer.setAnimationLoop( animate );
@@ -86,18 +89,12 @@
 
 				scene.add( new THREE.AmbientLight( 0xaaaaaa, 0.6 ) );
 
-				const light = new THREE.DirectionalLight( 0xddffdd, 2 );
+				const light = new SunLight( 0xddffdd, 2 );
 				light.position.set( 5, 5, 5 );
 				light.castShadow = true;
 				light.shadow.mapSize.width = 2048;
 				light.shadow.mapSize.height = 2048;
 
-				const d = 10;
-
-				light.shadow.camera.left = - d;
-				light.shadow.camera.right = d;
-				light.shadow.camera.top = d;
-				light.shadow.camera.bottom = - d;
 				light.shadow.camera.far = 25;
 
 				scene.add( light );

--- a/examples/webgpu_postprocessing_pixel.html
+++ b/examples/webgpu_postprocessing_pixel.html
@@ -39,6 +39,8 @@
 
 		import * as THREE from 'three/webgpu';
 
+		import { SunLight } from 'three/addons/lights/SunLight.js';
+		import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 		import { Inspector } from 'three/addons/inspector/Inspector.js';
 
@@ -120,11 +122,12 @@
 
 			scene.add( new THREE.AmbientLight( 0x757f8e, 3 ) );
 
-			const directionalLight = new THREE.DirectionalLight( 0xfffecd, 1.5 );
-			directionalLight.position.set( 100, 100, 100 );
-			directionalLight.castShadow = true;
-			directionalLight.shadow.mapSize.set( 2048, 2048 );
-			scene.add( directionalLight );
+			const sunLight = new SunLight( 0xfffecd, 1.5 );
+			sunLight.position.set( 100, 100, 100 );
+			sunLight.castShadow = true;
+			sunLight.shadow.camera.far = 10;
+			sunLight.shadow.mapSize.set( 2048, 2048 );
+			scene.add( sunLight );
 
 			const spotLight = new THREE.SpotLight( 0xffc100, 10, 10, Math.PI / 16, .02, 2 );
 			spotLight.position.set( 2, 2, 0 );
@@ -135,6 +138,7 @@
 			scene.add( spotLight );
 
 			renderer = new THREE.WebGPURenderer();
+			renderer.library.addLight( SunLightNode, SunLight );
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			renderer.setAnimationLoop( animate );
 			renderer.inspector = new Inspector();

--- a/examples/webgpu_postprocessing_ssr_denoise.html
+++ b/examples/webgpu_postprocessing_ssr_denoise.html
@@ -60,6 +60,8 @@
 
 		import * as THREE from 'three/webgpu';
 		import { pass, mrt, output, normalView, materialMetalness, materialRoughness, screenUV, sample, packNormalToRGB, unpackRGBToNormal, vec2, velocity, diffuseColor, vec3, vec4, uniform, mix, step, abs, float, renderOutput, saturation } from 'three/tsl';
+		import { SunLight } from 'three/addons/lights/SunLight.js';
+		import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 		import { ssr } from 'three/addons/tsl/display/SSRNode.js';
 		import { temporalReproject } from 'three/addons/tsl/display/TemporalReprojectNode.js';
 		import { recurrentDenoise } from 'three/addons/tsl/display/RecurrentDenoiseNode.js';
@@ -206,6 +208,7 @@
 			} );
 
 			renderer = new THREE.WebGPURenderer();
+			renderer.library.addLight( SunLightNode, SunLight );
 			renderer.inspector = new Inspector();
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			renderer.toneMapping = THREE.AgXToneMapping;
@@ -221,21 +224,14 @@
 			hdrTexture.generateMipmaps = true;
 			hdrTexture.needsUpdate = true;
 
-			const directionalLight = new THREE.DirectionalLight( '#ffffff', 20 );
-			directionalLight.position.set( - 10.9, 2.2, 10.75 );
-			directionalLight.castShadow = true;
-			directionalLight.shadow.autoUpdate = false;
-			directionalLight.shadow.needsUpdate = true;
-			directionalLight.shadow.mapSize.width = 4096;
-			directionalLight.shadow.mapSize.height = 4096;
-			directionalLight.shadow.camera.left = - 1.75;
-			directionalLight.shadow.camera.right = 1.75;
-			directionalLight.shadow.camera.top = 1.75;
-			directionalLight.shadow.camera.bottom = - 1.75;
-			directionalLight.shadow.camera.near = 0.1;
-			directionalLight.shadow.camera.far = 50;
-			directionalLight.shadow.bias = - 0.0005;
-			scene.add( directionalLight );
+			const sunLight = new SunLight( '#ffffff', 20 );
+			sunLight.position.set( - 10.9, 2.2, 10.75 );
+			sunLight.castShadow = true;
+			sunLight.shadow.mapSize.width = 4096;
+			sunLight.shadow.mapSize.height = 4096;
+			sunLight.shadow.camera.far = 50;
+			sunLight.shadow.normalBias = 0.0015;
+			scene.add( sunLight );
 
 			await renderer.init();
 
@@ -400,11 +396,10 @@
 			const lightGui = renderer.inspector.createParameters( 'Light' ).close();
 			[ 'x', 'y', 'z' ].forEach( axis => {
 
-				lightGui.add( directionalLight.position, axis, - 30, 30 ).name( axis.toUpperCase() )
-					.onChange( () => directionalLight.shadow.needsUpdate = true );
+				lightGui.add( sunLight.position, axis, - 30, 30 ).name( axis.toUpperCase() );
 
 			} );
-			lightGui.add( directionalLight, 'intensity', 0, 50 ).name( 'Intensity' );
+			lightGui.add( sunLight, 'intensity', 0, 50 ).name( 'Intensity' );
 
 			updateOutputNode();
 			renderer.setAnimationLoop( animate );

--- a/examples/webgpu_skinning_instancing_individual.html
+++ b/examples/webgpu_skinning_instancing_individual.html
@@ -40,6 +40,8 @@
 			import * as THREE from 'three/webgpu';
 			import { Fn, add, attributeArray, color, instanceIndex, screenUV, storage, transformNormal, transformNormalToView, uint, uniform, vec4, vertexIndex, mat3 } from 'three/tsl';
 
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
@@ -207,18 +209,12 @@
 
 				scene.add( new THREE.HemisphereLight( 0xffffff, 0x939b9e, 1.2 ) );
 
-				const directionalLight = new THREE.DirectionalLight( 0xfffbf4, 2.8 );
-				directionalLight.position.set( - 4, 10, 8 );
-				directionalLight.castShadow = true;
-				directionalLight.shadow.mapSize.set( 2048, 2048 );
-				directionalLight.shadow.camera.left = - 5;
-				directionalLight.shadow.camera.right = 5;
-				directionalLight.shadow.camera.top = 5;
-				directionalLight.shadow.camera.bottom = - 5;
-				directionalLight.shadow.camera.near = 0.1;
-				directionalLight.shadow.camera.far = 30;
-				directionalLight.shadow.camera.updateProjectionMatrix();
-				scene.add( directionalLight );
+				const sunLight = new SunLight( 0xfffbf4, 2.8 );
+				sunLight.position.set( - 4, 10, 8 );
+				sunLight.castShadow = true;
+				sunLight.shadow.mapSize.set( 2048, 2048 );
+				sunLight.shadow.camera.far = 30;
+				scene.add( sunLight );
 
 				const rimLight = new THREE.DirectionalLight( 0xe8f4ff, 0.85 );
 				rimLight.position.set( 7, 5, - 5 );
@@ -319,6 +315,7 @@
 				} );
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/examples/webgpu_tsl_angular_slicing.html
+++ b/examples/webgpu_tsl_angular_slicing.html
@@ -40,6 +40,9 @@
 			import * as THREE from 'three/webgpu';
 			import { If, TWO_PI, atan, color, frontFacing, output, positionLocal, Fn, uniform, vec4 } from 'three/tsl';
 
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
+
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 
 			import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
@@ -72,18 +75,13 @@
 
 				// lights
 
-				const directionalLight = new THREE.DirectionalLight( '#ffffff', 4 );
-				directionalLight.position.set( 6.25, 3, 4 );
-				directionalLight.castShadow = true;
-				directionalLight.shadow.mapSize.set( 2048, 2048 );
-				directionalLight.shadow.camera.near = 0.1;
-				directionalLight.shadow.camera.far = 30;
-				directionalLight.shadow.camera.top = 8;
-				directionalLight.shadow.camera.right = 8;
-				directionalLight.shadow.camera.bottom = - 8;
-				directionalLight.shadow.camera.left = - 8;
-				directionalLight.shadow.normalBias = 0.05;
-				scene.add( directionalLight );
+				const sunLight = new SunLight( '#ffffff', 4 );
+				sunLight.position.set( 6.25, 3, 4 );
+				sunLight.castShadow = true;
+				sunLight.shadow.mapSize.set( 4096, 4096 );
+				sunLight.shadow.camera.far = 20;
+				sunLight.shadow.normalBias = 0.05;
+				scene.add( sunLight );
 
 				// TSL functions
 			
@@ -186,6 +184,7 @@
 				// renderer
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
 				renderer.shadowMap.enabled = true;

--- a/examples/webgpu_tsl_procedural_terrain.html
+++ b/examples/webgpu_tsl_procedural_terrain.html
@@ -40,6 +40,9 @@
 			import * as THREE from 'three/webgpu';
 			import { mx_noise_float, color, cross, dot, float, transformNormalToView, positionLocal, sign, step, Fn, uniform, varying, vec2, vec3, Loop } from 'three/tsl';
 
+			import { SunLight } from 'three/addons/lights/SunLight.js';
+			import { SunLightNode } from 'three/addons/lights/SunLightNode.js';
+
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
@@ -72,18 +75,12 @@
 
 				// lights
 			
-				const directionalLight = new THREE.DirectionalLight( '#ffffff', 2 );
-				directionalLight.position.set( 6.25, 3, 4 );
-				directionalLight.castShadow = true;
-				directionalLight.shadow.mapSize.set( 1024, 1024 );
-				directionalLight.shadow.camera.near = 0.1;
-				directionalLight.shadow.camera.far = 30;
-				directionalLight.shadow.camera.top = 8;
-				directionalLight.shadow.camera.right = 8;
-				directionalLight.shadow.camera.bottom = - 8;
-				directionalLight.shadow.camera.left = - 8;
-				directionalLight.shadow.normalBias = 0.05;
-				scene.add( directionalLight );
+				const sunLight = new SunLight( '#ffffff', 2 );
+				sunLight.position.set( 6.25, 3, 4 );
+				sunLight.castShadow = true;
+				sunLight.shadow.camera.far = 30;
+				sunLight.shadow.normalBias = 0.05;
+				scene.add( sunLight );
 
 				// terrain
 
@@ -271,6 +268,7 @@
 				// renderer
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer.library.addLight( SunLightNode, SunLight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.shadowMap.enabled = true;
 				renderer.setPixelRatio( window.devicePixelRatio );


### PR DESCRIPTION
Related: #34259

Use `SunLight` in the 13 WebGPU examples whose sun casts shadows, replacing manual shadow bounds with camera-fitted cascades.

Probe baking swaps each shadow-casting `SunLight` for a directional light fitted to the shadow casters, shared with `LightProbeGridWebGL` through `LightProbeGridUtils.js`. The bake light is cached per `SunLight` so incremental bakes reuse their pipelines. Examples whose sun does not cast shadows keep `DirectionalLight`, as do the reflection demo (its zoomed ortho shadow resolves the tree better than the cascades), backdrop water, material arrays, custom fog, city generation and VXGI. The Sponza probe scene already uses `SunLight` on `dev`.

**Validation**

Lint passes. Local E2E on macOS matches the Linux baselines for 10 of the 13 examples; the three remaining differences reproduce on `dev` unchanged. Both Sponza probe scenes bake fully with the swap, with steady frame times and no per-call recompiles. The `webgpu_postprocessing_ssr_denoise` validation errors (destroyed `TRAANode.resolve` and `TemporalReprojectNode.resolve` textures used in a submit) reproduce on `dev` unchanged.

**Examples**

- [webgpu_clipping](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_clipping.html)
- [webgpu_clipping_stencil](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_clipping_stencil.html)
- [webgpu_generator_building](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_generator_building.html)
- [webgpu_geometry_loft](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_geometry_loft.html)
- [webgpu_instancing_morph](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_instancing_morph.html)
- [webgpu_postprocessing_fog](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_postprocessing_fog.html)
- [webgpu_postprocessing_motion_blur](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_postprocessing_motion_blur.html)
- [webgpu_postprocessing_outline](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_postprocessing_outline.html)
- [webgpu_postprocessing_pixel](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_postprocessing_pixel.html)
- [webgpu_postprocessing_ssr_denoise](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_postprocessing_ssr_denoise.html)
- [webgpu_skinning_instancing_individual](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_skinning_instancing_individual.html)
- [webgpu_tsl_angular_slicing](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_tsl_angular_slicing.html)
- [webgpu_tsl_procedural_terrain](https://raw.githack.com/mrdoob/three.js/7e3712527958fa73079373a0bb594758adca5e85/examples/webgpu_tsl_procedural_terrain.html)









