### PR TITLE
FirstPersonControls: Restore R/F shortcuts and unify example look speed.

### DIFF
--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -279,7 +279,7 @@ class FirstPersonControls extends Controls {
 		}
 
 		// target velocity in world space: keys are world axis aligned, moving in the
-		// XZ plane from the camera's yaw only (Q / E along world Y), while pointer
+		// XZ plane from the camera's yaw only (R / F along world Y), while pointer
 		// and touch input moves along the look direction
 
 		const yaw = MathUtils.degToRad( this._lon );
@@ -471,8 +471,8 @@ function onKeyDown( event ) {
 		case 'ArrowRight':
 		case 'KeyD': this._moveRight = true; break;
 
-		case 'KeyE': this._moveUp = true; break;
-		case 'KeyQ': this._moveDown = true; break;
+		case 'KeyR': this._moveUp = true; break;
+		case 'KeyF': this._moveDown = true; break;
 
 	}
 
@@ -494,8 +494,8 @@ function onKeyUp( event ) {
 		case 'ArrowRight':
 		case 'KeyD': this._moveRight = false; break;
 
-		case 'KeyE': this._moveUp = false; break;
-		case 'KeyQ': this._moveDown = false; break;
+		case 'KeyR': this._moveUp = false; break;
+		case 'KeyF': this._moveDown = false; break;
 
 	}
 

--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -227,7 +227,7 @@
 				controls = new FirstPersonControls( camera, renderer.domElement );
 
 				controls.movementSpeed = 70;
-				controls.lookSpeed = 0.05;
+				controls.lookSpeed = 0.2;
 				controls.lookVertical = false;
 
 				//

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -177,7 +177,7 @@
 				controls = new FirstPersonControls( camera, renderer.domElement );
 
 				controls.movementSpeed = 1000;
-				controls.lookSpeed = 0.125;
+				controls.lookSpeed = 0.2;
 				controls.lookVertical = true;
 
 				stats = new Stats();

--- a/examples/webgl_geometry_terrain.html
+++ b/examples/webgl_geometry_terrain.html
@@ -94,7 +94,7 @@
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
 				controls.movementSpeed = 150;
-				controls.lookSpeed = 0.1;
+				controls.lookSpeed = 0.2;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );

--- a/examples/webgl_lightprobes_sponza.html
+++ b/examples/webgl_lightprobes_sponza.html
@@ -85,7 +85,7 @@
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
 				controls.movementSpeed = 2.0;
-				controls.lookSpeed = 0.16;
+				controls.lookSpeed = 0.2;
 
 				const progressBar = document.getElementById( 'progressBar' );
 

--- a/examples/webgl_lights_sunlight.html
+++ b/examples/webgl_lights_sunlight.html
@@ -123,7 +123,7 @@
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
 				controls.movementSpeed = 40;
-				controls.lookSpeed = 0.05;
+				controls.lookSpeed = 0.2;
 
 				timer = new THREE.Timer();
 				pmremGenerator = new THREE.PMREMGenerator( renderer );

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -108,7 +108,7 @@
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
 
-				controls.lookSpeed = 0.0125;
+				controls.lookSpeed = 0.2;
 				controls.movementSpeed = 500;
 				controls.lookVertical = true;
 

--- a/examples/webgpu_custom_fog.html
+++ b/examples/webgpu_custom_fog.html
@@ -194,7 +194,7 @@
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
 				controls.movementSpeed = 20;
-				controls.lookSpeed = 0.1;
+				controls.lookSpeed = 0.2;
 				controls.lookAt( 0, 5, - 120 ); // face across the valley
 
 				window.addEventListener( 'resize', resize );

--- a/examples/webgpu_custom_fog_scattering.html
+++ b/examples/webgpu_custom_fog_scattering.html
@@ -174,7 +174,7 @@
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
 				controls.movementSpeed = 2;
-				controls.lookSpeed = 0.1;
+				controls.lookSpeed = 0.2;
 				controls.lookAt( - 0.2, 1.7, - 8 );
 
 				renderPipeline = new THREE.RenderPipeline( renderer );

