### PR TITLE
Fix editor lint warnings

### DIFF
--- a/editor/js/libs/app.js
+++ b/editor/js/libs/app.js
@@ -1,3 +1,5 @@
+/* global THREE */ /* assigned at ./app/index.html */
+
 const APP = {
 
 	Player: function () {


### PR DESCRIPTION
**Description**

Add `/* global THREE */` to resolve `no-undef` warnings.