### PR TITLE
GaussianBlurNode: Merge adjacent taps into bilinear fetches.

### DIFF
--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -253,10 +253,18 @@ class GaussianBlurNode extends TempNode {
 
 			const diffuseSum = vec4( sampleTexture( uvNode ).mul( gaussianCoefficients[ 0 ] ) ).toVar();
 
-			for ( let i = 1; i < kernelSize; i ++ ) {
+			// adjacent taps are merged into one bilinear fetch at their weighted offset.
+			// not possible with premultiplied alpha since the hardware lerp happens before the multiply.
 
-				const x = float( i );
-				const w = float( gaussianCoefficients[ i ] );
+			const step = this.premultipliedAlpha ? 1 : 2;
+
+			for ( let i = 1; i < kernelSize; i += step ) {
+
+				const wa = gaussianCoefficients[ i ];
+				const wb = ( step === 2 && i + 1 < kernelSize ) ? gaussianCoefficients[ i + 1 ] : 0;
+
+				const x = float( ( i * wa + ( i + 1 ) * wb ) / ( wa + wb ) );
+				const w = float( wa + wb );
 
 				const uvOffset = vec2( direction.mul( invSize.mul( x ) ) ).toVar();
 


### PR DESCRIPTION
Pairs of adjacent Gaussian taps are fetched once at their weighted offset, relying on the linear filtering of the render targets (the same linear-sampling trick `BloomNode` already uses). Taps per pass drop from `2 * kernelSize - 1` to `kernelSize`: 21 to 11 at the default sigma, 45 to 23 at sigma 10. The premultiplied alpha path keeps single taps, since the hardware lerp happens before the per-tap premultiplication.

Measured on an M1 with GPU timestamps (blur passes only, contenders interleaved in one page):

| Input | sigma | before | after |
|---|---|---|---|
| `pass()` texture, 1080p | 4 | 3.41 ms | 1.87 ms |
| `pass()` texture, 1080p | 10 | 8.07 ms | 3.81 ms |
| `pass()` texture, 4K | 4 | 13.2 ms | 7.0 ms |
| `pass()` texture, 4K | 10 | 32.9 ms | 14.7 ms |

Output is unchanged in exact arithmetic; on hardware the result differs by at most one 8-bit step on 0.6% of pixels (half-float: 1 to 2 ulp). The e2e screenshots for `webgpu_postprocessing_lensflare`, `webgpu_volume_lighting`, `webgpu_mrt_mask` and `webgpu_shadow_contact` pass with 0.0% diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfmxBc2caqoNZRmM44vCgF