--- a/examples/webgpu_generator_city.html
+++ b/examples/webgpu_generator_city.html
@@ -107,7 +107,7 @@
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
 				controls.movementSpeed = 15;
-				controls.lookSpeed = 0.25;
+				controls.lookSpeed = 0.2;
 				controls.lookAt( 35, 55, 0 );
 
 				timer = new THREE.Timer();

--- a/examples/webgpu_lightprobes_sponza.html
+++ b/examples/webgpu_lightprobes_sponza.html
@@ -94,7 +94,7 @@
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
 				controls.movementSpeed = 2.0;
-				controls.lookSpeed = 0.16;
+				controls.lookSpeed = 0.2;
 
 				const progressBar = document.getElementById( 'progressBar' );
 

--- a/examples/webgpu_lights_sunlight.html
+++ b/examples/webgpu_lights_sunlight.html
@@ -136,7 +136,7 @@
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
 				controls.movementSpeed = 40;
-				controls.lookSpeed = 0.05;
+				controls.lookSpeed = 0.2;
 
 				timer = new THREE.Timer();
 				pmremGenerator = new THREE.PMREMGenerator( renderer );

--- a/examples/webgpu_vxgi_sponza.html
+++ b/examples/webgpu_vxgi_sponza.html
@@ -102,7 +102,7 @@
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
 				controls.movementSpeed = 2.0;
-				controls.lookSpeed = 0.16;
+				controls.lookSpeed = 0.2;
 
 				const progressBar = document.getElementById( 'progressBar' );
 


### PR DESCRIPTION
**Description**

Restore `R` for up and `F` for down in `FirstPersonControls`, reverting the key change in #33874. Set `lookSpeed = 0.2` in all 14 FirstPersonControls examples for consistent turning across demos.

**Validation**

- `npm test` passed: 1,315 core tests and 385 addon tests, with one existing TODO.
- Browser checks passed in the WebGL terrain and WebGPU fog-scattering examples at `lookSpeed = 0.2`: R/F movement and release, inactive Q/E keys, and horizontal and vertical looking.
- Confirmed all 14 example settings are `0.2`. Targeted ESLint reports only the two existing `array-bracket-spacing` errors in `webgpu_custom_fog_scattering.html:149`; all other changed source files pass. `git diff --check` passed.

**Example previews**

All 14 previews use `lookSpeed = 0.2`. Links are pinned to this PR commit.

| Example | Look speed (base → PR) |
| --- | --- |
| [webaudio_sandbox](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webaudio_sandbox.html) | `0.05` → `0.2` |
| [webgl_geometry_minecraft](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgl_geometry_minecraft.html) | `0.125` → `0.2` |
| [webgl_geometry_terrain](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgl_geometry_terrain.html) | `0.1` → `0.2` |
| [webgl_lightprobes_sponza](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgl_lightprobes_sponza.html) | `0.16` → `0.2` |
| [webgl_lights_sunlight](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgl_lights_sunlight.html) | `0.05` → `0.2` |
| [webgl_shadowmap_performance](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgl_shadowmap_performance.html) | `0.0125` → `0.2` |
| [webgpu_compute_rasterizer](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgpu_compute_rasterizer.html) | `0.2` (unchanged) |
| [webgpu_compute_rasterizer_ibl](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgpu_compute_rasterizer_ibl.html) | `0.2` (unchanged) |
| [webgpu_custom_fog](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgpu_custom_fog.html) | `0.1` → `0.2` |
| [webgpu_custom_fog_scattering](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgpu_custom_fog_scattering.html) | `0.1` → `0.2` |
| [webgpu_generator_city](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgpu_generator_city.html) | `0.25` → `0.2` |
| [webgpu_lightprobes_sponza](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgpu_lightprobes_sponza.html) | `0.16` → `0.2` |
| [webgpu_lights_sunlight](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgpu_lights_sunlight.html) | `0.05` → `0.2` |
| [webgpu_vxgi_sponza](https://raw.githack.com/mrdoob/three.js/f9d486f1cda5dc75b8262573b8aa77456f836ee3/examples/webgpu_vxgi_sponza.html) | `0.16` → `0.2` |
