### PR TITLE
CubeTextureNode: Apply material environment rotation only to environment sampling

### DIFF
--- a/src/nodes/accessors/CubeTextureNode.js
+++ b/src/nodes/accessors/CubeTextureNode.js
@@ -3,7 +3,6 @@ import { reflectVector, refractVector } from './ReflectVector.js';
 import { nodeObject, nodeProxy, vec3 } from '../tsl/TSLBase.js';
 
 import { CubeReflectionMapping, CubeRefractionMapping, WebGPUCoordinateSystem } from '../../constants.js';
-import { materialEnvRotation } from './MaterialProperties.js';
 
 import { CubeTexture } from '../../textures/CubeTexture.js';
 import { error } from '../../utils.js';
@@ -126,7 +125,11 @@ class CubeTextureNode extends TextureNode {
 
 		// rotate first
 
-		uvNode = materialEnvRotation.mul( uvNode );
+		if ( builder.context.environmentRotation ) {
+
+			uvNode = builder.context.environmentRotation.mul( uvNode );
+
+		}
 
 		// flip
 

--- a/src/nodes/lighting/BasicEnvironmentNode.js
+++ b/src/nodes/lighting/BasicEnvironmentNode.js
@@ -1,5 +1,6 @@
 import LightingNode from './LightingNode.js';
 import { cubeMapNode } from '../utils/CubeMapNode.js';
+import { materialEnvRotation } from '../accessors/MaterialProperties.js';
 
 /**
  * Represents a basic model for Image-based lighting (IBL). The environment
@@ -40,7 +41,7 @@ class BasicEnvironmentNode extends LightingNode {
 
 		// environment property is used in the finish() method of BasicLightingModel
 
-		builder.context.environment = cubeMapNode( this.envNode );
+		builder.context.environment = cubeMapNode( this.envNode ).context( { environmentRotation: materialEnvRotation } );
 
 	}
 

--- a/test/unit/addons/tsl/TSLCubeTexture.tests.js
+++ b/test/unit/addons/tsl/TSLCubeTexture.tests.js
@@ -1,0 +1,107 @@
+import { CubeTexture, CubeRefractionMapping, Mesh, MeshBasicNodeMaterial, OrthographicCamera, PlaneGeometry, RenderTarget, Scene } from 'three/webgpu';
+import { cubeTexture, vec3 } from 'three/tsl';
+import { getSharedRenderer } from './gpu-test-utils.js';
+
+function createCubeTexture() {
+
+	const colors = [ '#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff', '#00ffff' ];
+
+	const texture = new CubeTexture( colors.map( ( color ) => {
+
+		const canvas = document.createElement( 'canvas' );
+		canvas.width = canvas.height = 4;
+		const context = canvas.getContext( '2d' );
+		context.fillStyle = color;
+		context.fillRect( 0, 0, 4, 4 );
+		return canvas;
+
+	} ) );
+
+	texture.needsUpdate = true;
+	return texture;
+
+}
+
+export default QUnit.module( 'TSL', () => {
+
+	QUnit.module( 'cube texture environment rotation', () => {
+
+		for ( const backend of [ 'webgpu', 'webgl' ] ) {
+
+			QUnit.test( `only environment sampling follows envMapRotation [${ backend }]`, async ( assert ) => {
+
+				const renderer = await getSharedRenderer( backend );
+
+				if ( renderer === null ) {
+
+					assert.ok( true, `SKIPPED: "${ backend }" backend is not available in this environment.` );
+					return;
+
+				}
+
+				const environment = createCubeTexture();
+				const custom = createCubeTexture();
+				const target = new RenderTarget( 8, 8 );
+				const scene = new Scene();
+				const camera = new OrthographicCamera( - 1, 1, 1, - 1, 0.1, 10 );
+				camera.position.z = 2;
+				const geometry = new PlaneGeometry( 2, 2 );
+				let material = new MeshBasicNodeMaterial( { envMap: environment } );
+				const mesh = new Mesh( geometry, material );
+				scene.add( mesh );
+				const previousTarget = renderer.getRenderTarget();
+
+				try {
+
+					renderer.setRenderTarget( target );
+
+					const sample = async ( angle ) => {
+
+						material.envMapRotation.y = angle;
+						renderer.render( scene, camera );
+						return Array.from( await renderer.readRenderTargetPixelsAsync( target, 4, 4, 1, 1 ) );
+
+					};
+
+					material.reflectivity = 0;
+					material.colorNode = cubeTexture( custom, vec3( 1, 0, 0 ) ).rgb;
+					const explicit = await sample( 0 );
+					assert.deepEqual( explicit, [ 0, 255, 0, 255 ], 'the fixed direction samples the green cube face' );
+					assert.deepEqual( await sample( Math.PI / 2 ), explicit, 'an unrelated cube texture with explicit coordinates does not rotate' );
+
+					material.colorNode = cubeTexture( custom ).rgb;
+					material.needsUpdate = true;
+					const implicit = await sample( 0 );
+					assert.deepEqual( await sample( Math.PI / 2 ), implicit, 'an unrelated cube texture with default coordinates does not rotate' );
+
+					material.colorNode = null;
+					material.reflectivity = 1;
+					material.needsUpdate = true;
+					const reflection = await sample( 0 );
+					assert.notDeepEqual( await sample( Math.PI / 2 ), reflection, 'the material environment reflection still rotates' );
+
+					environment.mapping = CubeRefractionMapping;
+					material.dispose();
+					material = new MeshBasicNodeMaterial( { envMap: environment, reflectivity: 1 } );
+					mesh.material = material;
+					const refraction = await sample( 0 );
+					assert.notDeepEqual( await sample( Math.PI / 2 ), refraction, 'the material environment refraction still rotates' );
+
+				} finally {
+
+					renderer.setRenderTarget( previousTarget );
+					geometry.dispose();
+					material.dispose();
+					target.dispose();
+					custom.dispose();
+					environment.dispose();
+
+				}
+
+			} );
+
+		}
+
+	} );
+
+} );

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -30,6 +30,7 @@ import './addons/tsl/TSLRotate.tests.js';
 import './addons/tsl/TSLSinc.tests.js';
 import './addons/tsl/TSLBRDF.tests.js';
 import './addons/tsl/TSLDepthConversion.tests.js';
+import './addons/tsl/TSLCubeTexture.tests.js';
 import './addons/tsl/TSLColorSpaceConversion.tests.js';
 import './addons/tsl/TSLTypeConstructors.tests.js';
 import './addons/tsl/TSLBitOps.tests.js';


### PR DESCRIPTION
Fixes #34521.

**Description**

`CubeTextureNode` currently applies `materialEnvRotation` to every cube texture lookup, including unrelated textures sampled through `cubeTexture()`. Rotating a material's environment therefore also changes those lookups, even when they use explicit coordinates.

This change provides the rotation through the basic environment sampling context instead. Regular cube texture lookups keep their original directions, while environment reflections and refractions still follow `envMapRotation`.

The regression tests render six-color cube maps on both WebGPU and WebGL. They cover unrelated cube textures with explicit and default coordinates, as well as environment reflection and refraction. Both unrelated-texture assertions fail on the previous implementation and pass with this change.

Validation: `npm run lint`, `npm run build`, `npm run test-unit` (1315 passed, 1 todo), and `npm run test-unit-addons` (391 passed).