### PR TITLE
PixelationPassNode: Simplify Code.

### DIFF
--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -114,21 +114,21 @@ class PixelationPassNode extends PassNode {
 		const sampleDepth = ( x, y ) => depthNode.sample( uvNodeDepth.add( vec2( x, y ).mul( invSize ) ) ).r;
 		const sampleNormal = ( x, y ) => normalNode.sample( uvNodeNormal.add( vec2( x, y ).mul( invSize ) ) ).rgb.normalize();
 
-		const depthEdgeIndicator = ( depth ) => {
+		const depthEdgeIndicator = ( depth, depthE, depthW, depthN, depthS ) => {
 
 			const diff = property( 'float', 'diff' );
-			diff.addAssign( clamp( sampleDepth( 1, 0 ).sub( depth ) ) );
-			diff.addAssign( clamp( sampleDepth( - 1, 0 ).sub( depth ) ) );
-			diff.addAssign( clamp( sampleDepth( 0, 1 ).sub( depth ) ) );
-			diff.addAssign( clamp( sampleDepth( 0, - 1 ).sub( depth ) ) );
+			diff.addAssign( clamp( depthE.sub( depth ) ) );
+			diff.addAssign( clamp( depthW.sub( depth ) ) );
+			diff.addAssign( clamp( depthN.sub( depth ) ) );
+			diff.addAssign( clamp( depthS.sub( depth ) ) );
 
 			return floor( smoothstep( 0.01, 0.02, diff ).mul( 2 ) ).div( 2 );
 
 		};
 
-		const neighborNormalEdgeIndicator = ( x, y, depth, normal ) => {
+		const neighborNormalEdgeIndicator = ( x, y, neighborDepth, depth, normal ) => {
 
-			const depthDiff = sampleDepth( x, y ).sub( depth );
+			const depthDiff = neighborDepth.sub( depth );
 			const neighborNormal = sampleNormal( x, y );
 
 			// Edge pixels should yield to faces who's normals are closer to the bias normal.
@@ -145,14 +145,14 @@ class PixelationPassNode extends PassNode {
 
 		};
 
-		const normalEdgeIndicator = ( depth, normal ) => {
+		const normalEdgeIndicator = ( depth, normal, depthE, depthW, depthN, depthS ) => {
 
 			const indicator = property( 'float', 'indicator' );
 
-			indicator.addAssign( neighborNormalEdgeIndicator( 0, - 1, depth, normal ) );
-			indicator.addAssign( neighborNormalEdgeIndicator( 0, 1, depth, normal ) );
-			indicator.addAssign( neighborNormalEdgeIndicator( - 1, 0, depth, normal ) );
-			indicator.addAssign( neighborNormalEdgeIndicator( 1, 0, depth, normal ) );
+			indicator.addAssign( neighborNormalEdgeIndicator( 0, - 1, depthS, depth, normal ) );
+			indicator.addAssign( neighborNormalEdgeIndicator( 0, 1, depthN, depth, normal ) );
+			indicator.addAssign( neighborNormalEdgeIndicator( - 1, 0, depthW, depth, normal ) );
+			indicator.addAssign( neighborNormalEdgeIndicator( 1, 0, depthE, depth, normal ) );
 
 			return step( 0.1, indicator );
 
@@ -165,10 +165,20 @@ class PixelationPassNode extends PassNode {
 			const depth = property( 'float', 'depth' );
 			const normal = property( 'vec3', 'normal' );
 
+			const depthE = float().toVar();
+			const depthW = float().toVar();
+			const depthN = float().toVar();
+			const depthS = float().toVar();
+
 			If( this.depthEdgeStrength.greaterThan( 0.0 ).or( this.normalEdgeStrength.greaterThan( 0.0 ) ), () => {
 
 				depth.assign( sampleDepth( 0, 0 ) );
 				normal.assign( sampleNormal( 0, 0 ) );
+
+				depthE.assign( sampleDepth( 1, 0 ) );
+				depthW.assign( sampleDepth( - 1, 0 ) );
+				depthN.assign( sampleDepth( 0, 1 ) );
+				depthS.assign( sampleDepth( 0, - 1 ) );
 
 			} );
 
@@ -176,7 +186,7 @@ class PixelationPassNode extends PassNode {
 
 			If( this.depthEdgeStrength.greaterThan( 0.0 ), () => {
 
-				dei.assign( depthEdgeIndicator( depth ) );
+				dei.assign( depthEdgeIndicator( depth, depthE, depthW, depthN, depthS ) );
 
 			} );
 
@@ -184,7 +194,7 @@ class PixelationPassNode extends PassNode {
 
 			If( this.normalEdgeStrength.greaterThan( 0.0 ).and( normal.length().greaterThan( 0 ) ), () => {
 
-				nei.assign( normalEdgeIndicator( depth, normal ) );
+				nei.assign( normalEdgeIndicator( depth, normal, depthE, depthW, depthN, depthS ) );
 
 			} );
 

--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -46,7 +46,7 @@ class PixelationPassNode extends PassNode {
 		 * @type {Node<float> | number}
 		 * @default 0.3
 		 */
-		this.normalEdgeStrength = normalEdgeStrength;
+		this.normalEdgeStrength = nodeObject( normalEdgeStrength );
 
 		/**
 		 * The depth edge strength.
@@ -54,7 +54,7 @@ class PixelationPassNode extends PassNode {
 		 * @type {Node<float> | number}
 		 * @default 0.4
 		 */
-		this.depthEdgeStrength = depthEdgeStrength;
+		this.depthEdgeStrength = nodeObject( depthEdgeStrength );
 
 		/**
 		 * This flag can be used for type testing.
@@ -103,9 +103,6 @@ class PixelationPassNode extends PassNode {
 		const textureNode = this.getTextureNode( 'output' );
 		const depthNode = this.getTextureNode( 'depth' );
 		const normalNode = this.getTextureNode( 'normal' );
-
-		const normalEdgeStrength = nodeObject( this.normalEdgeStrength );
-		const depthEdgeStrength = nodeObject( this.depthEdgeStrength );
 
 		const uvNodeTexture = textureNode.uvNode || uv();
 		const uvNodeDepth = depthNode.uvNode || uv();
@@ -168,7 +165,7 @@ class PixelationPassNode extends PassNode {
 			const depth = property( 'float', 'depth' );
 			const normal = property( 'vec3', 'normal' );
 
-			If( depthEdgeStrength.greaterThan( 0.0 ).or( normalEdgeStrength.greaterThan( 0.0 ) ), () => {
+			If( this.depthEdgeStrength.greaterThan( 0.0 ).or( this.normalEdgeStrength.greaterThan( 0.0 ) ), () => {
 
 				depth.assign( sampleDepth( 0, 0 ) );
 				normal.assign( sampleNormal( 0, 0 ) );
@@ -177,7 +174,7 @@ class PixelationPassNode extends PassNode {
 
 			const dei = property( 'float', 'dei' );
 
-			If( depthEdgeStrength.greaterThan( 0.0 ), () => {
+			If( this.depthEdgeStrength.greaterThan( 0.0 ), () => {
 
 				dei.assign( depthEdgeIndicator( depth ) );
 
@@ -185,13 +182,13 @@ class PixelationPassNode extends PassNode {
 
 			const nei = property( 'float', 'nei' );
 
-			If( normalEdgeStrength.greaterThan( 0.0 ).and( normal.length().greaterThan( 0 ) ), () => {
+			If( this.normalEdgeStrength.greaterThan( 0.0 ).and( normal.length().greaterThan( 0 ) ), () => {
 
 				nei.assign( normalEdgeIndicator( depth, normal ) );
 
 			} );
 
-			const strength = dei.greaterThan( 0 ).select( float( 1.0 ).sub( dei.mul( depthEdgeStrength ) ), nei.mul( normalEdgeStrength ).add( 1 ) );
+			const strength = dei.greaterThan( 0 ).select( float( 1.0 ).sub( dei.mul( this.depthEdgeStrength ) ), nei.mul( this.normalEdgeStrength ).add( 1 ) );
 
 			return vec4( texel.mul( strength ).rgb, texel.a );
 

--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -5,7 +5,7 @@ import { nodeObject, Fn, float, uv, vec2, vec3, clamp, floor, dot, smoothstep, I
  * A special render pass node that renders the scene with a pixelation effect,
  * creating a visual presentation similar to that of a 2D pixel art game.
  *
- * The effect is achieved by rendered into a render target whose dimensions
+ * The effect is achieved by rendering into a render target whose dimensions
  * are scaled down by {@link PixelationPassNode#pixelSize}.
  *
  * @augments PassNode
@@ -24,7 +24,7 @@ class PixelationPassNode extends PassNode {
 	 *
 	 * @param {Scene} scene - The scene to render.
 	 * @param {Camera} camera - The camera to render the scene with.
-	 * @param {Node<float> | number} [pixelSize=6] - The pixel size.
+	 * @param {number} [pixelSize=6] - The pixel size.
 	 * @param {Node<float> | number} [normalEdgeStrength=0.3] - The normal edge strength.
 	 * @param {Node<float> | number} [depthEdgeStrength=0.4] - The depth edge strength.
 	 */
@@ -35,7 +35,7 @@ class PixelationPassNode extends PassNode {
 		/**
 		 * The pixel size. This value scales the pass's render target.
 		 *
-		 * @type {Node<float> | number}
+		 * @type {number}
 		 * @default 6
 		 */
 		this.pixelSize = pixelSize;
@@ -43,7 +43,7 @@ class PixelationPassNode extends PassNode {
 		/**
 		 * The normal edge strength.
 		 *
-		 * @type {Node<float> | number}
+		 * @type {Node<float>}
 		 * @default 0.3
 		 */
 		this.normalEdgeStrength = nodeObject( normalEdgeStrength );
@@ -51,7 +51,7 @@ class PixelationPassNode extends PassNode {
 		/**
 		 * The depth edge strength.
 		 *
-		 * @type {Node<float> | number}
+		 * @type {Node<float>}
 		 * @default 0.4
 		 */
 		this.depthEdgeStrength = nodeObject( depthEdgeStrength );
@@ -83,10 +83,8 @@ class PixelationPassNode extends PassNode {
 	 */
 	setSize( width, height ) {
 
-		const pixelSize = this.pixelSize.value ? this.pixelSize.value : this.pixelSize;
-
-		const adjustedWidth = Math.floor( width / pixelSize );
-		const adjustedHeight = Math.floor( height / pixelSize );
+		const adjustedWidth = Math.floor( width / this.pixelSize );
+		const adjustedHeight = Math.floor( height / this.pixelSize );
 
 		super.setSize( adjustedWidth, adjustedHeight );
 
@@ -108,11 +106,9 @@ class PixelationPassNode extends PassNode {
 		const uvNodeDepth = depthNode.uvNode || uv();
 		const uvNodeNormal = normalNode.uvNode || uv();
 
-		const invSize = vec2( 1 ).div( textureSize( textureNode ) );
-
 		const sampleTexture = () => textureNode.sample( uvNodeTexture );
-		const sampleDepth = ( x, y ) => depthNode.sample( uvNodeDepth.add( vec2( x, y ).mul( invSize ) ) ).r;
-		const sampleNormal = ( x, y ) => normalNode.sample( uvNodeNormal.add( vec2( x, y ).mul( invSize ) ) ).rgb.normalize();
+		const sampleDepth = ( uv ) => depthNode.sample( uv ).r;
+		const sampleNormal = ( uv ) => normalNode.sample( uv ).rgb.normalize();
 
 		const depthEdgeIndicator = ( depth, depthE, depthW, depthN, depthS ) => {
 
@@ -126,33 +122,33 @@ class PixelationPassNode extends PassNode {
 
 		};
 
-		const neighborNormalEdgeIndicator = ( x, y, neighborDepth, depth, normal ) => {
+		const neighborNormalEdgeIndicator = ( x, y, neighborDepth, depth, normal, invSize ) => {
 
-			const depthDiff = neighborDepth.sub( depth );
-			const neighborNormal = sampleNormal( x, y );
+			const depthDiff = neighborDepth.sub( depth ).toConst();
+			const neighborNormal = sampleNormal( uvNodeNormal.add( vec2( x, y ).mul( invSize ) ) ).toConst();
 
 			// Edge pixels should yield to faces who's normals are closer to the bias normal.
 
 			const normalEdgeBias = vec3( 1, 1, 1 ); // This should probably be a parameter.
-			const normalDiff = dot( normal.sub( neighborNormal ), normalEdgeBias );
-			const normalIndicator = clamp( smoothstep( - 0.01, 0.01, normalDiff ), 0.0, 1.0 );
+			const normalDiff = dot( normal.sub( neighborNormal ), normalEdgeBias ).toConst();
+			const normalIndicator = clamp( smoothstep( - 0.01, 0.01, normalDiff ), 0.0, 1.0 ).toConst();
 
 			// Only the shallower pixel should detect the normal edge.
 
-			const depthIndicator = clamp( sign( depthDiff.mul( .25 ).add( .0025 ) ), 0.0, 1.0 );
+			const depthIndicator = clamp( sign( depthDiff.mul( .25 ).add( .0025 ) ), 0.0, 1.0 ).toConst();
 
 			return float( 1.0 ).sub( dot( normal, neighborNormal ) ).mul( depthIndicator ).mul( normalIndicator );
 
 		};
 
-		const normalEdgeIndicator = ( depth, normal, depthE, depthW, depthN, depthS ) => {
+		const normalEdgeIndicator = ( depth, normal, depthE, depthW, depthN, depthS, invSize ) => {
 
 			const indicator = property( 'float', 'indicator' );
 
-			indicator.addAssign( neighborNormalEdgeIndicator( 0, - 1, depthS, depth, normal ) );
-			indicator.addAssign( neighborNormalEdgeIndicator( 0, 1, depthN, depth, normal ) );
-			indicator.addAssign( neighborNormalEdgeIndicator( - 1, 0, depthW, depth, normal ) );
-			indicator.addAssign( neighborNormalEdgeIndicator( 1, 0, depthE, depth, normal ) );
+			indicator.addAssign( neighborNormalEdgeIndicator( 0, - 1, depthS, depth, normal, invSize ) );
+			indicator.addAssign( neighborNormalEdgeIndicator( 0, 1, depthN, depth, normal, invSize ) );
+			indicator.addAssign( neighborNormalEdgeIndicator( - 1, 0, depthW, depth, normal, invSize ) );
+			indicator.addAssign( neighborNormalEdgeIndicator( 1, 0, depthE, depth, normal, invSize ) );
 
 			return step( 0.1, indicator );
 
@@ -170,15 +166,17 @@ class PixelationPassNode extends PassNode {
 			const depthN = float().toVar();
 			const depthS = float().toVar();
 
+			const invSize = vec2( 1 ).div( textureSize( textureNode ) ).toConst();
+
 			If( this.depthEdgeStrength.greaterThan( 0.0 ).or( this.normalEdgeStrength.greaterThan( 0.0 ) ), () => {
 
-				depth.assign( sampleDepth( 0, 0 ) );
-				normal.assign( sampleNormal( 0, 0 ) );
+				depth.assign( sampleDepth( uvNodeDepth ) );
+				normal.assign( sampleNormal( uvNodeNormal ) );
 
-				depthE.assign( sampleDepth( 1, 0 ) );
-				depthW.assign( sampleDepth( - 1, 0 ) );
-				depthN.assign( sampleDepth( 0, 1 ) );
-				depthS.assign( sampleDepth( 0, - 1 ) );
+				depthE.assign( sampleDepth( uvNodeDepth.add( vec2( 1, 0 ).mul( invSize ) ) ) );
+				depthW.assign( sampleDepth( uvNodeDepth.add( vec2( - 1, 0 ).mul( invSize ) ) ) );
+				depthN.assign( sampleDepth( uvNodeDepth.add( vec2( 0, 1 ).mul( invSize ) ) ) );
+				depthS.assign( sampleDepth( uvNodeDepth.add( vec2( 0, - 1 ).mul( invSize ) ) ) );
 
 			} );
 
@@ -194,7 +192,7 @@ class PixelationPassNode extends PassNode {
 
 			If( this.normalEdgeStrength.greaterThan( 0.0 ).and( normal.length().greaterThan( 0 ) ), () => {
 
-				nei.assign( normalEdgeIndicator( depth, normal, depthE, depthW, depthN, depthS ) );
+				nei.assign( normalEdgeIndicator( depth, normal, depthE, depthW, depthN, depthS, invSize ) );
 
 			} );
 
@@ -219,7 +217,7 @@ class PixelationPassNode extends PassNode {
  * @function
  * @param {Scene} scene - The scene to render.
  * @param {Camera} camera - The camera to render the scene with.
- * @param {Node<float> | number} [pixelSize=6] - The pixel size.
+ * @param {number} [pixelSize=6] - The pixel size.
  * @param {Node<float> | number} [normalEdgeStrength=0.3] - The normal edge strength.
  * @param {Node<float> | number} [depthEdgeStrength=0.4] - The depth edge strength.
  * @returns {PixelationPassNode}

--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -1,108 +1,94 @@
-import { NearestFilter, Vector4, TempNode, NodeUpdateType, PassNode } from 'three/webgpu';
-import { nodeObject, Fn, float, uv, uniform, convertToTexture, vec2, vec3, clamp, floor, dot, smoothstep, If, sign, step, mrt, output, normalView, property, vec4 } from 'three/tsl';
+import { NearestFilter, PassNode } from 'three/webgpu';
+import { nodeObject, Fn, float, uv, vec2, vec3, clamp, floor, dot, smoothstep, If, sign, step, mrt, output, normalView, property, vec4, textureSize } from 'three/tsl';
 
 /**
- * A inner node definition that implements the actual pixelation TSL code.
+ * A special render pass node that renders the scene with a pixelation effect,
+ * creating a visual presentation similar to that of a 2D pixel art game.
  *
- * @inner
- * @augments TempNode
+ * The effect is achieved by rendered into a render target whose dimensions
+ * are scaled down by {@link PixelationPassNode#pixelSize}.
+ *
+ * @augments PassNode
+ * @three_import import { pixelationPass } from 'three/addons/tsl/display/PixelationPassNode.js';
  */
-class PixelationNode extends TempNode {
+class PixelationPassNode extends PassNode {
 
 	static get type() {
 
-		return 'PixelationNode';
+		return 'PixelationPassNode';
 
 	}
 
 	/**
-	 * Constructs a new pixelation node.
+	 * Constructs a new pixelation pass node.
 	 *
-	 * @param {TextureNode} textureNode - The texture node that represents the beauty pass.
-	 * @param {TextureNode} depthNode - The texture that represents the beauty's depth.
-	 * @param {TextureNode} normalNode - The texture that represents the beauty's normals.
-	 * @param {Node<float>} pixelSize - The pixel size.
-	 * @param {Node<float>} normalEdgeStrength - The normal edge strength.
-	 * @param {Node<float>} depthEdgeStrength - The depth edge strength.
+	 * @param {Scene} scene - The scene to render.
+	 * @param {Camera} camera - The camera to render the scene with.
+	 * @param {Node<float> | number} [pixelSize=6] - The pixel size.
+	 * @param {Node<float> | number} [normalEdgeStrength=0.3] - The normal edge strength.
+	 * @param {Node<float> | number} [depthEdgeStrength=0.4] - The depth edge strength.
 	 */
-	constructor( textureNode, depthNode, normalNode, pixelSize, normalEdgeStrength, depthEdgeStrength ) {
+	constructor( scene, camera, pixelSize = 6, normalEdgeStrength = 0.3, depthEdgeStrength = 0.4 ) {
 
-		super( 'vec4' );
-
-		/**
-		 * The texture node that represents the beauty pass.
-		 *
-		 * @type {TextureNode}
-		 */
-		this.textureNode = textureNode;
+		super( PassNode.COLOR, scene, camera, { minFilter: NearestFilter, magFilter: NearestFilter } );
 
 		/**
-		 * The texture that represents the beauty's depth.
+		 * The pixel size. This value scales the pass's render target.
 		 *
-		 * @type {TextureNode}
-		 */
-		this.depthNode = depthNode;
-
-		/**
-		 * The texture that represents the beauty's normals.
-		 *
-		 * @type {TextureNode}
-		 */
-		this.normalNode = normalNode;
-
-		/**
-		 * The pixel size.
-		 *
-		 * @type {Node<float>}
+		 * @type {Node<float> | number}
+		 * @default 6
 		 */
 		this.pixelSize = pixelSize;
 
 		/**
-		 * The pixel size.
+		 * The normal edge strength.
 		 *
-		 * @type {Node<float>}
+		 * @type {Node<float> | number}
+		 * @default 0.3
 		 */
 		this.normalEdgeStrength = normalEdgeStrength;
 
 		/**
 		 * The depth edge strength.
 		 *
-		 * @type {Node<float>}
+		 * @type {Node<float> | number}
+		 * @default 0.4
 		 */
 		this.depthEdgeStrength = depthEdgeStrength;
 
 		/**
-		 * Uniform node that represents the resolution.
+		 * This flag can be used for type testing.
 		 *
-		 * @private
-		 * @type {Node<vec4>}
+		 * @type {boolean}
+		 * @readonly
+		 * @default true
 		 */
-		this._resolution = uniform( new Vector4() );
+		this.isPixelationPassNode = true;
 
-		/**
-		 * The `updateType` is set to `NodeUpdateType.FRAME` since the node updates
-		 * its internal uniforms once per frame in `updateBefore()`.
-		 *
-		 * @type {string}
-		 * @default 'frame'
-		 */
-		this.updateType = NodeUpdateType.FRAME;
+		this._mrt = mrt( {
+			output: output,
+			normal: normalView
+		} );
 
 	}
 
 	/**
-	 * This method is used to update uniforms once per frame.
+	 * Sets the size of the pass.
 	 *
-	 * @param {NodeFrame} frame - The current node frame.
+	 * `PassNode.updateBefore()` calls this method once per frame, so
+	 * {@link PixelationPassNode#pixelSize} can be changed at any time.
+	 *
+	 * @param {number} width - The width of the pass.
+	 * @param {number} height - The height of the pass.
 	 */
-	update() {
+	setSize( width, height ) {
 
-		const map = this.textureNode.value;
+		const pixelSize = this.pixelSize.value ? this.pixelSize.value : this.pixelSize;
 
-		const width = map.image.width;
-		const height = map.image.height;
+		const adjustedWidth = Math.floor( width / pixelSize );
+		const adjustedHeight = Math.floor( height / pixelSize );
 
-		this._resolution.value.set( width, height, 1 / width, 1 / height );
+		super.setSize( adjustedWidth, adjustedHeight );
 
 	}
 
@@ -112,19 +98,24 @@ class PixelationNode extends TempNode {
 	 * @param {NodeBuilder} builder - The current node builder.
 	 * @return {ShaderCallNodeInternal}
 	 */
-	setup() {
+	setup( /* builder */ ) {
 
-		const { textureNode, depthNode, normalNode } = this;
+		const textureNode = this.getTextureNode( 'output' );
+		const depthNode = this.getTextureNode( 'depth' );
+		const normalNode = this.getTextureNode( 'normal' );
+
+		const normalEdgeStrength = nodeObject( this.normalEdgeStrength );
+		const depthEdgeStrength = nodeObject( this.depthEdgeStrength );
 
 		const uvNodeTexture = textureNode.uvNode || uv();
 		const uvNodeDepth = depthNode.uvNode || uv();
 		const uvNodeNormal = normalNode.uvNode || uv();
 
+		const invSize = vec2( 1 ).div( textureSize( textureNode ) );
+
 		const sampleTexture = () => textureNode.sample( uvNodeTexture );
-
-		const sampleDepth = ( x, y ) => depthNode.sample( uvNodeDepth.add( vec2( x, y ).mul( this._resolution.zw ) ) ).r;
-
-		const sampleNormal = ( x, y ) => normalNode.sample( uvNodeNormal.add( vec2( x, y ).mul( this._resolution.zw ) ) ).rgb.normalize();
+		const sampleDepth = ( x, y ) => depthNode.sample( uvNodeDepth.add( vec2( x, y ).mul( invSize ) ) ).r;
+		const sampleNormal = ( x, y ) => normalNode.sample( uvNodeNormal.add( vec2( x, y ).mul( invSize ) ) ).rgb.normalize();
 
 		const depthEdgeIndicator = ( depth ) => {
 
@@ -177,7 +168,7 @@ class PixelationNode extends TempNode {
 			const depth = property( 'float', 'depth' );
 			const normal = property( 'vec3', 'normal' );
 
-			If( this.depthEdgeStrength.greaterThan( 0.0 ).or( this.normalEdgeStrength.greaterThan( 0.0 ) ), () => {
+			If( depthEdgeStrength.greaterThan( 0.0 ).or( normalEdgeStrength.greaterThan( 0.0 ) ), () => {
 
 				depth.assign( sampleDepth( 0, 0 ) );
 				normal.assign( sampleNormal( 0, 0 ) );
@@ -186,7 +177,7 @@ class PixelationNode extends TempNode {
 
 			const dei = property( 'float', 'dei' );
 
-			If( this.depthEdgeStrength.greaterThan( 0.0 ), () => {
+			If( depthEdgeStrength.greaterThan( 0.0 ), () => {
 
 				dei.assign( depthEdgeIndicator( depth ) );
 
@@ -194,13 +185,13 @@ class PixelationNode extends TempNode {
 
 			const nei = property( 'float', 'nei' );
 
-			If( this.normalEdgeStrength.greaterThan( 0.0 ).and( normal.length().greaterThan( 0 ) ), () => {
+			If( normalEdgeStrength.greaterThan( 0.0 ).and( normal.length().greaterThan( 0 ) ), () => {
 
 				nei.assign( normalEdgeIndicator( depth, normal ) );
 
 			} );
 
-			const strength = dei.greaterThan( 0 ).select( float( 1.0 ).sub( dei.mul( this.depthEdgeStrength ) ), nei.mul( this.normalEdgeStrength ).add( 1 ) );
+			const strength = dei.greaterThan( 0 ).select( float( 1.0 ).sub( dei.mul( depthEdgeStrength ) ), nei.mul( normalEdgeStrength ).add( 1 ) );
 
 			return vec4( texel.mul( strength ).rgb, texel.a );
 
@@ -209,110 +200,6 @@ class PixelationNode extends TempNode {
 		const outputNode = pixelation();
 
 		return outputNode;
-
-	}
-
-}
-
-const pixelation = ( node, depthNode, normalNode, pixelSize = 6, normalEdgeStrength = 0.3, depthEdgeStrength = 0.4 ) => new PixelationNode( convertToTexture( node ), convertToTexture( depthNode ), convertToTexture( normalNode ), nodeObject( pixelSize ), nodeObject( normalEdgeStrength ), nodeObject( depthEdgeStrength ) );
-
-/**
- * A special render pass node that renders the scene with a pixelation effect.
- *
- * @augments PassNode
- * @three_import import { pixelationPass } from 'three/addons/tsl/display/PixelationPassNode.js';
- */
-class PixelationPassNode extends PassNode {
-
-	static get type() {
-
-		return 'PixelationPassNode';
-
-	}
-
-	/**
-	 * Constructs a new pixelation pass node.
-	 *
-	 * @param {Scene} scene - The scene to render.
-	 * @param {Camera} camera - The camera to render the scene with.
-	 * @param {Node<float> | number} [pixelSize=6] - The pixel size.
-	 * @param {Node<float> | number} [normalEdgeStrength=0.3] - The normal edge strength.
-	 * @param {Node<float> | number} [depthEdgeStrength=0.4] - The depth edge strength.
-	 */
-	constructor( scene, camera, pixelSize = 6, normalEdgeStrength = 0.3, depthEdgeStrength = 0.4 ) {
-
-		super( PassNode.COLOR, scene, camera, { minFilter: NearestFilter, magFilter: NearestFilter } );
-
-		/**
-		 * The pixel size.
-		 *
-		 * @type {number}
-		 * @default 6
-		 */
-		this.pixelSize = pixelSize;
-
-		/**
-		 * The normal edge strength.
-		 *
-		 * @type {number}
-		 * @default 0.3
-		 */
-		this.normalEdgeStrength = normalEdgeStrength;
-
-		/**
-		 * The depth edge strength.
-		 *
-		 * @type {number}
-		 * @default 0.4
-		 */
-		this.depthEdgeStrength = depthEdgeStrength;
-
-		/**
-		 * This flag can be used for type testing.
-		 *
-		 * @type {boolean}
-		 * @readonly
-		 * @default true
-		 */
-		this.isPixelationPassNode = true;
-
-		this._mrt = mrt( {
-			output: output,
-			normal: normalView
-		} );
-
-	}
-
-	/**
-	 * Sets the size of the pass.
-	 *
-	 * @param {number} width - The width of the pass.
-	 * @param {number} height - The height of the pass.
-	 */
-	setSize( width, height ) {
-
-		const pixelSize = this.pixelSize.value ? this.pixelSize.value : this.pixelSize;
-
-		const adjustedWidth = Math.floor( width / pixelSize );
-		const adjustedHeight = Math.floor( height / pixelSize );
-
-		super.setSize( adjustedWidth, adjustedHeight );
-
-	}
-
-	/**
-	 * This method is used to setup the effect's TSL code.
-	 *
-	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {PixelationNode}
-	 */
-	setup() {
-
-		const color = super.getTextureNode( 'output' );
-		const depth = super.getTextureNode( 'depth' );
-		const normal = super.getTextureNode( 'normal' );
-
-		return pixelation( color, depth, normal, this.pixelSize, this.normalEdgeStrength, this.depthEdgeStrength );
 
 	}
 

--- a/examples/webgpu_postprocessing_pixel.html
+++ b/examples/webgpu_postprocessing_pixel.html
@@ -48,7 +48,11 @@
 		import { pixelationPass } from 'three/addons/tsl/display/PixelationPassNode.js';
 
 		let camera, scene, renderer, renderPipeline, crystalMesh, timer;
-		let effectController;
+		let scenePass;
+
+		const params = {
+			pixelAlignedPanning: true
+		};
 
 		init();
 
@@ -146,15 +150,8 @@
 			renderer.shadowMap.type = THREE.BasicShadowMap;
 			document.body.appendChild( renderer.domElement );
 
-			effectController = {
-				pixelSize: uniform( 6 ),
-				normalEdgeStrength: uniform( 0.3 ),
-				depthEdgeStrength: uniform( 0.4 ),
-				pixelAlignedPanning: true
-			};
-
 			renderPipeline = new THREE.RenderPipeline( renderer );
-			const scenePass = pixelationPass( scene, camera, effectController.pixelSize, effectController.normalEdgeStrength, effectController.depthEdgeStrength );
+			scenePass = pixelationPass( scene, camera, 6, uniform( 0.3 ), uniform( 0.4 ) );
 			renderPipeline.outputNode = scenePass;
 
 			window.addEventListener( 'resize', onWindowResize );
@@ -165,10 +162,10 @@
 			// gui
 
 			const gui = renderer.inspector.createParameters( 'Settings' );
-			gui.add( effectController.pixelSize, 'value', 1, 16, 1 ).name( 'Pixel Size' );
-			gui.add( effectController.normalEdgeStrength, 'value', 0, 2, 0.05 ).name( 'Normal Edge Strength' );
-			gui.add( effectController.depthEdgeStrength, 'value', 0, 1, 0.05 ).name( 'Depth Edge Strength' );
-			gui.add( effectController, 'pixelAlignedPanning' );
+			gui.add( scenePass, 'pixelSize', 1, 16, 1 ).name( 'Pixel Size' );
+			gui.add( scenePass.normalEdgeStrength, 'value', 0, 2, 0.05 ).name( 'Normal Edge Strength' );
+			gui.add( scenePass.depthEdgeStrength, 'value', 0, 1, 0.05 ).name( 'Depth Edge Strength' );
+			gui.add( params, 'pixelAlignedPanning' );
 
 		}
 
@@ -196,9 +193,9 @@
 			const rendererSize = renderer.getSize( new THREE.Vector2() );
 			const aspectRatio = rendererSize.x / rendererSize.y;
 
-			if ( effectController.pixelAlignedPanning ) {
+			if ( params.pixelAlignedPanning ) {
 
-				const pixelSize = effectController.pixelSize.value;
+				const pixelSize = scenePass.pixelSize;
 
 				pixelAlignFrustum( camera, aspectRatio, Math.floor( rendererSize.x / pixelSize ),
 					Math.floor( rendererSize.y / pixelSize ) );


### PR DESCRIPTION
**Description**

Simplifies the PixelationPassNode code by properly using getTextureNode and textureSize. Additionally adds some comments to specify how the effect might differ from RetroPassNode.