### PR TITLE
WebGPURenderer: Make canvas optional

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -102,7 +102,8 @@ class Renderer {
 			samples = 0,
 			getFallback = null,
 			outputBufferType = HalfFloatType,
-			multiview = false
+			multiview = false,
+			canvas = true
 		} = parameters;
 
 		/**
@@ -288,9 +289,15 @@ class Renderer {
 		 * @private
 		 * @type {CanvasTarget}
 		 */
-		this._canvasTarget = new CanvasTarget( backend.getDomElement() );
-		this._canvasTarget.addEventListener( 'resize', this._onCanvasTargetResize );
-		this._canvasTarget.isDefaultCanvasTarget = true;
+		this._canvasTarget = null;
+
+		if ( canvas !== false ) {
+
+			this._canvasTarget = new CanvasTarget( backend.getDomElement() )
+			this._canvasTarget.addEventListener( 'resize', this._onCanvasTargetResize );
+			this._canvasTarget.isDefaultCanvasTarget = true;
+
+		}
 
 		/**
 		 * The inspector provides information about the internal renderer state.
@@ -1562,7 +1569,7 @@ class Renderer {
 
 		if ( this.needsFrameBufferTarget === false ) return null;
 
-		const { width, height } = this.getDrawingBufferSize( _drawingBufferSize );
+		const { width, height } = this._outputRenderTarget || this.getDrawingBufferSize( _drawingBufferSize );
 		const { depth, stencil } = this;
 
 		// TODO: Unify CanvasTarget and OutputRenderTarget
@@ -1768,21 +1775,32 @@ class Renderer {
 
 		//
 
-		const canvasTarget = this._canvasTarget;
-
-		let viewport = canvasTarget._viewport;
-		let scissor = canvasTarget._scissor;
-		let pixelRatio = canvasTarget._pixelRatio;
+		let viewport;
+		let scissor;
+		let scissorTest;
+		let pixelRatio;
 
 		if ( renderTarget !== null ) {
 
 			viewport = renderTarget.viewport;
 			scissor = renderTarget.scissor;
+			scissorTest = renderTarget.scissorTest;
 			pixelRatio = 1;
 
-		}
+			_drawingBufferSize.set( renderTarget.width, renderTarget.height );
 
-		this.getDrawingBufferSize( _drawingBufferSize );
+		} else {
+
+			const canvasTarget = this._canvasTarget;
+
+			viewport = canvasTarget._viewport;
+			scissor = canvasTarget._scissor;
+			scissorTest = canvasTarget._scissorTest;
+			pixelRatio = canvasTarget._pixelRatio;
+
+			this.getDrawingBufferSize( _drawingBufferSize );
+
+		}
 
 		_screen.set( 0, 0, _drawingBufferSize.width, _drawingBufferSize.height );
 
@@ -1797,7 +1815,7 @@ class Renderer {
 		renderContext.viewport = renderContext.viewportValue.equals( _screen ) === false;
 
 		renderContext.scissorValue.copy( scissor ).multiplyScalar( pixelRatio ).floor();
-		renderContext.scissor = canvasTarget._scissorTest && renderContext.scissorValue.equals( _screen ) === false;
+		renderContext.scissor = scissorTest && renderContext.scissorValue.equals( _screen ) === false;
 		renderContext.scissorValue.width >>= activeMipmapLevel;
 		renderContext.scissorValue.height >>= activeMipmapLevel;
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1774,28 +1774,18 @@ class Renderer {
 
 		//
 
-		let viewport;
-		let scissor;
-		let scissorTest;
-		let pixelRatio;
+		const canvasTarget = this._canvasTarget;
+
+		const viewport = renderTarget ? renderTarget.viewport : canvasTarget._viewport;
+		const scissor = renderTarget ? renderTarget.scissor : canvasTarget._scissor;
+		const scissorTest = renderTarget ? renderTarget.scissorTest : canvasTarget._scissorTest;
+		const pixelRatio = renderTarget ? 1 : canvasTarget._pixelRatio;
 
 		if ( renderTarget !== null ) {
-
-			viewport = renderTarget.viewport;
-			scissor = renderTarget.scissor;
-			scissorTest = renderTarget.scissorTest;
-			pixelRatio = 1;
 
 			_drawingBufferSize.set( renderTarget.width, renderTarget.height );
 
 		} else {
-
-			const canvasTarget = this._canvasTarget;
-
-			viewport = canvasTarget._viewport;
-			scissor = canvasTarget._scissor;
-			scissorTest = canvasTarget._scissorTest;
-			pixelRatio = canvasTarget._pixelRatio;
 
 			this.getDrawingBufferSize( _drawingBufferSize );
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -102,8 +102,7 @@ class Renderer {
 			samples = 0,
 			getFallback = null,
 			outputBufferType = HalfFloatType,
-			multiview = false,
-			canvas = true
+			multiview = false
 		} = parameters;
 
 		/**
@@ -291,9 +290,9 @@ class Renderer {
 		 */
 		this._canvasTarget = null;
 
