### PR TITLE
Line3: Fix at() return description.

### DIFF
--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -121,7 +121,7 @@ class Line3 {
 	 *
 	 * @param {number} t - A value between `[0,1]` to represent a position along the line segment.
 	 * @param {Vector3} target - The target vector that is used to store the method's result.
-	 * @return {Vector3} The delta vector.
+	 * @return {Vector3} The point along the line segment.
 	 */
 	at( t, target ) {
 


### PR DESCRIPTION
`Line3.at()` returns a point on the line segment, computed as `start + t * (end - start)`. Its JSDoc return description currently calls the result "The delta vector", which describes `Line3.delta()` instead.

Update the return description to "The point along the line segment."

Validation: `npm test` passed (lint, core unit tests, and addon unit tests). JSDoc parsed the updated description successfully. For a segment from `(10, 0, 0)` to `(20, 0, 0)`, `at(0.5)` returned `(15, 0, 0)` while `delta()` returned `(10, 0, 0)`.
