### PR TITLE
WebGLBackend: Make clear of default framebuffer more consistent.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -825,8 +825,10 @@ class WebGLBackend extends Backend {
 
 			if ( descriptor.textures === null ) {
 
-				gl.clearColor( clearColor.r, clearColor.g, clearColor.b, clearColor.a );
+				if ( color ) gl.clearColor( clearColor.r, clearColor.g, clearColor.b, clearColor.a );
 				if ( depth ) gl.clearDepth( clearDepth );
+				if ( stencil ) gl.clearStencil( clearStencil );
+
 				gl.clear( clear );
 
 			} else {

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -826,6 +826,7 @@ class WebGLBackend extends Backend {
 			if ( descriptor.textures === null ) {
 
 				gl.clearColor( clearColor.r, clearColor.g, clearColor.b, clearColor.a );
+				if ( depth ) gl.clearDepth( clearDepth );
 				gl.clear( clear );
 
 			} else {


### PR DESCRIPTION
Fixed #34501

**Description**

Applies the renderer's clear depth when clearing the default framebuffer, fixing reversed depth and custom clear depth values when rendering directly to the canvas.

Validation:

- `npm run lint`
- `npm run build`
- `npm run test-unit` and `npm run test-unit-addons`
- WebGL2 rendering checks using the local build
