### PR TITLE
chore: remove code deprecated in r177

### DIFF
--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -615,7 +615,6 @@ export const transformNormal = TSL.transformNormal;
 export const transformNormalByInverseViewMatrix = TSL.transformNormalByInverseViewMatrix;
 export const transformNormalByViewMatrix = TSL.transformNormalByViewMatrix;
 export const transformNormalToView = TSL.transformNormalToView;
-
 export const transmission = TSL.transmission;
 export const transpose = TSL.transpose;
 export const triNoise3D = TSL.triNoise3D;

--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -615,9 +615,7 @@ export const transformNormal = TSL.transformNormal;
 export const transformNormalByInverseViewMatrix = TSL.transformNormalByInverseViewMatrix;
 export const transformNormalByViewMatrix = TSL.transformNormalByViewMatrix;
 export const transformNormalToView = TSL.transformNormalToView;
-export const transformedClearcoatNormalView = TSL.transformedClearcoatNormalView;
-export const transformedNormalView = TSL.transformedNormalView;
-export const transformedNormalWorld = TSL.transformedNormalWorld;
+
 export const transmission = TSL.transmission;
 export const transpose = TSL.transpose;
 export const triNoise3D = TSL.triNoise3D;

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -1,6 +1,5 @@
 import { SRGBColorSpace, LinearSRGBColorSpace, SRGBTransfer, LinearTransfer, NoColorSpace } from '../constants.js';
 import { Matrix3 } from './Matrix3.js';
-import { warnOnce } from '../utils.js';
 
 const LINEAR_REC709_TO_XYZ = /*@__PURE__*/ new Matrix3().set(
 	0.4123908, 0.3575843, 0.1804808,
@@ -140,24 +139,6 @@ function createColorManagement() {
 		_getUnpackColorSpace: function ( colorSpace = this.workingColorSpace ) {
 
 			return this.spaces[ colorSpace ].workingColorSpaceConfig.unpackColorSpace;
-
-		},
-
-		// Deprecated
-
-		fromWorkingColorSpace: function ( color, targetColorSpace ) {
-
-			warnOnce( 'ColorManagement: .fromWorkingColorSpace() has been renamed to .workingToColorSpace().' ); // @deprecated, r177
-
-			return ColorManagement.workingToColorSpace( color, targetColorSpace );
-
-		},
-
-		toWorkingColorSpace: function ( color, sourceColorSpace ) {
-
-			warnOnce( 'ColorManagement: .toWorkingColorSpace() has been renamed to .colorSpaceToWorking().' ); // @deprecated, r177
-
-			return ColorManagement.colorSpaceToWorking( color, sourceColorSpace );
 
 		},
 

--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -198,46 +198,4 @@ export const transformNormalToView = /*@__PURE__*/ Fn( ( [ normal ], builder ) =
 
 } );
 
-// Deprecated
 
-/**
- * TSL object that represents the transformed vertex normal of the current rendered object in view space.
- *
- * @tsl
- * @type {Node<vec3>}
- * @deprecated since r178. Use `normalView` instead.
- */
-export const transformedNormalView = ( Fn( () => { // @deprecated, r177
-
-	warn( 'TSL: "transformedNormalView" is deprecated. Use "normalView" instead.' );
-	return normalView;
-
-} ).once( [ 'NORMAL', 'VERTEX' ] ) )();
-
-/**
- * TSL object that represents the transformed vertex normal of the current rendered object in world space.
- *
- * @tsl
- * @type {Node<vec3>}
- * @deprecated since r178. Use `normalWorld` instead.
- */
-export const transformedNormalWorld = ( Fn( () => { // @deprecated, r177
-
-	warn( 'TSL: "transformedNormalWorld" is deprecated. Use "normalWorld" instead.' );
-	return normalWorld;
-
-} ).once( [ 'NORMAL', 'VERTEX' ] ) )();
-
-/**
- * TSL object that represents the transformed clearcoat vertex normal of the current rendered object in view space.
- *
- * @tsl
- * @type {Node<vec3>}
- * @deprecated since r178. Use `clearcoatNormalView` instead.
- */
-export const transformedClearcoatNormalView = ( Fn( () => { // @deprecated, r177
-
-	warn( 'TSL: "transformedClearcoatNormalView" is deprecated. Use "clearcoatNormalView" instead.' );
-	return clearcoatNormalView;
-
-} ).once( [ 'NORMAL', 'VERTEX' ] ) )();


### PR DESCRIPTION
Related issue: #XXXX

**Description**

- Remove transformedNormalView, transformedNormalWorld, transformedClearcoatNormalView from TSL
- Remove fromWorkingColorSpace and toWorkingColorSpace from ColorManagement

> Generated with AI assistance.