### PR TITLE
VarNode: Fix `.before()` nodes being skipped for intent variables.

### DIFF
--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -228,6 +228,22 @@ class VarNode extends Node {
 
 			if ( this.isAssign( builder ) !== true ) {
 
+				if ( this._beforeNodes !== null ) {
+
+					const currentBeforeNodes = this._beforeNodes;
+
+					this._beforeNodes = null;
+
+					for ( const beforeNode of currentBeforeNodes ) {
+
+						beforeNode.build( ...params );
+
+					}
+
+					this._beforeNodes = currentBeforeNodes;
+
+				}
+
 				return this.node.build( ...params );
 
 			}

--- a/test/unit/src/nodes/core/VarNode.tests.js
+++ b/test/unit/src/nodes/core/VarNode.tests.js
@@ -1,0 +1,55 @@
+import { Fn } from '../../../../../src/nodes/tsl/TSLCore.js';
+import { uv } from '../../../../../src/nodes/accessors/UV.js';
+import NodeBuilder from '../../../../../src/nodes/core/NodeBuilder.js';
+import InspectorBase from '../../../../../src/renderers/common/InspectorBase.js';
+import MeshBasicNodeMaterial from '../../../../../src/materials/nodes/MeshBasicNodeMaterial.js';
+import { PlaneGeometry } from '../../../../../src/geometries/PlaneGeometry.js';
+import { Mesh } from '../../../../../src/objects/Mesh.js';
+
+function countInspectorNodes( createNode ) {
+
+	const geometry = new PlaneGeometry();
+	const material = new MeshBasicNodeMaterial();
+	const mesh = new Mesh( geometry, material );
+
+	const renderer = {
+		backend: { isWebGPUBackend: true },
+		inspector: new InspectorBase()
+	};
+
+	const builder = new NodeBuilder( mesh, renderer );
+	builder.setBuildStage( 'setup' );
+	builder.setShaderStage( 'fragment' );
+
+	createNode().build( builder );
+
+	const count = [ ...builder.nodes ].filter( node => node.isInspectorNode ).length;
+
+	geometry.dispose();
+	material.dispose();
+
+	return count;
+
+}
+
+export default QUnit.module( 'Nodes', () => {
+
+	QUnit.module( 'Core', () => {
+
+		QUnit.module( 'VarNode', () => {
+
+			QUnit.test( 'toInspector() registers on an intent VarNode returned by Fn()', ( assert ) => {
+
+				const makeValue = () => Fn( () => uv().x )();
+
+				const count = countInspectorNodes( () => makeValue().toInspector( 'Fn' ) );
+
+				assert.strictEqual( count, 1, 'InspectorNode should be registered even without an explicit toVar()' );
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -260,6 +260,9 @@ import './src/textures/TextureSource.tests.js';
 import './src/textures/VideoTexture.tests.js';
 
 
+//src/nodes/core
+import './src/nodes/core/VarNode.tests.js';
+
 //src/nodes/display
 import './src/nodes/display/ViewportTextureNode.tests.js';
 import './src/nodes/display/ViewportDepthTextureNode.tests.js';


### PR DESCRIPTION
Fixed #34489.

**Description**

`VarNode.build()` returns `this.node.build(...)` directly when the node is an unassigned intent variable, bypassing `Node.prototype.build()`'s handling of `_beforeNodes`. Anything attached via `.before()` on the intent node, such as `.toInspector()`, is silently dropped. `.toVar()` and `.debug()` happen to work because each wraps the intent node instead of attaching to it directly. The fix processes `_beforeNodes` before forwarding the build call, matching the handling already in `Node.build()`.