### PR TITLE
WGSLNodeBuilder: Add Directives to Fragment Stage and Update NodeBuilder.

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1203,6 +1203,75 @@ class NodeBuilder {
 	}
 
 	/**
+	 * Returns a builtin representing the size of a subgroup within the current shader.
+	 *
+	 * @abstract
+	 * @return {string} The subgroup size shader string.
+	 */
+	getSubgroupSize() {
+
+		warn( 'Abstract function.' );
+
+	}
+
+	/**
+	 * Returns a builtin representing the index of an invocation within its subgroup.
+	 *
+	 * @abstract
+	 * @return {string} The invocation subgroup index shader string.
+	 */
+	getInvocationSubgroupIndex() {
+
+		warn( 'Abstract function.' );
+
+	}
+
+	/**
+	 * Returns a builtin representing the index of the current invocation's subgroup within its workgroup.
+	 *
+	 * @abstract
+	 * @return {string} The subgroup index shader string.
+	 */
+	getSubgroupIndex() {
+
+		warn( 'Abstract function.' );
+
+	}
+
+	/**
+	 * Enables subgroups.
+	 *
+	 * @abstract
+	 */
+	enableSubGroups() {
+
+		warn( 'Abstract function.' );
+
+	}
+
+	/**
+	 * Enables 16 bit floats.
+	 *
+	 * @abstract
+	 */
+	enableShaderF16() {
+
+		warn( 'Abstract function.' );
+
+	}
+
+	/**
+	 * Enables dual source blending.
+	 *
+	 * @abstract
+	 */
+	enableDualSourceBlending() {
+
+		warn( 'Abstract function.' );
+
+	}
+
+	/**
 	 * Whether to flip texture data along its vertical axis or not. WebGL needs
 	 * this method evaluate to `true`, WebGPU to `false`.
 	 *

--- a/src/nodes/gpgpu/SubgroupFunctionNode.js
+++ b/src/nodes/gpgpu/SubgroupFunctionNode.js
@@ -76,6 +76,22 @@ class SubgroupFunctionNode extends TempNode {
 
 	}
 
+	setup( builder ) {
+
+		const renderer = builder.renderer;
+
+		if ( renderer.backend.isWebGPUBackend !== true || ! renderer.hasFeature( 'subgroups' ) ) {
+
+			error( `TSL: "${this.method}" requires the 'subgroups' feature, which is not supported by the current device.` );
+
+		}
+
+		builder.enableSubGroups();
+
+		return super.setup( builder );
+
+	}
+
 	generateNodeType( builder ) {
 
 		const method = this.method;

--- a/src/nodes/gpgpu/SubgroupFunctionNode.js
+++ b/src/nodes/gpgpu/SubgroupFunctionNode.js
@@ -78,14 +78,6 @@ class SubgroupFunctionNode extends TempNode {
 
 	setup( builder ) {
 
-		const renderer = builder.renderer;
-
-		if ( renderer.backend.isWebGPUBackend !== true || renderer.hasFeature( 'subgroups' ) === false ) {
-
-			error( `TSL: "${this.method}" requires the 'subgroups' feature, which is not supported by the current device.` );
-
-		}
-
 		builder.enableSubGroups();
 
 		return super.setup( builder );

--- a/src/nodes/gpgpu/SubgroupFunctionNode.js
+++ b/src/nodes/gpgpu/SubgroupFunctionNode.js
@@ -80,7 +80,7 @@ class SubgroupFunctionNode extends TempNode {
 
 		const renderer = builder.renderer;
 
-		if ( renderer.backend.isWebGPUBackend !== true || ! renderer.hasFeature( 'subgroups' ) ) {
+		if ( renderer.backend.isWebGPUBackend !== true || renderer.hasFeature( 'subgroups' ) === false ) {
 
 			error( `TSL: "${this.method}" requires the 'subgroups' feature, which is not supported by the current device.` );
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -1288,6 +1288,36 @@ ${ flowData.code }
 	}
 
 	/**
+	 * Enables subgroups.
+	 */
+	enableSubGroups() {
+
+		error( 'GLSLNodeBuilder: WebGLBackend does not support subgroup operations' );
+
+	}
+
+	/**
+	 * Enables 16 bit floats.
+	 */
+	enableShaderF16() {
+
+		error( 'GLSLNodeBuilder: WebGLBackend does not support 16 bit floats' );
+
+	}
+
+	/**
+	 * Enables dual source blending.
+	 *
+	 * WebGL 2 can express this through the `WEBGL_blend_func_extended` extension,
+	 * but WebGLBackend does not implement it.
+	 */
+	enableDualSourceBlending() {
+
+		error( 'GLSLNodeBuilder: WebGLBackend does not support dual source blending' );
+
+	}
+
+	/**
 	 * Returns the draw index builtin.
 	 *
 	 * @return {?string} The drawIndex shader string. Returns `null` if `WEBGL_multi_draw` isn't supported by the device.

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1716,7 +1716,7 @@ ${ flowData.code }
 	 */
 	enableSubGroups() {
 
-		if ( ! this.renderer.hasFeature( 'subgroups' ) ) {
+		if ( this.renderer.hasFeature( 'subgroups' ) === false ) {
 
 			error( 'WGSLNodeBuilder: "The \'subgroups\' feature is not supported by the current device.' );
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1695,7 +1695,6 @@ ${ flowData.code }
 	getDirectives( shaderStage ) {
 
 		const snippets = [];
-
 		const directives = this.directives[ shaderStage ];
 
 		if ( directives !== undefined ) {

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1716,6 +1716,12 @@ ${ flowData.code }
 	 */
 	enableSubGroups() {
 
+		if ( ! this.renderer.hasFeature( 'subgroups' ) ) {
+
+			error( 'WGSLNodeBuilder: "The \'subgroups\' feature is not supported by the current device.' );
+
+		}
+
 		this.enableDirective( 'subgroups' );
 
 	}

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -2642,11 +2642,11 @@ fn main( ${shaderData.attributes} ) -> VaryingsStruct {
 	_getWGSLFragmentCode( shaderData ) {
 
 		return `${ this.getSignature() }
-// directives
-${shaderData.directives}
-
 // global
 ${ diagnostics }
+
+// directives
+${shaderData.directives}
 
 // structs
 ${shaderData.structs}

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1719,20 +1719,11 @@ ${ flowData.code }
 	}
 
 	/**
-	 * Enables the 'subgroups' directive.
+	 * Enables subgroups.
 	 */
 	enableSubGroups() {
 
 		this.enableDirective( 'subgroups' );
-
-	}
-
-	/**
-	 * Enables the 'subgroups-f16' directive.
-	 */
-	enableSubgroupsF16() {
-
-		this.enableDirective( 'subgroups-f16' );
 
 	}
 
@@ -1746,7 +1737,7 @@ ${ flowData.code }
 	}
 
 	/**
-	 * Enables the 'f16' directive.
+	 * Enables 16 bit floats.
 	 */
 	enableShaderF16() {
 
@@ -1755,7 +1746,7 @@ ${ flowData.code }
 	}
 
 	/**
-	 * Enables the 'dual_source_blending' directive.
+	 * Enables dual source blending.
 	 */
 	enableDualSourceBlending() {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1695,6 +1695,13 @@ ${ flowData.code }
 	getDirectives( shaderStage ) {
 
 		const snippets = [];
+
+		if ( this.renderer.hasFeature( 'subgroups' ) && shaderStage !== 'vertex' ) {
+
+			this.enableDirective( 'subgroups', shaderStage );
+
+		}
+
 		const directives = this.directives[ shaderStage ];
 
 		if ( directives !== undefined ) {
@@ -1873,7 +1880,6 @@ ${ flowData.code }
 
 			if ( this.renderer.hasFeature( 'subgroups' ) ) {
 
-				this.enableDirective( 'subgroups', shaderStage );
 				this.getBuiltin( 'subgroup_size', 'subgroupSize', 'u32', 'attribute' );
 
 			}
@@ -2636,6 +2642,9 @@ fn main( ${shaderData.attributes} ) -> VaryingsStruct {
 	_getWGSLFragmentCode( shaderData ) {
 
 		return `${ this.getSignature() }
+// directives
+${shaderData.directives}
+
 // global
 ${ diagnostics }
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1718,7 +1718,7 @@ ${ flowData.code }
 
 		if ( this.renderer.hasFeature( 'subgroups' ) === false ) {
 
-			error( 'WGSLNodeBuilder: "The \'subgroups\' feature is not supported by the current device.' );
+			error( 'WGSLNodeBuilder: The \'subgroups\' feature is not supported by the current device.' );
 
 		}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1696,12 +1696,6 @@ ${ flowData.code }
 
 		const snippets = [];
 
-		if ( this.renderer.hasFeature( 'subgroups' ) && shaderStage !== 'vertex' ) {
-
-			this.enableDirective( 'subgroups', shaderStage );
-
-		}
-
 		const directives = this.directives[ shaderStage ];
 
 		if ( directives !== undefined ) {
@@ -1871,6 +1865,7 @@ ${ flowData.code }
 
 			if ( this.renderer.hasFeature( 'subgroups' ) ) {
 
+				this.enableDirective( 'subgroups', shaderStage );
 				this.getBuiltin( 'subgroup_size', 'subgroupSize', 'u32', 'attribute' );
 
 			}


### PR DESCRIPTION
**Description**

Ensures that subgroup operations (like quad swaps) can be called from the fragment stage. The enable directive is automatically inserted into the shader if the feature is present within the renderer, as it already is for the compute stage.

Also update NodeBuilder with abstract or warning versions of functions in WGSLNodeBuilder
