### PR TITLE
RTTNode: Keep the renderer state per instance.

### DIFF
--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -14,8 +14,6 @@ import { resetRendererState, restoreRendererState } from '../../renderers/common
 
 const _size = /*@__PURE__*/ new Vector2();
 
-let _rendererState;
-
 /**
  * `RTTNode` takes another node and uses it with a `QuadMesh` to render into a texture (RTT).
  * This module is especially relevant in context of post processing where certain nodes require
@@ -126,6 +124,15 @@ class RTTNode extends TextureNode {
 		 * @type {QuadMesh}
 		 */
 		this._quadMesh = new QuadMesh( new NodeMaterial() );
+
+		/**
+		 * The renderer state saved and restored around the RTT render.
+		 * Kept per instance because nested RTT nodes must not share it.
+		 *
+		 * @private
+		 * @type {Object}
+		 */
+		this._rendererState = {};
 
 		/**
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node updates
@@ -287,13 +294,13 @@ class RTTNode extends TextureNode {
 
 		//
 
-		_rendererState = resetRendererState( renderer, _rendererState );
+		resetRendererState( renderer, this._rendererState );
 
 		renderer.setRenderTarget( this.renderTarget );
 
 		this._quadMesh.render( renderer );
 
-		restoreRendererState( renderer, _rendererState );
+		restoreRendererState( renderer, this._rendererState );
 
 	}
 


### PR DESCRIPTION
Related issue: regression from #34385

**Description**

`RTTNode` saves and restores the renderer state through a single module-level object. RTT nodes nest whenever `convertToTexture()` wraps both the input and the output of a pass, for example `sharpen( traa( applyGrading( source ) ) )`: the inner RTT runs inside the outer one's update. The inner node overwrites the shared state while the outer node is still rendering, so the outer node restores the *inner* render target, and the renderer is left pointing at an internal target when the frame ends. From the next frame on, the post-processing quad renders into that leaked target instead of the canvas.

Symptoms in `webgpu_postprocessing_ssr_denoise` on `dev`:

- The canvas is drawn once (frame 0) and never again.
- Each resize disposes a resolve target that the leaked outer pass is still using: `Destroyed texture [Texture "TRAANode.resolve"] used in a submit`, later `TemporalReprojectNode.resolve`.

This keeps the saved state per instance. That is safe because `NodeFrame` already prevents the same node from re-entering its update within a frame.

**Verification**

Traced the WebGPU calls in the example (texture create/destroy, pass attachments, bind group views, submits, per rAF frame):

| Build | Frames drawn to canvas | Validation errors |
|:--|:--|:--|
| commit before #34385 | every frame | 0 |
| `dev` | 1 of ~350 | 1 at load, 1 per resize |
| `dev` + this PR | every frame | 0 |

**Before / After**

Before is the last build without the fix (e7eaf9e329, 2026-08-31). After is the build with it (9769a98e50, 2026-09-08). Orbit the camera: before, the view never updates after the first frame.

| Example | Before | After |
|:--|:--|:--|
| `webgpu_postprocessing_ssr_denoise` | [before](https://raw.githack.com/mrdoob/three.js/e7eaf9e3290439d75a9ef59709fb4347eb472e6c/examples/webgpu_postprocessing_ssr_denoise.html) | [after](https://raw.githack.com/mrdoob/three.js/9769a98e5079348c5ef34c67e35e0ddb176873f5/examples/webgpu_postprocessing_ssr_denoise.html) |
| `webgpu_postprocessing_lensflare` | [before](https://raw.githack.com/mrdoob/three.js/e7eaf9e3290439d75a9ef59709fb4347eb472e6c/examples/webgpu_postprocessing_lensflare.html) | [after](https://raw.githack.com/mrdoob/three.js/9769a98e5079348c5ef34c67e35e0ddb176873f5/examples/webgpu_postprocessing_lensflare.html) |

Scanning all 32 `webgpu_postprocessing_*` examples on `dev` with the same trace, `webgpu_postprocessing_lensflare` (`gaussianBlur( lensflare( bloom( ... ) ) )`) is the only other one affected. Both render every frame with the fix.

Not caught by E2E: the harness captures exactly the first frame, which is the one frame that still reaches the canvas. The lensflare example is not even on the exception list and passes.

The same module-level pattern exists in the addon nodes (`TRAANode`, `TemporalReprojectNode`, `GaussianBlurNode`, `BloomNode`, ...). Those only break when two instances of the same class nest, so this PR leaves them alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQoCToBoF8hFzYGrrCuHQF