-		if ( canvas !== false ) {
+		if ( parameters.device === undefined ) {
 
-			this._canvasTarget = new CanvasTarget( backend.getDomElement() )
+			this._canvasTarget = new CanvasTarget( backend.getDomElement() );
 			this._canvasTarget.addEventListener( 'resize', this._onCanvasTargetResize );
 			this._canvasTarget.isDefaultCanvasTarget = true;
 


### PR DESCRIPTION
_Draft for discussion. I don't expect this can merge as a whole, but I'm hoping at least some parts of it might be OK._

In the past, if you wanted to use three.js without a browser, you'd need to use `headless-gl`, and polyfills to replace browser and DOM APIs. Lately `headless-gl` is becoming a dead end: it doesn't support WebGL 2, which three.js has now required for several years. In theory, we could be better off today, with either [`node-webgpu`](https://github.com/dawn-gpu/node-webgpu#lifetime) or [Deno's WebGPU API](https://docs.deno.com/api/web/gpu/).

I tried with `node-webgpu`, starting with a simple background color (no textures or network requests!) and ran into some small problems. Several of these look like they might be good things to fix regardless of Node.js usage, based on the "TODO: Unify CanvasTarget and OutputRenderTarget" comment already in the code?

Is it reasonable to think that if we're using WebGPU, and the user provides both `device` and `outputRenderTarget`, the canvas could become optional? That would allow running a script like this in Node.js, for example:

```javascript
// main.js
import { create, globals } from 'webgpu';
import { Color, PerspectiveCamera, RenderTarget, Scene, WebGPURenderer } from 'three/webgpu';

Object.assign(
  globalThis,
  globals,
  {
    self: globalThis,
    requestAnimationFrame: () => {}, // ⚠️ Prevent crash in renderer.init()
    cancelAnimationFrame: () => {}, // ⚠️ Prevent crash in renderer.dispose()
  }
);

const WIDTH = 4;
const HEIGHT = 4;

const navigator = { gpu: create( [] ) };
const adapter = await navigator.gpu.requestAdapter();
const device = await adapter.requestDevice();

const renderTarget = new RenderTarget( WIDTH, HEIGHT );
const renderer = new WebGPURenderer( { device } );
renderer.setOutputRenderTarget( renderTarget );
renderer.setAnimationLoop( null );

await renderer.init();

const scene = new Scene();
scene.background = new Color(1.0, 0.0, 0.0);

const camera = new PerspectiveCamera();

renderer.render(scene, camera);

const pixels = await renderer.readRenderTargetPixelsAsync(renderTarget, 0, 0, 1, 1);
console.log(pixels);

//
renderTarget.dispose();
renderer.dispose();
device.destroy();
```

```bash
node main.js
```

With the changes proposed in this PR, the script above runs and reads back pixels from the GPU.