### PR TITLE
TSL: Automatically render non-texture nodes in .toInspector().

### DIFF
--- a/src/nodes/TSL.js
+++ b/src/nodes/TSL.js
@@ -9,6 +9,7 @@ export * from './core/IsolateNode.js';
 export * from './core/ContextNode.js';
 export * from './core/OverrideContextNode.js';
 export * from './core/IndexNode.js';
+export * from './core/InspectorNode.js'; // inspect(), .toInspector()
 export * from './core/ParameterNode.js';
 export * from './core/PropertyNode.js';
 export * from './core/StackNode.js';

--- a/src/nodes/core/InspectorNode.js
+++ b/src/nodes/core/InspectorNode.js
@@ -1,12 +1,18 @@
 import Node from './Node.js';
 import InspectorBase from '../../renderers/common/InspectorBase.js';
 import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
+import { context } from './ContextNode.js';
+import { rtt } from '../utils/RTTNode.js';
 import { NodeUpdateType } from './constants.js';
 import { warnOnce } from '../../utils.js';
 
 /**
  * InspectorNode is a wrapper node that allows inspection of node values during rendering.
  * It can be used to debug or analyze node outputs in the rendering pipeline.
+ *
+ * The inspector expects a texture to display. Texture and pass nodes are presented as they are,
+ * any other node is automatically rendered into a texture via {@link RTTNode} when the inspector
+ * builds the node, so `rtt()` does not have to be used manually.
  *
  * @augments Node
  */
