### PR TITLE
Clean MaterialX loader + compiler.

### DIFF
--- a/examples/jsm/loaders/materialx/MaterialXDocument.js
+++ b/examples/jsm/loaders/materialx/MaterialXDocument.js
@@ -1,8 +1,5 @@
 import {
 	Texture,
-	RepeatWrapping,
-	ClampToEdgeWrapping,
-	MirroredRepeatWrapping,
 	ImageLoader,
 	ImageBitmapLoader,
 	Matrix3,
@@ -34,7 +31,7 @@ import { parseMaterialXNodeTree, parseMaterialXText } from './parse/MaterialXPar
 import { getSurfaceMapper } from './MaterialXSurfaceMappings.js';
 import { MtlXLibrary } from './MaterialXNodeLibrary.js';
 import { mxHextileCoord, mxHextileComputeBlendWeights } from './MaterialXHextile.js';
-import { resolveTextureAddressMode, toBooleanNode } from './MaterialXUtils.js';
+import { resolveTextureAddressMode, TEXTURE_ADDRESS_MODE_WRAPPING, toBooleanNode } from './MaterialXUtils.js';
 
 const colorSpaceLib = {
 	mx_srgb_texture_to_lin_rec709,
@@ -45,12 +42,6 @@ const IDENTITY_MAT3_VALUES = [ 1, 0, 0, 0, 1, 0, 0, 0, 1 ];
 const IDENTITY_MAT4_VALUES = [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 ];
 const MATRIX_INVERSE_EPSILON = 1e-8;
 const COMPILE_REGISTRY = createMaterialXCompileRegistry();
-const TEXTURE_ADDRESS_MODE_WRAPPING = {
-	constant: ClampToEdgeWrapping,
-	clamp: ClampToEdgeWrapping,
-	periodic: RepeatWrapping,
-	mirror: MirroredRepeatWrapping,
-};
 const NODE_CLASS_BY_TYPE = {
 	integer: int,
 	float,

--- a/examples/jsm/loaders/materialx/MaterialXDocument.js
+++ b/examples/jsm/loaders/materialx/MaterialXDocument.js
@@ -453,7 +453,7 @@ class MaterialXNode {
 
 			}
 
-			node = this.materialX.compileContext.mxToBottomLeftUvSpace( uv( index ) );
+			node = this.materialX.compileContext.getTexcoordNode( index );
 
 		} else {
 
@@ -803,6 +803,7 @@ class MaterialXDocument {
 			compileRegistry: COMPILE_REGISTRY,
 			nodeLibrary: MtlXLibrary,
 			...bottomLeftUvSpaceHelpers,
+			getTexcoordNode: ( index = 0 ) => bottomLeftUvSpaceHelpers.mxToBottomLeftUvSpace( uv( index ) ),
 			mxTransformUv: mx_transform_uv,
 			mxHextileCoord,
 			mxHextileComputeBlendWeights,

--- a/examples/jsm/loaders/materialx/MaterialXDocument.js
+++ b/examples/jsm/loaders/materialx/MaterialXDocument.js
@@ -34,7 +34,7 @@ import { parseMaterialXNodeTree, parseMaterialXText } from './parse/MaterialXPar
 import { getSurfaceMapper } from './MaterialXSurfaceMappings.js';
 import { MtlXLibrary } from './MaterialXNodeLibrary.js';
 import { mxHextileCoord, mxHextileComputeBlendWeights } from './MaterialXHextile.js';
-import { toBooleanNode } from './MaterialXUtils.js';
+import { resolveTextureAddressMode, toBooleanNode } from './MaterialXUtils.js';
 
 const colorSpaceLib = {
 	mx_srgb_texture_to_lin_rec709,
@@ -108,15 +108,6 @@ function isSvgUri( uri ) {
 
 	if ( typeof uri !== 'string' ) return false;
 	return /\.svg(?:$|[?#])/i.test( uri );
-
-}
-
-function normalizeTextureAddressMode( value ) {
-
-	if ( value === null || value === undefined || value === '' ) return 'periodic';
-
-	const mode = value.trim().toLowerCase();
-	return mode in TEXTURE_ADDRESS_MODE_WRAPPING ? mode : null;
 
 }
 
@@ -290,10 +281,20 @@ class MaterialXNode {
 
 	}
 
+	logUnsupportedNode() {
+
+		this.materialX.log.add(
+			MaterialXLogCodes.UNSUPPORTED_NODE,
+			`Unsupported MaterialX node category "${this.element}" on "${this.name}".`,
+			this.name,
+		);
+
+	}
+
 	getTextureAddressMode( inputName ) {
 
 		const rawMode = this.getInputValueByName( inputName );
-		const mode = normalizeTextureAddressMode( rawMode );
+		const mode = resolveTextureAddressMode( rawMode );
 		if ( mode ) return mode;
 
 		this.materialX.log.add(
@@ -397,11 +398,11 @@ class MaterialXNode {
 
 			} else if ( type === 'matrix33' ) {
 
-				node = this.getMatrix( 3 ) || mat3( 1, 0, 0, 0, 1, 0, 0, 0, 1 );
+				node = this.getMatrix( 3 ) || mat3( ...IDENTITY_MAT3_VALUES );
 
 			} else if ( type === 'matrix44' ) {
 
-				node = this.getMatrix( 4 ) || mat4( 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 );
+				node = this.getMatrix( 4 ) || mat4( ...IDENTITY_MAT4_VALUES );
 
 			} else if ( type === 'string' ) {
 
@@ -463,11 +464,7 @@ class MaterialXNode {
 
 		if ( node === null || node === undefined ) {
 
-			this.materialX.log.add(
-				MaterialXLogCodes.UNSUPPORTED_NODE,
-				`Unsupported MaterialX node category "${this.element}" on "${this.name}".`,
-				this.name,
-			);
+			this.logUnsupportedNode();
 			node = float( 0 );
 
 		}
@@ -649,11 +646,7 @@ class MaterialXNode {
 
 		} else {
 
-			this.materialX.log.add(
-				MaterialXLogCodes.UNSUPPORTED_NODE,
-				`Unsupported MaterialX node category "${this.element}" on "${this.name}".`,
-				this.name,
-			);
+			this.logUnsupportedNode();
 
 		}
 

--- a/examples/jsm/loaders/materialx/MaterialXInterfaceValidation.js
+++ b/examples/jsm/loaders/materialx/MaterialXInterfaceValidation.js
@@ -7,28 +7,10 @@ const CONTAINER_ELEMENTS = new Set( [ 'nodegraph' ] );
 
 const LIBRARY_FALLBACK_OUTPUT = 'out';
 
-function formatInputElement( inputNodeX ) {
+function formatElement( nodeX, attrNames, tagName = nodeX.element ) {
 
 	const attrs = [];
-	for ( const name of [ 'name', 'type', 'nodename', 'nodegraph', 'interfacename', 'output', 'value' ] ) {
-
-		const value = inputNodeX.getAttribute( name );
-		if ( value !== null && value !== '' ) {
-
-			attrs.push( `${name}="${value}"` );
-
-		}
-
-	}
-
-	return `<input ${attrs.join( ' ' )}>`;
-
-}
-
-function formatNodeElement( nodeX ) {
-
-	const attrs = [];
-	for ( const name of [ 'name', 'type', 'nodedef' ] ) {
+	for ( const name of attrNames ) {
 
 		const value = nodeX.getAttribute( name );
 		if ( value !== null && value !== '' ) {
@@ -39,7 +21,19 @@ function formatNodeElement( nodeX ) {
 
 	}
 
-	return `<${nodeX.element} ${attrs.join( ' ' )}>`;
+	return `<${tagName} ${attrs.join( ' ' )}>`;
+
+}
+
+function formatInputElement( inputNodeX ) {
+
+	return formatElement( inputNodeX, [ 'name', 'type', 'nodename', 'nodegraph', 'interfacename', 'output', 'value' ], 'input' );
+
+}
+
+function formatNodeElement( nodeX ) {
+
+	return formatElement( nodeX, [ 'name', 'type', 'nodedef' ] );
 
 }
 

--- a/examples/jsm/loaders/materialx/MaterialXSurfaceMappings.js
+++ b/examples/jsm/loaders/materialx/MaterialXSurfaceMappings.js
@@ -151,16 +151,17 @@ function isEffectivelyZero( node, epsilon = 1e-6 ) {
 
 }
 
-function isEffectivelyOne( node, epsilon = 1e-6 ) {
+// True when `node` has an authored value that differs from `target` (default 0),
+// i.e. it's worth wiring into the material instead of relying on the default.
+function isMeaningfulNode( node, target = 0 ) {
 
-	return isConstNear( node, 1, epsilon );
+	return hasNodeValue( node ) && isConstNear( node, target ) === false;
 
 }
 
 function isEnabledWeightNode( node ) {
 
-	if ( hasNodeValue( node ) === false ) return false;
-	return isEffectivelyZero( node ) === false;
+	return isMeaningfulNode( node );
 
 }
 
@@ -177,7 +178,7 @@ function setAnisotropy( material, strengthNode, rotationNode ) {
 
 function setTransmissionFlags( material, transmissionNode, opacityNode, allowOpacityTransparency = true ) {
 
-	if ( allowOpacityTransparency && hasNodeValue( opacityNode ) && isEffectivelyOne( opacityNode ) === false ) {
+	if ( allowOpacityTransparency && isMeaningfulNode( opacityNode, 1 ) ) {
 
 		material.transparent = true;
 
@@ -256,20 +257,20 @@ function applyStandardSurface( material, inputs, log, nodeName ) {
 	}
 
 	material.colorNode = colorNode || color( 0.8, 0.8, 0.8 );
-	if ( hasNodeValue( opacityNode ) && isEffectivelyOne( opacityNode ) === false ) {
+	if ( isMeaningfulNode( opacityNode, 1 ) ) {
 
 		material.opacityNode = opacityNode;
 
 	}
 
 	material.roughnessNode = roughnessNode || float( 0.2 );
-	if ( hasNodeValue( inputs.metalness ) && isEffectivelyZero( inputs.metalness ) === false ) {
+	if ( isMeaningfulNode( inputs.metalness ) ) {
 
 		material.metalnessNode = inputs.metalness;
 
 	}
 
-	if ( hasNodeValue( inputs.specular ) && isEffectivelyOne( inputs.specular ) === false ) {
+	if ( isMeaningfulNode( inputs.specular, 1 ) ) {
 
 		material.specularIntensityNode = inputs.specular;
 
@@ -277,7 +278,7 @@ function applyStandardSurface( material, inputs, log, nodeName ) {
 
 	material.specularColorNode = inputs.specular_color || color( 1, 1, 1 );
 	const iorNode = inputs.specular_IOR;
-	if ( hasNodeValue( iorNode ) && isConstNear( iorNode, 1.5 ) === false ) {
+	if ( isMeaningfulNode( iorNode, 1.5 ) ) {
 
 		material.iorNode = iorNode;
 
@@ -289,7 +290,7 @@ function applyStandardSurface( material, inputs, log, nodeName ) {
 
 		material.transmissionNode = transmissionNode;
 		if ( hasNodeValue( transmissionColorNode ) ) material.transmissionColorNode = transmissionColorNode;
-		if ( hasNodeValue( inputs.transmission_depth ) && isEffectivelyZero( inputs.transmission_depth ) === false ) {
+		if ( isMeaningfulNode( inputs.transmission_depth ) ) {
 
 			material.thicknessNode = inputs.transmission_depth;
 
@@ -363,20 +364,20 @@ function applyGltfPbrSurface( material, inputs, log, nodeName ) {
 	if ( hasNodeValue( inputs.occlusion ) ) material.aoNode = inputs.occlusion;
 	material.roughnessNode = inputs.roughness || float( 1 );
 	material.metalnessNode = inputs.metallic || float( 1 );
-	if ( hasNodeValue( inputs.specular ) && isEffectivelyOne( inputs.specular ) === false ) {
+	if ( isMeaningfulNode( inputs.specular, 1 ) ) {
 
 		material.specularIntensityNode = inputs.specular;
 
 	}
 
 	material.specularColorNode = inputs.specular_color || color( 1, 1, 1 );
-	if ( hasNodeValue( inputs.ior ) && isConstNear( inputs.ior, 1.5 ) === false ) {
+	if ( isMeaningfulNode( inputs.ior, 1.5 ) ) {
 
 		material.iorNode = inputs.ior;
 
 	}
 
-	if ( hasNodeValue( opacityNode ) && isEffectivelyOne( opacityNode ) === false ) {
+	if ( isMeaningfulNode( opacityNode, 1 ) ) {
 
 		material.opacityNode = opacityNode;
 
@@ -399,7 +400,7 @@ function applyGltfPbrSurface( material, inputs, log, nodeName ) {
 	if ( clearcoatEnabled ) {
 
 		material.clearcoatNode = inputs.clearcoat;
-		if ( hasNodeValue( inputs.clearcoat_roughness ) && isEffectivelyZero( inputs.clearcoat_roughness ) === false ) {
+		if ( isMeaningfulNode( inputs.clearcoat_roughness ) ) {
 
 			material.clearcoatRoughnessNode = inputs.clearcoat_roughness;
 
@@ -419,13 +420,13 @@ function applyGltfPbrSurface( material, inputs, log, nodeName ) {
 	if ( iridescenceEnabled ) {
 
 		material.iridescenceNode = inputs.iridescence;
-		if ( hasNodeValue( inputs.iridescence_ior ) && isConstNear( inputs.iridescence_ior, 1.3 ) === false ) {
+		if ( isMeaningfulNode( inputs.iridescence_ior, 1.3 ) ) {
 
 			material.iridescenceIORNode = inputs.iridescence_ior;
 
 		}
 
-		if ( hasNodeValue( inputs.iridescence_thickness ) && isConstNear( inputs.iridescence_thickness, 100 ) === false ) {
+		if ( isMeaningfulNode( inputs.iridescence_thickness, 100 ) ) {
 
 			material.iridescenceThicknessNode = inputs.iridescence_thickness;
 
@@ -450,7 +451,7 @@ function applyGltfPbrSurface( material, inputs, log, nodeName ) {
 
 	}
 
-	if ( hasNodeValue( inputs.dispersion ) && isEffectivelyZero( inputs.dispersion ) === false ) {
+	if ( isMeaningfulNode( inputs.dispersion ) ) {
 
 		material.dispersionNode = inputs.dispersion;
 
@@ -486,14 +487,14 @@ function applyOpenPbrSurface( material, inputs, log, nodeName ) {
 	const thinFilmEnabled = isEnabledWeightNode( inputs.thin_film_weight );
 	material.colorNode = mul( baseWeight, baseColor );
 
-	if ( hasNodeValue( inputs.base_metalness ) && isEffectivelyZero( inputs.base_metalness ) === false ) {
+	if ( isMeaningfulNode( inputs.base_metalness ) ) {
 
 		material.metalnessNode = inputs.base_metalness;
 
 	}
 
 	material.roughnessNode = inputs.specular_roughness || float( 0.3 );
-	if ( hasNodeValue( inputs.specular_weight ) && isEffectivelyOne( inputs.specular_weight ) === false ) {
+	if ( isMeaningfulNode( inputs.specular_weight, 1 ) ) {
 
 		material.specularIntensityNode = inputs.specular_weight;
 
@@ -501,7 +502,7 @@ function applyOpenPbrSurface( material, inputs, log, nodeName ) {
 
 	material.specularColorNode = inputs.specular_color || color( 1, 1, 1 );
 	const openPbrIorNode = inputs.specular_ior;
-	if ( hasNodeValue( openPbrIorNode ) && isConstNear( openPbrIorNode, 1.5 ) === false ) {
+	if ( isMeaningfulNode( openPbrIorNode, 1.5 ) ) {
 
 		material.iorNode = openPbrIorNode;
 
@@ -527,7 +528,7 @@ function applyOpenPbrSurface( material, inputs, log, nodeName ) {
 
 		}
 
-		if ( hasNodeValue( inputs.coat_roughness ) && isEffectivelyZero( inputs.coat_roughness ) === false ) {
+		if ( isMeaningfulNode( inputs.coat_roughness ) ) {
 
 			material.clearcoatRoughnessNode = inputs.coat_roughness;
 
@@ -562,7 +563,7 @@ function applyOpenPbrSurface( material, inputs, log, nodeName ) {
 	}
 
 	const transmissionDepthNode = inputs.transmission_depth;
-	if ( transmissionEnabled && hasNodeValue( transmissionDepthNode ) && isEffectivelyZero( transmissionDepthNode ) === false ) {
+	if ( transmissionEnabled && isMeaningfulNode( transmissionDepthNode ) ) {
 
 		material.thicknessNode = hasNodeValue( inputs.geometry_thin_walled )
 			? inputs.geometry_thin_walled.select( float( 0 ), transmissionDepthNode )
@@ -577,13 +578,13 @@ function applyOpenPbrSurface( material, inputs, log, nodeName ) {
 	}
 
 	const transmissionDispersionAbbe = inputs.transmission_dispersion_abbe_number || float( 20 );
-	if ( transmissionEnabled && hasNodeValue( inputs.transmission_dispersion_scale ) && isEffectivelyZero( inputs.transmission_dispersion_scale ) === false ) {
+	if ( transmissionEnabled && isMeaningfulNode( inputs.transmission_dispersion_scale ) ) {
 
 		material.dispersionNode = inputs.transmission_dispersion_scale.mul( float( 20 ) ).div( transmissionDispersionAbbe );
 
 	}
 
-	if ( hasNodeValue( inputs.geometry_opacity ) && isEffectivelyOne( inputs.geometry_opacity ) === false ) {
+	if ( isMeaningfulNode( inputs.geometry_opacity, 1 ) ) {
 
 		material.opacityNode = inputs.geometry_opacity;
 
@@ -594,13 +595,13 @@ function applyOpenPbrSurface( material, inputs, log, nodeName ) {
 	if ( thinFilmEnabled ) {
 
 		material.iridescenceNode = inputs.thin_film_weight;
-		if ( hasNodeValue( inputs.thin_film_thickness ) && isConstNear( inputs.thin_film_thickness, 0.5 ) === false ) {
+		if ( isMeaningfulNode( inputs.thin_film_thickness, 0.5 ) ) {
 
 			material.iridescenceThicknessNode = inputs.thin_film_thickness.mul( float( 1000 ) );
 
 		}
 
-		if ( hasNodeValue( inputs.thin_film_ior ) && isConstNear( inputs.thin_film_ior, 1.4 ) === false ) {
+		if ( isMeaningfulNode( inputs.thin_film_ior, 1.4 ) ) {
 
 			material.iridescenceIORNode = inputs.thin_film_ior;
 
@@ -616,7 +617,7 @@ function applyOpenPbrSurface( material, inputs, log, nodeName ) {
 
 	}
 
-	if ( hasNodeValue( inputs.geometry_opacity ) && isEffectivelyOne( inputs.geometry_opacity ) === false ) material.transparent = true;
+	if ( isMeaningfulNode( inputs.geometry_opacity, 1 ) ) material.transparent = true;
 	if ( transmissionEnabled ) material.transparent = true;
 
 	setTransmissionFlags( material, inputs.transmission_weight, inputs.geometry_opacity );

--- a/examples/jsm/loaders/materialx/MaterialXUtils.js
+++ b/examples/jsm/loaders/materialx/MaterialXUtils.js
@@ -1,4 +1,10 @@
 import {
+	RepeatWrapping,
+	ClampToEdgeWrapping,
+	MirroredRepeatWrapping,
+} from 'three/webgpu';
+
+import {
 	bool,
 	element,
 	float,
@@ -6,7 +12,12 @@ import {
 } from 'three/tsl';
 
 const BOOLEAN_OPERATOR_OPS = new Set( [ '&&', '||', '^^', '!', '==', '!=', '<', '>', '<=', '>=' ] );
-const TEXTURE_ADDRESS_MODES = new Set( [ 'constant', 'clamp', 'periodic', 'mirror' ] );
+const TEXTURE_ADDRESS_MODE_WRAPPING = {
+	constant: ClampToEdgeWrapping,
+	clamp: ClampToEdgeWrapping,
+	periodic: RepeatWrapping,
+	mirror: MirroredRepeatWrapping,
+};
 
 function normalizeSpaceName( value, fallback = 'world' ) {
 
@@ -56,7 +67,7 @@ function resolveTextureAddressMode( value ) {
 	if ( value === null || value === undefined || value === '' ) return 'periodic';
 
 	const mode = value.trim().toLowerCase();
-	return TEXTURE_ADDRESS_MODES.has( mode ) ? mode : null;
+	return mode in TEXTURE_ADDRESS_MODE_WRAPPING ? mode : null;
 
 }
 
@@ -65,6 +76,7 @@ export {
 	isBooleanNode,
 	normalizeSpaceName,
 	resolveTextureAddressMode,
+	TEXTURE_ADDRESS_MODE_WRAPPING,
 	toBooleanNode,
 	toVec3Channels,
 };

--- a/examples/jsm/loaders/materialx/MaterialXUtils.js
+++ b/examples/jsm/loaders/materialx/MaterialXUtils.js
@@ -6,6 +6,7 @@ import {
 } from 'three/tsl';
 
 const BOOLEAN_OPERATOR_OPS = new Set( [ '&&', '||', '^^', '!', '==', '!=', '<', '>', '<=', '>=' ] );
+const TEXTURE_ADDRESS_MODES = new Set( [ 'constant', 'clamp', 'periodic', 'mirror' ] );
 
 function normalizeSpaceName( value, fallback = 'world' ) {
 
@@ -48,10 +49,22 @@ function toVec3Channels( input ) {
 
 }
 
+// Normalizes a raw `*addressmode` attribute value, defaulting to `'periodic'`
+// when unset and returning `null` when the value isn't a recognized mode.
+function resolveTextureAddressMode( value ) {
+
+	if ( value === null || value === undefined || value === '' ) return 'periodic';
+
+	const mode = value.trim().toLowerCase();
+	return TEXTURE_ADDRESS_MODES.has( mode ) ? mode : null;
+
+}
+
 export {
 	getComponentCountForType,
 	isBooleanNode,
 	normalizeSpaceName,
+	resolveTextureAddressMode,
 	toBooleanNode,
 	toVec3Channels,
 };

--- a/examples/jsm/loaders/materialx/compile/MaterialXCompileRegistry.js
+++ b/examples/jsm/loaders/materialx/compile/MaterialXCompileRegistry.js
@@ -7,7 +7,6 @@ import {
 	mul,
 	normalMap,
 	texture,
-	uv,
 	vec2,
 	vec3,
 	vec4,
@@ -61,7 +60,7 @@ const TEXTURE_ADDRESS_MODES = new Set( [ 'constant', 'clamp', 'periodic', 'mirro
 const SWITCH_MIN_INDEX = 1;
 const SWITCH_MAX_INDEX = 10;
 
-const getDefaultUvNode = ( compileContext ) => compileContext.mxToBottomLeftUvSpace( uv( 0 ) );
+const getDefaultUvNode = ( compileContext ) => compileContext.getTexcoordNode( 0 );
 
 const toBooleanMaskNode = ( node ) => toBooleanNode( node ).select( float( 1 ), float( 0 ) );
 
@@ -344,7 +343,7 @@ const compileTexcoordNode = ( nodeX, compileContext ) => {
 
 	const indexNode = nodeX.getChildByName( 'index' );
 	const index = indexNode ? parseInt( indexNode.value, 10 ) : 0;
-	return compileContext.mxToBottomLeftUvSpace( uv( index ) );
+	return compileContext.getTexcoordNode( index );
 
 };
 

--- a/examples/jsm/loaders/materialx/compile/MaterialXCompileRegistry.js
+++ b/examples/jsm/loaders/materialx/compile/MaterialXCompileRegistry.js
@@ -38,6 +38,7 @@ import {
 import {
 	getComponentCountForType,
 	normalizeSpaceName,
+	resolveTextureAddressMode,
 	toBooleanNode,
 	toVec3Channels,
 } from '../MaterialXUtils.js';
@@ -56,7 +57,6 @@ const register = ( registry, categories, handler ) => {
 const UV_FALLBACK_CATEGORIES = new Set( [ 'checkerboard', 'noise2d', 'fractal2d', 'cellnoise2d', 'worleynoise2d', 'unifiednoise2d', 'heighttonormal' ] );
 const SCALAR_TYPES = new Set( [ 'boolean', 'integer', 'float' ] );
 const THREE_COMPONENT_TYPES = new Set( [ 'vector2', 'vector3', 'vector4', 'color3', 'color4' ] );
-const TEXTURE_ADDRESS_MODES = new Set( [ 'constant', 'clamp', 'periodic', 'mirror' ] );
 const SWITCH_MIN_INDEX = 1;
 const SWITCH_MAX_INDEX = 10;
 
@@ -67,10 +67,7 @@ const toBooleanMaskNode = ( node ) => toBooleanNode( node ).select( float( 1 ), 
 const getTextureAddressMode = ( nodeX, inputName ) => {
 
 	const value = nodeX.getInputValueByName( inputName );
-	if ( value === null || value === undefined || value === '' ) return 'periodic';
-
-	const mode = value.trim().toLowerCase();
-	return TEXTURE_ADDRESS_MODES.has( mode ) ? mode : 'periodic';
+	return resolveTextureAddressMode( value ) ?? 'periodic';
 
 };
 


### PR DESCRIPTION
## Summary

Small dedup pass over the MaterialX loader/compiler, no behavior change:

- `compileContext.mxToBottomLeftUvSpace( uv( index ) )` was duplicated across three call sites — routed through one `compileContext.getTexcoordNode( index )`.
- `hasNodeValue(x) && isEffectivelyZero/One/ConstNear(x) === false` was repeated ~20 times in `MaterialXSurfaceMappings.js` — collapsed into one `isMeaningfulNode( node, target )` helper.
- Texture address-mode resolution (`*addressmode` attribute → `'periodic'` fallback) was implemented independently in `MaterialXDocument.js` and `MaterialXCompileRegistry.js` — now shares `resolveTextureAddressMode()` in `MaterialXUtils.js`.
- The "unsupported node category" log call was duplicated verbatim twice in `MaterialXDocument.js` — factored into `MaterialXNode.logUnsupportedNode()`.
- `formatInputElement`/`formatNodeElement` in `MaterialXInterfaceValidation.js` were near-duplicate — merged into one `formatElement()` helper.
- Two spots re-typed the identity matrix literals instead of using the existing `IDENTITY_MAT3_VALUES`/`IDENTITY_MAT4_VALUES` constants.
