### PR TITLE
Texture: Ignore render target texture disposal

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -646,6 +646,13 @@ class Texture extends EventDispatcher {
 	 */
 	dispose() {
 
+		if ( this.isRenderTargetTexture === true ) {
+
+			warn( 'Texture: Render target textures should be disposed by their render target.' );
+			return;
+
+		}
+
 		/**
 		 * Fires when the texture has been disposed of.
 		 *

--- a/test/unit/src/textures/Texture.tests.js
+++ b/test/unit/src/textures/Texture.tests.js
@@ -46,6 +46,26 @@ export default QUnit.module( 'Textures', () => {
 
 		} );
 
+		QUnit.test( 'dispose does not dispatch for render target textures', ( assert ) => {
+
+			assert.expect( 1 );
+
+			const object = new Texture();
+			let disposed = false;
+
+			object.isRenderTargetTexture = true;
+			object.addEventListener( 'dispose', () => {
+
+				disposed = true;
+
+			} );
+
+			object.dispose();
+
+			assert.strictEqual( disposed, false, 'Render target textures are disposed by their render target.' );
+
+		} );
+
 	} );
 
 } );


### PR DESCRIPTION
Related issue: #34466

**Description**

Render target textures are owned and disposed by their render target. If user code calls `renderTarget.texture.dispose()` first, the texture dispatches a disposal event and renderer-owned GPU resources can be torn down before `renderTarget.dispose()` runs.

This updates `Texture.dispose()` to ignore render target textures, matching the ownership model discussed in #34466, and adds unit coverage so render target textures do not dispatch `dispose` directly.

Tests:

- `npm run lint-core`
- `npx eslint test/unit/src/textures/Texture.tests.js`
- `npm run test-unit`
- `git diff --check`
