### PR TITLE
WebGPURenderer: Fix render target texture dispose crash.

### DIFF
--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -482,6 +482,9 @@ class RenderTarget extends EventDispatcher {
 	 * Frees the GPU-related resources allocated by this instance. Call this
 	 * method whenever this instance is no longer used in your app.
 	 *
+	 * This also frees the resources of the render target's textures. There is
+	 * no need to dispose them separately.
+	 *
 	 * @fires RenderTarget#dispose
 	 */
 	dispose() {

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1594,13 +1594,13 @@ class Renderer {
 
 				this._frameBufferTargets.delete( target );
 
-				const quadData = this._quadCache.get( frameBufferTarget.texture );
+				const quadData = this._quadCache.get( frameBufferTarget );
 
 				if ( quadData !== undefined ) {
 
 					quadData.quad.material.dispose();
 
-					this._quadCache.delete( frameBufferTarget.texture );
+					this._quadCache.delete( frameBufferTarget );
 
 				}
 
@@ -1970,7 +1970,7 @@ class Renderer {
 
 		const cacheKey = this._nodes.getOutputCacheKey();
 
-		let quadData = this._quadCache.get( renderTarget.texture );
+		let quadData = this._quadCache.get( renderTarget );
 		let quad;
 
 		if ( quadData === undefined ) {
@@ -1986,7 +1986,7 @@ class Renderer {
 				cacheKey
 			};
 
-			this._quadCache.set( renderTarget.texture, quadData );
+			this._quadCache.set( renderTarget, quadData );
 
 		} else {
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1594,6 +1594,16 @@ class Renderer {
 
 				this._frameBufferTargets.delete( target );
 
+				const quadData = this._quadCache.get( frameBufferTarget.texture );
+
+				if ( quadData !== undefined ) {
+
+					quadData.quad.material.dispose();
+
+					this._quadCache.delete( frameBufferTarget.texture );
+
+				}
+
 			};
 
 			target.addEventListener( 'dispose', dispose );
@@ -1977,20 +1987,6 @@ class Renderer {
 			};
 
 			this._quadCache.set( renderTarget.texture, quadData );
-
-			// dispose logic
-
-			const dispose = () => {
-
-				quad.material.dispose();
-
-				this._quadCache.delete( renderTarget.texture );
-
-				renderTarget.texture.removeEventListener( 'dispose', dispose );
-
-			};
-
-			renderTarget.texture.addEventListener( 'dispose', dispose );
 
 		} else {
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -401,13 +401,17 @@ class Textures extends DataMap {
 
 			// dispose
 
-			textureData.onDispose = () => {
+			if ( texture.isRenderTargetTexture !== true ) {
 
-				this._destroyTexture( texture );
+				textureData.onDispose = () => {
 
-			};
+					this._destroyTexture( texture );
 
-			texture.addEventListener( 'dispose', textureData.onDispose );
+				};
+
+				texture.addEventListener( 'dispose', textureData.onDispose );
+
+			}
 
 		}
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -642,6 +642,10 @@ class Texture extends EventDispatcher {
 	 * Frees the GPU-related resources allocated by this instance. Call this
 	 * method whenever this instance is no longer used in your app.
 	 *
+	 * Textures that belong to a render target are managed by the render target.
+	 * Calling this method on such a texture only dispatches the dispose event but
+	 * does not free any GPU resources. Use {@link RenderTarget#dispose} instead.
+	 *
 	 * @fires Texture#dispose
 	 */
 	dispose() {


### PR DESCRIPTION
Fixed #34466.

**Description**

The PR makes sure calling `dispose()` on a render target texture does not produce an invalid state in `WebGPURenderer`.

In general, calling `dispose()` on a render target texture is not supported since its lifetime is managed by its render target. This is a policy already present in `WebGLRenderer` which only adds texture dispose event listeners to non-render target textures. The same is now done in `WebGPURenderer`.

That is better to what I have suggested in https://github.com/mrdoob/three.js/issues/34466#issuecomment-5558002001 first because textures still uniformly dispatch their dispose event. Also `WebGPURenderer` just adapts the existing policy of `WebGLRenderer`.