### PR TITLE
ImageBitmapLoader: Avoid mutating loader options

### DIFF
--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -176,7 +176,7 @@ class ImageBitmapLoader extends Loader {
 
 		} ).then( function ( blob ) {
 
-			return createImageBitmap( blob, Object.assign( scope.options, { colorSpaceConversion: 'none' } ) );
+			return createImageBitmap( blob, Object.assign( {}, scope.options, { colorSpaceConversion: 'none' } ) );
 
 		} ).then( function ( imageBitmap ) {
 

--- a/test/unit/src/loaders/ImageBitmapLoader.tests.js
+++ b/test/unit/src/loaders/ImageBitmapLoader.tests.js
@@ -110,6 +110,35 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
+		QUnit.test( 'does not mutate options', async ( assert ) => {
+
+			const canvas = document.createElement( 'canvas' );
+			canvas.width = 8;
+			canvas.height = 8;
+
+			const url = canvas.toDataURL( 'image/png' );
+			const options = Object.freeze( { imageOrientation: 'flipY' } );
+			const loader = new ImageBitmapLoader().setOptions( options );
+
+			const enabled = Cache.enabled;
+			Cache.enabled = true;
+
+			try {
+
+				const imageBitmap = await loader.loadAsync( url );
+
+				assert.ok( imageBitmap instanceof ImageBitmap, 'The request resolves with an image bitmap.' );
+				assert.deepEqual( options, { imageOrientation: 'flipY' }, 'The loader does not mutate the options.' );
+
+			} finally {
+
+				Cache.remove( `image-bitmap:${url}` );
+				Cache.enabled = enabled;
+
+			}
+
+		} );
+
 	} );
 
 } );

--- a/test/unit/src/loaders/ImageBitmapLoader.tests.js
+++ b/test/unit/src/loaders/ImageBitmapLoader.tests.js
@@ -110,35 +110,6 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		QUnit.test( 'does not mutate options', async ( assert ) => {
-
-			const canvas = document.createElement( 'canvas' );
-			canvas.width = 8;
-			canvas.height = 8;
-
-			const url = canvas.toDataURL( 'image/png' );
-			const options = Object.freeze( { imageOrientation: 'flipY' } );
-			const loader = new ImageBitmapLoader().setOptions( options );
-
-			const enabled = Cache.enabled;
-			Cache.enabled = true;
-
-			try {
-
-				const imageBitmap = await loader.loadAsync( url );
-
-				assert.ok( imageBitmap instanceof ImageBitmap, 'The request resolves with an image bitmap.' );
-				assert.deepEqual( options, { imageOrientation: 'flipY' }, 'The loader does not mutate the options.' );
-
-			} finally {
-
-				Cache.remove( `image-bitmap:${url}` );
-				Cache.enabled = enabled;
-
-			}
-
-		} );
-
 	} );
 
 } );


### PR DESCRIPTION
Related issue: #XXXX

**Description**

`ImageBitmapLoader` currently passes `scope.options` directly as the target of `Object.assign()`. As a result, loading an image mutates the object supplied to `setOptions()` by adding `colorSpaceConversion: 'none'`.

This can unexpectedly modify caller-owned objects and causes `loadAsync()` to reject when the options object is frozen.

This change creates a new options object before applying the internal `colorSpaceConversion` override. The behavior passed to `createImageBitmap()` is unchanged, while caller-provided options remain untouched.

