### PR TITLE
WebGLRenderer: Improve geometry disposal.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1097,6 +1097,7 @@ class WebGLRenderer {
 			properties.dispose();
 			environments.dispose();
 			objects.dispose();
+			geometries.dispose();
 			bindingStates.dispose();
 			uniformsGroups.dispose();
 			programCache.dispose();

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -5,9 +5,15 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 	const geometries = {};
 	const wireframeAttributes = new WeakMap();
 
+	const registry = new FinalizationRegistry( ( id ) => delete geometries[ id ] );
+
 	function onGeometryDispose( event ) {
 
-		const geometry = event.target;
+		destroyGeometry( event.target );
+
+	}
+
+	function destroyGeometry( geometry ) {
 
 		if ( geometry.index !== null ) {
 
@@ -24,6 +30,7 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 		geometry.removeEventListener( 'dispose', onGeometryDispose );
 
 		delete geometries[ geometry.id ];
+		registry.unregister( geometry );
 
 		const attribute = wireframeAttributes.get( geometry );
 
@@ -50,11 +57,12 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
 	function get( object, geometry ) {
 
-		if ( geometries[ geometry.id ] === true ) return geometry;
+		if ( geometries[ geometry.id ] !== undefined ) return geometry;
 
 		geometry.addEventListener( 'dispose', onGeometryDispose );
 
-		geometries[ geometry.id ] = true;
+		geometries[ geometry.id ] = new WeakRef( geometry );
+		registry.register( geometry, geometry.id, geometry );
 
 		info.memory.geometries ++;
 
@@ -171,12 +179,26 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
 	}
 
+	function dispose() {
+
+		for ( const id in geometries ) {
+
+			const geometry = geometries[ id ].deref();
+
+			if ( geometry !== undefined ) destroyGeometry( geometry );
+
+		}
+
+	}
+
 	return {
 
 		get: get,
 		update: update,
 
-		getWireframeAttribute: getWireframeAttribute
+		getWireframeAttribute: getWireframeAttribute,
+
+		dispose: dispose
 
 	};
 


### PR DESCRIPTION
Related PR: #20698

**Description**

We have recently introduced the usage of `WeakRef` and `FinalizationRegistry` in `WebGPURenderer` so we are able to remove existing dispose event listeners during `renderer.dispose()`. If we don't do that, it's not possible to fully free the resources of a renderer instance.

The same issue exists in `WebGLRenderer` and this PR adapts the first part of the solution to `WebGLGeometries`. Interestingly, @gkjohnson suggested this exact fix years ago in #20698. At that time, the browser support for `WeakRef` and `FinalizationRegistry` was still problematic but now it should be safe to use. In any event, the approach of #20698 was correct and we should have merged this PR a bit sooner.