### PR TITLE
Nodes: Make build more efficient.

### DIFF
--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -141,11 +141,9 @@ class ContextNode extends Node {
 
 		const previousContext = builder.addContext( this.value );
 
-		const node = this.node.build( builder );
+		this.node.build( builder );
 
 		builder.setContext( previousContext );
-
-		return node;
 
 	}
 

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -207,26 +207,6 @@ class LightsNode extends Node {
 	}
 
 	/**
-	 * Analyzes the node's dependencies by building all nested light nodes
-	 * and the output node.
-	 *
-	 * @param {NodeBuilder} builder - A reference to the current node builder.
-	 */
-	analyze( builder ) {
-
-		const properties = builder.getNodeProperties( this );
-
-		for ( const node of properties.nodes ) {
-
-			node.build( builder );
-
-		}
-
-		properties.outputNode.build( builder );
-
-	}
-
-	/**
 	 * Creates lighting nodes for each scene light. This makes it possible to further
 	 * process lights in the node system.
 	 *
@@ -381,17 +361,13 @@ class LightsNode extends Node {
 		const context = builder.context;
 		const lightingModel = context.lightingModel;
 
-		const properties = builder.getNodeProperties( this );
-
 		if ( lightingModel ) {
 
 			const { totalDiffuseNode, totalSpecularNode } = this;
 
 			context.outgoingLight = outgoingLightNode;
 
-			const stack = builder.addStack();
-
-			properties.nodes = stack.nodes;
+			builder.addStack();
 
 			lightingModel.start( builder );
 
@@ -422,10 +398,6 @@ class LightsNode extends Node {
 			lightingModel.finish( builder );
 
 			outgoingLightNode = outgoingLightNode.bypass( builder.removeStack() );
-
-		} else {
-
-			properties.nodes = [];
 
 		}
 


### PR DESCRIPTION
Fixed #34386.

**Description**

The PR fixes two open bugs that improve the performance of the node material build. The findings come from #34386 where also performance data are shared. 

- `ContextNode.setup()` no longer returns the child's build. Returning it (added in #34251) stored the child's output node in the context node's own properties, so `Node.build()` then re-built it generically outside the context. The override of `generateNodeType()`, `analyze()` and `generate()` already routes everything through the wrapped node.
- In `LightsNode`, the custom `analyze()` is removed. It looped over every stack node and then built the output node which walks the same stack again. Every intermediate therefore reached usage count 2 and `TempNode` emitted a var for each. The default `Node.analyze()` builds the output node once and keeps the usage counter single-pass. That left `properties.nodes` unused so its two assignments in `setup()` are deleted as well.

I think we should merge this asap. In another test the node count drop from 3141 to 1282 when using a standard material with an env map.