### PR TITLE
Clean up.

### DIFF
--- a/tsl/js/imports/scripts/scenes/empty.js
+++ b/tsl/js/imports/scripts/scenes/empty.js
@@ -47,16 +47,16 @@ export async function init() {
 
 	scene = new THREE.Scene();
 
-	camera = new THREE.PerspectiveCamera( 45, renderer.domElement.clientWidth / renderer.domElement.clientHeight, 0.1, 100 );
+	camera = new THREE.PerspectiveCamera( 45, renderer.domElement.clientWidth / renderer.domElement.clientHeight, 0.1, 100 ); // eslint-disable-line no-undef
 	camera.position.set( 2, 3, 4 );
 	camera.lookAt( 0, 1, 0 );
 
 	defaultPass = pass( scene, camera );
 	defaultAA = smaa( defaultPass );
 
-	renderPipeline = new THREE.RenderPipeline( renderer );
+	renderPipeline = new THREE.RenderPipeline( renderer ); // eslint-disable-line no-undef
 
-	controls = new OrbitControls( camera, renderer.domElement );
+	controls = new OrbitControls( camera, renderer.domElement ); // eslint-disable-line no-undef
 	controls.enableDamping = true;
 	controls.minDistance = 2;
 	controls.maxDistance = 20;

--- a/tsl/js/imports/scripts/scenes/plane.js
+++ b/tsl/js/imports/scripts/scenes/plane.js
@@ -55,16 +55,16 @@ export async function init() {
 
 	scene = new THREE.Scene();
 
-	camera = new THREE.PerspectiveCamera( 45, renderer.domElement.clientWidth / renderer.domElement.clientHeight, 0.1, 100 );
+	camera = new THREE.PerspectiveCamera( 45, renderer.domElement.clientWidth / renderer.domElement.clientHeight, 0.1, 100 ); // eslint-disable-line no-undef
 	camera.position.set( 2, 3, 4 );
 	camera.lookAt( 0, 1.5, 0 );
 
 	defaultPass = pass( scene, camera );
 	defaultAA = smaa( defaultPass );
 
-	renderPipeline = new THREE.RenderPipeline( renderer );
+	renderPipeline = new THREE.RenderPipeline( renderer ); // eslint-disable-line no-undef
 
-	controls = new OrbitControls( camera, renderer.domElement );
+	controls = new OrbitControls( camera, renderer.domElement ); // eslint-disable-line no-undef
 	controls.enableDamping = true;
 	controls.minDistance = 2;
 	controls.maxDistance = 20;

--- a/tsl/js/imports/scripts/scenes/shaderball.js
+++ b/tsl/js/imports/scripts/scenes/shaderball.js
@@ -31,16 +31,16 @@ export async function init() {
 
 	scene = new THREE.Scene();
 
-	camera = new THREE.PerspectiveCamera( 45, renderer.domElement.clientWidth / renderer.domElement.clientHeight, 0.1, 100 );
+	camera = new THREE.PerspectiveCamera( 45, renderer.domElement.clientWidth / renderer.domElement.clientHeight, 0.1, 100 ); // eslint-disable-line no-undef
 	camera.position.set( 2, 3, 4 );
 	camera.lookAt( 0, 1, 0 );
 
 	defaultPass = pass( scene, camera );
 	defaultAA = smaa( defaultPass );
 
-	renderPipeline = new THREE.RenderPipeline( renderer );
+	renderPipeline = new THREE.RenderPipeline( renderer ); // eslint-disable-line no-undef
 
-	controls = new OrbitControls( camera, renderer.domElement );
+	controls = new OrbitControls( camera, renderer.domElement ); // eslint-disable-line no-undef
 	controls.enableDamping = true;
 	controls.minDistance = 2;
 	controls.maxDistance = 20;


### PR DESCRIPTION
Related issue: #34488

**Description**

The PR makes sure the warnings are gone which are now reported by the linter.

It reports about undefined values but the `renderer` reference is injected by the environment. So disabling the rule per line.