### PR TITLE
NURBSCurve: Fix `clone()`.

### DIFF
--- a/examples/jsm/curves/NURBSCurve.js
+++ b/examples/jsm/curves/NURBSCurve.js
@@ -122,6 +122,20 @@ class NURBSCurve extends Curve {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.degree = source.degree;
+		this.knots = [ ...source.knots ];
+		this.controlPoints = source.controlPoints.map( p => p.clone() );
+		this.startKnot = source.startKnot;
+		this.endKnot = source.endKnot;
+
+		return this;
+
+	}
+
 	toJSON() {
 
 		const data = super.toJSON();

--- a/test/unit/addons/curves/NURBSCurve.tests.js
+++ b/test/unit/addons/curves/NURBSCurve.tests.js
@@ -35,6 +35,23 @@ export default QUnit.module( 'Extras', () => {
 
 			} );
 
+			QUnit.test( 'clone', ( assert ) => {
+
+				const clone = _nurbsCurve.clone();
+
+				assert.equal( clone.degree, _nurbsCurve.degree, 'clone.degree ok' );
+				assert.deepEqual( clone.knots, _nurbsCurve.knots, 'clone.knots ok' );
+				assert.deepEqual( clone.controlPoints, _nurbsCurve.controlPoints, 'clone.controlPoints ok' );
+				assert.equal( clone.startKnot, _nurbsCurve.startKnot, 'clone.startKnot ok' );
+				assert.equal( clone.endKnot, _nurbsCurve.endKnot, 'clone.endKnot ok' );
+
+				assert.notStrictEqual( clone.knots, _nurbsCurve.knots, 'clone.knots is not shared' );
+				assert.notStrictEqual( clone.controlPoints[ 0 ], _nurbsCurve.controlPoints[ 0 ], 'clone.controlPoints are not shared' );
+
+				assert.deepEqual( clone.getPoint( 0.5 ), _nurbsCurve.getPoint( 0.5 ), 'clone.getPoint() ok' );
+
+			} );
+
 			QUnit.test( 'toJSON', ( assert ) => {
 
 				const json = _nurbsCurve.toJSON();


### PR DESCRIPTION
Related issue: none

**Description**

I noticed that `NURBSCurve.clone()` returns a curve that can't be used. `NURBSCurve` got `toJSON()` and `fromJSON()` in #29514 but never a `copy()`, so `clone()` falls back to `Curve.copy()`, which only copies `arcLengthDivisions`. The clone ends up with `degree` and `knots` undefined and no control points, and the first `getPoint()` call throws:

```js
const curve = new NURBSCurve( 3, knots, controlPoints );
const clone = curve.clone();

clone.degree; // undefined
clone.controlPoints.length; // 0
clone.getPoint( 0.5 ); // TypeError: Cannot read properties of undefined (reading '0')
```

The same thing happens to a `CurvePath` (and so a `Path` or `Shape`) holding a `NURBSCurve`, since `CurvePath.copy()` clones each of its curves.

The new `copy()` mirrors `fromJSON()`. The knots array is copied and the control points are cloned, so the clone doesn't share state with the source.

I added a `clone` test next to the existing `toJSON`/`fromJSON` ones. Without the fix it fails on the degree, knots, control points and end knot assertions, then dies in `getPoint()`. With it, `npm run test-unit-addons` passes (398/398) and eslint is clean on both files.

AI tools used
