### PR TITLE
BufferGeometryUtils: Validate morph attributes in mergeGeometries()

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -150,6 +150,7 @@ function mergeGeometries( geometries, useGroups = false ) {
 
 		const geometry = geometries[ i ];
 		let attributesCount = 0;
+		let morphAttributesCount = 0;
 
 		// ensure that all geometries are indexed, or none
 
@@ -206,9 +207,27 @@ function mergeGeometries( geometries, useGroups = false ) {
 
 			}
 
+			if ( geometry.morphAttributes[ name ].length !== geometries[ 0 ].morphAttributes[ name ].length ) {
+
+				console.error( 'THREE.BufferGeometryUtils: .mergeGeometries() failed with geometry at index ' + i + '. All geometries must have the same number of morph targets for the "' + name + '" morph attribute.' );
+				return null;
+
+			}
+
 			if ( morphAttributes[ name ] === undefined ) morphAttributes[ name ] = [];
 
 			morphAttributes[ name ].push( geometry.morphAttributes[ name ] );
+
+			morphAttributesCount ++;
+
+		}
+
+		// ensure geometries have the same number of morph attributes
+
+		if ( morphAttributesCount !== morphAttributesUsed.size ) {
+
+			console.error( 'THREE.BufferGeometryUtils: .mergeGeometries() failed with geometry at index ' + i + '. Make sure all geometries have the same number of morph attributes.' );
+			return null;
 
 		}
 

--- a/test/unit/addons/utils/BufferGeometryUtils.tests.js
+++ b/test/unit/addons/utils/BufferGeometryUtils.tests.js
@@ -36,6 +36,107 @@ export default QUnit.module( 'Addons', () => {
 
 		QUnit.module( 'BufferGeometryUtils', () => {
 
+			QUnit.module( 'mergeGeometries', () => {
+
+				QUnit.test( 'rejects missing morph attributes', ( assert ) => {
+
+					const geometry1 = getGeometry();
+					const geometry2 = getGeometry();
+					delete geometry2.morphAttributes.position;
+
+					assert.strictEqual( BufferGeometryUtils.mergeGeometries( [ geometry1, geometry2 ] ), null, 'rejects a missing morph attribute' );
+					assert.strictEqual( BufferGeometryUtils.mergeGeometries( [ geometry2, geometry1 ] ), null, 'rejects an unexpected morph attribute' );
+
+				} );
+
+				for ( const [ count1, count2 ] of [[ 2, 1 ], [ 1, 2 ], [ 0, 1 ], [ 1, 0 ]] ) {
+
+					QUnit.test( `rejects inconsistent morph target counts (${count1}, ${count2})`, ( assert ) => {
+
+						const geometry1 = getGeometry();
+						const geometry2 = getGeometry();
+
+						geometry1.morphAttributes.position = Array.from( { length: count1 }, () => geometry1.attributes.position.clone() );
+						geometry2.morphAttributes.position = Array.from( { length: count2 }, () => geometry2.attributes.position.clone() );
+
+						assert.strictEqual( BufferGeometryUtils.mergeGeometries( [ geometry1, geometry2 ] ), null, 'rejects mismatched target counts' );
+
+					} );
+
+				}
+
+				QUnit.test( 'merges compatible morph targets', ( assert ) => {
+
+					const geometry1 = getGeometry();
+					const geometry2 = getGeometry();
+
+					for ( const [ i, geometry ] of [ geometry1, geometry2 ].entries() ) {
+
+						geometry.setAttribute( 'normal', geometry.attributes.position.clone() );
+						geometry.morphAttributes.position.push( geometry.attributes.position.clone() );
+						geometry.morphAttributes.normal = [ geometry.attributes.normal.clone() ];
+
+						for ( const name in geometry.morphAttributes ) {
+
+							for ( const [ j, attribute ] of geometry.morphAttributes[ name ].entries() ) {
+
+								attribute.array.fill( ( i + 1 ) * 10 + j );
+
+							}
+
+						}
+
+					}
+
+					const merged = BufferGeometryUtils.mergeGeometries( [ geometry1, geometry2 ] );
+
+					assert.strictEqual( merged.attributes.position.count, 8 );
+					assert.deepEqual( Object.keys( merged.morphAttributes ), [ 'position', 'normal' ] );
+
+					for ( const name in geometry1.morphAttributes ) {
+
+						assert.strictEqual( merged.morphAttributes[ name ].length, geometry1.morphAttributes[ name ].length );
+
+						for ( let i = 0; i < merged.morphAttributes[ name ].length; i ++ ) {
+
+							assert.strictEqual( merged.morphAttributes[ name ][ i ].count, merged.attributes[ name ].count );
+							assert.deepEqual( Array.from( merged.morphAttributes[ name ][ i ].array ), [
+								...geometry1.morphAttributes[ name ][ i ].array,
+								...geometry2.morphAttributes[ name ][ i ].array
+							] );
+
+						}
+
+					}
+
+				} );
+
+				QUnit.test( 'merges geometries without morph attributes', ( assert ) => {
+
+					const geometry = getGeometry();
+					delete geometry.morphAttributes.position;
+
+					const merged = BufferGeometryUtils.mergeGeometries( [ geometry, geometry ] );
+
+					assert.strictEqual( merged.attributes.position.count, 8 );
+					assert.deepEqual( merged.morphAttributes, {} );
+
+				} );
+
+				QUnit.test( 'merges geometries with empty morph target arrays', ( assert ) => {
+
+					const geometry = getGeometry();
+					geometry.morphAttributes.position = [];
+
+					const merged = BufferGeometryUtils.mergeGeometries( [ geometry, geometry ] );
+
+					assert.strictEqual( merged.attributes.position.count, 8 );
+					assert.deepEqual( merged.morphAttributes, {} );
+
+				} );
+
+			} );
+
 			QUnit.module( 'mergeVertices', () => {
 
 				QUnit.test( 'can handle morphAttributes without crashing', ( assert ) => {


### PR DESCRIPTION
Related issue: None.

**Description**

`mergeGeometries()` checks for unexpected morph attributes but does not reject missing ones or inconsistent target counts.

A missing morph attribute produces merged morph data with fewer vertices than the base geometry. Inconsistent target counts either throw when a later geometry has fewer targets or silently discard targets when it has more.

This PR validates that all geometries have the same morph attribute names and the same target count for each corresponding attribute. Incompatible inputs log an error and return `null`, following the existing validation behavior.

