### PR TITLE
OrbitControls: Improve `disconnect()`.

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -511,6 +511,8 @@ class OrbitControls extends Controls {
 
 	disconnect() {
 
+		this.state = _STATE.NONE;
+
 		this.domElement.removeEventListener( 'pointerdown', this._onPointerDown );
 		this.domElement.ownerDocument.removeEventListener( 'pointermove', this._onPointerMove );
 		this.domElement.ownerDocument.removeEventListener( 'pointerup', this._onPointerUp );
@@ -523,8 +525,15 @@ class OrbitControls extends Controls {
 
 		const document = this.domElement.getRootNode(); // offscreen canvas compatibility
 		document.removeEventListener( 'keydown', this._interceptControlDown, { capture: true } );
+		document.removeEventListener( 'keyup', this._interceptControlUp, { capture: true } );
+
+		this._controlActive = false;
+
+		this._pointers.length = 0;
+		this._pointerPositions = {};
 
 		this.domElement.style.touchAction = ''; // Restore touch scroll
+		this.domElement.style.cursor = 'auto';
 
 	}
 


### PR DESCRIPTION
Fixed #34503.

**Description**

The PR makes sure `OrbitControls` removes the `keyup` listener which was overlooked in `disconnect()`.

While testing, I've noticed `disconnect()` should do a bit more to ensure a consistent controls state if the method is called during an interaction. It resets the global state, the `_controlActive ` flag, the cursor style and the data structures tracking pointer events.

With all this in place, the controls can properly recover if a `connect()` follows a `disconnect()`.