### PR TITLE
Fix resize flickering in Playground

### DIFF
--- a/tsl/js/Guide.js
+++ b/tsl/js/Guide.js
@@ -460,13 +460,13 @@ class Guide {
 				const height = Math.floor( entry.contentRect.height );
 				if ( width > 0 && height > 0 ) {
 
-					cancelAnimationFrame( resizeTimeout );
-					resizeTimeout = requestAnimationFrame( () => {
+					clearTimeout( resizeTimeout );
+					resizeTimeout = setTimeout( () => {
 
 						this.renderer.setSize( width, height );
 						this.runner.call( 'resize', width, height );
 
-					} );
+					}, 0 );
 
 				}
 


### PR DESCRIPTION
**Description**

This PR fixes a flickering issue that occurs when the renderer is resized. The flicker happens because `ResizeObserver` callbacks are executed after `requestAnimationFrame` callbacks in the event loop. When we previously scheduled `renderer.setSize()` via an rAF inside the observer, that rAF was queued for the next event loop iteration. However, the animation loop's render rAF was already queued earlier in that same iteration, so the next iteration first rendered the scene at the old size and then cleared the canvas with `setSize`, producing a blank frame. 

To solve this, we now use `setTimeot` to trigger the resize. As a macrotask, `setTimeout` is guaranteed to execute before any rAF callbacks in the event loop iteration where it is processed, ensuring the canvas is resized and cleared before rendering, which eliminates the flicker. One caveat is that a macrotask may be delayed by other pending macrotasks, but given our app's workload, this delay is negligible and does not affect UX.

Before: https://raw.githack.com/mrdoob/three.js/dev/tsl/#if-else

<details>
  <summary><b>WARNING: The video shows a flickering screen</b> (click to watch)</summary>

  https://github.com/user-attachments/assets/96cd821a-33af-451f-b4e5-62650e6e3058
</details>

After: https://raw.githack.com/ycw/three.js/noflick/tsl/#if-else

https://github.com/user-attachments/assets/7d5aeb1c-48aa-4289-8fd5-f1bbf078ea11