@@ -38,6 +44,15 @@ class InspectorNode extends Node {
 		this.name = name;
 		this.callback = callback;
 
+		/**
+		 * The RTT node used to render a non-texture node into a texture for the inspector.
+		 * It is created on demand when the inspector builds the node.
+		 *
+		 * @type {?RTTNode}
+		 * @default null
+		 */
+		this.rttNode = null;
+
 		this.updateType = NodeUpdateType.FRAME;
 
 		this.isInspectorNode = true;
@@ -67,14 +82,52 @@ class InspectorNode extends Node {
 	}
 
 	/**
-	 * Returns the type of the wrapped node.
+	 * Returns the type of the wrapped node. When the node is built by the inspector,
+	 * the type of the node presented to the inspector is returned.
 	 *
 	 * @param {NodeBuilder} builder - The node builder.
+	 * @param {?string} [output=null] - The output of the node.
 	 * @returns {string}
 	 */
-	generateNodeType( builder ) {
+	generateNodeType( builder, output = null ) {
 
-		return this.node.getNodeType( builder );
+		const nodeProperties = builder.getNodeProperties( this );
+
+		if ( nodeProperties.outputNode ) {
+
+			return nodeProperties.outputNode.getNodeType( builder, output );
+
+		}
+
+		return this.node.getNodeType( builder, output );
+
+	}
+
+	/**
+	 * Returns the node presented to the inspector. Texture and pass nodes are returned as they are,
+	 * any other node is wrapped in a {@link RTTNode} so the inspector always receives a texture.
+	 *
+	 * @private
+	 * @param {Node} node - The node to present to the inspector.
+	 * @returns {Node} The node presented to the inspector.
+	 */
+	_getInspectorNode( node ) {
+
+		if ( node.isTextureNode === true || node.isPassNode === true ) return node;
+
+		if ( this.rttNode === null ) {
+
+			const rttNode = rtt( node );
+			rttNode.name = this.getName();
+
+			// Let the inspector define the UV, e.g. for aspect ratio correction.
+			rttNode.uvNode = null;
+
+			this.rttNode = rttNode;
+
+		}
+
+		return this.rttNode;
 
 	}
 
@@ -88,9 +141,20 @@ class InspectorNode extends Node {
 
 		let node = this.node;
 
-		if ( builder.context.inspector === true && this.callback !== null ) {
+		if ( builder.context.inspector === true ) {
 
-			node = this.callback( node );
+			if ( this.callback !== null ) {
+
+				node = this.callback( node );
+
+			}
+
+			node = this._getInspectorNode( node );
+
+			// Disable the inspector context for the presented node, so nested
+			// inspector nodes are not processed while building it.
+
+			node = context( node, { inspector: false } );
 
 		}
 
@@ -104,12 +168,62 @@ class InspectorNode extends Node {
 
 	}
 
+	/**
+	 * Generates the code of the node presented to the inspector.
+	 *
+	 * @param {NodeBuilder} builder - The node builder.
+	 * @param {?string} output - The output type.
+	 * @returns {string} The generated code snippet.
+	 */
+	generate( builder, output ) {
+
+		const nodeData = builder.getDataFromNode( this );
+
+		if ( nodeData.generating === true ) {
+
+			// The node presented to the inspector uses the inspected node (e.g. the inspector samples
+			// the texture with `screenUV` while `screenUV` is inspected), so this node is built
+			// again as "before" node of the inspected node. Only the inspected node is generated then.
+
+			return this.node.build( builder, output );
+
+		}
+
+		nodeData.generating = true;
+
+		const snippet = super.generate( builder, output );
+
+		nodeData.generating = false;
+
+		return snippet;
+
+	}
+
+	/**
+	 * Frees internal resources. Should be called when the node is no longer in use.
+	 */
+	dispose() {
+
+		if ( this.rttNode !== null ) {
+
+			this.rttNode.dispose();
+			this.rttNode = null;
+
+		}
+
+		super.dispose();
+
+	}
+
 }
 
 export default InspectorNode;
 
 /**
  * Creates an inspector node to wrap around a given node for inspection purposes.
+ *
+ * Texture and pass nodes are presented to the inspector as they are, any other node
+ * is automatically rendered into a texture via `rtt()` when the inspector builds it.
  *
  * @tsl
  * @param {Node} node - The node to inspect.

--- a/src/nodes/core/IsolateNode.js
+++ b/src/nodes/core/IsolateNode.js
@@ -70,6 +70,8 @@ class IsolateNode extends Node {
 
 	build( builder, ...params ) {
 
+		this._buildBeforeNodes( builder, params[ 0 ] );
+
 		const previousCache = builder.getCache();
 		const cache = builder.getCacheFromNode( this, this.parent );
 

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -836,6 +836,34 @@ class Node extends EventDispatcher {
 	}
 
 	/**
+	 * Builds the nodes added with {@link Node#before}. This method must be called by
+	 * `build()` implementations that do not call the build method of the base class.
+	 *
+	 * @private
+	 * @param {NodeBuilder} builder - The current node builder.
+	 * @param {?(string|Node)} [output=null] - Can be used to define the output type.
+	 */
+	_buildBeforeNodes( builder, output = null ) {
+
+		if ( this._beforeNodes !== null ) {
+
+			const currentBeforeNodes = this._beforeNodes;
+
+			this._beforeNodes = null;
+
+			for ( const beforeNode of currentBeforeNodes ) {
+
+				beforeNode.build( builder, output );
+
+			}
+
+			this._beforeNodes = currentBeforeNodes;
+
+		}
+
+	}
+
+	/**
 	 * This method performs the build of a node. The behavior and return value depend on the current build stage:
 	 * - **setup**: Prepares the node and its children for the build process. This process can also create new nodes. Returns the node itself or a variant.
 	 * - **analyze**: Analyzes the node hierarchy for optimizations in the code generation stage. Returns `null`.
@@ -857,21 +885,7 @@ class Node extends EventDispatcher {
 
 		//
 
-		if ( this._beforeNodes !== null ) {
-
-			const currentBeforeNodes = this._beforeNodes;
-
-			this._beforeNodes = null;
-
-			for ( const beforeNode of currentBeforeNodes ) {
-
-				beforeNode.build( builder, output );
-
-			}
-
-			this._beforeNodes = currentBeforeNodes;
-
-		}
+		this._buildBeforeNodes( builder, output );
 
 		//
 

--- a/src/nodes/core/SubBuildNode.js
+++ b/src/nodes/core/SubBuildNode.js
@@ -62,6 +62,8 @@ class SubBuildNode extends Node {
 
 	build( builder, ...params ) {
 
+		this._buildBeforeNodes( builder, params[ 0 ] );
+
 		builder.addSubBuild( this.name );
 
 		const data = this.node.build( builder, ...params );

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -228,6 +228,8 @@ class VarNode extends Node {
 
 			if ( this.isAssign( builder ) !== true ) {
 
+				this._buildBeforeNodes( builder, params[ 1 ] );
+
 				return this.node.build( ...params );
 
 			}

--- a/src/nodes/tsl/TSLBase.js
+++ b/src/nodes/tsl/TSLBase.js
@@ -27,7 +27,6 @@ export * from '../utils/Discard.js'; // Discard(), Return()
 export * from '../display/RenderOutputNode.js'; // .renderOutput()
 export * from '../utils/DebugNode.js'; // debug()
 export * from '../core/SubBuildNode.js'; // subBuild()
-export * from '../core/InspectorNode.js'; // inspector(), .toInspector()
 
 export function addNodeElement( name/*, nodeElement*/ ) {
 

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -636,6 +636,8 @@ class ShaderCallNodeInternal extends Node {
 
 	build( builder, output = null ) {
 
+		this._buildBeforeNodes( builder, output );
+
 		let result = null;
 
 		const buildStage = builder.getBuildStage();


### PR DESCRIPTION
The idea came up while talking with @sunag in person.

**Description**

`.toInspector()` currently requires manually wrapping non-texture nodes in `rtt()` to display them reliably. This change creates and reuses an RTT automatically when the inspector displays a non-texture node. Texture and pass nodes keep their existing behavior.

It also ensures that operator results, `Fn()` calls, `isolate()` and `subBuild()` honor `Node.before()`, so their `.toInspector()` calls are registered. The inspector export moves to `TSL.js` to avoid a circular import through `RTTNode`.

**Testing**

Lint, build, core unit tests and addon unit tests pass. Generated bundles are not included. The Inspector UI has not been verified in a WebGPU browser.
