### PR TITLE
Remove iOS iframe auto-resize workaround

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -193,16 +193,6 @@
 
 			};
 
-			// iOS iframe auto-resize workaround
-
-			if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
-
-				viewer.style.width = getComputedStyle( viewer ).width;
-				viewer.style.height = getComputedStyle( viewer ).height;
-				viewer.setAttribute( 'scrolling', 'no' );
-
-			}
-
 		}
 
 		function createLink( file, tags ) {


### PR DESCRIPTION
This workaround no longer appears necessary. iPadOS has been reporting its user agent without the search term "iPad" for some time. While iOS on phones still has this identifying string, testing on iOS 26 does not produce the iframe growth that was the cause of this workaround.

Since I contributed to having this workaround included back when, I figured I should remove it once it is not needed.
