### PR TITLE
CubeTextureNode: Apply environment rotation only to environment maps.

### DIFF
--- a/src/nodes/accessors/CubeTextureNode.js
+++ b/src/nodes/accessors/CubeTextureNode.js
@@ -3,7 +3,6 @@ import { reflectVector, refractVector } from './ReflectVector.js';
 import { nodeObject, nodeProxy, vec3 } from '../tsl/TSLBase.js';
 
 import { CubeReflectionMapping, CubeRefractionMapping, WebGPUCoordinateSystem } from '../../constants.js';
-import { materialEnvRotation } from './MaterialProperties.js';
 
 import { CubeTexture } from '../../textures/CubeTexture.js';
 import { error } from '../../utils.js';
@@ -123,10 +122,6 @@ class CubeTextureNode extends TextureNode {
 			return uvNode;
 
 		}
-
-		// rotate first
-
-		uvNode = materialEnvRotation.mul( uvNode );
 
 		// flip
 

--- a/src/nodes/lighting/BasicEnvironmentNode.js
+++ b/src/nodes/lighting/BasicEnvironmentNode.js
@@ -1,5 +1,6 @@
 import LightingNode from './LightingNode.js';
 import { cubeMapNode } from '../utils/CubeMapNode.js';
+import { materialEnvRotation } from '../accessors/MaterialProperties.js';
 
 /**
  * Represents a basic model for Image-based lighting (IBL). The environment
@@ -38,9 +39,26 @@ class BasicEnvironmentNode extends LightingNode {
 
 	setup( builder ) {
 
+		const { getUV, forceUVContext } = builder.context;
+
 		// environment property is used in the finish() method of BasicLightingModel
 
-		builder.context.environment = cubeMapNode( this.envNode );
+		builder.context.environment = cubeMapNode( this.envNode ).context( {
+			getUV: ( node, builder ) => {
+
+				let uvNode = node.uvNode;
+
+				if ( ( uvNode === null || forceUVContext === true ) && getUV ) {
+
+					uvNode = getUV( node, builder );
+
+				}
+
+				return materialEnvRotation.mul( uvNode || node.getDefaultUV() );
+
+			},
+			forceUVContext: true
+		} );
 
 	}
 

--- a/test/unit/src/nodes/accessors/CubeTextureNode.tests.js
+++ b/test/unit/src/nodes/accessors/CubeTextureNode.tests.js
@@ -1,0 +1,57 @@
+import { CubeTexture, WebGPUCoordinateSystem, WebGLCoordinateSystem } from '../../../../../src/Three.WebGPU.js';
+import CubeTextureNode from '../../../../../src/nodes/accessors/CubeTextureNode.js';
+import { vec3 } from '../../../../../src/nodes/tsl/TSLBase.js';
+import WGSLNodeBuilder from '../../../../../src/renderers/webgpu/nodes/WGSLNodeBuilder.js';
+
+export default QUnit.module( 'Nodes', () => {
+
+	QUnit.module( 'Accessors', () => {
+
+		QUnit.module( 'CubeTextureNode', () => {
+
+			QUnit.test( 'cube sampling only applies the backend coordinate conversion', ( assert ) => {
+
+				for ( const coordinateSystem of [ WebGPUCoordinateSystem, WebGLCoordinateSystem ] ) {
+
+					for ( const isRenderTargetTexture of [ false, true ] ) {
+
+						const texture = new CubeTexture();
+						texture.isRenderTargetTexture = isRenderTargetTexture;
+
+						const builder = new WGSLNodeBuilder( null, {
+							coordinateSystem,
+							debug: { diagnostics: { keywords: false } }
+						} );
+						const node = new CubeTextureNode( texture );
+						const uv = node.setupUV( builder, vec3( 1, 2, 3 ) );
+
+						builder.setShaderStage( 'fragment' );
+
+						let snippet;
+
+						for ( const stage of [ 'setup', 'analyze', 'generate' ] ) {
+
+							builder.setBuildStage( stage );
+							snippet = uv.build( builder, 'vec3' );
+
+						}
+
+						const flipX = coordinateSystem === WebGPUCoordinateSystem || ! isRenderTargetTexture;
+						const expected = flipX
+							? 'vec3<f32>( ( - vec3<f32>( 1.0, 2.0, 3.0 ).x ), vec3<f32>( 1.0, 2.0, 3.0 ).yz )'
+							: 'vec3<f32>( 1.0, 2.0, 3.0 )';
+
+						assert.strictEqual( snippet, expected, 'The supplied direction is preserved apart from the required X flip' );
+						assert.strictEqual( builder.uniforms.fragment.length, 0, 'Custom cube sampling does not depend on material environment rotation' );
+
+					}
+
+				}
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -261,5 +261,6 @@ import './src/textures/VideoTexture.tests.js';
 
 
 //src/nodes/display
+import './src/nodes/accessors/CubeTextureNode.tests.js';
 import './src/nodes/display/ViewportTextureNode.tests.js';
 import './src/nodes/display/ViewportDepthTextureNode.tests.js';


### PR DESCRIPTION
Related issue: #34521

Fixes #34521.

**Description**

Changing `material.envMapRotation` currently rotates every cube texture sampled by that material, including explicit custom shader samples. A fixed `cubeTexture(cube, vec3(1, 0, 0))` changes from green to magenta when the material's environment rotates by 90 degrees.

Move the rotation from `CubeTextureNode.setupUV()` into the sampling context of `BasicEnvironmentNode`. Custom cube sampling retains only the existing backend coordinate conversion. Basic and Phong environment maps still rotate, including equirectangular inputs and explicit environment-node UVs. Existing UV context overrides are preserved. PBR environment rotation remains in the existing PMREM path.

Validation:

- Added a QUnit regression covering uploaded/render-target cube textures with WebGPU/WebGL coordinate conventions. All 8 assertions fail against the original implementation and pass with the fix.
- The complete core QUnit page passes: 1316 passed tests, 0 failed, 1 existing Mesh.raycast TODO (1317 total).
- Core lint and lint of both changed test files pass using Node 24.19.0.
- `npm run build` passes; generated build files are excluded from the patch.
- Browser pixel tests pass for 10 cases on each of the WebGPU and WebGL backends: custom NodeMaterial/Standard sampling, default reflection directions, Basic/Phong environment maps, equirectangular conversion, explicit envNode UVs, PBR material/scene environments, and scene backgrounds. The three custom-sampling cases fail before the fix on both backends. No uncaptured WebGPU validation errors were observed.
- Interactively toggled environment rotation and verified that the custom samples remain unchanged while the environment-map examples rotate.

The browser matrix was run in Chromium 152 on macOS. The repository-wide example screenshot suite and addon unit suite were not run. No quantitative performance improvement is claimed.

AI assistance was used for implementation and validation.
