### PR TITLE
WebGLRenderer: Dispose the renderer-owned DFG lookup texture

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -54,7 +54,7 @@ import { WebGLMaterials } from './webgl/WebGLMaterials.js';
 import { WebGLUniformsGroups } from './webgl/WebGLUniformsGroups.js';
 import { createCanvasElement, probeAsync, error, warn, log } from '../utils.js';
 import { ColorManagement } from '../math/ColorManagement.js';
-import { getDFGLUT } from './shaders/DFGLUTData.js';
+import { createDFGLUT } from './shaders/DFGLUTData.js';
 
 /**
  * This renderer uses WebGL 2 to display scenes.
@@ -303,6 +303,7 @@ class WebGLRenderer {
 
 		let _isContextLost = false;
 		let _nodesHandler = null;
+		let _dfgLUT = null;
 
 		let _scratchFramebuffer = null;
 		let _srcFramebuffer = null;
@@ -1092,6 +1093,14 @@ class WebGLRenderer {
 			canvas.removeEventListener( 'webglcontextcreationerror', onContextCreationError, false );
 
 			background.dispose();
+			// A global LUT retains every renderer through its texture dispose listeners.
+			// Release this renderer's internal texture before clearing WebGL properties.
+			if ( _dfgLUT !== null ) {
+
+				_dfgLUT.dispose();
+				_dfgLUT = null;
+
+			}
 			renderLists.dispose();
 			renderStates.dispose();
 			properties.dispose();
@@ -2757,7 +2766,8 @@ class WebGLRenderer {
 			// Set DFG LUT for physically-based materials
 			if ( m_uniforms.dfgLUT !== undefined ) {
 
-				m_uniforms.dfgLUT.value = getDFGLUT();
+				if ( _dfgLUT === null ) _dfgLUT = createDFGLUT();
+				m_uniforms.dfgLUT.value = _dfgLUT;
 
 			}
 

--- a/src/renderers/shaders/DFGLUTData.js
+++ b/src/renderers/shaders/DFGLUTData.js
@@ -28,22 +28,17 @@ const DATA = new Uint16Array( [
 	0x3c00, 0x0000, 0x3c00, 0x0001, 0x3bff, 0x0015, 0x3bfb, 0x0059, 0x3bf2, 0x00fd, 0x3bdd, 0x01df, 0x3bb7, 0x031c, 0x3b79, 0x047c, 0x3b1d, 0x05d4, 0x3aa0, 0x06d5, 0x3a08, 0x075a, 0x395d, 0x075e, 0x38aa, 0x06f7, 0x37f4, 0x0648, 0x36ac, 0x0576, 0x3586, 0x049f
 ] );
 
-let lut = null;
+export function createDFGLUT() {
 
-export function getDFGLUT() {
-
-	if ( lut === null ) {
-
-		lut = new DataTexture( DATA, 16, 16, RGFormat, HalfFloatType );
-		lut.name = 'DFG_LUT';
-		lut.minFilter = LinearFilter;
-		lut.magFilter = LinearFilter;
-		lut.wrapS = ClampToEdgeWrapping;
-		lut.wrapT = ClampToEdgeWrapping;
-		lut.generateMipmaps = false;
-		lut.needsUpdate = true;
-
-	}
+	// Pixel data is shared; the texture and its WebGL listeners belong to one renderer.
+	const lut = new DataTexture( DATA, 16, 16, RGFormat, HalfFloatType );
+	lut.name = 'DFG_LUT';
+	lut.minFilter = LinearFilter;
+	lut.magFilter = LinearFilter;
+	lut.wrapS = ClampToEdgeWrapping;
+	lut.wrapT = ClampToEdgeWrapping;
+	lut.generateMipmaps = false;
+	lut.needsUpdate = true;
 
 	return lut;
 


### PR DESCRIPTION
Rendering a PBR material initializes a module-global DFG lookup texture. Its `dispose` listeners retain the WebGL texture managers of every renderer that used it. Calling `WebGLRenderer.dispose()` does not dispose that texture, so the global texture keeps the discarded renderers, WebGL contexts, and canvases alive.

Create the LUT lazily per renderer and dispose it before clearing the renderer's WebGL properties. The lookup pixel data remains shared. Each renderer reuses its texture across frames, and disposing one renderer does not invalidate another renderer's LUT.

Validation:
- Compared upstream `dev` before and after the patch in Chrome with `--js-flags=--expose-gc`. Two renderers render a `MeshStandardMaterial`; after disposing one and releasing its caller-owned geometry/material resources, its `WeakRef` stays alive before the patch and is collected afterward. The surviving renderer continues issuing draw calls.
- The downstream engine's 17 focused browser regression tests pass, including repeated scene removal and renderer collection.
- Upstream lint could not run with the local dependency installation (`eslint-plugin-jsdoc` is missing and the installed ESLint is older than upstream's requirement).

Only source changes are included; generated bundles are excluded.
