### PR TITLE
Use `hashArray()` instead of `hash()` for generating cache keys

### DIFF
--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -13,7 +13,7 @@ const _parentBuildStage = {
 };
 
 let _nodeId = 0;
-const _scratchArray2 = new Array(2);
+const _scratchArray2 = new Array( 2 );
 
 /**
  * Base class for all nodes.

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -1,5 +1,5 @@
 import { NodeUpdateType } from './constants.js';
-import { hash, hashArray, hashString } from './NodeUtils.js';
+import { hashArray, hashString } from './NodeUtils.js';
 
 import { EventDispatcher } from '../../core/EventDispatcher.js';
 import { MathUtils } from '../../math/MathUtils.js';
@@ -13,6 +13,7 @@ const _parentBuildStage = {
 };
 
 let _nodeId = 0;
+const _scratchArray2 = new Array(2);
 
 /**
  * Base class for all nodes.
@@ -452,8 +453,9 @@ class Node extends EventDispatcher {
 			}
 
 			//
-
-			this._cacheKey = hash( hashArray( values ), this.customCacheKey() );
+			_scratchArray2[ 0 ] = hashArray( values );
+			_scratchArray2[ 1 ] = this.customCacheKey();
+			this._cacheKey = hashArray( _scratchArray2 );
 			this._cacheKeyVersion = this.version;
 
 		}

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -453,8 +453,13 @@ class Node extends EventDispatcher {
 			}
 
 			//
-			_scratchArray2[ 0 ] = hashArray( values );
-			_scratchArray2[ 1 ] = this.customCacheKey();
+
+			const childrenKey = hashArray( values );
+			const customKey = this.customCacheKey();
+
+			_scratchArray2[ 0 ] = childrenKey;
+			_scratchArray2[ 1 ] = customKey;
+
 			this._cacheKey = hashArray( _scratchArray2 );
 			this._cacheKeyVersion = this.version;
 

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -67,6 +67,7 @@ class ToneMappingNode extends TempNode {
 	customCacheKey() {
 
 		_scratchArray1[ 0 ] = this._toneMapping;
+
 		return hashArray( _scratchArray1 );
 
 	}

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -3,8 +3,10 @@ import { addMethodChaining, nodeObject, vec4 } from '../tsl/TSLCore.js';
 import { rendererReference } from '../accessors/RendererReferenceNode.js';
 
 import { NoToneMapping } from '../../constants.js';
-import { hash } from '../core/NodeUtils.js';
+import { hashArray } from '../core/NodeUtils.js';
 import { error } from '../../utils.js';
+
+const _scratchArray1 = new Array(1);
 
 /**
  * This node represents a tone mapping operation.
@@ -64,7 +66,8 @@ class ToneMappingNode extends TempNode {
 	 */
 	customCacheKey() {
 
-		return hash( this._toneMapping );
+		_scratchArray1[ 0 ] = this._toneMapping;
+		return hashArray( _scratchArray1 );
 
 	}
 

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -6,7 +6,7 @@ import { NoToneMapping } from '../../constants.js';
 import { hashArray } from '../core/NodeUtils.js';
 import { error } from '../../utils.js';
 
-const _scratchArray1 = new Array(1);
+const _scratchArray1 = new Array( 1 );
 
 /**
  * This node represents a tone mapping operation.

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -942,6 +942,7 @@ class RenderObject {
 
 			_scratchArray2[ 0 ] = cacheKey;
 			_scratchArray2[ 1 ] = this.camera.cameras.length;
+
 			cacheKey = hashArray( _scratchArray2 );
 
 		}
@@ -950,6 +951,7 @@ class RenderObject {
 
 			_scratchArray2[ 0 ] = cacheKey;
 			_scratchArray2[ 1 ] = 1;
+
 			cacheKey = hashArray( _scratchArray2 );
 
 		}
@@ -957,6 +959,7 @@ class RenderObject {
 		_scratchArray3[ 0 ] = cacheKey;
 		_scratchArray3[ 1 ] = this.renderer.contextNode.id;
 		_scratchArray3[ 2 ] = this.renderer.contextNode.version;
+
 		cacheKey = hashArray( _scratchArray3 );
 
 		return cacheKey;

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -2,8 +2,8 @@ import { hashArray, hashString } from '../../nodes/core/NodeUtils.js';
 
 let _id = 0;
 const _protoKeysCache = new WeakMap();
-const _scratchArray2 = new Array(2);
-const _scratchArray3 = new Array(3);
+const _scratchArray2 = new Array( 2 );
+const _scratchArray3 = new Array( 3 );
 
 function getKeys( obj ) {
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -1,7 +1,9 @@
-import { hash, hashString } from '../../nodes/core/NodeUtils.js';
+import { hashArray, hashString } from '../../nodes/core/NodeUtils.js';
 
 let _id = 0;
 const _protoKeysCache = new WeakMap();
+const _scratchArray2 = new Array(2);
+const _scratchArray3 = new Array(3);
 
 function getKeys( obj ) {
 
@@ -938,17 +940,24 @@ class RenderObject {
 
 		if ( this.camera.isArrayCamera ) {
 
-			cacheKey = hash( cacheKey, this.camera.cameras.length );
+			_scratchArray2[ 0 ] = cacheKey;
+			_scratchArray2[ 1 ] = this.camera.cameras.length;
+			cacheKey = hashArray( _scratchArray2 );
 
 		}
 
 		if ( this.object.receiveShadow ) {
 
-			cacheKey = hash( cacheKey, 1 );
+			_scratchArray2[ 0 ] = cacheKey;
+			_scratchArray2[ 1 ] = 1;
+			cacheKey = hashArray( _scratchArray2 );
 
 		}
 
-		cacheKey = hash( cacheKey, this.renderer.contextNode.id, this.renderer.contextNode.version );
+		_scratchArray3[ 0 ] = cacheKey;
+		_scratchArray3[ 1 ] = this.renderer.contextNode.id;
+		_scratchArray3[ 2 ] = this.renderer.contextNode.version;
+		cacheKey = hashArray( _scratchArray3 );
 
 		return cacheKey;
 


### PR DESCRIPTION
Related issue: #34535 

**Description**

This PR replaces `hash()` calls with `hashArray()` and reusable module-level scratch arrays in:

- `RenderObject.getDynamicCacheKey()`
- `Node.getCacheKey()`
- `ToneMappingNode.customCacheKey()`

This is done to reduce pressure on the garbage collector and to improve rendering performance (less likelihood that the garbage collector activates).