### PR TITLE
3DMLoader: add views, namedViews, and strings to userData

### DIFF
--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -553,7 +553,10 @@ class Rhino3dmLoader extends Loader {
 		const instanceReferences = [];
 
 		object.userData[ 'layers' ] = data.layers;
+		object.userData[ 'views' ] = data.views;
+		object.userData[ 'namedViews' ] = data.namedViews;
 		object.userData[ 'groups' ] = data.groups;
+		object.userData[ 'strings' ] = data.strings;
 		object.userData[ 'settings' ] = data.settings;
 		object.userData.settings[ 'renderSettings' ] = data.renderSettings;
 		object.userData[ 'objectType' ] = 'File3dm';


### PR DESCRIPTION
Views, named views, and document user text from the Rhino 3dm file gets loaded but was left unused. This change adds them to userData.

The existing 3dm file used in the example (examples/models/3dm/Rhino_Logo.3dm) contains all three of the above and I have checked that it works.